### PR TITLE
Expand supported document discovery, skip common generated dirs, and improve CLI hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build artifacts
+node_modules/
 target/
 dist/
 *.whl

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -3773,12 +3773,12 @@ def cmd_optimize(args):
 def cmd_ingest(args):
     """entroly ingest PATH - build a local multi-document Context Receipt index."""
     from entroly.context_receipts import ingest_documents
-    from entroly.context_receipts.ingest import read_documents_from_path
+    from entroly.context_receipts.ingest import read_documents_from_path, supported_documents_hint
     from entroly.context_receipts.store import DEFAULT_INDEX, write_json
 
     docs = read_documents_from_path(args.path)
     if not docs:
-        print(f"  {C.RED}No supported documents found.{C.RESET} Use .md, .txt, or .rst files.", file=sys.stderr)
+        print(f"  {C.RED}No supported documents found.{C.RESET} {supported_documents_hint()}", file=sys.stderr)
         return 1
     index = ingest_documents(
         docs,

--- a/entroly/context_receipts/ingest.py
+++ b/entroly/context_receipts/ingest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -14,12 +15,93 @@ from .models import (
     text_fingerprint,
 )
 
-SUPPORTED_EXTENSIONS = {
+DOCUMENT_EXTENSIONS = frozenset({
     ".txt",
     ".md",
     ".markdown",
     ".rst",
-}
+})
+
+SOURCE_EXTENSIONS = frozenset({
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cs",
+    ".css",
+    ".go",
+    ".h",
+    ".hpp",
+    ".html",
+    ".java",
+    ".js",
+    ".jsx",
+    ".json",
+    ".kt",
+    ".mjs",
+    ".py",
+    ".rb",
+    ".rs",
+    ".sh",
+    ".sql",
+    ".swift",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".xml",
+    ".yaml",
+    ".yml",
+})
+
+SUPPORTED_FILENAMES = frozenset({
+    "Containerfile",
+    "Dockerfile",
+    "Justfile",
+    "Makefile",
+    "Procfile",
+    "Rakefile",
+})
+
+SUPPORTED_FILENAME_PREFIXES = (
+    "Containerfile.",
+    "Dockerfile.",
+)
+
+SUPPORTED_EXTENSIONS = DOCUMENT_EXTENSIONS | SOURCE_EXTENSIONS
+
+SKIP_DIRECTORIES = frozenset({
+    ".entroly",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "target",
+    "venv",
+})
+
+SKIP_DIRECTORY_SUFFIXES = (
+    ".egg-info",
+)
+
+SKIP_FILENAMES = frozenset({
+    "Cargo.lock",
+    "Gemfile.lock",
+    "Pipfile.lock",
+    "bun.lockb",
+    "composer.lock",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "yarn.lock",
+})
 
 TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_\-']*|[^\w\s]", re.UNICODE)
 HEADING_RE = re.compile(
@@ -48,17 +130,50 @@ def _title_for_path(source_path: str) -> str:
     return Path(name).stem.replace("_", " ").replace("-", " ").strip() or name
 
 
+def _is_skipped_directory(name: str) -> bool:
+    return name in SKIP_DIRECTORIES or name.endswith(SKIP_DIRECTORY_SUFFIXES)
+
+
+def _is_skipped_filename(name: str) -> bool:
+    return name in SKIP_FILENAMES
+
+
+def _has_supported_filename(name: str) -> bool:
+    return name in SUPPORTED_FILENAMES or name.startswith(SUPPORTED_FILENAME_PREFIXES)
+
+
+def _is_supported_document_path(path: Path) -> bool:
+    return (
+        path.is_file()
+        and not _is_skipped_filename(path.name)
+        and (path.suffix.lower() in SUPPORTED_EXTENSIONS or _has_supported_filename(path.name))
+    )
+
+
+def _discover_supported_paths(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root] if _is_supported_document_path(root) else []
+
+    paths: list[Path] = []
+    for current_root, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if not _is_skipped_directory(d))
+        current_path = Path(current_root)
+        for filename in sorted(filenames):
+            candidate = current_path / filename
+            if _is_supported_document_path(candidate):
+                paths.append(candidate)
+    return paths
+
+
+def supported_documents_hint() -> str:
+    extensions = ", ".join(sorted(DOCUMENT_EXTENSIONS | SOURCE_EXTENSIONS))
+    filenames = ", ".join(sorted(SUPPORTED_FILENAMES | {"Dockerfile.*", "Containerfile.*"}))
+    return f"Use supported text/source files ({extensions}) or filenames ({filenames})."
+
+
 def read_documents_from_path(path: str | Path) -> list[tuple[str, str]]:
     root = Path(path)
-    paths: list[Path]
-    if root.is_file():
-        paths = [root]
-    else:
-        paths = [
-            p
-            for p in sorted(root.rglob("*"))
-            if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS
-        ]
+    paths = _discover_supported_paths(root)
     documents: list[tuple[str, str]] = []
     for p in paths:
         source_path = p.as_posix()

--- a/tests/test_context_receipts.py
+++ b/tests/test_context_receipts.py
@@ -313,9 +313,32 @@ def test_cli_ingest_select_receipt_explain_smoke(tmp_path: Path):
 
 def test_read_documents_from_path_filters_supported_files(tmp_path: Path):
     (tmp_path / "a.md").write_text("# A\n\nalpha", encoding="utf-8")
+    (tmp_path / "app.py").write_text("def answer():\n    return 42\n", encoding="utf-8")
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (tmp_path / "Dockerfile.prod").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (tmp_path / "Containerfile.dev").write_text("FROM fedora:latest\n", encoding="utf-8")
+    (tmp_path / "Justfile").write_text("test:\n    pytest\n", encoding="utf-8")
     (tmp_path / "b.bin").write_bytes(b"\x00\x01")
 
     docs = read_documents_from_path(tmp_path)
+    sources = {Path(source).name for source, _ in docs}
 
-    assert len(docs) == 1
-    assert docs[0][0].endswith("a.md")
+    assert sources == {"Containerfile.dev", "Dockerfile", "Dockerfile.prod", "Justfile", "a.md", "app.py"}
+
+
+def test_read_documents_from_path_skips_generated_dependency_dirs(tmp_path: Path):
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+    node_modules = tmp_path / "node_modules" / "dep"
+    node_modules.mkdir(parents=True)
+    (node_modules / "README.md").write_text("# Dependency copy\n", encoding="utf-8")
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "config.toml").write_text("[core]\n", encoding="utf-8")
+    (tmp_path / "package-lock.json").write_text("{}\n", encoding="utf-8")
+    egg_info = tmp_path / "sample.egg-info"
+    egg_info.mkdir()
+    (egg_info / "PKG-INFO").write_text("Metadata-Version: 2.1\n", encoding="utf-8")
+
+    docs = read_documents_from_path(tmp_path)
+
+    assert [Path(source).name for source, _ in docs] == ["README.md"]


