### PR TITLE
[codex] fix: harden context receipts and change detection

### DIFF
--- a/entroly/change_listener.py
+++ b/entroly/change_listener.py
@@ -16,6 +16,7 @@ This is the change-driven glue between Truth, Belief, and Verification.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import threading
@@ -96,7 +97,7 @@ class WorkspaceChangeListener:
         changed = []
         for rel_path, mtime in current.items():
             prev = previous.get(rel_path)
-            if force or prev is None or mtime > prev:
+            if force or prev is None or mtime != prev:
                 changed.append(rel_path)
 
         deleted = [rel_path for rel_path in previous.keys() if rel_path not in current]
@@ -187,15 +188,26 @@ class WorkspaceChangeListener:
         self._stop.set()
         return {"status": "stopped", "project_dir": str(self._project_dir)}
 
-    def _snapshot(self) -> dict[str, float]:
-        snapshot: dict[str, float] = {}
+    def _snapshot(self) -> dict[str, str]:
+        snapshot: dict[str, str] = {}
         for path in self._discover_source_files():
             try:
                 rel = path.relative_to(self._project_dir).as_posix()
-                snapshot[rel] = path.stat().st_mtime
+                snapshot[rel] = self._file_signature(path)
             except OSError:
                 continue
         return snapshot
+
+    def _file_signature(self, path: Path) -> str:
+        """Return a content-sensitive signature for change detection.
+
+        Some filesystems expose coarse mtimes, so rapid edit/test cycles can
+        write different content with the same recorded modification timestamp.
+        Include a content hash to avoid missing those changes.
+        """
+        stat = path.stat()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        return f"{stat.st_size}:{stat.st_mtime_ns}:{digest}"
 
     def _discover_source_files(self) -> list[Path]:
         files: list[Path] = []
@@ -211,16 +223,21 @@ class WorkspaceChangeListener:
         files.sort()
         return files
 
-    def _load_state(self) -> dict[str, float]:
+    def _load_state(self) -> dict[str, str]:
         if not self._state_path.exists():
             return {}
         try:
-            return json.loads(self._state_path.read_text(encoding="utf-8"))
+            state = json.loads(self._state_path.read_text(encoding="utf-8"))
+            if not isinstance(state, dict):
+                return {}
+            return {str(k): str(v) for k, v in state.items()}
         except Exception:
             return {}
 
-    def _save_state(self, state: dict[str, float]) -> None:
-        self._state_path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    def _save_state(self, state: dict[str, str]) -> None:
+        self._state_path.write_text(
+            json.dumps(state, indent=2, sort_keys=True), encoding="utf-8"
+        )
 
     def _render_summary(self, result: WorkspaceSyncResult) -> str:
         changed = ", ".join(result.changed_files[:20]) or "None"

--- a/entroly/config.py
+++ b/entroly/config.py
@@ -8,6 +8,7 @@ All tunable parameters live here — no magic numbers buried in code.
 
 import hashlib
 import json
+import math
 import os
 import tempfile
 from dataclasses import dataclass, field
@@ -34,7 +35,9 @@ def _project_checkpoint_dir() -> Path:
         probe.unlink(missing_ok=True)
         return default_dir
     except OSError:
-        fallback_dir = Path(tempfile.gettempdir()) / "entroly" / "checkpoints" / project_hash
+        fallback_dir = (
+            Path(tempfile.gettempdir()) / "entroly" / "checkpoints" / project_hash
+        )
         fallback_dir.mkdir(parents=True, exist_ok=True)
         return fallback_dir
 
@@ -46,13 +49,18 @@ def tuning_config_candidates() -> list[Path]:
     explicit = os.environ.get("ENTROLY_TUNING_CONFIG")
     if explicit:
         candidates.append(Path(explicit))
-    candidates.extend([
-        _project_checkpoint_dir() / "tuning_config.json",
-        here.parent / "bench" / "tuning_config.json",
-        here / "tuning_config.json",
-        here.parent / "tuning_config.json",
-        here / "data" / "tuning_defaults.json",
-    ])
+    candidates.extend(
+        [
+            _project_checkpoint_dir() / "tuning_config.json",
+            here / "data" / "tuning_defaults.json",
+            here / "tuning_config.json",
+            here.parent / "tuning_config.json",
+            # Historical benchmark output is kept as a last-resort development
+            # fallback only. It may use legacy flat keys and should never outrank
+            # the packaged runtime defaults shipped to fresh projects.
+            here.parent / "bench" / "tuning_config.json",
+        ]
+    )
     return candidates
 
 
@@ -138,9 +146,7 @@ class EntrolyConfig:
     """Maximum fragments to pre-fetch per symbol lookup."""
 
     # ── Checkpoint ──────────────────────────────────────────────────────
-    checkpoint_dir: Path = field(
-        default_factory=lambda: _project_checkpoint_dir()
-    )
+    checkpoint_dir: Path = field(default_factory=lambda: _project_checkpoint_dir())
     """Directory for persisting checkpoint state (project-isolated)."""
 
     auto_checkpoint_interval: int = 5
@@ -162,7 +168,9 @@ class EntrolyConfig:
     # ── Server ──────────────────────────────────────────────────────────
     server_name: str = "entroly"
     server_version: str = field(
-        default_factory=lambda: __import__("entroly", fromlist=["__version__"]).__version__
+        default_factory=lambda: (
+            __import__("entroly", fromlist=["__version__"]).__version__
+        )
     )
 
 
@@ -202,11 +210,15 @@ def resolve_tuning_kwargs(cfg: dict) -> dict:
         val = nested
         if val is None:
             val = cfg.get(flat_key)
-        if val is None:
+        if val is None or isinstance(val, bool):
+            return default
+        if cast is int and isinstance(val, float) and not val.is_integer():
             return default
         try:
             val = cast(val)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
+            return default
+        if isinstance(val, float) and not math.isfinite(val):
             return default
         if val < lo or val > hi:
             return default
@@ -215,29 +227,95 @@ def resolve_tuning_kwargs(cfg: dict) -> dict:
     return {
         # ── knapsack scoring weights ──
         "weight_recency": pick(
-            weights.get("recency"), "weight_recency", _d("weight_recency"), float, 0.0, 1.0),
+            weights.get("recency"),
+            "weight_recency",
+            _d("weight_recency"),
+            float,
+            0.0,
+            1.0,
+        ),
         "weight_frequency": pick(
-            weights.get("frequency"), "weight_frequency", _d("weight_frequency"), float, 0.0, 1.0),
+            weights.get("frequency"),
+            "weight_frequency",
+            _d("weight_frequency"),
+            float,
+            0.0,
+            1.0,
+        ),
         "weight_semantic_sim": pick(
-            weights.get("semantic_sim"), "weight_semantic_sim", _d("weight_semantic_sim"), float, 0.0, 1.0),
+            weights.get("semantic_sim"),
+            "weight_semantic_sim",
+            _d("weight_semantic_sim"),
+            float,
+            0.0,
+            1.0,
+        ),
         "weight_entropy": pick(
-            weights.get("entropy"), "weight_entropy", _d("weight_entropy"), float, 0.0, 1.0),
+            weights.get("entropy"),
+            "weight_entropy",
+            _d("weight_entropy"),
+            float,
+            0.0,
+            1.0,
+        ),
         # ── decay ──
         "decay_half_life_turns": pick(
-            decay.get("half_life_turns"), "decay_half_life_turns", _d("decay_half_life_turns"), int, 1, 1000),
+            decay.get("half_life_turns"),
+            "decay_half_life_turns",
+            _d("decay_half_life_turns"),
+            int,
+            1,
+            1000,
+        ),
         "min_relevance_threshold": pick(
-            decay.get("min_relevance_threshold"), "min_relevance_threshold", _d("min_relevance_threshold"), float, 0.0, 1.0),
+            decay.get("min_relevance_threshold"),
+            "min_relevance_threshold",
+            _d("min_relevance_threshold"),
+            float,
+            0.0,
+            1.0,
+        ),
         # ── knapsack exploration ──
         "exploration_rate": pick(
-            knapsack.get("exploration_rate"), "exploration_rate", _d("exploration_rate"), float, 0.0, 1.0),
+            knapsack.get("exploration_rate"),
+            "exploration_rate",
+            _d("exploration_rate"),
+            float,
+            0.0,
+            1.0,
+        ),
         # ── dedup (Hamming distance, int) ──
         "dedup_hamming_threshold": pick(
-            dedup.get("hamming_threshold"), "hamming_threshold", _d("dedup_hamming_threshold"), int, 0, 64),
+            dedup.get("hamming_threshold"),
+            "hamming_threshold",
+            _d("dedup_hamming_threshold"),
+            int,
+            0,
+            64,
+        ),
         # ── IOS resolution factors ──
         "ios_skeleton_info_factor": pick(
-            ios.get("skeleton_info_factor"), "ios_skeleton_info_factor", _d("ios_skeleton_info_factor"), float, 0.0, 1.0),
+            ios.get("skeleton_info_factor"),
+            "ios_skeleton_info_factor",
+            _d("ios_skeleton_info_factor"),
+            float,
+            0.0,
+            1.0,
+        ),
         "ios_reference_info_factor": pick(
-            ios.get("reference_info_factor"), "ios_reference_info_factor", _d("ios_reference_info_factor"), float, 0.0, 1.0),
+            ios.get("reference_info_factor"),
+            "ios_reference_info_factor",
+            _d("ios_reference_info_factor"),
+            float,
+            0.0,
+            1.0,
+        ),
         "ios_diversity_floor": pick(
-            ios.get("diversity_floor"), "ios_diversity_floor", _d("ios_diversity_floor"), float, 0.0, 1.0),
+            ios.get("diversity_floor"),
+            "ios_diversity_floor",
+            _d("ios_diversity_floor"),
+            float,
+            0.0,
+            1.0,
+        ),
     }

--- a/entroly/context_receipts/__init__.py
+++ b/entroly/context_receipts/__init__.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import json
-from collections.abc import Iterable
+import sys
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
 from . import store as _store
 from .ingest import ingest_documents as _py_ingest_documents
+from .ingest import normalize_document_pairs as _normalize_document_pairs
 from .models import ContextIndex, ContextReceipt
+from .novelty import NoveltyAssessmentPolicy, novelty_frontier_assessment
+from .receipts import attach_novelty_frontier as _attach_novelty_frontier
 from .receipts import build_receipt as _py_build_receipt
 from .receipts import explain_omitted as _py_explain_omitted
 from .receipts import markdown_report as _py_markdown_report
@@ -18,20 +24,102 @@ from .recover import recover_omitted as _recover_omitted
 from .recover import save_recovery_bundle as _save_recovery_bundle
 
 
