### PR TITLE
chore(release): bump to 0.19.4 + fix entroly doctor guidance

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "flate2",
  "md-5",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 description = "Rust core for Entroly — information-theoretic context optimization"
 

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "0.19.3"
+version = "0.19.4"
 description = "Rust core for Entroly — information-theoretic context optimization (knapsack, entropy, dedup, SAST, query analysis)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "flate2",
  "js-sys",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 description = "WebAssembly build of Entroly - information-theoretic context optimization for JavaScript/TypeScript"
 

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Information-theoretic context optimization for AI coding agents. Zero-friction, pure WebAssembly - no Python dependency.",
   "main": "index.js",
   "types": "pkg/entroly_wasm.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "0.19.3"
+__version__ = "0.19.4"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -42,7 +42,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "0.19.3"
+    __version__ = "0.19.4"
 
 # ── Force UTF-8 output on Windows ──
 # Windows terminals default to cp1252 which can't encode ✓/✗/─/⚡.
@@ -2682,11 +2682,17 @@ def cmd_doctor(args):
     except ImportError:
         print(f"  {C.RED}x{C.RESET} Rust engine (entroly-core) not loaded "
               f"{C.GRAY}— optional; core features still work{C.RESET}")
-        print(f"    {C.GRAY}Install:  pip install \"entroly[full]\"{C.RESET}")
-        print(f"    {C.GRAY}If it fails to compile on a very new Python, use "
-              f"Python 3.10–3.13 or set{C.RESET}")
-        print(f"    {C.GRAY}PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 before "
-              f"installing.{C.RESET}")
+        # Prebuilt abi3 wheels (py>=3.10, incl. 3.14) ship for
+        # mac/linux/windows. The usual failure is pip reusing a stale
+        # cache or being too old to match the wheel, then falling back
+        # to compiling an ancient sdist. Bust the cache + upgrade pip
+        # first — that fixes it without any compile.
+        print(f"    {C.GRAY}Fix:  pip install --no-cache-dir -U pip && "
+              f"pip install --no-cache-dir -U entroly-core{C.RESET}")
+        print(f"    {C.GRAY}(If pip still compiles from source and fails on "
+              f"a new Python, your pip is too old to{C.RESET}")
+        print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
+              f"fix, not a different Python.){C.RESET}")
 
     # 3. Check config validity
     checks_total += 1

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -68,7 +68,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "0.19.3"
+    version: str = "0.19.4"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Information-theoretic context optimization MCP server for AI coding agents.",
   "main": "index.js",
   "bin": {

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "0.19.3"
+version = "0.19.4"
 
 description = "Information-theoretic context optimization for AI coding agents. Knapsack-optimal token budgeting, Shannon entropy scoring, SimHash dedup, predictive pre-fetch. MCP server."
 readme = "README.md"
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 native = [
-    "entroly-core>=0.19.3,<1",
+    "entroly-core>=0.19.4,<1",
     "mcp>=1.0.0,<2",
 ]
 

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -3922,7 +3922,7 @@ def main():
         from importlib.metadata import version as _pkg_version
         _version = _pkg_version("entroly")
     except Exception:
-        _version = "0.19.3"
+        _version = "0.19.4"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "0.19.3"
+version = "0.19.4"
 
 description = "The token saving proxy and context compression engine for AI coding agents. Reduce LLM API costs by 80% while providing full codebase context to Cursor, Claude Code, and Copilot."
 readme = "README.md"
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.6.0,<2",
-    "entroly-core>=0.19.3,<1",
+    "entroly-core>=0.19.4,<1",
 ]
 
 [project.optional-dependencies]
@@ -44,10 +44,10 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=0.19.3,<1",
+    "entroly-core>=0.19.4,<1",
 ]
 full = [
-    "entroly-core>=0.19.3,<1",
+    "entroly-core>=0.19.4,<1",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",


### PR DESCRIPTION
Prepares the release that ships the gh#44 fixes (codex tracking, Claude-3 400, version-drift) merged in #45.

Version bumped to 0.19.4 in every tracked declaration (lockstep):
  pyproject.toml, entroly/__init__.py, entroly/cli.py (__version__
  fallback), entroly/daemon.py, entroly/server.py (version fallback),
  entroly-core/{Cargo.toml,Cargo.lock,pyproject.toml},
  entroly-wasm/{Cargo.toml,Cargo.lock,package.json},
  entroly/npm/package.json, .claude-plugin/manifest.json.
  entroly-core compat pins moved to >=0.19.4,<1 to keep the pair
  locked.

entroly doctor: the previous hint pointed at the wrong remedy. The real failure (gh#44) is pip reusing a stale cache / being too old to match the published abi3 wheel, then falling back to compiling an ancient sdist. Doctor now leads with the actual fix:
  pip install --no-cache-dir -U pip && \
  pip install --no-cache-dir -U entroly-core

Not touched, by design:
  - packaging/homebrew/{entroly.rb,README.md}: the formula URL+sha256 are content-bound to the published sdist and can only be updated AFTER 0.19.4 is on PyPI. Post-release downstream step.
  - .entroly_verification.json / entroly-wasm/pkg/: gitignored generated artifacts; refreshed by their generators.