### PR TITLE
release: bump all manifests to v0.19.5

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "flate2",
  "md-5",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "0.19.4"
+version = "0.19.5"
 edition = "2021"
 description = "Rust core for Entroly — information-theoretic context optimization"
 

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "0.19.4"
+version = "0.19.5"
 description = "Rust core for Entroly — information-theoretic context optimization (knapsack, entropy, dedup, SAST, query analysis)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "flate2",
  "js-sys",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "0.19.4"
+version = "0.19.5"
 edition = "2021"
 description = "WebAssembly build of Entroly - information-theoretic context optimization for JavaScript/TypeScript"
 

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Information-theoretic context optimization for AI coding agents. Zero-friction, pure WebAssembly - no Python dependency.",
   "main": "index.js",
   "types": "pkg/entroly_wasm.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "0.19.4"
+__version__ = "0.19.5"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -42,7 +42,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "0.19.4"
+    __version__ = "0.19.5"
 
 # ── Force UTF-8 output on Windows ──
 # Windows terminals default to cp1252 which can't encode ✓/✗/─/⚡.

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -68,7 +68,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "0.19.4"
+    version: str = "0.19.5"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Information-theoretic context optimization MCP server for AI coding agents.",
   "main": "index.js",
   "bin": {

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "0.19.4"
+version = "0.19.5"
 
 description = "Information-theoretic context optimization for AI coding agents. Knapsack-optimal token budgeting, Shannon entropy scoring, SimHash dedup, predictive pre-fetch. MCP server."
 readme = "README.md"
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 native = [
-    "entroly-core>=0.19.4,<1",
+    "entroly-core>=0.19.5,<1",
     "mcp>=1.0.0,<2",
 ]
 

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -4068,7 +4068,7 @@ def main():
         from importlib.metadata import version as _pkg_version
         _version = _pkg_version("entroly")
     except Exception:
-        _version = "0.19.4"
+        _version = "0.19.5"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -17,7 +17,7 @@ mkdir -p /tmp/homebrew-entroly/Formula
 cp packaging/homebrew/entroly.rb /tmp/homebrew-entroly/Formula/
 
 # 3. Fill in the sha256 (after publishing to PyPI):
-VER=0.19.3
+VER=0.19.5
 curl -sLO "https://files.pythonhosted.org/packages/source/e/entroly/entroly-${VER}.tar.gz"
 SHA=$(shasum -a 256 "entroly-${VER}.tar.gz" | awk '{print $1}')
 sed -i.bak "s/REPLACE_WITH_SDIST_SHA256_AT_RELEASE_TIME/${SHA}/" \
@@ -35,7 +35,7 @@ git push origin main
 Either bump manually:
 
 ```bash
-VER=0.19.3
+VER=0.19.5
 sed -i.bak "s|entroly-[0-9.]*\.tar\.gz|entroly-${VER}.tar.gz|" Formula/entroly.rb
 curl -sLO "https://files.pythonhosted.org/packages/source/e/entroly/entroly-${VER}.tar.gz"
 SHA=$(shasum -a 256 "entroly-${VER}.tar.gz" | awk '{print $1}')

--- a/packaging/homebrew/entroly.rb
+++ b/packaging/homebrew/entroly.rb
@@ -21,7 +21,7 @@ class Entroly < Formula
 
   desc "Token-saving proxy and context compression engine for AI coding agents"
   homepage "https://entroly.dev"
-  url "https://files.pythonhosted.org/packages/98/bf/7c364526a976d3442a543f4b1a5cb68a2a2e324585223a6a8965ecfb7e20/entroly-0.19.3.tar.gz"
+  url "https://files.pythonhosted.org/packages/98/bf/7c364526a976d3442a543f4b1a5cb68a2a2e324585223a6a8965ecfb7e20/entroly-0.19.5.tar.gz"
   sha256 "b4ca09f4835c153edaefd7c1f512054154a4807e01e508dac62c5ed40cdb1f30"
   license "Apache-2.0"
   head "https://github.com/juyterman1000/entroly.git", branch: "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "0.19.4"
+version = "0.19.5"
 
 description = "The token saving proxy and context compression engine for AI coding agents. Reduce LLM API costs by 80% while providing full codebase context to Cursor, Claude Code, and Copilot."
 readme = "README.md"
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.6.0,<2",
-    "entroly-core>=0.19.4,<1",
+    "entroly-core>=0.19.5,<1",
 ]
 
 [project.optional-dependencies]
@@ -44,10 +44,10 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=0.19.4,<1",
+    "entroly-core>=0.19.5,<1",
 ]
 full = [
-    "entroly-core>=0.19.4,<1",
+    "entroly-core>=0.19.5,<1",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",


### PR DESCRIPTION
Unified version bump across all distribution channels:
- Python: __init__.py, cli.py, server.py, daemon.py, pyproject.toml (x3)
- Rust: entroly-core/Cargo.toml, entroly-wasm/Cargo.toml, Cargo.lock (x2)
- npm: package.json (x3), pkg/package.json
- Plugins: .claude-plugin/manifest.json
- Packaging: homebrew entroly.rb, homebrew README.md
- Meta: .entroly_verification.json

New in v0.19.5:
- verify_response MCP/npm tool (4-signal hallucination cascade)
- detect_hallucination() + optimize() pip SDK functions
- Full cross-surface feature parity (all surfaces 4-5/5)