-def _rust_core():
+def _int_or_default(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return default
     try:
-        import entroly_core  # type: ignore
-    except Exception:
-        return None
-    required = (
-        "context_receipts_ingest",
-        "context_receipts_select",
-        "context_receipts_report",
-        "context_receipts_explain_omitted",
-    )
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _at_least(value: object, *, default: int, floor: int) -> int:
+    return max(floor, _int_or_default(value, default))
+
+
+def _str_or_default(value: object, default: str = "") -> str:
+    return default if value is None else str(value)
+
+
+def _chunk_tokens_or_default(value: object, default: int = 360) -> int:
+    token_count = _int_or_default(value, default)
+    return max(40, token_count) if token_count > 0 else 40
+
+
+def _overlap_tokens_or_default(
+    value: object, *, chunk_tokens: int, default: int = 32
+) -> int:
+    overlap = _at_least(value, default=default, floor=0)
+    max_overlap = max(0, chunk_tokens - 1)
+    return min(overlap, max_overlap)
+
+
+def _rust_core(*required: str):
+    entroly_core = sys.modules.get("entroly_core")
+    if entroly_core is None:
+        if importlib.util.find_spec("entroly_core") is None:
+            return None
+        entroly_core = importlib.import_module("entroly_core")
     if all(hasattr(entroly_core, name) for name in required):
         return entroly_core
     return None
+
+
+def _has_novelty_summary(receipt: Mapping[str, Any]) -> bool:
+    risk_summary = receipt.get("risk_summary", {})
+    return isinstance(risk_summary, Mapping) and "novelty_summary" in risk_summary
+
+
+def _list_contains_only_mappings(value: object) -> bool:
+    return isinstance(value, list) and all(isinstance(item, Mapping) for item in value)
+
+
+def _list_contains_only_strings(value: object) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _mapping_contains_only_string_lists(value: object) -> bool:
+    return isinstance(value, Mapping) and all(
+        isinstance(key, str) and _list_contains_only_strings(items)
+        for key, items in value.items()
+    )
+
+
+def _is_rust_report_safe(receipt: Mapping[str, Any]) -> bool:
+    """Return whether a receipt can be delegated to Rust report rendering.
+
+    The Rust renderer is fast for canonical receipts, but the Python renderer is
+    intentionally more defensive for rehydrated or hand-edited artifacts. Route
+    malformed optional containers through Python so public ``markdown_report``
+    keeps its tolerant contract instead of surfacing native renderer errors.
+    """
+    if _has_novelty_summary(receipt):
+        return False
+    mapping_fields = {"source_fingerprints", "risk_summary", "compression_ratio"}
+    list_fields = {
+        "selected_context",
+        "omitted_context",
+        "dependency_links",
+        "outcome_links",
+    }
+    return (
+        all(
+            field not in receipt or isinstance(receipt[field], Mapping)
+            for field in mapping_fields
+        )
+        and all(
+            field not in receipt or _list_contains_only_mappings(receipt[field])
+            for field in list_fields
+        )
+        and (
+            "ranking_reasons" not in receipt
+            or _mapping_contains_only_string_lists(receipt["ranking_reasons"])
+        )
+        and (
+            "warnings" not in receipt
+            or _list_contains_only_strings(receipt["warnings"])
+        )
+    )
 
 
 def ingest_documents(
@@ -43,10 +131,18 @@ def ingest_documents(
 ) -> dict[str, Any]:
     """Ingest ``(source_path, text)`` pairs into a deterministic receipt index."""
 
-    docs = list(documents)
-    if prefer_rust and (core := _rust_core()) is not None:
-        return json.loads(core.context_receipts_ingest(docs, int(chunk_tokens), int(overlap_tokens)))
-    index = _py_ingest_documents(docs, chunk_tokens=chunk_tokens, overlap_tokens=overlap_tokens)
+    docs = _normalize_document_pairs(documents)
+    chunk_token_count = _chunk_tokens_or_default(chunk_tokens)
+    overlap_token_count = _overlap_tokens_or_default(
+        overlap_tokens, chunk_tokens=chunk_token_count
+    )
+    if prefer_rust and (core := _rust_core("context_receipts_ingest")) is not None:
+        return json.loads(
+            core.context_receipts_ingest(docs, chunk_token_count, overlap_token_count)
+        )
+    index = _py_ingest_documents(
+        docs, chunk_tokens=chunk_token_count, overlap_tokens=overlap_token_count
+    )
     return index.to_dict()
 
 
@@ -59,11 +155,18 @@ def select_from_index(
 ) -> dict[str, Any]:
     """Select context and produce a machine-readable Context Receipt."""
 
-    if prefer_rust and (core := _rust_core()) is not None:
-        index_json = json.dumps(index if isinstance(index, dict) else index.to_dict(), sort_keys=True)
-        return json.loads(core.context_receipts_select(index_json, query, int(token_budget)))
+    budget = _at_least(token_budget, default=0, floor=0)
+    safe_query = _str_or_default(query)
+    if prefer_rust and (core := _rust_core("context_receipts_select")) is not None:
+        index_json = json.dumps(
+            index if isinstance(index, dict) else index.to_dict(), sort_keys=True
+        )
+        receipt = json.loads(
+            core.context_receipts_select(index_json, safe_query, budget)
+        )
+        return _attach_novelty_frontier(receipt, index)
     py_index = ContextIndex.from_dict(index) if isinstance(index, dict) else index
-    receipt = _py_build_receipt(py_index, query=query, token_budget=token_budget)
+    receipt = _py_build_receipt(py_index, query=safe_query, token_budget=budget)
     return receipt.to_dict()
 
 
@@ -78,20 +181,54 @@ def run_receipt_pipeline(
 ) -> dict[str, Any]:
     """Ingest documents and immediately produce a Context Receipt."""
 
-    docs = list(documents)
-    if prefer_rust and (core := _rust_core()) is not None:
-        raw = core.context_receipts_run(docs, query, int(token_budget), int(chunk_tokens), int(overlap_tokens))
-        return json.loads(raw)
-    index = _py_ingest_documents(docs, chunk_tokens=chunk_tokens, overlap_tokens=overlap_tokens)
-    return _py_build_receipt(index, query=query, token_budget=token_budget).to_dict()
+    docs = _normalize_document_pairs(documents)
+    budget = _at_least(token_budget, default=0, floor=0)
+    chunk_token_count = _chunk_tokens_or_default(chunk_tokens)
+    overlap_token_count = _overlap_tokens_or_default(
+        overlap_tokens, chunk_tokens=chunk_token_count
+    )
+    if (
+        prefer_rust
+        and (
+            core := _rust_core(
+                "context_receipts_run",
+                "context_receipts_ingest",
+            )
+        )
+        is not None
+    ):
+        safe_query = _str_or_default(query)
+        raw = core.context_receipts_run(
+            docs, safe_query, budget, chunk_token_count, overlap_token_count
+        )
+        receipt = json.loads(raw)
+        rust_index = json.loads(
+            core.context_receipts_ingest(docs, chunk_token_count, overlap_token_count)
+        )
+        return _attach_novelty_frontier(receipt, rust_index)
+    index = _py_ingest_documents(
+        docs, chunk_tokens=chunk_token_count, overlap_tokens=overlap_token_count
+    )
+    return _py_build_receipt(
+        index, query=_str_or_default(query), token_budget=budget
+    ).to_dict()
 
 
-def markdown_report(receipt: dict[str, Any] | ContextReceipt, *, prefer_rust: bool = True) -> str:
+def markdown_report(
+    receipt: dict[str, Any] | ContextReceipt, *, prefer_rust: bool = True
+) -> str:
     """Render a human-readable Markdown report from a receipt dict."""
 
-    if prefer_rust and isinstance(receipt, dict) and (core := _rust_core()) is not None:
+    if (
+        prefer_rust
+        and isinstance(receipt, dict)
+        and _is_rust_report_safe(receipt)
+        and (core := _rust_core("context_receipts_report")) is not None
+    ):
         return core.context_receipts_report(json.dumps(receipt, sort_keys=True))
-    py_receipt = ContextReceipt.from_dict(receipt) if isinstance(receipt, dict) else receipt
+    py_receipt = (
+        ContextReceipt.from_dict(receipt) if isinstance(receipt, dict) else receipt
+    )
     return _py_markdown_report(py_receipt)
 
 
@@ -103,10 +240,45 @@ def explain_omitted(
 ) -> str:
     """Explain why a specific chunk was omitted from a receipt."""
 
-    if prefer_rust and isinstance(receipt, dict) and (core := _rust_core()) is not None:
-        return core.context_receipts_explain_omitted(json.dumps(receipt, sort_keys=True), chunk_id)
-    py_receipt = ContextReceipt.from_dict(receipt) if isinstance(receipt, dict) else receipt
+    if (
+        prefer_rust
+        and isinstance(receipt, dict)
+        and _is_rust_report_safe(receipt)
+        and (core := _rust_core("context_receipts_explain_omitted")) is not None
+    ):
+        return core.context_receipts_explain_omitted(
+            json.dumps(receipt, sort_keys=True), chunk_id
+        )
+    py_receipt = (
+        ContextReceipt.from_dict(receipt) if isinstance(receipt, dict) else receipt
+    )
     return _py_explain_omitted(py_receipt, chunk_id)
+
+
+def assess_novelty_frontier(
+    receipt_or_summary: Mapping[str, Any] | object,
+    *,
+    policy: NoveltyAssessmentPolicy | None = None,
+) -> dict[str, object]:
+    """Assess novelty-frontier pressure from a receipt dict or novelty summary.
+
+    Passing a full receipt lets callers re-classify stored receipts without
+    knowing the internal ``risk_summary.novelty_summary`` location. Passing an
+    already-extracted novelty summary keeps the helper useful for lower-level
+    integrations.
+    """
+    payload = receipt_or_summary if isinstance(receipt_or_summary, Mapping) else {}
+    risk_summary = payload.get("risk_summary")
+    novelty = (
+        risk_summary.get("novelty_summary")
+        if isinstance(risk_summary, Mapping)
+        else None
+    )
+    if not isinstance(novelty, Mapping):
+        novelty = payload
+    if policy is None:
+        return novelty_frontier_assessment(novelty)
+    return novelty_frontier_assessment(novelty, policy=policy)
 
 
 def run_recoverable_pipeline(
@@ -125,11 +297,16 @@ def run_recoverable_pipeline(
     can later be recovered, byte-exact and verified, from the store alone — no
     need to keep the index around. Returns ``{receipt, receipt_path, recovery_path}``.
     """
-    docs = list(documents)
+    docs = _normalize_document_pairs(documents)
     index = ingest_documents(
-        docs, chunk_tokens=chunk_tokens, overlap_tokens=overlap_tokens, prefer_rust=prefer_rust
+        docs,
+        chunk_tokens=chunk_tokens,
+        overlap_tokens=overlap_tokens,
+        prefer_rust=prefer_rust,
     )
-    receipt = select_from_index(index, query=query, token_budget=token_budget, prefer_rust=prefer_rust)
+    receipt = select_from_index(
+        index, query=query, token_budget=token_budget, prefer_rust=prefer_rust
+    )
     receipt_id = str(receipt.get("receipt_id", ""))
     receipt_path: Path | None = None
     recovery_p: Path | None = None
@@ -137,7 +314,9 @@ def run_recoverable_pipeline(
         base = Path(store_dir) if store_dir is not None else _store.DEFAULT_STORE
         base.mkdir(parents=True, exist_ok=True)
         receipt_path = _store.write_json(base / f"{receipt_id}.json", receipt)
-        recovery_p = _save_recovery_bundle(receipt_id, _build_recovery_bundle(index), store_dir)
+        recovery_p = _save_recovery_bundle(
+            receipt_id, _build_recovery_bundle(index), store_dir
+        )
     return {
         "receipt": receipt,
         "receipt_path": str(receipt_path) if receipt_path else None,
@@ -171,5 +350,7 @@ __all__ = [
     "run_recoverable_pipeline",
     "markdown_report",
     "explain_omitted",
+    "NoveltyAssessmentPolicy",
+    "assess_novelty_frontier",
     "recover_omitted",
 ]

--- a/entroly/context_receipts/ingest.py
+++ b/entroly/context_receipts/ingest.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import os
 import re
-from pathlib import Path
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePath
 
 from .models import (
     SCHEMA_VERSION,
@@ -113,6 +114,68 @@ HEADING_RE = re.compile(
 PAGE_RE = re.compile(r"\bpage\s+(\d+)\b", re.IGNORECASE)
 
 
+def _int_or_default(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _overlap_tokens_or_default(
+    value: object, *, chunk_tokens: int, default: int = 32
+) -> int:
+    overlap = max(0, _int_or_default(value, default))
+    max_overlap = max(0, chunk_tokens - 1)
+    return min(overlap, max_overlap)
+
+
+def _source_path_to_str(source: object) -> str:
+    if isinstance(source, PurePath):
+        return source.as_posix()
+    return str(source)
+
+
+def normalize_document_pairs(documents: object) -> list[tuple[str, str]]:
+    """Return deterministic ``(source_path, text)`` pairs from public input.
+
+    Public SDK callers and older integrations occasionally pass ``Path`` objects,
+    bytes text, mapping-shaped records, or malformed rows.  Normalize valid rows
+    and skip rows that cannot identify both a source and text so ingestion never
+    fails before receipt generation can produce an auditable empty result.
+    """
+    pairs: list[tuple[str, str]] = []
+    if isinstance(documents, Mapping) or isinstance(documents, str | bytes):
+        iterable = ()
+    else:
+        try:
+            iterable = iter(documents)  # type: ignore[arg-type]
+        except TypeError:
+            iterable = ()
+
+    for item in iterable:
+        source: object
+        text: object
+        if isinstance(item, Mapping):
+            source = item.get("source_path", item.get("path"))
+            text = item.get("text", item.get("content"))
+        elif isinstance(item, Sequence) and not isinstance(item, str | bytes):
+            if len(item) < 2:
+                continue
+            source, text = item[0], item[1]
+        else:
+            continue
+        if source is None or text is None:
+            continue
+        if isinstance(text, bytes):
+            normalized_text = text.decode("utf-8", errors="replace")
+        else:
+            normalized_text = str(text)
+        pairs.append((_source_path_to_str(source), normalized_text))
+    return pairs
+
+
 def estimate_tokens(text: str) -> int:
     return max(1, len(TOKEN_RE.findall(text)))
 
@@ -180,7 +243,9 @@ def read_documents_from_path(path: str | Path) -> list[tuple[str, str]]:
         try:
             documents.append((source_path, p.read_text(encoding="utf-8")))
         except UnicodeDecodeError:
-            documents.append((source_path, p.read_text(encoding="utf-8", errors="replace")))
+            documents.append(
+                (source_path, p.read_text(encoding="utf-8", errors="replace"))
+            )
     return documents
 
 
@@ -329,7 +394,9 @@ def _chunk_document(
             flush()
         if start is None:
             start = int(block["start"])
-            heading = block.get("heading") if isinstance(block.get("heading"), str) else None
+            heading = (
+                block.get("heading") if isinstance(block.get("heading"), str) else None
+            )
             page = block.get("page") if isinstance(block.get("page"), int) else None
         pending.append(str(block["text"]))
         end = int(block["end"])
@@ -344,23 +411,32 @@ def _chunk_document(
         count = estimate_tokens(chunk_text)
         start_char = int(raw["start"])
         end_char = int(raw["end"])
-        fp = text_fingerprint(f"{document_fingerprint}\n{start_char}:{end_char}\n{chunk_text}")
-        chunk_id = "chk_" + stable_hash(
-            {
-                "doc": document_id,
-                "start": start_char,
-                "end": end_char,
-                "fingerprint": fp,
-            }
-        )[:12]
+        fp = text_fingerprint(
+            f"{document_fingerprint}\n{start_char}:{end_char}\n{chunk_text}"
+        )
+        chunk_id = (
+            "chk_"
+            + stable_hash(
+                {
+                    "doc": document_id,
+                    "start": start_char,
+                    "end": end_char,
+                    "fingerprint": fp,
+                }
+            )[:12]
+        )
         result.append(
             DocumentChunk(
                 chunk_id=chunk_id,
                 document_id=document_id,
                 source_path=source_path,
                 title=title,
-                section_heading=raw.get("heading") if isinstance(raw.get("heading"), str) else None,
-                page_number=raw.get("page") if isinstance(raw.get("page"), int) else None,
+                section_heading=raw.get("heading")
+                if isinstance(raw.get("heading"), str)
+                else None,
+                page_number=raw.get("page")
+                if isinstance(raw.get("page"), int)
+                else None,
                 chunk_index=idx,
                 byte_start=_byte_offset(text, start_char),
                 byte_end=_byte_offset(text, end_char),
@@ -384,17 +460,25 @@ def ingest_documents(
     records: list[DocumentRecord] = []
     chunks: list[DocumentChunk] = []
     source_fingerprints: dict[str, str] = {}
+    chunk_token_count = max(40, _int_or_default(chunk_tokens, 360))
+    overlap_token_count = _overlap_tokens_or_default(
+        overlap_tokens, chunk_tokens=chunk_token_count
+    )
 
-    for source_path, text in sorted(documents, key=lambda item: item[0]):
+    for source_path, text in sorted(
+        normalize_document_pairs(documents), key=lambda item: item[0]
+    ):
         doc_fp = text_fingerprint(text)
-        doc_id = "doc_" + stable_hash({"source": source_path, "fingerprint": doc_fp})[:12]
+        doc_id = (
+            "doc_" + stable_hash({"source": source_path, "fingerprint": doc_fp})[:12]
+        )
         doc_chunks = _chunk_document(
             source_path,
             text,
             document_id=doc_id,
             document_fingerprint=doc_fp,
-            chunk_tokens=max(40, int(chunk_tokens)),
-            overlap_tokens=max(0, int(overlap_tokens)),
+            chunk_tokens=chunk_token_count,
+            overlap_tokens=overlap_token_count,
         )
         source_fingerprints[source_path] = doc_fp
         records.append(
@@ -414,7 +498,7 @@ def ingest_documents(
         schema_version=SCHEMA_VERSION,
         documents=records,
         chunks=chunks,
-        chunk_token_limit=max(40, int(chunk_tokens)),
-        chunk_overlap=max(0, int(overlap_tokens)),
+        chunk_token_limit=chunk_token_count,
+        chunk_overlap=overlap_token_count,
         source_fingerprints=source_fingerprints,
     )

--- a/entroly/context_receipts/models.py
+++ b/entroly/context_receipts/models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -17,6 +19,71 @@ def stable_json(value: Any) -> str:
 
 def stable_hash(value: Any) -> str:
     return hashlib.sha256(stable_json(value).encode("utf-8")).hexdigest()
+
+
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_or_empty(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, tuple):
+        return [str(item) for item in value]
+    if value is None:
+        return []
+    return [str(value)]
+
+
+def _str_or_default(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _int_or_default(value: Any, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _float_or_default(value: Any, default: float = 0.0) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return coerced if math.isfinite(coerced) else default
+
+
+def _bool_or_default(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in {0, 1}:
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "yes", "1"}:
+            return True
+        if normalized in {"false", "no", "0"}:
+            return False
+    return default
+
+
+def _mapping_items(value: Any) -> list[dict[str, Any]]:
+    return [dict(item) for item in _list_or_empty(value) if isinstance(item, Mapping)]
 
 
 def text_fingerprint(text: str) -> str:
@@ -35,8 +102,17 @@ class DocumentRecord:
     chunk_ids: list[str]
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "DocumentRecord":
-        return cls(**data)
+    def from_dict(cls, data: Mapping[str, Any] | object) -> "DocumentRecord":
+        payload = data if isinstance(data, Mapping) else {}
+        return cls(
+            document_id=_str_or_default(payload.get("document_id")),
+            source_path=_str_or_default(payload.get("source_path")),
+            title=_str_or_default(payload.get("title")),
+            fingerprint=_str_or_default(payload.get("fingerprint")),
+            token_count=_int_or_default(payload.get("token_count")),
+            byte_count=_int_or_default(payload.get("byte_count")),
+            chunk_ids=_list_of_str(payload.get("chunk_ids", [])),
+        )
 
 
 @dataclass
@@ -57,8 +133,28 @@ class DocumentChunk:
     text: str
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "DocumentChunk":
-        return cls(**data)
+    def from_dict(cls, data: Mapping[str, Any] | object) -> "DocumentChunk":
+        payload = data if isinstance(data, Mapping) else {}
+        return cls(
+            chunk_id=_str_or_default(payload.get("chunk_id")),
+            document_id=_str_or_default(payload.get("document_id")),
+            source_path=_str_or_default(payload.get("source_path")),
+            title=_str_or_default(payload.get("title")),
+            section_heading=_optional_str(payload.get("section_heading")),
+            page_number=(
+                None
+                if payload.get("page_number") is None
+                else _int_or_default(payload.get("page_number"))
+            ),
+            chunk_index=_int_or_default(payload.get("chunk_index")),
+            byte_start=_int_or_default(payload.get("byte_start")),
+            byte_end=_int_or_default(payload.get("byte_end")),
+            token_start=_int_or_default(payload.get("token_start")),
+            token_end=_int_or_default(payload.get("token_end")),
+            token_count=_int_or_default(payload.get("token_count")),
+            fingerprint=_str_or_default(payload.get("fingerprint")),
+            text=_str_or_default(payload.get("text")),
+        )
 
 
 @dataclass
@@ -74,14 +170,23 @@ class ContextIndex:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ContextIndex":
+    def from_dict(cls, data: Mapping[str, Any] | object) -> "ContextIndex":
+        payload = data if isinstance(data, Mapping) else {}
         return cls(
-            schema_version=data.get("schema_version", SCHEMA_VERSION),
-            documents=[DocumentRecord.from_dict(d) for d in data.get("documents", [])],
-            chunks=[DocumentChunk.from_dict(c) for c in data.get("chunks", [])],
-            chunk_token_limit=int(data.get("chunk_token_limit", 360)),
-            chunk_overlap=int(data.get("chunk_overlap", 32)),
-            source_fingerprints=dict(data.get("source_fingerprints", {})),
+            schema_version=_str_or_default(
+                payload.get("schema_version"), SCHEMA_VERSION
+            ),
+            documents=[
+                DocumentRecord.from_dict(d)
+                for d in _mapping_items(payload.get("documents", []))
+            ],
+            chunks=[
+                DocumentChunk.from_dict(c)
+                for c in _mapping_items(payload.get("chunks", []))
+            ],
+            chunk_token_limit=_int_or_default(payload.get("chunk_token_limit"), 360),
+            chunk_overlap=_int_or_default(payload.get("chunk_overlap"), 32),
+            source_fingerprints=_dict_or_empty(payload.get("source_fingerprints", {})),
         )
 
 
@@ -106,6 +211,19 @@ class DependencyLink:
     resolved: bool
     warning: str | None = None
 
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DependencyLink":
+        return cls(
+            source_chunk_id=_str_or_default(data.get("source_chunk_id")),
+            target_chunk_id=_optional_str(data.get("target_chunk_id")),
+            relation_type=_str_or_default(data.get("relation_type")),
+            evidence=_str_or_default(data.get("evidence")),
+            source_document_id=_str_or_default(data.get("source_document_id")),
+            target_document_id=_optional_str(data.get("target_document_id")),
+            resolved=_bool_or_default(data.get("resolved", False)),
+            warning=_optional_str(data.get("warning")),
+        )
+
 
 @dataclass
 class SelectedContextItem:
@@ -125,6 +243,30 @@ class SelectedContextItem:
     fingerprint: str
     text: str
 
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "SelectedContextItem":
+        return cls(
+            chunk_id=_str_or_default(data.get("chunk_id")),
+            source_path=_str_or_default(data.get("source_path")),
+            section_heading=_optional_str(data.get("section_heading")),
+            page_number=(
+                None
+                if data.get("page_number") is None
+                else _int_or_default(data.get("page_number"))
+            ),
+            byte_start=_int_or_default(data.get("byte_start")),
+            byte_end=_int_or_default(data.get("byte_end")),
+            token_start=_int_or_default(data.get("token_start")),
+            token_end=_int_or_default(data.get("token_end")),
+            token_count=_int_or_default(data.get("token_count")),
+            score=_float_or_default(data.get("score")),
+            reasons=_list_of_str(data.get("reasons", [])),
+            dependencies_included=_list_of_str(data.get("dependencies_included", [])),
+            dependencies_missing=_list_of_str(data.get("dependencies_missing", [])),
+            fingerprint=_str_or_default(data.get("fingerprint")),
+            text=_str_or_default(data.get("text")),
+        )
+
 
 @dataclass
 class OmittedContextItem:
@@ -139,6 +281,25 @@ class OmittedContextItem:
     fingerprint: str
     text_preview: str
 
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "OmittedContextItem":
+        return cls(
+            chunk_id=_str_or_default(data.get("chunk_id")),
+            source_path=_str_or_default(data.get("source_path")),
+            section_heading=_optional_str(data.get("section_heading")),
+            page_number=(
+                None
+                if data.get("page_number") is None
+                else _int_or_default(data.get("page_number"))
+            ),
+            token_count=_int_or_default(data.get("token_count")),
+            score=_float_or_default(data.get("score")),
+            reasons=_list_of_str(data.get("reasons", [])),
+            omission_reason=_str_or_default(data.get("omission_reason")),
+            fingerprint=_str_or_default(data.get("fingerprint")),
+            text_preview=_str_or_default(data.get("text_preview")),
+        )
+
 
 @dataclass
 class CompressionRatio:
@@ -148,6 +309,21 @@ class CompressionRatio:
     selected_to_source_ratio: float
     source_to_selected_ratio: float
     reduction_pct: float
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CompressionRatio":
+        return cls(
+            source_tokens=_int_or_default(data.get("source_tokens")),
+            selected_tokens=_int_or_default(data.get("selected_tokens")),
+            tokens_saved=_int_or_default(data.get("tokens_saved")),
+            selected_to_source_ratio=_float_or_default(
+                data.get("selected_to_source_ratio")
+            ),
+            source_to_selected_ratio=_float_or_default(
+                data.get("source_to_selected_ratio"), 1.0
+            ),
+            reduction_pct=_float_or_default(data.get("reduction_pct")),
+        )
 
 
 @dataclass
@@ -171,20 +347,37 @@ class ContextReceipt:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ContextReceipt":
+    def from_dict(cls, data: Mapping[str, Any] | object) -> "ContextReceipt":
+        payload = data if isinstance(data, Mapping) else {}
         return cls(
-            receipt_id=data["receipt_id"],
-            schema_version=data.get("schema_version", SCHEMA_VERSION),
-            query=data["query"],
-            token_budget=int(data["token_budget"]),
-            selected_context=[SelectedContextItem(**x) for x in data.get("selected_context", [])],
-            omitted_context=[OmittedContextItem(**x) for x in data.get("omitted_context", [])],
-            dependency_links=[DependencyLink(**x) for x in data.get("dependency_links", [])],
-            ranking_reasons={str(k): list(v) for k, v in data.get("ranking_reasons", {}).items()},
-            compression_ratio=CompressionRatio(**data["compression_ratio"]),
-            source_fingerprints=dict(data.get("source_fingerprints", {})),
-            risk_summary=dict(data.get("risk_summary", {})),
-            warnings=list(data.get("warnings", [])),
-            reproducibility_hash=data["reproducibility_hash"],
-            outcome_links=list(data.get("outcome_links", [])),
+            receipt_id=_str_or_default(payload.get("receipt_id")),
+            schema_version=_str_or_default(
+                payload.get("schema_version"), SCHEMA_VERSION
+            ),
+            query=_str_or_default(payload.get("query")),
+            token_budget=_int_or_default(payload.get("token_budget")),
+            selected_context=[
+                SelectedContextItem.from_dict(x)
+                for x in _mapping_items(payload.get("selected_context", []))
+            ],
+            omitted_context=[
+                OmittedContextItem.from_dict(x)
+                for x in _mapping_items(payload.get("omitted_context", []))
+            ],
+            dependency_links=[
+                DependencyLink.from_dict(x)
+                for x in _mapping_items(payload.get("dependency_links", []))
+            ],
+            ranking_reasons={
+                str(k): _list_of_str(v)
+                for k, v in _dict_or_empty(payload.get("ranking_reasons", {})).items()
+            },
+            compression_ratio=CompressionRatio.from_dict(
+                _dict_or_empty(payload.get("compression_ratio", {}))
+            ),
+            source_fingerprints=_dict_or_empty(payload.get("source_fingerprints", {})),
+            risk_summary=_dict_or_empty(payload.get("risk_summary", {})),
+            warnings=_list_of_str(payload.get("warnings", [])),
+            reproducibility_hash=_str_or_default(payload.get("reproducibility_hash")),
+            outcome_links=_mapping_items(payload.get("outcome_links", [])),
         )

--- a/entroly/context_receipts/novelty.py
+++ b/entroly/context_receipts/novelty.py
@@ -1,0 +1,389 @@
+"""Local novelty-frontier accounting for Context Receipts.
+
+The novelty frontier is intentionally deterministic and local-only. It audits
+whether selected context contributes concepts beyond the query, then contrasts
+that selected concept set with concepts still stranded in omitted chunks.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+import math
+import re
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+
+class _SelectedLike(Protocol):
+    chunk_id: str
+    source_path: str
+    text: str
+
+
+class _OmittedLike(Protocol):
+    chunk_id: str
+    source_path: str
+    text_preview: str
+
+
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "have",
+    "if",
+    "in",
+    "is",
+    "it",
+    "may",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "this",
+    "to",
+    "was",
+    "were",
+    "what",
+    "when",
+    "where",
+    "which",
+    "who",
+    "why",
+    "with",
+    "without",
+    "does",
+    "do",
+    "did",
+    "after",
+    "before",
+    "under",
+    "over",
+}
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
+
+
+MEDIUM_FRONTIER_SCORE_RATIO = 0.18
+HIGH_FRONTIER_SCORE_RATIO = 0.45
+
+
+@dataclass(frozen=True)
+class NoveltyAssessmentPolicy:
+    """Thresholds for mapping novelty-frontier metrics to reviewer pressure."""
+
+    medium_score_ratio: float = MEDIUM_FRONTIER_SCORE_RATIO
+    high_score_ratio: float = HIGH_FRONTIER_SCORE_RATIO
+    minimum_medium_terms: int = 2
+    minimum_high_terms: int = 4
+
+    def __post_init__(self) -> None:
+        _validate_ratio("medium_score_ratio", self.medium_score_ratio)
+        _validate_ratio("high_score_ratio", self.high_score_ratio)
+        if self.medium_score_ratio > self.high_score_ratio:
+            raise ValueError(
+                "medium_score_ratio must be less than or equal to high_score_ratio"
+            )
+        _validate_non_negative_int("minimum_medium_terms", self.minimum_medium_terms)
+        _validate_non_negative_int("minimum_high_terms", self.minimum_high_terms)
+
+    def medium_term_floor(self, selected_terms: int) -> int:
+        return max(self.minimum_medium_terms, selected_terms // 2)
+
+    def high_term_floor(self, selected_terms: int) -> int:
+        return max(self.minimum_high_terms - 1, selected_terms)
+
+
+def _validate_ratio(name: str, value: float) -> None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{name} must be a finite numeric ratio between 0.0 and 1.0")
+    try:
+        ratio = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError(
+            f"{name} must be a finite numeric ratio between 0.0 and 1.0"
+        ) from None
+    if not math.isfinite(ratio):
+        raise ValueError(f"{name} must be a finite numeric ratio between 0.0 and 1.0")
+    if not 0.0 <= ratio <= 1.0:
+        raise ValueError(f"{name} must be between 0.0 and 1.0")
+
+
+def _validate_non_negative_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+
+def _coerce_non_negative_float(raw: Any) -> float | None:
+    if isinstance(raw, bool):
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return value if math.isfinite(value) and value >= 0.0 else None
+
+
+def _summary_float(
+    novelty: Mapping[str, Any], primary: str, fallback: str, default: float = 0.0
+) -> float:
+    for name in (primary, fallback):
+        if name in novelty:
+            value = _coerce_non_negative_float(novelty[name])
+            if value is not None:
+                return value
+    return default
+
+
+def _summary_int(novelty: Mapping[str, Any], name: str, default: int = 0) -> int:
+    raw = novelty.get(name, default)
+    if isinstance(raw, bool):
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return max(default, value)
+
+
+DEFAULT_NOVELTY_ASSESSMENT_POLICY = NoveltyAssessmentPolicy()
+
+
+@dataclass(frozen=True)
+class _ConceptProfile:
+    """Aggregate evidence for a term without letting one chunk dominate."""
+
+    frequency: int
+    chunk_count: int
+    source_paths: tuple[str, ...]
+
+    @property
+    def score(self) -> float:
+        # Prefer terms corroborated across chunks, while still giving a small
+        # signal to repeated terms.  The square root prevents repeated boilerplate
+        # in one chunk from overwhelming a broader counterfactual frontier.
+        return self.chunk_count + math.sqrt(self.frequency) / 10.0
+
+
+def concept_terms(text: str) -> list[str]:
+    """Extract stable concept terms for novelty accounting."""
+    terms: list[str] = []
+    for token in _TOKEN_RE.findall(text):
+        term = _normalize_term(token)
+        if term and term not in _STOPWORDS:
+            terms.append(term)
+    return terms
+
+
+def _normalize_term(token: str) -> str:
+    """Normalize lightweight lexical variants without a language model or stemmer."""
+    term = token.lower().strip("_-")
+    if len(term) > 4 and term.endswith("ies"):
+        return term[:-3] + "y"
+    if len(term) > 3 and term.endswith("s") and not term.endswith("ss"):
+        return term[:-1]
+    return term
+
+
+def _profiles(
+    chunk_term_counts: list[tuple[str, str, Counter[str]]],
+) -> dict[str, _ConceptProfile]:
+    frequencies: Counter[str] = Counter()
+    chunks_by_term: dict[str, set[str]] = defaultdict(set)
+    sources_by_term: dict[str, set[str]] = defaultdict(set)
+    for chunk_id, source_path, terms in chunk_term_counts:
+        frequencies.update(terms)
+        for term in terms:
+            chunks_by_term[term].add(chunk_id)
+            sources_by_term[term].add(source_path)
+    return {
+        term: _ConceptProfile(
+            frequency=frequencies[term],
+            chunk_count=len(chunks_by_term[term]),
+            source_paths=tuple(sorted(sources_by_term[term])),
+        )
+        for term in frequencies
+    }
+
+
+def _top_terms(profiles: dict[str, _ConceptProfile], *, limit: int = 8) -> list[str]:
+    ranked = sorted(
+        profiles.items(),
+        key=lambda item: (
+            -item[1].score,
+            -item[1].chunk_count,
+            -item[1].frequency,
+            item[0],
+        ),
+    )
+    return [term for term, _profile in ranked[:limit]]
+
+
+def _serializable_profiles(
+    profiles: dict[str, _ConceptProfile], terms: list[str]
+) -> dict[str, dict[str, object]]:
+    return {
+        term: {
+            "frequency": profiles[term].frequency,
+            "chunk_count": profiles[term].chunk_count,
+            "source_paths": list(profiles[term].source_paths),
+            "score": round(profiles[term].score, 6),
+        }
+        for term in terms
+        if term in profiles
+    }
+
+
+def novelty_summary(
+    query: str,
+    selected: list[_SelectedLike],
+    omitted: list[_OmittedLike],
+    *,
+    omitted_text_by_chunk_id: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Describe selected evidence novelty and omitted evidence frontier gaps.
+
+    ``omitted_text_by_chunk_id`` lets receipt generation use full omitted chunk
+    text while report rehydration can still fall back to the recorded preview.
+    """
+    omitted_text_by_chunk_id = omitted_text_by_chunk_id or {}
+    query_terms = set(concept_terms(query))
+    selected_chunk_terms: list[tuple[str, str, Counter[str]]] = []
+    omitted_chunk_terms: list[tuple[str, str, Counter[str]]] = []
+    per_chunk: list[dict[str, object]] = []
+    omitted_full_text_chunks = 0
+
+    for item in selected:
+        text_terms = Counter(
+            term for term in concept_terms(item.text) if term not in query_terms
+        )
+        selected_chunk_terms.append((item.chunk_id, item.source_path, text_terms))
+        profiles = _profiles([(item.chunk_id, item.source_path, text_terms)])
+        top_terms = _top_terms(profiles, limit=6)
+        per_chunk.append(
+            {
+                "chunk_id": item.chunk_id,
+                "source_path": item.source_path,
+                "novel_terms": top_terms,
+                "novel_term_count": len(text_terms),
+                "novel_term_occurrences": sum(text_terms.values()),
+            }
+        )
+
+    for item in omitted:
+        text = omitted_text_by_chunk_id.get(item.chunk_id)
+        if text is not None:
+            omitted_full_text_chunks += 1
+        else:
+            text = item.text_preview
+        omitted_chunk_terms.append(
+            (
+                item.chunk_id,
+                item.source_path,
+                Counter(
+                    term for term in concept_terms(text) if term not in query_terms
+                ),
+            )
+        )
+
+    selected_profiles = _profiles(selected_chunk_terms)
+    omitted_profiles = _profiles(omitted_chunk_terms)
+    selected_set = set(selected_profiles)
+    omitted_set = set(omitted_profiles)
+    frontier_gap = omitted_set - selected_set
+    overlap = selected_set & omitted_set
+    frontier_profiles = {term: omitted_profiles[term] for term in frontier_gap}
+    selected_top = _top_terms(selected_profiles)
+    frontier_top = _top_terms(frontier_profiles)
+    selected_occurrences = sum(
+        profile.frequency for profile in selected_profiles.values()
+    )
+    frontier_score = sum(profile.score for profile in frontier_profiles.values())
+    omitted_score = sum(profile.score for profile in omitted_profiles.values())
+
+    return {
+        "query_terms": sorted(query_terms),
+        "selected_novel_terms": selected_top,
+        "omitted_frontier_terms": frontier_top,
+        "shared_selected_omitted_terms": sorted(overlap)[:8],
+        "selected_novel_term_count": len(selected_set),
+        "selected_novel_term_occurrences": selected_occurrences,
+        "omitted_frontier_term_count": len(frontier_gap),
+        "omitted_full_text_chunks": omitted_full_text_chunks,
+        "omitted_truncated_chunks": max(0, len(omitted) - omitted_full_text_chunks),
+        "novelty_density": round(len(selected_set) / max(1, selected_occurrences), 6),
+        "frontier_gap_ratio": round(len(frontier_gap) / max(1, len(omitted_set)), 6),
+        "frontier_gap_score_ratio": round(frontier_score / max(1.0, omitted_score), 6),
+        "selected_term_profiles": _serializable_profiles(
+            selected_profiles, selected_top
+        ),
+        "omitted_frontier_profiles": _serializable_profiles(
+            frontier_profiles, frontier_top
+        ),
+        "per_selected_chunk": per_chunk,
+        "control": "local_counterfactual_concept_frontier.v3",
+    }
+
+
+def novelty_frontier_assessment(
+    novelty: Mapping[str, Any] | object,
+    *,
+    policy: NoveltyAssessmentPolicy = DEFAULT_NOVELTY_ASSESSMENT_POLICY,
+) -> dict[str, object]:
+    """Map a novelty summary to an auditable reviewer action.
+
+    The assessment lives with novelty accounting so receipt generation can stay
+    orchestration-focused and downstream callers can classify stored novelty
+    summaries without rebuilding a receipt.  A policy can be supplied by callers
+    that need stricter or more permissive review thresholds.
+    """
+    summary = novelty if isinstance(novelty, Mapping) else {}
+    score_ratio = _summary_float(
+        summary, "frontier_gap_score_ratio", "frontier_gap_ratio"
+    )
+    gap_terms = _summary_int(summary, "omitted_frontier_term_count")
+    selected_terms = _summary_int(summary, "selected_novel_term_count")
+    term_pressure_floor = policy.high_term_floor(selected_terms)
+    medium_term_floor = policy.medium_term_floor(selected_terms)
+
+    pressure = "low"
+    rationale = "no omitted frontier concepts were detected"
+    action = "No novelty-specific review is required."
+    if gap_terms > 0 and score_ratio > 0:
+        pressure = "low"
+        rationale = "omitted frontier is present but below escalation thresholds"
+        action = "Spot-check omitted frontier terms if this receipt supports a high-stakes answer."
+        if score_ratio >= policy.high_score_ratio or gap_terms > term_pressure_floor:
+            pressure = "high"
+            rationale = "omitted frontier is large or score-dominant relative to selected novelty"
+            action = "Review omitted frontier terms before relying on this receipt."
+        elif score_ratio >= policy.medium_score_ratio or gap_terms >= medium_term_floor:
+            pressure = "medium"
+            rationale = (
+                "omitted frontier is material enough to require reviewer attention"
+            )
+            action = "Review omitted frontier terms when validating the answer."
+
+    return {
+        "pressure": pressure,
+        "rationale": rationale,
+        "action": action,
+        "frontier_gap_score_ratio": round(score_ratio, 6),
+        "omitted_frontier_term_count": gap_terms,
+        "selected_novel_term_count": selected_terms,
+        "thresholds": {
+            "medium_score_ratio": policy.medium_score_ratio,
+            "high_score_ratio": policy.high_score_ratio,
+            "medium_term_floor": medium_term_floor,
+            "high_term_floor": term_pressure_floor + 1,
+        },
+    }

--- a/entroly/context_receipts/receipts.py
+++ b/entroly/context_receipts/receipts.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+import copy
+import math
 from dataclasses import asdict
+from typing import Any
 
 from .dependencies import detect_dependencies
 from .models import (
@@ -12,13 +16,23 @@ from .models import (
     ContextReceipt,
     stable_hash,
 )
+from .novelty import novelty_frontier_assessment, novelty_summary
 from .retrieval import rank_chunks
 from .selection import select_context
 
 
+def _int_or_default(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
 def _compression_ratio(source_tokens: int, selected_tokens: int) -> CompressionRatio:
-    source = max(0, int(source_tokens))
-    selected = max(0, int(selected_tokens))
+    source = max(0, _int_or_default(source_tokens))
+    selected = max(0, _int_or_default(selected_tokens))
     if source == 0:
         return CompressionRatio(0, selected, 0, 1.0, 1.0, 0.0)
     selected_ratio = selected / source
@@ -33,6 +47,75 @@ def _compression_ratio(source_tokens: int, selected_tokens: int) -> CompressionR
     )
 
 
+_REVIEW_ORDER = {"low": 0, "medium": 1, "high": 2}
+
+
+def _max_review_level(current: str, candidate: str) -> str:
+    return (
+        candidate
+        if _REVIEW_ORDER.get(candidate, 0) > _REVIEW_ORDER.get(current, 0)
+        else current
+    )
+
+
+def _apply_novelty_risk(
+    risk_summary: dict[str, Any], novelty: dict[str, Any], warnings: list[str]
+) -> None:
+    assessment = novelty_frontier_assessment(novelty)
+    pressure = str(assessment["pressure"])
+    controls = risk_summary.get("controls")
+    if not isinstance(controls, dict):
+        controls = {}
+        risk_summary["controls"] = controls
+    controls["novelty_frontier"] = pressure
+    risk_summary["novelty_summary"] = novelty
+    risk_summary["novelty_frontier_assessment"] = assessment
+    if pressure == "high":
+        risk_summary["review_level"] = _max_review_level(
+            str(risk_summary.get("review_level", "low")), "high"
+        )
+        warnings.append(
+            "Novelty frontier is high: omitted context contains distinctive concepts absent from selected context."
+        )
+    elif pressure == "medium":
+        risk_summary["review_level"] = _max_review_level(
+            str(risk_summary.get("review_level", "low")), "medium"
+        )
+        warnings.append(
+            "Novelty frontier is medium: review omitted frontier terms before relying on this receipt."
+        )
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _float_metric(value: object, default: float = 0.0) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        metric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return metric if math.isfinite(metric) else default
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _warning_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, tuple):
+        return [str(item) for item in value]
+    if value is None:
+        return []
+    return [str(value)]
+
+
 def _risk_summary(
     index: ContextIndex,
     *,
@@ -44,14 +127,27 @@ def _risk_summary(
 ) -> dict:
     total_chunks = len(index.chunks)
     unresolved = sum(1 for dep in dependencies if not dep.resolved)
-    missing_dependency_warnings = sum(1 for warning in warnings if "Dependency not included" in warning)
-    token_coverage = selected_tokens / max(1, sum(chunk.token_count for chunk in index.chunks))
+    missing_dependency_warnings = sum(
+        1 for warning in warnings if "Dependency not included" in warning
+    )
+    token_coverage = selected_tokens / max(
+        1, sum(chunk.token_count for chunk in index.chunks)
+    )
     chunk_coverage = selected_count / max(1, total_chunks)
-    omission_pressure = min(1.0, omitted_relevant / max(1, selected_count + omitted_relevant))
-    dependency_pressure = min(1.0, (unresolved + missing_dependency_warnings) / max(1, len(dependencies)))
+    omission_pressure = min(
+        1.0, omitted_relevant / max(1, selected_count + omitted_relevant)
+    )
+    dependency_pressure = min(
+        1.0, (unresolved + missing_dependency_warnings) / max(1, len(dependencies))
+    )
     coverage_score = max(
         0.0,
-        min(1.0, 0.45 * token_coverage + 0.35 * chunk_coverage + 0.20 * (1.0 - dependency_pressure)),
+        min(
+            1.0,
+            0.45 * token_coverage
+            + 0.35 * chunk_coverage
+            + 0.20 * (1.0 - dependency_pressure),
+        ),
     )
     review_level = "low"
     if coverage_score < 0.45 or dependency_pressure > 0.4:
@@ -69,18 +165,76 @@ def _risk_summary(
         "unresolved_dependency_count": unresolved,
         "missing_dependency_warning_count": missing_dependency_warnings,
         "controls": {
-            "dependency_closure": "complete" if unresolved == 0 and missing_dependency_warnings == 0 else "partial",
-            "omitted_evidence_pressure": "high" if omission_pressure > 0.4 else "medium" if omission_pressure > 0.15 else "low",
+            "dependency_closure": "complete"
+            if unresolved == 0 and missing_dependency_warnings == 0
+            else "partial",
+            "omitted_evidence_pressure": "high"
+            if omission_pressure > 0.4
+            else "medium"
+            if omission_pressure > 0.15
+            else "low",
             "replayable_fingerprints": True,
             "local_no_llm_judgment": True,
         },
     }
 
 
-def build_receipt(index: ContextIndex, *, query: str, token_budget: int) -> ContextReceipt:
-    ranked = rank_chunks(index, query)
+def attach_novelty_frontier(
+    receipt: dict[str, Any],
+    index: ContextIndex | dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a receipt dict with Python novelty-frontier fields attached.
+
+    The Python SDK normally prefers the Rust engine for speed. Until the native
+    engine grows the same novelty-frontier implementation, this bridge keeps the
+    public Python receipt contract consistent by post-processing Rust receipts
+    with the deterministic Python novelty audit and then recomputing the receipt
+    id/hash over the enriched payload.
+    """
+    enriched = copy.deepcopy(receipt)
+    risk_summary = enriched.setdefault("risk_summary", {})
+    if not isinstance(risk_summary, dict):
+        risk_summary = {}
+        enriched["risk_summary"] = risk_summary
+
+    py_receipt = ContextReceipt.from_dict(enriched)
+    py_index = ContextIndex.from_dict(index) if isinstance(index, dict) else index
+    omitted_text_by_chunk_id = (
+        {chunk.chunk_id: chunk.text for chunk in py_index.chunks}
+        if py_index is not None
+        else None
+    )
+    novelty = novelty_summary(
+        py_receipt.query,
+        py_receipt.selected_context,
+        py_receipt.omitted_context,
+        omitted_text_by_chunk_id=omitted_text_by_chunk_id,
+    )
+    warnings = _warning_list(enriched.get("warnings", []))
+    _apply_novelty_risk(risk_summary, novelty, warnings)
+    enriched["warnings"] = list(dict.fromkeys(warnings))
+
+    payload = {
+        key: value
+        for key, value in enriched.items()
+        if key not in {"receipt_id", "reproducibility_hash"}
+    }
+    reproducibility_hash = stable_hash(payload)
+    enriched["receipt_id"] = "cr_" + reproducibility_hash[:12]
+    enriched["reproducibility_hash"] = reproducibility_hash
+    return enriched
+
+
+def build_receipt(
+    index: ContextIndex, *, query: str, token_budget: int
+) -> ContextReceipt:
+    safe_token_budget = max(0, _int_or_default(token_budget))
+    safe_query = "" if query is None else str(query)
+    ranked = rank_chunks(index, safe_query)
     dependencies = detect_dependencies(index)
-    selection = select_context(index, ranked, dependencies, token_budget=token_budget)
+    selection = select_context(
+        index, ranked, dependencies, token_budget=safe_token_budget
+    )
     source_tokens = sum(chunk.token_count for chunk in index.chunks)
     selected_tokens = sum(item.token_count for item in selection.selected)
     ratio = _compression_ratio(source_tokens, selected_tokens)
@@ -92,7 +246,9 @@ def build_receipt(index: ContextIndex, *, query: str, token_budget: int) -> Cont
     warning_candidates = list(selection.warnings)
     high_omitted = [item for item in selection.omitted if item.score > 0]
     if high_omitted:
-        warning_candidates.append(f"{len(high_omitted)} relevant chunk(s) were omitted; inspect omitted_context.")
+        warning_candidates.append(
+            f"{len(high_omitted)} relevant chunk(s) were omitted; inspect omitted_context."
+        )
     warnings = list(dict.fromkeys(warning_candidates))
     risk_summary = _risk_summary(
         index,
@@ -102,10 +258,19 @@ def build_receipt(index: ContextIndex, *, query: str, token_budget: int) -> Cont
         dependencies=dependencies,
         warnings=warnings,
     )
+    omitted_text_by_chunk_id = {chunk.chunk_id: chunk.text for chunk in index.chunks}
+    novelty = novelty_summary(
+        safe_query,
+        selection.selected,
+        selection.omitted,
+        omitted_text_by_chunk_id=omitted_text_by_chunk_id,
+    )
+    _apply_novelty_risk(risk_summary, novelty, warnings)
+    warnings = list(dict.fromkeys(warnings))
     payload = {
         "schema_version": SCHEMA_VERSION,
-        "query": query,
-        "token_budget": int(token_budget),
+        "query": safe_query,
+        "token_budget": safe_token_budget,
         "selected_context": [asdict(item) for item in selection.selected],
         "omitted_context": [asdict(item) for item in selection.omitted],
         "dependency_links": [asdict(link) for link in dependencies],
@@ -120,8 +285,8 @@ def build_receipt(index: ContextIndex, *, query: str, token_budget: int) -> Cont
     return ContextReceipt(
         receipt_id="cr_" + reproducibility_hash[:12],
         schema_version=SCHEMA_VERSION,
-        query=query,
-        token_budget=int(token_budget),
+        query=safe_query,
+        token_budget=safe_token_budget,
         selected_context=selection.selected,
         omitted_context=selection.omitted,
         dependency_links=dependencies,
@@ -137,6 +302,10 @@ def build_receipt(index: ContextIndex, *, query: str, token_budget: int) -> Cont
 
 def markdown_report(receipt: ContextReceipt) -> str:
     ratio = receipt.compression_ratio
+    risk_summary = _mapping(receipt.risk_summary)
+    controls = _mapping(risk_summary.get("controls"))
+    novelty = _mapping(risk_summary.get("novelty_summary"))
+    novelty_assessment = _mapping(risk_summary.get("novelty_frontier_assessment"))
     lines = [
         f"# Context Receipt {receipt.receipt_id}",
         "",
@@ -152,11 +321,22 @@ def markdown_report(receipt: ContextReceipt) -> str:
         "",
         "## Coverage And Risk Controls",
         "",
-        f"- Coverage score: {receipt.risk_summary.get('coverage_score', 0):.3f}",
-        f"- Review level: {receipt.risk_summary.get('review_level', 'unknown')}",
-        f"- Dependency closure: {receipt.risk_summary.get('controls', {}).get('dependency_closure', 'unknown')}",
-        f"- Omitted evidence pressure: {receipt.risk_summary.get('controls', {}).get('omitted_evidence_pressure', 'unknown')}",
-        f"- Replayable fingerprints: {receipt.risk_summary.get('controls', {}).get('replayable_fingerprints', False)}",
+        f"- Coverage score: {_float_metric(risk_summary.get('coverage_score')):.3f}",
+        f"- Review level: {risk_summary.get('review_level', 'unknown')}",
+        f"- Dependency closure: {controls.get('dependency_closure', 'unknown')}",
+        f"- Omitted evidence pressure: {controls.get('omitted_evidence_pressure', 'unknown')}",
+        f"- Novelty frontier pressure: {controls.get('novelty_frontier', 'unknown')}",
+        f"- Novelty frontier action: {novelty_assessment.get('action', 'unknown')}",
+        f"- Replayable fingerprints: {controls.get('replayable_fingerprints', False)}",
+        "",
+        "## Novelty Frontier",
+        "",
+        f"- Control: {novelty.get('control', 'unknown')}",
+        f"- Selected novel terms: {', '.join(_string_list(novelty.get('selected_novel_terms'))) or 'none'}",
+        f"- Omitted frontier terms: {', '.join(_string_list(novelty.get('omitted_frontier_terms'))) or 'none'}",
+        f"- Frontier gap ratio: {_float_metric(novelty.get('frontier_gap_ratio')):.3f}",
+        f"- Frontier score ratio: {_float_metric(novelty.get('frontier_gap_score_ratio')):.3f}",
+        f"- Assessment rationale: {novelty_assessment.get('rationale', 'unknown')}",
         "",
         "## Included Context",
         "",
@@ -174,9 +354,13 @@ def markdown_report(receipt: ContextReceipt) -> str:
                 ]
             )
             if item.dependencies_included:
-                lines.append(f"- Dependencies included: {', '.join(item.dependencies_included)}")
+                lines.append(
+                    f"- Dependencies included: {', '.join(item.dependencies_included)}"
+                )
             if item.dependencies_missing:
-                lines.append(f"- Dependencies missing or unresolved: {', '.join(item.dependencies_missing)}")
+                lines.append(
+                    f"- Dependencies missing or unresolved: {', '.join(item.dependencies_missing)}"
+                )
             lines.append("")
     else:
         lines.extend(["No context chunks were selected.", ""])

--- a/entroly/context_receipts/recover.py
+++ b/entroly/context_receipts/recover.py
@@ -21,6 +21,7 @@ omission *and* hand back the exact content, with a cryptographic guarantee.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,44 @@ from .models import ContextReceipt, text_fingerprint
 RECOVERY_SCHEMA = "context-receipt.recovery.v1"
 RECOVERY_SUFFIX = ".recovery.json"
 
+
+def _dict_or_empty(value: object) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_of_mappings(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, Mapping)]
+
+
+def _str_or_default(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def _optional_str(value: object) -> str | None:
+    return None if value is None else str(value)
+
+
+def _int_or_default(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _chunk_entries(value: object) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(chunk_id): dict(entry)
+        for chunk_id, entry in value.items()
+        if isinstance(entry, Mapping)
+    }
 
 @dataclass
 class RecoveredChunk:
@@ -58,15 +97,18 @@ def build_recovery_bundle(index: dict[str, Any]) -> dict[str, Any]:
     This is the *only* place full omitted text is retained; keep it project-local.
     """
     chunks: dict[str, Any] = {}
-    for c in index.get("chunks", []):
-        text = c.get("text", "") or ""
-        chunks[str(c["chunk_id"])] = {
+    for c in _list_of_mappings(_dict_or_empty(index).get("chunks", [])):
+        chunk_id = _str_or_default(c.get("chunk_id"))
+        if not chunk_id:
+            continue
+        text = _str_or_default(c.get("text"))
+        chunks[chunk_id] = {
             "text": text,
-            "fingerprint": c.get("fingerprint", ""),
+            "fingerprint": _str_or_default(c.get("fingerprint")),
             "content_sha": text_fingerprint(text),
-            "source_path": c.get("source_path", ""),
-            "section_heading": c.get("section_heading"),
-            "token_count": int(c.get("token_count", 0) or 0),
+            "source_path": _str_or_default(c.get("source_path")),
+            "section_heading": _optional_str(c.get("section_heading")),
+            "token_count": max(0, _int_or_default(c.get("token_count"))),
         }
     return {"schema": RECOVERY_SCHEMA, "chunk_count": len(chunks), "chunks": chunks}
 
@@ -102,11 +144,11 @@ def _resolve_source(
     """Resolve chunk_id -> recovery entry, in priority order: explicit bundle,
     explicit index (converted), then the persisted bundle for this receipt."""
     if bundle is not None:
-        return dict(bundle.get("chunks", {}))
+        return _chunk_entries(_dict_or_empty(bundle).get("chunks", {}))
     if index is not None:
-        return dict(build_recovery_bundle(index).get("chunks", {}))
+        return _chunk_entries(build_recovery_bundle(index).get("chunks", {}))
     loaded = load_recovery_bundle(receipt_id, store_dir) if receipt_id else None
-    return dict(loaded.get("chunks", {})) if loaded else {}
+    return _chunk_entries(_dict_or_empty(loaded).get("chunks", {})) if loaded else {}
 
 
 def recover_omitted(
@@ -126,8 +168,8 @@ def recover_omitted(
     True only when the returned text is provably the exact omitted content.
     """
     rec = receipt if isinstance(receipt, dict) else receipt.to_dict()
-    receipt_id = str(rec.get("receipt_id", ""))
-    omitted = list(rec.get("omitted_context", []))
+    receipt_id = _str_or_default(rec.get("receipt_id", ""))
+    omitted = _list_of_mappings(rec.get("omitted_context", []))
     if chunk_id is not None:
         omitted = [o for o in omitted if o.get("chunk_id") == chunk_id]
 
@@ -135,14 +177,14 @@ def recover_omitted(
 
     results: list[RecoveredChunk] = []
     for item in omitted:
-        cid = str(item.get("chunk_id", ""))
-        recorded_fp = item.get("fingerprint", "")
+        cid = _str_or_default(item.get("chunk_id"))
+        recorded_fp = _str_or_default(item.get("fingerprint"))
         common = dict(
             chunk_id=cid,
-            source_path=item.get("source_path", ""),
-            section_heading=item.get("section_heading"),
-            token_count=int(item.get("token_count", 0) or 0),
-            omission_reason=item.get("omission_reason", ""),
+            source_path=_str_or_default(item.get("source_path")),
+            section_heading=_optional_str(item.get("section_heading")),
+            token_count=max(0, _int_or_default(item.get("token_count"))),
+            omission_reason=_str_or_default(item.get("omission_reason")),
             fingerprint=recorded_fp,
         )
         entry = source.get(cid)
@@ -154,10 +196,14 @@ def recover_omitted(
             ))
             continue
 
-        text = entry.get("text", "") or ""
+        text = _str_or_default(entry.get("text"))
         # (a) is this the chunk the receipt omitted?  (b) is the stored text intact?
-        chunk_matches = (not recorded_fp) or entry.get("fingerprint", "") == recorded_fp
-        text_intact = text_fingerprint(text) == entry.get("content_sha", "")
+        chunk_matches = (
+            not recorded_fp
+        ) or _str_or_default(entry.get("fingerprint")) == recorded_fp
+        text_intact = text_fingerprint(text) == _str_or_default(
+            entry.get("content_sha")
+        )
         verified = bool(chunk_matches and text_intact)
         results.append(RecoveredChunk(
             **common, text=text, verified=verified,

--- a/entroly/context_receipts/retrieval.py
+++ b/entroly/context_receipts/retrieval.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import re
 from collections import Counter, defaultdict
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Protocol
 
 from .models import ContextIndex, DocumentChunk, RankedChunk
@@ -37,15 +37,90 @@ class SemanticScorer(Protocol):
         """Return semantic/vector scores by chunk id."""
 
 
-Reranker = Callable[[str, list[RankedChunk]], list[RankedChunk]]
+Reranker = Callable[[str, list[RankedChunk]], object]
+
+
+def _finite_score(value: object, default: float = 0.0) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        score = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return score if math.isfinite(score) else default
+
+
+def _reason_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, tuple):
+        return [str(item) for item in value]
+    if value is None:
+        return []
+    return [str(value)]
+
+
+def _rank_value(
+    rank: RankedChunk | Mapping[str, object], name: str, default: object
+) -> object:
+    if isinstance(rank, Mapping):
+        return rank.get(name, default)
+    return getattr(rank, name, default)
+
+
+def _sanitize_rank(rank: RankedChunk | Mapping[str, object]) -> RankedChunk:
+    return RankedChunk(
+        chunk_id=str(_rank_value(rank, "chunk_id", "")),
+        lexical_score=round(
+            _finite_score(_rank_value(rank, "lexical_score", 0.0)), 6
+        ),
+        semantic_score=round(
+            _finite_score(_rank_value(rank, "semantic_score", 0.0)), 6
+        ),
+        rerank_score=round(_finite_score(_rank_value(rank, "rerank_score", 0.0)), 6),
+        final_score=round(_finite_score(_rank_value(rank, "final_score", 0.0)), 6),
+        reasons=_reason_list(_rank_value(rank, "reasons", [])),
+    )
+
+
+def _sanitize_reranked(
+    reranked: Iterable[RankedChunk | Mapping[str, object]] | object,
+    original: Sequence[RankedChunk],
+    valid_chunk_ids: set[str],
+) -> list[RankedChunk]:
+    """Normalize custom reranker output without losing receipt audit coverage."""
+    normalized: list[RankedChunk] = []
+    seen: set[str] = set()
+    if isinstance(reranked, Mapping):
+        candidates = (reranked,) if "chunk_id" in reranked else reranked.values()
+    else:
+        candidates = reranked if isinstance(reranked, Iterable) else ()
+    for rank in candidates:
+        sanitized = _sanitize_rank(rank)
+        if sanitized.chunk_id not in valid_chunk_ids or sanitized.chunk_id in seen:
+            continue
+        normalized.append(sanitized)
+        seen.add(sanitized.chunk_id)
+
+    for rank in original:
+        if rank.chunk_id not in seen:
+            normalized.append(_sanitize_rank(rank))
+            seen.add(rank.chunk_id)
+    return normalized
 
 
 def tokenize(text: str) -> list[str]:
     text = text.replace("-", " ")
-    return [t.lower() for t in TOKEN_RE.findall(text) if len(t) > 1 and t.lower() not in STOPWORDS]
+    return [
+        t.lower()
+        for t in TOKEN_RE.findall(text)
+        if len(t) > 1 and t.lower() not in STOPWORDS
+    ]
 
 
-def _score_reason(chunk: DocumentChunk, query_terms: list[str], matched_terms: list[str]) -> list[str]:
+def _score_reason(
+    chunk: DocumentChunk, query_terms: list[str], matched_terms: list[str]
+) -> list[str]:
     reasons: list[str] = []
     if matched_terms:
         reasons.append("lexical match: " + ", ".join(matched_terms[:8]))
@@ -58,7 +133,10 @@ def _score_reason(chunk: DocumentChunk, query_terms: list[str], matched_terms: l
     if source_hits:
         reasons.append("file name/path match: " + ", ".join(source_hits[:6]))
     lower = chunk.text.lower()
-    if any(phrase in lower for phrase in ("as defined in", "subject to", "pursuant to", "see section")):
+    if any(
+        phrase in lower
+        for phrase in ("as defined in", "subject to", "pursuant to", "see section")
+    ):
         reasons.append("contains explicit dependency/reference language")
     if not reasons:
         reasons.append("low lexical overlap; retained as lower-ranked candidate")
@@ -84,9 +162,16 @@ def rank_chunks(
         for term in set(terms):
             df[term] += 1
     doc_count = max(1, len(index.chunks))
-    avg_len = sum(len(t) for t in docs_tokens.values()) / doc_count if docs_tokens else 1.0
+    avg_len = (
+        sum(len(t) for t in docs_tokens.values()) / doc_count if docs_tokens else 1.0
+    )
 
-    semantic_scores = semantic_scorer.score(query, index.chunks) if semantic_scorer else {}
+    raw_semantic_scores = (
+        semantic_scorer.score(query, index.chunks) if semantic_scorer else {}
+    )
+    semantic_scores = (
+        raw_semantic_scores if isinstance(raw_semantic_scores, Mapping) else {}
+    )
     ranked: list[RankedChunk] = []
     for chunk in index.chunks:
         terms = docs_tokens[chunk.chunk_id]
@@ -100,16 +185,21 @@ def rank_chunks(
             in_path = term in chunk.source_path.lower()
             if freq or in_heading or in_path:
                 matched.append(term)
-            idf = math.log((doc_count - df.get(term, 0) + 0.5) / (df.get(term, 0) + 0.5) + 1.0)
+            idf = math.log(
+                (doc_count - df.get(term, 0) + 0.5) / (df.get(term, 0) + 0.5) + 1.0
+            )
             if freq:
-                lexical += idf * ((freq * 2.2) / (freq + 1.2 * (1 - 0.75 + 0.75 * doc_len / max(1.0, avg_len))))
+                lexical += idf * (
+                    (freq * 2.2)
+                    / (freq + 1.2 * (1 - 0.75 + 0.75 * doc_len / max(1.0, avg_len)))
+                )
             if in_heading:
                 lexical += idf * 2.5
             if in_path:
                 lexical += idf * 1.5
         coverage = len(set(matched)) / max(1, len(set(query_terms)))
         lexical *= 1.0 + coverage
-        semantic = float(semantic_scores.get(chunk.chunk_id, 0.0))
+        semantic = _finite_score(semantic_scores.get(chunk.chunk_id, 0.0))
         final = lexical + 0.25 * semantic
         ranked.append(
             RankedChunk(
@@ -124,5 +214,11 @@ def rank_chunks(
 
     ranked.sort(key=lambda item: (-item.final_score, item.chunk_id))
     if reranker is not None:
-        ranked = reranker(query, ranked)
+        ranked = _sanitize_reranked(
+            reranker(query, ranked),
+            ranked,
+            set(docs_tokens),
+        )
+    else:
+        ranked = [_sanitize_rank(rank) for rank in ranked]
     return ranked

--- a/entroly/context_receipts/selection.py
+++ b/entroly/context_receipts/selection.py
@@ -72,6 +72,8 @@ def select_context(
         return True
 
     for rank in ranked:
+        if rank.chunk_id not in chunks:
+            continue
         if rank.final_score <= 0 and selected_ids:
             continue
         chunk = chunks[rank.chunk_id]
@@ -120,7 +122,7 @@ def select_context(
 
     omitted: list[OmittedContextItem] = []
     for rank in ranked:
-        if rank.chunk_id in selected_set:
+        if rank.chunk_id in selected_set or rank.chunk_id not in chunks:
             continue
         chunk = chunks[rank.chunk_id]
         reason = "lower ranked than selected context under token budget"

--- a/tests/test_context_receipts.py
+++ b/tests/test_context_receipts.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import inspect
 import os
@@ -8,15 +9,28 @@ from pathlib import Path
 
 import pytest
 
+import entroly.context_receipts as context_receipts_module
 import entroly.server as entroly_server
-from entroly import create_context_receipt, explain_receipt_omission, render_context_receipt
+from entroly import (
+    create_context_receipt,
+    explain_receipt_omission,
+    render_context_receipt,
+)
 from entroly.context_receipts import (
+    NoveltyAssessmentPolicy,
+    assess_novelty_frontier,
     explain_omitted,
     ingest_documents,
     markdown_report,
+    run_receipt_pipeline,
     select_from_index,
 )
 from entroly.context_receipts.ingest import read_documents_from_path
+from entroly.context_receipts.models import RankedChunk
+from entroly.context_receipts.selection import select_context
+from entroly.context_receipts.receipts import attach_novelty_frontier
+from entroly.context_receipts.novelty import novelty_frontier_assessment
+from entroly.context_receipts.retrieval import rank_chunks
 
 
 def _contract_docs() -> list[tuple[str, str]]:
@@ -52,7 +66,227 @@ def test_ingest_preserves_cross_document_metadata_and_fingerprints():
     assert first["documents"][0]["fingerprint"] == second["documents"][0]["fingerprint"]
     assert first["chunks"][0]["chunk_id"] == second["chunks"][0]["chunk_id"]
     assert all(chunk["byte_end"] >= chunk["byte_start"] for chunk in first["chunks"])
-    assert any((chunk["section_heading"] or "").startswith("Section 1") for chunk in first["chunks"])
+    assert any(
+        (chunk["section_heading"] or "").startswith("Section 1")
+        for chunk in first["chunks"]
+    )
+
+
+def test_public_pipeline_sanitizes_malformed_numeric_options():
+    receipt = run_receipt_pipeline(
+        _contract_docs(),
+        query="Which addendum modifies change of control?",
+        token_budget=float("inf"),
+        chunk_tokens=float("inf"),
+        overlap_tokens=float("nan"),
+        prefer_rust=False,
+    )
+
+    assert receipt["token_budget"] == 0
+    assert "No chunks fit inside the token budget." in receipt["warnings"]
+    assert receipt["compression_ratio"]["source_tokens"] > 0
+    assert receipt["compression_ratio"]["selected_tokens"] == 0
+
+
+def test_rust_pipeline_receives_sanitized_numeric_options(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: dict[str, object] = {}
+
+    class FakeCore:
+        @staticmethod
+        def context_receipts_run(
+            docs, query, token_budget, chunk_tokens, overlap_tokens
+        ):
+            calls["run"] = (token_budget, chunk_tokens, overlap_tokens)
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "query": query,
+                    "token_budget": token_budget,
+                    "selected_context": [],
+                    "omitted_context": [],
+                    "dependency_links": [],
+                    "ranking_reasons": {},
+                    "compression_ratio": {},
+                    "source_fingerprints": {},
+                    "risk_summary": {},
+                    "warnings": [],
+                    "outcome_links": [],
+                    "receipt_id": "cr_fake",
+                    "reproducibility_hash": "fake",
+                }
+            )
+
+        @staticmethod
+        def context_receipts_ingest(docs, chunk_tokens, overlap_tokens):
+            calls["ingest"] = (chunk_tokens, overlap_tokens)
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "documents": [],
+                    "chunks": [],
+                    "chunk_token_limit": chunk_tokens,
+                    "chunk_overlap": overlap_tokens,
+                    "source_fingerprints": {},
+                }
+            )
+
+    monkeypatch.setitem(sys.modules, "entroly_core", FakeCore)
+
+    receipt = run_receipt_pipeline(
+        _contract_docs(),
+        query="change control",
+        token_budget=float("inf"),
+        chunk_tokens=float("inf"),
+        overlap_tokens=float("nan"),
+    )
+
+    assert calls["run"] == (0, 360, 32)
+    assert calls["ingest"] == (360, 32)
+    assert receipt["token_budget"] == 0
+
+
+def test_public_pipeline_clamps_negative_chunk_tokens_for_rust_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: dict[str, object] = {}
+
+    class FakeCore:
+        @staticmethod
+        def context_receipts_run(
+            docs, query, token_budget, chunk_tokens, overlap_tokens
+        ):
+            calls["run"] = (query, token_budget, chunk_tokens, overlap_tokens)
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "query": query,
+                    "token_budget": token_budget,
+                    "selected_context": [],
+                    "omitted_context": [],
+                    "dependency_links": [],
+                    "ranking_reasons": {},
+                    "compression_ratio": {},
+                    "source_fingerprints": {},
+                    "risk_summary": {},
+                    "warnings": [],
+                    "outcome_links": [],
+                    "receipt_id": "cr_fake",
+                    "reproducibility_hash": "fake",
+                }
+            )
+
+        @staticmethod
+        def context_receipts_ingest(docs, chunk_tokens, overlap_tokens):
+            calls["ingest"] = (chunk_tokens, overlap_tokens)
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "documents": [],
+                    "chunks": [],
+                    "chunk_token_limit": chunk_tokens,
+                    "chunk_overlap": overlap_tokens,
+                    "source_fingerprints": {},
+                }
+            )
+
+    monkeypatch.setitem(sys.modules, "entroly_core", FakeCore)
+
+    receipt = run_receipt_pipeline(
+        _contract_docs(),
+        query=None,
+        token_budget=-1,
+        chunk_tokens=-100,
+        overlap_tokens=-5,
+    )
+
+    assert calls["run"] == ("", 0, 40, 0)
+    assert calls["ingest"] == (40, 0)
+    assert receipt["query"] == ""
+
+
+def test_public_pipeline_clamps_overlap_below_chunk_tokens_for_rust_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: dict[str, object] = {}
+
+    class FakeCore:
+        @staticmethod
+        def context_receipts_run(
+            docs, query, token_budget, chunk_tokens, overlap_tokens
+        ):
+            calls["run"] = (chunk_tokens, overlap_tokens)
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "query": query,
+                    "token_budget": token_budget,
+                    "selected_context": [],
+                    "omitted_context": [],
+                    "dependency_links": [],
+                    "ranking_reasons": {},
+                    "compression_ratio": {},
+                    "source_fingerprints": {},
+                    "risk_summary": {},
+                    "warnings": [],
+                    "outcome_links": [],
+                    "receipt_id": "cr_fake",
+                    "reproducibility_hash": "fake",
+                }
+            )
+
+        @staticmethod
+        def context_receipts_ingest(docs, chunk_tokens, overlap_tokens):
+            calls["ingest"] = (chunk_tokens, overlap_tokens)
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "documents": [],
+                    "chunks": [],
+                    "chunk_token_limit": chunk_tokens,
+                    "chunk_overlap": overlap_tokens,
+                    "source_fingerprints": {},
+                }
+            )
+
+    monkeypatch.setitem(sys.modules, "entroly_core", FakeCore)
+
+    run_receipt_pipeline(
+        _contract_docs(),
+        query="change control",
+        token_budget=25,
+        chunk_tokens=9,
+        overlap_tokens=99,
+    )
+
+    assert calls["run"] == (40, 39)
+    assert calls["ingest"] == (40, 39)
+
+
+def test_python_ingest_clamps_overlap_below_internal_chunk_floor():
+    index = ingest_documents(
+        _contract_docs(),
+        chunk_tokens=8,
+        overlap_tokens=999,
+        prefer_rust=False,
+    )
+
+    assert index["chunk_token_limit"] == 40
+    assert index["chunk_overlap"] == 39
+
+
+def test_select_from_index_sanitizes_non_string_query():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+
+    receipt = select_from_index(
+        index,
+        query=None,
+        token_budget=40,
+        prefer_rust=False,
+    )
+
+    assert receipt["query"] == ""
 
 
 def test_receipt_schema_defined_terms_dependencies_and_compression_ratio():
@@ -80,7 +314,10 @@ def test_receipt_schema_defined_terms_dependencies_and_compression_ratio():
     }
     assert required <= set(receipt)
     assert receipt["selected_context"]
-    assert receipt["compression_ratio"]["source_tokens"] >= receipt["compression_ratio"]["selected_tokens"]
+    assert (
+        receipt["compression_ratio"]["source_tokens"]
+        >= receipt["compression_ratio"]["selected_tokens"]
+    )
     assert receipt["compression_ratio"]["selected_to_source_ratio"] <= 1.0
     assert receipt["source_fingerprints"]["documents"]
     assert receipt["risk_summary"]["controls"]["replayable_fingerprints"] is True
@@ -93,8 +330,18 @@ def test_receipt_schema_defined_terms_dependencies_and_compression_ratio():
 
 def test_reproducibility_hash_is_stable_for_same_inputs():
     index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
-    first = select_from_index(index, query="Which addendum modifies change of control?", token_budget=80, prefer_rust=False)
-    second = select_from_index(index, query="Which addendum modifies change of control?", token_budget=80, prefer_rust=False)
+    first = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    second = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
 
     assert first["receipt_id"] == second["receipt_id"]
     assert first["reproducibility_hash"] == second["reproducibility_hash"]
@@ -111,7 +358,8 @@ def test_dependency_warning_when_budget_excludes_required_reference():
 
     assert receipt["selected_context"]
     assert any(
-        "Dependency not included due to budget" in warning or "dependency reference" in warning
+        "Dependency not included due to budget" in warning
+        or "dependency reference" in warning
         for warning in receipt["warnings"]
     ) or any(item["dependencies_missing"] for item in receipt["selected_context"])
 
@@ -134,7 +382,10 @@ def test_omitted_nearby_context_and_explain():
     )
 
     assert receipt["omitted_context"]
-    assert any(item["omission_reason"] == "nearby_relevant_context_omitted_due_to_budget" for item in receipt["omitted_context"])
+    assert any(
+        item["omission_reason"] == "nearby_relevant_context_omitted_due_to_budget"
+        for item in receipt["omitted_context"]
+    )
     chunk_id = receipt["omitted_context"][0]["chunk_id"]
     explanation = explain_omitted(receipt, chunk_id, prefer_rust=False)
     assert chunk_id in explanation
@@ -143,7 +394,12 @@ def test_omitted_nearby_context_and_explain():
 
 def test_markdown_report_contains_receipt_sections():
     index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
-    receipt = select_from_index(index, query="Which policy depends on this definition?", token_budget=80, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which policy depends on this definition?",
+        token_budget=80,
+        prefer_rust=False,
+    )
     report = markdown_report(receipt, prefer_rust=False)
 
     assert "# Context Receipt" in report
@@ -162,7 +418,11 @@ def test_python_sdk_exports_context_receipt_api():
         prefer_rust=False,
     )
     report = render_context_receipt(receipt, prefer_rust=False)
-    chunk_id = receipt["omitted_context"][0]["chunk_id"] if receipt["omitted_context"] else receipt["selected_context"][0]["chunk_id"]
+    chunk_id = (
+        receipt["omitted_context"][0]["chunk_id"]
+        if receipt["omitted_context"]
+        else receipt["selected_context"][0]["chunk_id"]
+    )
 
     assert receipt["receipt_id"].startswith("cr_")
     assert "# Context Receipt" in report
@@ -180,7 +440,9 @@ def test_mcp_server_registers_context_receipt_tools():
 
 def test_npm_wasm_package_exposes_context_receipt_api():
     root = Path(__file__).resolve().parents[1]
-    package = json.loads((root / "entroly-wasm" / "package.json").read_text(encoding="utf-8"))
+    package = json.loads(
+        (root / "entroly-wasm" / "package.json").read_text(encoding="utf-8")
+    )
     index_js = (root / "entroly-wasm" / "index.js").read_text(encoding="utf-8")
     index_dts = (root / "entroly-wasm" / "index.d.ts").read_text(encoding="utf-8")
 
@@ -193,7 +455,9 @@ def test_npm_wasm_package_exposes_context_receipt_api():
 
 def test_npm_bridge_documents_context_receipt_cli():
     root = Path(__file__).resolve().parents[1]
-    package = json.loads((root / "entroly" / "npm" / "package.json").read_text(encoding="utf-8"))
+    package = json.loads(
+        (root / "entroly" / "npm" / "package.json").read_text(encoding="utf-8")
+    )
     readme = (root / "entroly" / "npm" / "README.md").read_text(encoding="utf-8")
 
     assert "context-receipts" in package["keywords"]
@@ -288,7 +552,11 @@ def test_cli_ingest_select_receipt_explain_smoke(tmp_path: Path):
     assert rendered.returncode == 0, rendered.stderr + rendered.stdout
     assert "# Context Receipt" in rendered.stdout
 
-    omitted_id = receipt["omitted_context"][0]["chunk_id"] if receipt["omitted_context"] else receipt["selected_context"][0]["chunk_id"]
+    omitted_id = (
+        receipt["omitted_context"][0]["chunk_id"]
+        if receipt["omitted_context"]
+        else receipt["selected_context"][0]["chunk_id"]
+    )
     explained = subprocess.run(
         [
             sys.executable,
@@ -323,7 +591,14 @@ def test_read_documents_from_path_filters_supported_files(tmp_path: Path):
     docs = read_documents_from_path(tmp_path)
     sources = {Path(source).name for source, _ in docs}
 
-    assert sources == {"Containerfile.dev", "Dockerfile", "Dockerfile.prod", "Justfile", "a.md", "app.py"}
+    assert sources == {
+        "Containerfile.dev",
+        "Dockerfile",
+        "Dockerfile.prod",
+        "Justfile",
+        "a.md",
+        "app.py",
+    }
 
 
 def test_read_documents_from_path_skips_generated_dependency_dirs(tmp_path: Path):
@@ -342,3 +617,935 @@ def test_read_documents_from_path_skips_generated_dependency_dirs(tmp_path: Path
     docs = read_documents_from_path(tmp_path)
 
     assert [Path(source).name for source, _ in docs] == ["README.md"]
+
+
+def test_receipt_tracks_local_novelty_frontier():
+    docs = [
+        (
+            "alpha.md",
+            "# Core Policy\n\nAccess review requires manager approval, ticket evidence, and quarterly attestation.\n",
+        ),
+        (
+            "beta.md",
+            "# Exception Policy\n\nAccess review exceptions require compensating controls and executive signoff.\n",
+        ),
+    ]
+    index = ingest_documents(docs, chunk_tokens=16, prefer_rust=False)
+    receipt = select_from_index(
+        index, query="access review", token_budget=18, prefer_rust=False
+    )
+
+    novelty = receipt["risk_summary"]["novelty_summary"]
+    assert novelty["control"] == "local_counterfactual_concept_frontier.v3"
+    assert "access" in novelty["query_terms"]
+    assert "review" in novelty["query_terms"]
+    assert "compensating" in novelty["selected_novel_terms"]
+    assert "manager" in novelty["omitted_frontier_terms"]
+    assert novelty["selected_novel_term_count"] >= len(novelty["selected_novel_terms"])
+    assert (
+        novelty["selected_novel_term_occurrences"]
+        >= novelty["selected_novel_term_count"]
+    )
+    assert novelty["frontier_gap_score_ratio"] > 0
+    assert novelty["omitted_frontier_profiles"]["manager"]["chunk_count"] == 1
+    assert novelty["omitted_frontier_term_count"] >= len(
+        novelty["omitted_frontier_terms"]
+    )
+    assert novelty["frontier_gap_ratio"] > 0
+    assert novelty["omitted_full_text_chunks"] == len(receipt["omitted_context"])
+    assert novelty["omitted_truncated_chunks"] == 0
+    assert novelty["per_selected_chunk"]
+    assert receipt["risk_summary"]["controls"]["novelty_frontier"] == "high"
+    assessment = receipt["risk_summary"]["novelty_frontier_assessment"]
+    assert assessment["pressure"] == "high"
+    assert (
+        assessment["action"]
+        == "Review omitted frontier terms before relying on this receipt."
+    )
+    assert assessment["thresholds"]["high_score_ratio"] == 0.45
+    assert receipt["risk_summary"]["review_level"] == "high"
+    assert any("Novelty frontier is high" in warning for warning in receipt["warnings"])
+
+
+def test_novelty_frontier_uses_full_omitted_text_not_preview_only():
+    long_tail = (
+        " ".join(["filler"] * 90)
+        + " ultradeepnovelty ultradeepnovelty ultradeepnovelty"
+    )
+    docs = [
+        (
+            "selected.md",
+            "# Access Review\n\nAccess review requires manager approval and ticket evidence.\n",
+        ),
+        (
+            "omitted.md",
+            f"# Access Review Exception\n\nAccess review exception details {long_tail}.\n",
+        ),
+    ]
+    index = ingest_documents(docs, chunk_tokens=110, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="manager approval ticket evidence",
+        token_budget=12,
+        prefer_rust=False,
+    )
+
+    omitted = receipt["omitted_context"]
+    assert omitted
+    assert all("ultradeepnovelty" not in item["text_preview"] for item in omitted)
+    novelty = receipt["risk_summary"]["novelty_summary"]
+    assert "ultradeepnovelty" in novelty["omitted_frontier_terms"]
+    assert novelty["omitted_full_text_chunks"] == len(omitted)
+
+
+def test_novelty_frontier_assessment_classifies_rehydrated_summaries():
+    low = novelty_frontier_assessment(
+        {"omitted_frontier_term_count": 0, "selected_novel_term_count": 4}
+    )
+    assert low["pressure"] == "low"
+    assert low["action"] == "No novelty-specific review is required."
+
+    medium = novelty_frontier_assessment(
+        {
+            "frontier_gap_score_ratio": 0.2,
+            "omitted_frontier_term_count": 1,
+            "selected_novel_term_count": 8,
+        }
+    )
+    assert medium["pressure"] == "medium"
+
+    high = novelty_frontier_assessment(
+        {
+            "frontier_gap_score_ratio": 0.46,
+            "omitted_frontier_term_count": 2,
+            "selected_novel_term_count": 8,
+        }
+    )
+    assert high["pressure"] == "high"
+    assert high["thresholds"]["high_score_ratio"] == 0.45
+
+    stricter = NoveltyAssessmentPolicy(
+        medium_score_ratio=0.3, high_score_ratio=0.9, minimum_high_terms=10
+    )
+    reassessed = novelty_frontier_assessment(
+        {
+            "frontier_gap_score_ratio": 0.46,
+            "omitted_frontier_term_count": 2,
+            "selected_novel_term_count": 8,
+        },
+        policy=stricter,
+    )
+    assert reassessed["pressure"] == "medium"
+    assert reassessed["thresholds"]["high_score_ratio"] == 0.9
+
+
+def test_novelty_assessment_policy_rejects_invalid_thresholds():
+    with pytest.raises(ValueError, match="medium_score_ratio"):
+        NoveltyAssessmentPolicy(medium_score_ratio=1.2)
+
+    with pytest.raises(ValueError, match="less than or equal"):
+        NoveltyAssessmentPolicy(medium_score_ratio=0.7, high_score_ratio=0.4)
+
+    with pytest.raises(ValueError, match="minimum_high_terms"):
+        NoveltyAssessmentPolicy(minimum_high_terms=-1)
+
+
+def test_novelty_frontier_assessment_sanitizes_rehydrated_metrics():
+    assessed = novelty_frontier_assessment(
+        {
+            "frontier_gap_score_ratio": float("inf"),
+            "frontier_gap_ratio": "not-a-number",
+            "omitted_frontier_term_count": -8,
+            "selected_novel_term_count": True,
+        }
+    )
+
+    assert assessed["pressure"] == "low"
+    assert assessed["frontier_gap_score_ratio"] == 0.0
+    assert assessed["omitted_frontier_term_count"] == 0
+    assert assessed["selected_novel_term_count"] == 0
+
+    fallback_assessed = novelty_frontier_assessment(
+        {
+            "frontier_gap_score_ratio": float("nan"),
+            "frontier_gap_ratio": 0.2,
+            "omitted_frontier_term_count": 1,
+            "selected_novel_term_count": 8,
+        }
+    )
+    assert fallback_assessed["pressure"] == "medium"
+    assert fallback_assessed["frontier_gap_score_ratio"] == 0.2
+
+
+def test_public_novelty_frontier_assessment_accepts_receipt_or_summary():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    novelty = receipt["risk_summary"]["novelty_summary"]
+
+    from_receipt = assess_novelty_frontier(receipt)
+    from_summary = assess_novelty_frontier(novelty)
+
+    assert from_receipt == from_summary
+    assert from_receipt["pressure"] in {"low", "medium", "high"}
+    assert assess_novelty_frontier({"risk_summary": "corrupt"})["pressure"] == "low"
+    assert assess_novelty_frontier("corrupt")["pressure"] == "low"
+
+
+def test_markdown_report_contains_novelty_frontier():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    report = markdown_report(receipt, prefer_rust=False)
+
+    assert "## Novelty Frontier" in report
+    assert "Novelty frontier pressure:" in report
+    assert "Novelty frontier action:" in report
+    assert "Frontier score ratio:" in report
+    assert "Assessment rationale:" in report
+    assert "local_counterfactual_concept_frontier.v3" in report
+
+
+def test_markdown_report_tolerates_malformed_rehydrated_risk_summary():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    receipt["risk_summary"] = {
+        "coverage_score": "not-a-number",
+        "controls": "corrupt",
+        "novelty_summary": {
+            "selected_novel_terms": "corrupt",
+            "omitted_frontier_terms": ["valid", 123],
+            "frontier_gap_ratio": "bad",
+            "frontier_gap_score_ratio": float("inf"),
+        },
+        "novelty_frontier_assessment": "corrupt",
+    }
+
+    report = markdown_report(receipt, prefer_rust=False)
+
+    assert "Coverage score: 0.000" in report
+    assert "Dependency closure: unknown" in report
+    assert "Selected novel terms: none" in report
+    assert "Omitted frontier terms: valid, 123" in report
+    assert "Frontier score ratio: 0.000" in report
+
+
+def test_markdown_report_tolerates_non_finite_metrics():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    receipt["risk_summary"]["coverage_score"] = float("nan")
+    receipt["risk_summary"]["novelty_summary"]["frontier_gap_score_ratio"] = float(
+        "inf"
+    )
+
+    report = markdown_report(receipt, prefer_rust=False)
+
+    assert "Coverage score: 0.000" in report
+    assert "Frontier score ratio: 0.000" in report
+
+
+def test_attach_novelty_frontier_normalizes_corrupt_controls_and_warnings():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    receipt["risk_summary"]["controls"] = "corrupt"
+    receipt["warnings"] = "legacy warning"
+
+    enriched = attach_novelty_frontier(receipt, index)
+
+    assert isinstance(enriched["risk_summary"]["controls"], dict)
+    assert enriched["risk_summary"]["controls"]["novelty_frontier"] in {
+        "low",
+        "medium",
+        "high",
+    }
+    assert "legacy warning" in enriched["warnings"]
+    assert all(isinstance(warning, str) for warning in enriched["warnings"])
+    assert enriched["receipt_id"].startswith("cr_")
+
+
+def test_attach_novelty_frontier_does_not_mutate_input_receipt():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    original = copy.deepcopy(receipt)
+
+    enriched = attach_novelty_frontier(receipt, index)
+
+    assert enriched is not receipt
+    assert enriched["risk_summary"] is not receipt["risk_summary"]
+    assert receipt == original
+
+
+def test_markdown_report_normalizes_scalar_rehydrated_warnings_and_risk_summary():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    receipt["risk_summary"] = "corrupt"
+    receipt["warnings"] = "legacy warning"
+    receipt["ranking_reasons"] = "corrupt"
+
+    report = markdown_report(receipt, prefer_rust=False)
+
+    assert "Coverage score: 0.000" in report
+    risks_section = report.split("## Risks And Warnings", maxsplit=1)[1].split(
+        "## Reproducibility", maxsplit=1
+    )[0]
+    warning_lines = [
+        line for line in risks_section.splitlines() if line.startswith("- ")
+    ]
+    assert warning_lines == ["- legacy warning"]
+
+
+def test_markdown_report_tolerates_malformed_rehydrated_context_items():
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    receipt["selected_context"] = [
+        "corrupt",
+        {
+            "chunk_id": 123,
+            "source_path": None,
+            "token_count": "bad",
+            "score": float("nan"),
+            "reasons": "legacy reason",
+            "dependencies_included": "corrupt",
+            "dependencies_missing": ["dep"],
+            "fingerprint": None,
+            "text": None,
+        },
+    ]
+    receipt["omitted_context"] = [
+        "corrupt",
+        {
+            "chunk_id": "omitted",
+            "score": float("inf"),
+            "reasons": "legacy omitted reason",
+            "text_preview": None,
+        },
+    ]
+    receipt["dependency_links"] = [
+        "corrupt",
+        {"source_chunk_id": "source", "target_chunk_id": 123, "resolved": "yes"},
+    ]
+    receipt["compression_ratio"] = "corrupt"
+
+    report = markdown_report(receipt, prefer_rust=False)
+
+    assert "### 123" in report
+    assert "score: 0.0000" in report
+    assert "### omitted" in report
+    assert "`source` -> `123` (, resolved):" in report
+    assert "Source tokens: 0" in report
+
+
+def test_default_markdown_report_bypasses_rust_for_malformed_context_items(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class ExplodingRustCore:
+        def context_receipts_report(self, _payload: str) -> str:
+            raise AssertionError(
+                "malformed nested receipt items should render in Python"
+            )
+
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    receipt["selected_context"] = ["corrupt"]
+    monkeypatch.setattr(
+        context_receipts_module, "_rust_core", lambda: ExplodingRustCore()
+    )
+
+    report = markdown_report(receipt)
+
+    assert "No context chunks were selected." in report
+
+
+def test_default_markdown_report_bypasses_rust_for_malformed_rehydrated_receipts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class ExplodingRustCore:
+        def context_receipts_report(self, _payload: str) -> str:
+            raise AssertionError("malformed receipt should render in Python")
+
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    receipt["risk_summary"] = "corrupt"
+    receipt["warnings"] = "legacy warning"
+    receipt["ranking_reasons"] = "corrupt"
+    monkeypatch.setattr(
+        context_receipts_module, "_rust_core", lambda: ExplodingRustCore()
+    )
+
+    report = markdown_report(receipt)
+
+    assert "Coverage score: 0.000" in report
+    assert "- legacy warning" in report
+
+
+def test_default_rust_sdk_path_enriches_context_receipts_with_novelty():
+    pytest.importorskip("entroly_core")
+    docs = _contract_docs()
+    index = ingest_documents(docs, chunk_tokens=55, prefer_rust=True)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=True,
+    )
+
+    novelty = receipt["risk_summary"]["novelty_summary"]
+    assert novelty["control"] == "local_counterfactual_concept_frontier.v3"
+    assert receipt["risk_summary"]["controls"]["novelty_frontier"] in {
+        "low",
+        "medium",
+        "high",
+    }
+    assert receipt["risk_summary"]["novelty_frontier_assessment"]["pressure"] in {
+        "low",
+        "medium",
+        "high",
+    }
+    assert novelty["omitted_full_text_chunks"] == len(receipt["omitted_context"])
+    assert receipt["receipt_id"].startswith("cr_")
+
+
+def test_default_markdown_report_renders_python_novelty_section_for_enriched_rust_receipts():
+    pytest.importorskip("entroly_core")
+    receipt = run_receipt_pipeline(
+        _contract_docs(),
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        chunk_tokens=55,
+        prefer_rust=True,
+    )
+
+    report = markdown_report(receipt)
+
+    assert "## Novelty Frontier" in report
+    assert "Novelty frontier pressure:" in report
+    assert "local_counterfactual_concept_frontier.v3" in report
+
+
+def test_rust_capability_checks_are_per_entrypoint(monkeypatch: pytest.MonkeyPatch):
+    class IngestOnlyRustCore:
+        def context_receipts_ingest(self, docs, chunk_tokens, overlap_tokens):
+            assert docs == [("doc.md", "hello world")]
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "documents": [],
+                    "chunks": [],
+                    "chunk_token_limit": chunk_tokens,
+                    "chunk_overlap": overlap_tokens,
+                    "source_fingerprints": {},
+                    "engine": "partial-rust",
+                }
+            )
+
+    core = IngestOnlyRustCore()
+
+    def capability_core(*required: str):
+        return core if all(hasattr(core, name) for name in required) else None
+
+    monkeypatch.setattr(context_receipts_module, "_rust_core", capability_core)
+
+    index = ingest_documents(
+        [("doc.md", "hello world")],
+        chunk_tokens=9,
+        overlap_tokens=1,
+        prefer_rust=True,
+    )
+
+    assert index["engine"] == "partial-rust"
+    assert index["chunk_token_limit"] == 40
+
+
+def test_explain_omitted_bypasses_rust_for_malformed_rehydrated_receipts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class ExplodingRustCore:
+        def context_receipts_explain_omitted(
+            self, _payload: str, _chunk_id: str
+        ) -> str:
+            raise AssertionError("malformed receipt should explain in Python")
+
+    index = ingest_documents(_contract_docs(), chunk_tokens=55, prefer_rust=False)
+    receipt = select_from_index(
+        index,
+        query="Which addendum modifies change of control?",
+        token_budget=80,
+        prefer_rust=False,
+    )
+    omitted_id = "manual-omitted"
+    receipt["omitted_context"] = [
+        {
+            "chunk_id": omitted_id,
+            "source_path": "manual.md",
+            "token_count": 3,
+            "score": 0.4,
+            "reasons": ["manual regression"],
+            "omission_reason": "outside budget",
+            "fingerprint": "sha256:test",
+            "text_preview": "manual omitted preview",
+        }
+    ]
+    receipt["warnings"] = "legacy warning"
+    receipt["ranking_reasons"] = "corrupt"
+    monkeypatch.setattr(
+        context_receipts_module,
+        "_rust_core",
+        lambda *required: (
+            ExplodingRustCore()
+            if "context_receipts_explain_omitted" in required
+            else None
+        ),
+    )
+
+    explanation = explain_omitted(receipt, omitted_id)
+
+    assert f"{omitted_id} was omitted" in explanation
+
+
+def test_context_index_from_dict_tolerates_malformed_rehydrated_index():
+    from entroly.context_receipts.models import ContextIndex
+
+    index = ContextIndex.from_dict(
+        {
+            "schema_version": None,
+            "documents": [
+                "corrupt",
+                {
+                    "document_id": 123,
+                    "source_path": None,
+                    "token_count": "bad",
+                    "byte_count": float("nan"),
+                    "chunk_ids": "legacy-chunk",
+                    "extra": "ignored",
+                },
+            ],
+            "chunks": [
+                "corrupt",
+                {
+                    "chunk_id": 456,
+                    "document_id": None,
+                    "source_path": None,
+                    "page_number": "bad",
+                    "chunk_index": "bad",
+                    "score": "ignored",
+                    "token_count": float("inf"),
+                    "text": None,
+                    "extra": "ignored",
+                },
+            ],
+            "chunk_token_limit": "bad",
+            "chunk_overlap": False,
+            "source_fingerprints": "corrupt",
+        }
+    )
+
+    assert index.schema_version == "context-receipt.v1"
+    assert len(index.documents) == 1
+    assert index.documents[0].document_id == "123"
+    assert index.documents[0].token_count == 0
+    assert index.documents[0].byte_count == 0
+    assert index.documents[0].chunk_ids == ["legacy-chunk"]
+    assert len(index.chunks) == 1
+    assert index.chunks[0].chunk_id == "456"
+    assert index.chunks[0].page_number == 0
+    assert index.chunks[0].token_count == 0
+    assert index.chunks[0].text == ""
+    assert index.chunk_token_limit == 360
+    assert index.chunk_overlap == 32
+    assert index.source_fingerprints == {}
+
+
+def test_rank_chunks_sanitizes_non_finite_semantic_scores_and_reranker_output():
+    index = ingest_documents(
+        [("policy.md", "Access review requires manager approval and ticket evidence.")],
+        chunk_tokens=55,
+        prefer_rust=False,
+    )
+    py_index = context_receipts_module.ContextIndex.from_dict(index)
+
+    class BadSemanticScorer:
+        def score(self, _query, chunks):
+            return {chunks[0].chunk_id: float("nan")}
+
+    semantic_rank = rank_chunks(
+        py_index, "access review", semantic_scorer=BadSemanticScorer()
+    )[0]
+    assert semantic_rank.semantic_score == 0.0
+    assert semantic_rank.final_score >= 0.0
+
+    def bad_reranker(_query, ranks):
+        ranks[0].final_score = float("inf")
+        ranks[0].semantic_score = float("nan")
+        ranks[0].rerank_score = True
+        ranks[0].reasons = "legacy rerank reason"
+        return ranks
+
+    reranked = rank_chunks(py_index, "access review", reranker=bad_reranker)[0]
+
+    assert reranked.final_score == 0.0
+    assert reranked.semantic_score == 0.0
+    assert reranked.rerank_score == 0.0
+    assert reranked.reasons == ["legacy rerank reason"]
+
+
+def test_rank_chunks_accepts_mapping_rows_from_legacy_rerankers():
+    index = ingest_documents(
+        [("policy.md", "Access review requires manager approval and ticket evidence.")],
+        chunk_tokens=55,
+        prefer_rust=False,
+    )
+    py_index = context_receipts_module.ContextIndex.from_dict(index)
+
+    def mapping_reranker(_query, ranks):
+        return [
+            {
+                "chunk_id": ranks[0].chunk_id,
+                "lexical_score": "1.25",
+                "semantic_score": float("inf"),
+                "rerank_score": False,
+                "final_score": "2.5",
+                "reasons": ("legacy mapping reranker",),
+            }
+        ]
+
+    reranked = rank_chunks(py_index, "access review", reranker=mapping_reranker)[0]
+
+    assert reranked.chunk_id == py_index.chunks[0].chunk_id
+    assert reranked.lexical_score == 1.25
+    assert reranked.semantic_score == 0.0
+    assert reranked.rerank_score == 0.0
+    assert reranked.final_score == 2.5
+    assert reranked.reasons == ["legacy mapping reranker"]
+
+
+def test_assess_novelty_frontier_tolerates_overflowing_integer_metrics():
+    assessment = assess_novelty_frontier(
+        {
+            "frontier_gap_score_ratio": 0.9,
+            "omitted_frontier_term_count": float("inf"),
+            "selected_novel_term_count": float("inf"),
+        }
+    )
+
+    assert assessment["pressure"] == "low"
+    assert assessment["omitted_frontier_term_count"] == 0
+    assert assessment["selected_novel_term_count"] == 0
+
+
+def test_rank_chunks_preserves_audit_coverage_after_partial_reranker_output():
+    index = ingest_documents(
+        [
+            ("access.md", "Access review requires manager approval."),
+            ("audit.md", "Audit evidence requires ticket retention."),
+        ],
+        chunk_tokens=8,
+        prefer_rust=False,
+    )
+    py_index = context_receipts_module.ContextIndex.from_dict(index)
+
+    def partial_reranker(_query, ranks):
+        return [
+            {"chunk_id": "unknown", "final_score": 999.0},
+            {"chunk_id": ranks[-1].chunk_id, "final_score": 3.0},
+            {"chunk_id": ranks[-1].chunk_id, "final_score": 2.0},
+        ]
+
+    reranked = rank_chunks(py_index, "access audit", reranker=partial_reranker)
+
+    assert [rank.chunk_id for rank in reranked] == [
+        py_index.chunks[-1].chunk_id,
+        py_index.chunks[0].chunk_id,
+    ]
+    assert reranked[0].final_score == 3.0
+
+
+def test_rank_chunks_falls_back_when_legacy_reranker_returns_non_iterable():
+    index = ingest_documents(
+        [
+            ("access.md", "Access review requires manager approval."),
+            ("audit.md", "Audit evidence requires ticket retention."),
+        ],
+        chunk_tokens=8,
+        prefer_rust=False,
+    )
+    py_index = context_receipts_module.ContextIndex.from_dict(index)
+    baseline = rank_chunks(py_index, "access audit")
+
+    def scalar_reranker(_query, _ranks):
+        return None
+
+    reranked = rank_chunks(py_index, "access audit", reranker=scalar_reranker)
+
+    assert [rank.chunk_id for rank in reranked] == [rank.chunk_id for rank in baseline]
+
+
+def test_rank_chunks_accepts_mapping_container_from_legacy_reranker():
+    index = ingest_documents(
+        [
+            ("access.md", "Access review requires manager approval."),
+            ("audit.md", "Audit evidence requires ticket retention."),
+        ],
+        chunk_tokens=8,
+        prefer_rust=False,
+    )
+    py_index = context_receipts_module.ContextIndex.from_dict(index)
+
+    def mapping_container_reranker(_query, ranks):
+        return {
+            "first": {"chunk_id": ranks[-1].chunk_id, "final_score": 4.0},
+            "ignored": {"chunk_id": "unknown", "final_score": 999.0},
+        }
+
+    reranked = rank_chunks(
+        py_index, "access audit", reranker=mapping_container_reranker
+    )
+
+    assert [rank.chunk_id for rank in reranked] == [
+        py_index.chunks[-1].chunk_id,
+        py_index.chunks[0].chunk_id,
+    ]
+    assert reranked[0].final_score == 4.0
+
+
+def test_rank_chunks_ignores_non_mapping_semantic_scorer_output():
+    index = ingest_documents(
+        [("policy.md", "Access review evidence with manager approval.")],
+        chunk_tokens=20,
+        prefer_rust=False,
+    )
+    py_index = context_receipts_module.ContextIndex.from_dict(index)
+
+    class LegacySemanticScorer:
+        def score(self, _query, _chunks):
+            return None
+
+    ranked = rank_chunks(
+        py_index, "access review", semantic_scorer=LegacySemanticScorer()
+    )
+
+    assert len(ranked) == len(py_index.chunks)
+    assert ranked[0].semantic_score == 0.0
+    assert ranked[0].final_score >= 0.0
+
+
+def test_rust_core_detects_preloaded_extension_without_import_spec(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class PreloadedCore:
+        def context_receipts_ingest(self, docs, chunk_tokens, overlap_tokens):
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "documents": [],
+                    "chunks": [],
+                    "chunk_token_limit": chunk_tokens,
+                    "chunk_overlap": overlap_tokens,
+                    "source_fingerprints": {},
+                    "doc_count": len(docs),
+                }
+            )
+
+    monkeypatch.setitem(sys.modules, "entroly_core", PreloadedCore())
+
+    index = ingest_documents(
+        [("policy.md", "Access review evidence.")], prefer_rust=True
+    )
+
+    assert index["doc_count"] == 1
+
+
+def test_float_coercion_handles_overflowing_custom_numbers():
+    class OverflowingFloat:
+        def __float__(self):
+            raise OverflowError("too large")
+
+    receipt = context_receipts_module.ContextReceipt.from_dict(
+        {
+            "selected_context": [
+                {
+                    "chunk_id": "c1",
+                    "score": OverflowingFloat(),
+                    "reasons": ["kept"],
+                }
+            ],
+            "omitted_context": [
+                {
+                    "chunk_id": "c2",
+                    "score": OverflowingFloat(),
+                    "reasons": ["omitted"],
+                }
+            ],
+            "compression_ratio": {
+                "selected_to_source_ratio": OverflowingFloat(),
+                "source_to_selected_ratio": OverflowingFloat(),
+                "reduction_pct": OverflowingFloat(),
+            },
+        }
+    )
+
+    assert receipt.selected_context[0].score == 0.0
+    assert receipt.omitted_context[0].score == 0.0
+    assert receipt.compression_ratio.selected_to_source_ratio == 0.0
+    assert receipt.compression_ratio.source_to_selected_ratio == 1.0
+    assert receipt.compression_ratio.reduction_pct == 0.0
+
+
+def test_rank_chunks_sanitizes_overflowing_float_values():
+    class OverflowingFloat:
+        def __float__(self):
+            raise OverflowError("too large")
+
+    index = ingest_documents(
+        [("policy.md", "Access review evidence with manager approval.")],
+        chunk_tokens=20,
+        prefer_rust=False,
+    )
+    py_index = context_receipts_module.ContextIndex.from_dict(index)
+
+    class OverflowingSemanticScorer:
+        def score(self, _query, chunks):
+            return {chunks[0].chunk_id: OverflowingFloat()}
+
+    def overflowing_reranker(_query, ranks):
+        return [
+            {
+                "chunk_id": ranks[0].chunk_id,
+                "semantic_score": OverflowingFloat(),
+                "final_score": OverflowingFloat(),
+            }
+        ]
+
+    ranked = rank_chunks(
+        py_index,
+        "access review",
+        semantic_scorer=OverflowingSemanticScorer(),
+        reranker=overflowing_reranker,
+    )
+
+    assert ranked[0].semantic_score == 0.0
+    assert ranked[0].final_score == 0.0
+
+
+def test_novelty_policy_rejects_huge_ratio_without_overflowing():
+    with pytest.raises(ValueError, match="finite numeric ratio"):
+        NoveltyAssessmentPolicy(medium_score_ratio=10**10000)
+
+
+def test_public_ingest_normalizes_mapping_path_and_bytes_documents(monkeypatch):
+    class FakeRustCore:
+        def context_receipts_ingest(self, docs, chunk_tokens, overlap_tokens):
+            assert docs == [
+                ("docs/policy.md", "Access evidence."),
+                ("bytes.md", "caf\ufffd"),
+            ]
+            return json.dumps(
+                {
+                    "schema_version": "context-receipt.v1",
+                    "documents": [],
+                    "chunks": [],
+                    "chunk_token_limit": chunk_tokens,
+                    "chunk_overlap": overlap_tokens,
+                    "source_fingerprints": {},
+                }
+            )
+
+    monkeypatch.setattr(context_receipts_module, "_rust_core", lambda *_: FakeRustCore())
+    index = ingest_documents(
+        [
+            {"path": Path("docs/policy.md"), "content": "Access evidence."},
+            ("bytes.md", b"caf\xff"),
+            "malformed",
+            ("missing-text.md",),
+            {"source_path": "missing-text.md"},
+        ]
+    )
+
+    assert index["chunk_token_limit"] == 360
+
+
+def test_python_ingest_skips_malformed_document_rows_without_crashing():
+    index = ingest_documents(
+        [
+            {"source_path": "valid.md", "text": "Access reviews require evidence."},
+            "not-a-document-row",
+            ("missing-text.md",),
+            {"path": "none-text.md", "content": None},
+        ],
+        chunk_tokens=20,
+        prefer_rust=False,
+    )
+
+    assert [doc["source_path"] for doc in index["documents"]] == ["valid.md"]
+    assert index["chunks"]
+
+
+def test_build_receipt_and_selection_tolerate_malformed_direct_inputs():
+    index = context_receipts_module.ContextIndex.from_dict(
+        ingest_documents(
+            [("policy.md", "Access review evidence with manager approval.")],
+            chunk_tokens=20,
+            prefer_rust=False,
+        )
+    )
+    receipt = context_receipts_module._py_build_receipt(
+        index, query=None, token_budget=50
+    )
+    bogus_rank = RankedChunk(
+        "missing", 1.0, 0.0, 0.0, 1.0, ["legacy rank row"]
+    )
+    valid_rank = RankedChunk(
+        index.chunks[0].chunk_id, 1.0, 0.0, 0.0, 1.0, ["valid rank row"]
+    )
+
+    selection = select_context(index, [bogus_rank, valid_rank], [], token_budget=50)
+
+    assert receipt.query == ""
+    assert [item.chunk_id for item in selection.selected] == [index.chunks[0].chunk_id]

--- a/tests/test_recoverable_receipts.py
+++ b/tests/test_recoverable_receipts.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import pytest
 
 from entroly import context_receipts as cr
+from entroly.context_receipts.models import text_fingerprint
+from entroly.context_receipts.recover import build_recovery_bundle
 
 # Enough distinct tokens that chunking yields many chunks and a small budget omits most.
 _TEXT = " ".join(f"token{i}" for i in range(800))
@@ -85,6 +87,69 @@ def test_unavailable_without_recovery_data(tmp_path):
     recovered = cr.recover_omitted(receipt, store_dir=tmp_path)  # empty store
     assert recovered
     assert all(r["status"] == "unavailable" and r["text"] is None for r in recovered)
+
+
+def test_recovery_tolerates_malformed_receipt_rows_and_bundle_entries():
+    receipt = {
+        "receipt_id": "r1",
+        "omitted_context": [
+            "not-a-row",
+            {
+                "chunk_id": "bad-count",
+                "source_path": None,
+                "section_heading": 123,
+                "token_count": float("inf"),
+                "omission_reason": None,
+                "fingerprint": "fp-bad",
+            },
+            {
+                "chunk_id": "ok",
+                "token_count": True,
+                "fingerprint": "fp-ok",
+            },
+        ],
+    }
+    bundle = {
+        "chunks": {
+            "bad-count": "not-a-mapping",
+            "ok": {
+                "text": 42,
+                "fingerprint": "fp-ok",
+                "content_sha": text_fingerprint("42"),
+            },
+        }
+    }
+
+    recovered = cr.recover_omitted(receipt, bundle=bundle)
+
+    assert [item["chunk_id"] for item in recovered] == ["bad-count", "ok"]
+    assert recovered[0]["status"] == "unavailable"
+    assert recovered[0]["token_count"] == 0
+    assert recovered[1]["status"] == "recovered"
+    assert recovered[1]["text"] == "42"
+    assert recovered[1]["token_count"] == 0
+
+
+def test_recovery_bundle_skips_malformed_index_chunks():
+    bundle = build_recovery_bundle(
+        {
+            "chunks": [
+                "not-a-row",
+                {"text": "missing id"},
+                {
+                    "chunk_id": "valid",
+                    "text": 123,
+                    "token_count": float("inf"),
+                    "fingerprint": None,
+                },
+            ]
+        }
+    )
+
+    assert list(bundle["chunks"]) == ["valid"]
+    assert bundle["chunks"]["valid"]["text"] == "123"
+    assert bundle["chunks"]["valid"]["token_count"] == 0
+    assert bundle["chunks"]["valid"]["fingerprint"] == ""
 
 
 def test_recover_no_omissions_returns_empty():

--- a/tests/test_tuning_config_wiring.py
+++ b/tests/test_tuning_config_wiring.py
@@ -64,6 +64,28 @@ def test_malformed_and_out_of_range_fall_back_without_raising():
     assert kw["min_relevance_threshold"] == _DEFAULTS.min_relevance_threshold  # > 1.0
 
 
+
+def test_non_finite_boolean_and_fractional_tuning_values_fall_back():
+    cfg = {
+        "weights": {
+            "recency": float("nan"),
+            "frequency": float("inf"),
+            "semantic_sim": True,
+        },
+        "decay": {"half_life_turns": 3.5, "min_relevance_threshold": False},
+        "dedup": {"hamming_threshold": float("inf")},
+    }
+
+    kw = resolve_tuning_kwargs(cfg)
+
+    assert kw["weight_recency"] == _DEFAULTS.weight_recency
+    assert kw["weight_frequency"] == _DEFAULTS.weight_frequency
+    assert kw["weight_semantic_sim"] == _DEFAULTS.weight_semantic_sim
+    assert kw["decay_half_life_turns"] == _DEFAULTS.decay_half_life_turns
+    assert kw["min_relevance_threshold"] == _DEFAULTS.min_relevance_threshold
+    assert kw["dedup_hamming_threshold"] == _DEFAULTS.dedup_hamming_threshold
+
+
 def test_zero_is_a_valid_value_not_treated_as_missing():
     """0.0 is falsy — the mapper must distinguish 'absent' from 'zero'."""
     cfg = {"weights": {"entropy": 0.0}, "decay": {"min_relevance_threshold": 0.0}}


### PR DESCRIPTION
## Summary

- Hardens Context Receipt public ingestion and lower-level ingestion against mapping rows, `Path` sources, bytes text, malformed rows, malformed numeric options, and partial Rust capability availability.
- Adds deterministic local novelty-frontier accounting to receipts and renders/reassesses that metadata in Python for both Python and Rust-produced receipts.
- Makes receipt rehydration, recovery, ranking, reranking, and selection tolerate malformed legacy/custom inputs without crashing.
- Makes workspace change detection content-sensitive so rapid edits with unchanged/coarse mtimes are not missed.
- Keeps the Windows path normalization fix so `Path("docs/policy.md")` is passed through as `docs/policy.md`, avoiding OS-dependent receipt identifiers.

## Validation

- `python -m ruff check entroly/change_listener.py entroly/config.py entroly/context_receipts tests/test_context_receipts.py tests/test_recoverable_receipts.py tests/test_tuning_config_wiring.py tests/test_change_listener.py`
- `python -m pytest tests/test_context_receipts.py tests/test_recoverable_receipts.py tests/test_change_listener.py tests/test_tuning_config_wiring.py -q` (`77 passed`)
- `git diff --cached --check`
- Pre-push hook: `ruff (entroly/)`, `clippy (entroly-core)`, `cargo test --lib (entroly-core)` (`523 passed`)

Note: a full `python -m pytest -q` run in this local environment previously failed in QCCR tests because the installed global `entroly-core` was `1.0.18` and lacked the QCCR symbols expected by this `1.0.24` checkout. The focused Python receipt/change-listener/config slice and Rust pre-push checks pass.