### PR TITLE
Fix v1.0.37 package publication

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -85,8 +85,16 @@ jobs:
       - name: Test suite
         run: .venv/bin/pytest tests/ -q --tb=short -x --timeout=60
 
+  # Build and publish the native dependency in this release run. Tags created
+  # with GITHUB_TOKEN do not start a second workflow, so relying on a tag-only
+  # core workflow can leave the public Python package uninstallable.
+  publish-core:
+    if: startsWith(github.ref, 'refs/tags/entroly-v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '') || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v'))
+    uses: ./.github/workflows/publish-core-wheels.yml
+    secrets: inherit
+
   publish-pypi:
-    needs: [build-and-push, quality-gate]
+    needs: [build-and-push, quality-gate, publish-core]
     if: startsWith(github.ref, 'refs/tags/entroly-v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '') || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v'))
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish-core-wheels.yml
+++ b/.github/workflows/publish-core-wheels.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'entroly-v*'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   # ── ABI3 wheels ──────────────────────────────────────────────────────
@@ -106,7 +107,7 @@ jobs:
     name: Publish to PyPI
     needs: [rust-gate, linux-x86_64, linux-aarch64, macos-universal, windows]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/entroly-v') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/entroly-v') || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v'))
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Summary
- make the native wheel publisher callable from the main release workflow
- publish `entroly-core` before the Python package that requires it
- allow release-qualified main pushes to publish core wheels

## Why
A tag created by `GITHUB_TOKEN` does not trigger a second workflow run. The existing tag-only core publisher therefore left `entroly-core` stale while the GitHub Release existed.

## Release behavior
Merge this PR with a commit title beginning `Release v1.0.37` to rerun idempotent publication. The existing GitHub Release is detected and skipped; registry steps use `skip-existing` or explicit existence checks.