### PR DESCRIPTION
### Motivation
- Allow the ingestion tooling to index more useful files (source code, Dockerfiles, Makefile-like files) in addition to plain text/markdown documents.
- Avoid indexing vendor/build artifacts and dependency directories like `node_modules` and other generated folders.
- Provide a clearer, dynamically generated hint in the CLI when no supported documents are found and ensure `node_modules/` is ignored by VCS.

### Description
- Add extensive lists of supported document and source file extensions, supported filenames and filename prefixes, and skip rules for directories, directory suffixes, and filenames in `context_receipts/ingest.py`.
- Implement `_discover_supported_paths`, helper predicate functions (`_is_supported_document_path`, `_is_skipped_directory`, etc.), and `supported_documents_hint`, and switch `read_documents_from_path` to use the new discovery logic.
- Use the new `supported_documents_hint()` in the CLI error message for `cmd_ingest` and add `node_modules/` to `.gitignore`.

### Testing
- Ran `pytest tests/test_context_receipts.py::test_read_documents_from_path_filters_supported_files` which exercised discovery of `app.py`, `Dockerfile*`, `Containerfile.*`, `Justfile`, and passed.
- Ran `pytest tests/test_context_receipts.py::test_read_documents_from_path_skips_generated_dependency_dirs` which verified skipping `node_modules`, `.git`, lockfiles, and `.egg-info`, and passed.
- Ran `pytest tests/test_context_receipts.py -q` to validate the modified ingestion tests together and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b05c00e288320b4e4ad83ff1b8ffa)