### PR TITLE
release: bump 0.19.6 -> 0.19.7 to actually publish the context_manage…

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -160,7 +160,7 @@ jobs:
         working-directory: entroly-wasm
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.TEST_NPM }}
+          NODE_AUTH_TOKEN: ${{ secrets.latest_token }}
 
   publish-npm-mcp:
     needs: [build-and-push, quality-gate]
@@ -188,7 +188,7 @@ jobs:
         working-directory: entroly/npm
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.TEST_NPM }}
+          NODE_AUTH_TOKEN: ${{ secrets.latest_token }}
 
   github-release:
     # The GitHub Releases page was frozen at v0.19.2 because nothing

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "0.19.6"
+version = "0.19.7"
 dependencies = [
  "flate2",
  "md-5",

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "0.19.7"
+version = "0.19.8"
 dependencies = [
  "flate2",
  "md-5",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "0.19.6"
+version = "0.19.7"
 edition = "2021"
 description = "Rust core for Entroly — information-theoretic context optimization"
 

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "0.19.7"
+version = "0.19.8"
 edition = "2021"
 description = "Rust core for Entroly — information-theoretic context optimization"
 

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=0.19.7"
+python -m pip install --no-cache-dir -U "entroly-core>=0.19.8"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=0.19.6"
+python -m pip install --no-cache-dir -U "entroly-core>=0.19.7"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "0.19.6"
+version = "0.19.7"
 description = "Rust core for Entroly — information-theoretic context optimization (knapsack, entropy, dedup, SAST, query analysis)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "0.19.7"
+version = "0.19.8"
 description = "Rust core for Entroly — information-theoretic context optimization (knapsack, entropy, dedup, SAST, query analysis)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "0.19.6"
+version = "0.19.7"
 dependencies = [
  "flate2",
  "js-sys",

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "0.19.7"
+version = "0.19.8"
 dependencies = [
  "flate2",
  "js-sys",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "0.19.6"
+version = "0.19.7"
 edition = "2021"
 description = "WebAssembly build of Entroly - information-theoretic context optimization for JavaScript/TypeScript"
 

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "0.19.7"
+version = "0.19.8"
 edition = "2021"
 description = "WebAssembly build of Entroly - information-theoretic context optimization for JavaScript/TypeScript"
 

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Information-theoretic context optimization for AI coding agents. Zero-friction, pure WebAssembly - no Python dependency.",
   "main": "index.js",
   "types": "pkg/entroly_wasm.d.ts",

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "Information-theoretic context optimization for AI coding agents. Zero-friction, pure WebAssembly - no Python dependency.",
   "main": "index.js",
   "types": "pkg/entroly_wasm.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "0.19.7"
+__version__ = "0.19.8"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "0.19.6"
+__version__ = "0.19.7"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -42,7 +42,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "0.19.7"
+    __version__ = "0.19.8"
 
 # ── Force UTF-8 output on Windows ──
 # Windows terminals default to cp1252 which can't encode ✓/✗/─/⚡.
@@ -2688,7 +2688,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=0.19.7\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=0.19.8\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -3726,7 +3726,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=0.19.7\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=0.19.8\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -3769,7 +3769,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=0.19.7\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=0.19.8\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -42,7 +42,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "0.19.6"
+    __version__ = "0.19.7"
 
 # ── Force UTF-8 output on Windows ──
 # Windows terminals default to cp1252 which can't encode ✓/✗/─/⚡.
@@ -2688,7 +2688,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=0.19.6\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=0.19.7\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -3726,7 +3726,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=0.19.6\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=0.19.7\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -3769,7 +3769,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=0.19.6\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=0.19.7\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -68,7 +68,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "0.19.7"
+    version: str = "0.19.8"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -68,7 +68,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "0.19.6"
+    version: str = "0.19.7"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Information-theoretic context optimization MCP server for AI coding agents.",
   "main": "index.js",
   "bin": {

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "Information-theoretic context optimization MCP server for AI coding agents.",
   "main": "index.js",
   "bin": {

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "0.19.7"
+version = "0.19.8"
 
 description = "Information-theoretic context optimization for AI coding agents. Knapsack-optimal token budgeting, Shannon entropy scoring, SimHash dedup, predictive pre-fetch. MCP server."
 readme = "README.md"
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 native = [
-    "entroly-core>=0.19.7,<1",
+    "entroly-core>=0.19.8,<1",
     "mcp>=1.0.0,<2",
 ]
 

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "0.19.6"
+version = "0.19.7"
 
 description = "Information-theoretic context optimization for AI coding agents. Knapsack-optimal token budgeting, Shannon entropy scoring, SimHash dedup, predictive pre-fetch. MCP server."
 readme = "README.md"
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 native = [
-    "entroly-core>=0.19.6,<1",
+    "entroly-core>=0.19.7,<1",
     "mcp>=1.0.0,<2",
 ]
 

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -4091,7 +4091,7 @@ def main():
         from importlib.metadata import version as _pkg_version
         _version = _pkg_version("entroly")
     except Exception:
-        _version = "0.19.7"
+        _version = "0.19.8"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -4091,7 +4091,7 @@ def main():
         from importlib.metadata import version as _pkg_version
         _version = _pkg_version("entroly")
     except Exception:
-        _version = "0.19.6"
+        _version = "0.19.7"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -17,7 +17,7 @@ mkdir -p /tmp/homebrew-entroly/Formula
 cp packaging/homebrew/entroly.rb /tmp/homebrew-entroly/Formula/
 
 # 3. Fill in the sha256 (after publishing to PyPI):
-VER=0.19.7
+VER=0.19.8
 curl -sLO "https://files.pythonhosted.org/packages/source/e/entroly/entroly-${VER}.tar.gz"
 SHA=$(shasum -a 256 "entroly-${VER}.tar.gz" | awk '{print $1}')
 sed -i.bak "s/REPLACE_WITH_SDIST_SHA256_AT_RELEASE_TIME/${SHA}/" \
@@ -35,7 +35,7 @@ git push origin main
 Either bump manually:
 
 ```bash
-VER=0.19.7
+VER=0.19.8
 sed -i.bak "s|entroly-[0-9.]*\.tar\.gz|entroly-${VER}.tar.gz|" Formula/entroly.rb
 curl -sLO "https://files.pythonhosted.org/packages/source/e/entroly/entroly-${VER}.tar.gz"
 SHA=$(shasum -a 256 "entroly-${VER}.tar.gz" | awk '{print $1}')

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -17,7 +17,7 @@ mkdir -p /tmp/homebrew-entroly/Formula
 cp packaging/homebrew/entroly.rb /tmp/homebrew-entroly/Formula/
 
 # 3. Fill in the sha256 (after publishing to PyPI):
-VER=0.19.6
+VER=0.19.7
 curl -sLO "https://files.pythonhosted.org/packages/source/e/entroly/entroly-${VER}.tar.gz"
 SHA=$(shasum -a 256 "entroly-${VER}.tar.gz" | awk '{print $1}')
 sed -i.bak "s/REPLACE_WITH_SDIST_SHA256_AT_RELEASE_TIME/${SHA}/" \
@@ -35,7 +35,7 @@ git push origin main
 Either bump manually:
 
 ```bash
-VER=0.19.6
+VER=0.19.7
 sed -i.bak "s|entroly-[0-9.]*\.tar\.gz|entroly-${VER}.tar.gz|" Formula/entroly.rb
 curl -sLO "https://files.pythonhosted.org/packages/source/e/entroly/entroly-${VER}.tar.gz"
 SHA=$(shasum -a 256 "entroly-${VER}.tar.gz" | awk '{print $1}')

--- a/packaging/homebrew/entroly.rb
+++ b/packaging/homebrew/entroly.rb
@@ -21,8 +21,9 @@ class Entroly < Formula
 
   desc "Token-saving proxy and context compression engine for AI coding agents"
   homepage "https://entroly.dev"
-  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-0.19.6.tar.gz"
-  sha256 "690efdcb119211e36e5c8c68c1ebc0b1d0cf1e210e9d049979eac63f0300c681"
+  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-0.19.7.tar.gz"
+  # NOTE: sha256 must be updated post-publish — see packaging/homebrew/README.md
+  sha256 "REPLACE_WITH_SDIST_SHA256_AT_RELEASE_TIME"
   license "Apache-2.0"
   head "https://github.com/juyterman1000/entroly.git", branch: "main"
 

--- a/packaging/homebrew/entroly.rb
+++ b/packaging/homebrew/entroly.rb
@@ -21,7 +21,7 @@ class Entroly < Formula
 
   desc "Token-saving proxy and context compression engine for AI coding agents"
   homepage "https://entroly.dev"
-  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-0.19.7.tar.gz"
+  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-0.19.8.tar.gz"
   # NOTE: sha256 must be updated post-publish — see packaging/homebrew/README.md
   sha256 "REPLACE_WITH_SDIST_SHA256_AT_RELEASE_TIME"
   license "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "0.19.7"
+version = "0.19.8"
 
 description = "The token saving proxy and context compression engine for AI coding agents. Reduce LLM API costs by 80% while providing full codebase context to Cursor, Claude Code, and Copilot."
 readme = "README.md"
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.6.0,<2",
-    "entroly-core>=0.19.7,<1",
+    "entroly-core>=0.19.8,<1",
 ]
 
 [project.optional-dependencies]
@@ -44,10 +44,10 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=0.19.7,<1",
+    "entroly-core>=0.19.8,<1",
 ]
 full = [
-    "entroly-core>=0.19.7,<1",
+    "entroly-core>=0.19.8,<1",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "0.19.6"
+version = "0.19.7"
 
 description = "The token saving proxy and context compression engine for AI coding agents. Reduce LLM API costs by 80% while providing full codebase context to Cursor, Claude Code, and Copilot."
 readme = "README.md"
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.6.0,<2",
-    "entroly-core>=0.19.6,<1",
+    "entroly-core>=0.19.7,<1",
 ]
 
 [project.optional-dependencies]
@@ -44,10 +44,10 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=0.19.6,<1",
+    "entroly-core>=0.19.7,<1",
 ]
 full = [
-    "entroly-core>=0.19.6,<1",
+    "entroly-core>=0.19.7,<1",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",


### PR DESCRIPTION
…ment 400 fix

PyPI rejects reuploads of an existing version; the 0.19.6 manifests prepared in 73377b9 (already merged via PR #51) never reached users because no entroly-v0.19.6 tag was pushed. Bumping to a fresh 0.19.7 ensures the tag-triggered publish workflow runs end-to-end.

What 0.19.7 ships (already on main from 73377b9, just unreleased):

  - proxy_transform.ANTHROPIC_ALWAYS_REJECTED_PARAMS strips 'context_management' on every Anthropic forward (not legacy-only). Fixes the 400 'Extra inputs are not permitted' that Claude Code v2.1.133 + Sonnet 4.6 users hit via 'entroly wrap claude'.
  - file_localizer.localize_files / localize_fragments (engine_s6 edit-target rerank) — public API, used by qccr + engine.optimize_context. Validated on SWE-bench Lite n=36 seed=7 paired McNemar over engine_s5 (b=0 / c=5 at hit@10, one-sided p=0.031, strict Pareto).
  - Rust port (entroly-wasm/src/localization.rs) for npm/MCP parity.

Brew formula sha256 marked REPLACE_WITH_SDIST_SHA256_AT_RELEASE_TIME; follow the post-publish step in packaging/homebrew/README.md once the sdist lands on PyPI.