### PR TITLE
Release 1.0.38 with live spend accounting and cache-aware routing

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/docs/gateway-accounting.md
+++ b/docs/gateway-accounting.md
@@ -15,6 +15,17 @@ Set a durable SQLite path to enable the ledger:
 export ENTROLY_USAGE_LEDGER=.entroly/usage.sqlite3
 ```
 
+A trusted ingress can attach bounded cost-allocation dimensions:
+
+```bash
+export ENTROLY_TRUST_USAGE_HEADERS=1
+# The ingress sets x-entroly-team, x-entroly-project, and x-entroly-tool.
+```
+
+Leave this disabled for direct or untrusted clients. When enabled, the reverse
+proxy must remove client-supplied `x-entroly-*` attribution headers and inject
+authenticated values. Invalid or oversized dimension values are ignored.
+
 Set a versioned pricing catalog to calculate cost and enable the cache-economics
 gate for RAVS recommendations:
 

--- a/docs/gateway-accounting.md
+++ b/docs/gateway-accounting.md
@@ -1,0 +1,128 @@
+# Live gateway accounting and cache-aware routing
+
+Entroly can use provider-reported token usage to maintain an idempotent local
+cost ledger and to avoid model switches that would discard a valuable warm
+prompt cache.
+
+Both persistent accounting and catalog-backed routing are operator-controlled.
+Entroly never downloads or invents provider prices.
+
+## Configuration
+
+Set a durable SQLite path to enable the ledger:
+
+```bash
+export ENTROLY_USAGE_LEDGER=.entroly/usage.sqlite3
+```
+
+Set a versioned pricing catalog to calculate cost and enable the cache-economics
+gate for RAVS recommendations:
+
+```bash
+export ENTROLY_PRICING_CATALOG=/etc/entroly/pricing.json
+export ENTROLY_RAVS_ROUTER=1
+```
+
+Example catalog structure:
+
+```json
+{
+  "source": "internal-finops-catalog-2026-06-28",
+  "models": {
+    "openai:model-name": {
+      "input_per_million": "0.00",
+      "output_per_million": "0.00",
+      "cache_read_per_million": "0.00",
+      "cache_write_per_million": "0.00"
+    },
+    "anthropic:*": {
+      "input_per_million": "0.00",
+      "output_per_million": "0.00",
+      "cache_read_per_million": "0.00"
+    }
+  }
+}
+```
+
+The values above are schema examples, not current provider prices. Replace them
+with the rates from the organization’s approved billing catalog. Exact
+`provider:model` entries take precedence over a `provider:*` fallback. An
+invalid catalog prevents proxy startup; a configured catalog that lacks either
+model in a proposed RAVS switch keeps the current model.
+
+Normal SSE forwarding retains only the final bounded transcript tail for usage
+parsing. The default is 256 KiB and can be adjusted from 16 KiB through 1 MiB:
+
+```bash
+export ENTROLY_USAGE_SSE_TAIL_BYTES=262144
+```
+
+## Accounting model
+
+The ledger normalizes these components:
+
+- uncached input tokens
+- cache-read input tokens
+- cache-write input tokens
+- output tokens
+
+Cost is stored as integer micro-USD:
+
+```text
+cost =
+  uncached_input * input_rate
+  + cache_read * cache_read_rate
+  + cache_write * cache_write_rate
+  + output * output_rate
+```
+
+Rates are USD per one million tokens, so multiplying tokens by a rate produces
+micro-USD directly. Decimal arithmetic and half-up rounding avoid binary
+floating-point drift.
+
+If usage is present but no price is available, Entroly stores the token event
+with zero computed cost and an `unpriced:provider:model` provenance marker.
+This preserves usage for later reconciliation without presenting a fabricated
+invoice amount.
+
+Request IDs are unique ledger keys. An identical replay is idempotent; a replay
+with different provider, model, token, cost, or pricing identity raises a
+conflict. Verification recovery calls use deterministic `:recovery:N` attempt
+suffixes because each successful provider call is independently billable.
+
+## Cache-aware routing
+
+RAVS remains the quality and risk gate. Cache economics run only after RAVS has
+recommended a different model.
+
+The cache router projects cost over a bounded turn horizon and compares:
+
+- the current model with provider-observed cached prefix tokens
+- the recommended model with a cold prefix on the first turn
+- provider-specific cache TTL
+- cache read and write rates
+- expected new input and output tokens
+- a switch hysteresis threshold
+
+Cache state is learned only from provider usage fields. Entroly does not infer a
+hit from conversation shape. A lease is reusable only for the same conversation
+anchor, provider, model, stable prefix hash, and unexpired TTL.
+
+## Operations
+
+The guarded `/stats` endpoint exposes:
+
+- `provider_cache.active_leases`
+- `provider_cache.observed_hits`
+- `provider_cache.observed_misses`
+- `provider_cache.routing_stays`
+- `provider_cache.routing_switches`
+- `provider_cache.last_decision`
+- `usage_accounting.recorded`
+- `usage_accounting.unpriced`
+- `usage_accounting.failures`
+- `usage_accounting.ledger`
+
+Back up, retain, and delete the SQLite ledger under the same policy as other
+billing telemetry. The ledger stores identifiers and normalized usage metadata,
+not prompt or response content.

--- a/docs/releases/v1.0.38.md
+++ b/docs/releases/v1.0.38.md
@@ -1,0 +1,27 @@
+# Entroly v1.0.38
+
+Entroly v1.0.38 integrates provider-reported usage and cache economics into the
+live gateway.
+
+## Gateway accounting
+
+- Normalizes OpenAI, Anthropic, and Gemini JSON/SSE usage.
+- Records idempotent SQLite events with integer micro-USD costs.
+- Supports exact and provider-wildcard versioned pricing catalogs.
+- Preserves unpriced token usage for later reconciliation.
+- Accounts verification recovery calls as separate billable attempts.
+
+## Cache-aware routing
+
+- Observes provider-reported cache reads and writes.
+- Tracks TTL-bound conversation cache leases.
+- Adds multi-turn cache economics after RAVS quality and risk gates.
+- Keeps warm models when switching would cost more.
+- Blocks catalog-backed switches when either price is missing.
+
+## Operations
+
+- Adds bounded-tail SSE accounting without rewriting streamed bytes.
+- Exposes cache and usage summaries from the guarded stats endpoint.
+- Documents pricing, retention, routing, and failure semantics.
+- Adds JSON/SSE, durability, idempotency, and routing lifecycle tests.

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "entroly-qccr",
  "flate2",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "regex",
  "serde",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "1.0.37"
+version = "1.0.38"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=1.0.37"
+python -m pip install --no-cache-dir -U "entroly-core>=1.0.38"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "1.0.37"
+version = "1.0.38"
 description = "Rust core for Entroly: Context Receipts, deterministic ingestion/ranking, dependency audits, and local context optimization"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-qccr/Cargo.lock
+++ b/entroly-qccr/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "regex",
  "regex-lite",

--- a/entroly-qccr/Cargo.toml
+++ b/entroly-qccr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-qccr"
-version = "1.0.37"
+version = "1.0.38"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "regex-lite",
  "serde",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "entroly-qccr",
  "flate2",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "1.0.37"
+version = "1.0.38"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Auditable context control plane for AI agents: context receipts, local optimization, MCP, and app SDK helpers. Pure WebAssembly, no Python dependency.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "1.0.37"
+__version__ = "1.0.38"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -50,7 +50,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "1.0.37"
+    __version__ = "1.0.38"
 
 from entroly.config import (
     load_active_tuning_config as _load_active_tuning_config,
@@ -3051,7 +3051,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.37\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.38\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -4220,7 +4220,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.37\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.38\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -4263,7 +4263,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.37\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.38\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -69,7 +69,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "1.0.37"
+    version: str = "1.0.38"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -7,7 +7,7 @@ from importlib import metadata
 from types import ModuleType
 
 
-MIN_ENTROLY_CORE_VERSION = "1.0.37"
+MIN_ENTROLY_CORE_VERSION = "1.0.38"
 QCCR_SYMBOLS = (
     "py_qccr_expand_query",
     "py_qccr_rank_files",

--- a/entroly/npm-alias/package.json
+++ b/entroly/npm-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Compatibility alias for Entroly's Node/WASM runtime. Installs and delegates to entroly-wasm.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "dependencies": {
-    "entroly-wasm": "1.0.37"
+    "entroly-wasm": "1.0.38"
   },
   "repository": {
     "type": "git",

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "NPX bridge for Entroly, an auditable context control plane with MCP tools, Context Receipts, and local optimization for AI agents.",
   "main": "index.js",
   "bin": {

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -59,6 +59,7 @@ from .proxy_transform import (
     strip_anthropic_unsupported_params,
 )
 from .cache_aligner import CacheAligner
+from .cache_routing import CacheAwareRouter
 from .control_plane import (
     ControlAudit,
     ControlPlaneDecision,
@@ -67,6 +68,14 @@ from .control_plane import (
     stable_request_fingerprint,
 )
 from .provider_policy import GatewayRedactionPolicy
+from .stable_prefix import conversation_anchor
+from .usage_ledger import (
+    TokenUsage,
+    UsageLedger,
+    UsagePricingCatalog,
+    parse_provider_usage,
+    parse_stream_usage,
+)
 from .value_tracker import get_tracker
 
 logger = logging.getLogger("entroly.proxy")
@@ -1027,6 +1036,21 @@ class PromptCompilerProxy:
             in {"1", "true", "yes", "on"}
         )
 
+        # Provider-reported cache and spend accounting. A ledger is opt-in;
+        # cache observations remain available in-memory for routing decisions.
+        self._cache_router = CacheAwareRouter()
+        ledger_path = os.environ.get("ENTROLY_USAGE_LEDGER", "").strip()
+        catalog_path = os.environ.get("ENTROLY_PRICING_CATALOG", "").strip()
+        self._usage_ledger = UsageLedger(ledger_path) if ledger_path else None
+        self._pricing_catalog = (
+            UsagePricingCatalog.from_file(catalog_path)
+            if catalog_path
+            else None
+        )
+        self._usage_recorded = 0
+        self._usage_unpriced = 0
+        self._usage_failures = 0
+
         # Gap #29: Last optimization context (for transparency endpoint)
         self._last_context_fragments: list = []
         self._last_excluded_fragments: list = []  # Top rejected candidates for /explain
@@ -1285,6 +1309,8 @@ class PromptCompilerProxy:
             logger.warning(f"Failed to persist state on shutdown: {e}")
         if self._client:
             await self._client.aclose()
+        if self._usage_ledger is not None:
+            await asyncio.to_thread(self._usage_ledger.close)
 
     def _persist_engine_state(self) -> None:
         """Flush learned PRISM weights, fragment index, and feedback to disk.
@@ -1423,6 +1449,179 @@ class PromptCompilerProxy:
             "X-Entroly-Redaction-Count": str(len(receipt.findings)),
         }
         return redacted, headers
+
+    @staticmethod
+    def _routing_conversation_id(
+        body: dict[str, Any],
+        provider: str,
+    ) -> str:
+        messages: list[dict[str, Any]] = []
+        if provider == "anthropic" and body.get("system"):
+            messages.append({"role": "system", "content": body["system"]})
+
+        raw_messages = body.get("messages")
+        if isinstance(raw_messages, list):
+            messages.extend(
+                dict(message)
+                for message in raw_messages
+                if isinstance(message, dict)
+            )
+        elif provider == "gemini" and isinstance(body.get("contents"), list):
+            for item in body["contents"]:
+                if not isinstance(item, dict):
+                    continue
+                role = "assistant" if item.get("role") == "model" else str(
+                    item.get("role", "")
+                )
+                parts = item.get("parts", [])
+                text = " ".join(
+                    str(part.get("text", ""))
+                    for part in parts
+                    if isinstance(part, dict) and part.get("text")
+                )
+                messages.append({"role": role, "content": text})
+        elif isinstance(body.get("input"), list):
+            messages.extend(
+                dict(item)
+                for item in body["input"]
+                if isinstance(item, dict)
+            )
+
+        tools = body.get("tools")
+        tool_items = (
+            tuple(tool for tool in tools if isinstance(tool, dict))
+            if isinstance(tools, list)
+            else ()
+        )
+        if not messages:
+            return ""
+        return conversation_anchor(messages, tools=tool_items)
+
+    @staticmethod
+    def _cache_prefix_hash(body: dict[str, Any], provider: str) -> str:
+        stable: dict[str, Any] = {"provider": provider}
+        if provider == "anthropic":
+            stable["system"] = body.get("system", "")
+        elif provider == "gemini":
+            stable["systemInstruction"] = body.get("systemInstruction")
+        elif "instructions" in body:
+            stable["instructions"] = body.get("instructions")
+        else:
+            messages = body.get("messages")
+            if (
+                isinstance(messages, list)
+                and messages
+                and isinstance(messages[0], dict)
+                and messages[0].get("role") == "system"
+            ):
+                stable["system"] = messages[0].get("content", "")
+        stable["tools"] = body.get("tools", ())
+        encoded = json.dumps(
+            stable,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    def _record_provider_usage(
+        self,
+        *,
+        body: dict[str, Any],
+        provider: str,
+        request_id: str,
+        usage: TokenUsage,
+        streaming: bool,
+    ) -> None:
+        model = extract_model(body) or str(body.get("model", "unknown"))
+        conversation_id = self._routing_conversation_id(body, provider)
+        prefix_hash = self._cache_prefix_hash(body, provider)
+        cached_prefix_tokens = max(
+            usage.cache_read_tokens,
+            usage.cache_write_tokens,
+        )
+        if conversation_id:
+            self._cache_router.observe(
+                conversation_id,
+                model=model,
+                provider=provider,
+                prefix_hash=prefix_hash,
+                cached_prefix_tokens=cached_prefix_tokens,
+                cache_hit=usage.cache_read_tokens > 0,
+            )
+
+        if self._usage_ledger is None:
+            return
+        pricing = (
+            self._pricing_catalog.resolve(provider, model)
+            if self._pricing_catalog is not None
+            else None
+        )
+        event = self._usage_ledger.record_usage(
+            request_id=request_id or uuid.uuid4().hex,
+            provider=provider,
+            model=model,
+            usage=usage,
+            pricing=pricing,
+            conversation_id=conversation_id,
+            metadata={"streaming": streaming},
+        )
+        with self._stats_lock:
+            self._usage_recorded += 1
+            if event.pricing_source.startswith("unpriced:"):
+                self._usage_unpriced += 1
+
+    async def _observe_json_usage(
+        self,
+        *,
+        body: dict[str, Any],
+        provider: str,
+        request_id: str,
+        payload: dict[str, Any],
+    ) -> None:
+        usage_keys = {"usage", "usage_metadata", "usageMetadata"}
+        if not usage_keys.intersection(payload):
+            return
+        try:
+            usage = parse_provider_usage(provider, payload)
+            await asyncio.to_thread(
+                self._record_provider_usage,
+                body=body,
+                provider=provider,
+                request_id=request_id,
+                usage=usage,
+                streaming=False,
+            )
+        except Exception:
+            with self._stats_lock:
+                self._usage_failures += 1
+            logger.warning("Provider usage accounting failed", exc_info=True)
+
+    async def _observe_stream_usage(
+        self,
+        *,
+        body: dict[str, Any],
+        provider: str,
+        request_id: str,
+        transcript: bytes,
+    ) -> None:
+        try:
+            usage = parse_stream_usage(provider, transcript)
+            if usage is None:
+                return
+            await asyncio.to_thread(
+                self._record_provider_usage,
+                body=body,
+                provider=provider,
+                request_id=request_id,
+                usage=usage,
+                streaming=True,
+            )
+        except Exception:
+            with self._stats_lock:
+                self._usage_failures += 1
+            logger.warning("Streaming usage accounting failed", exc_info=True)
 
     async def handle_proxy(self, request: Request) -> StreamingResponse | JSONResponse:
         """Main proxy handler — intercept, optimize, forward.

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1853,6 +1853,8 @@ class PromptCompilerProxy:
 
         path = request.url.path
         headers = {k: v for k, v in request.headers.items()}
+        request_id = headers.get("x-request-id") or uuid.uuid4().hex[:12]
+        usage_dimensions = self._usage_dimensions(headers)
         provider = detect_provider(path, headers, body)
         # Authoritative subscription-auth guard — fail fast with actionable guidance
         # before any forwarding, instead of a confusing upstream 401/429.
@@ -1938,13 +1940,18 @@ class PromptCompilerProxy:
                     forward_headers,
                     body,
                     provider=provider,
+                    request_id=request_id,
                     extra_headers=bypass_headers,
+                    usage_dimensions=usage_dimensions,
                 )
             return await self._forward_response(
                 target_url,
                 forward_headers,
                 body,
+                provider=provider,
+                request_id=request_id,
                 extra_headers=bypass_headers,
+                usage_dimensions=usage_dimensions,
             )
 
         # ── Pipelined: warmup connection while Rust pipeline runs ──
@@ -1966,8 +1973,6 @@ class PromptCompilerProxy:
         _recoverable_fragments: list[dict[str, Any]] = []
         user_message = ""
         witness_context = ""
-        request_id = headers.get("x-request-id") or uuid.uuid4().hex[:12]
-
         # Run the optimization pipeline (synchronous Rust, off the event loop)
         try:
             user_message = extract_user_message(body, provider)
@@ -2405,12 +2410,14 @@ class PromptCompilerProxy:
                 target_url, forward_headers, body, _selected_frag_ids,
                 witness_context, provider, _recoverable_fragments, request_id,
                 extra_headers=control_headers,
+                usage_dimensions=usage_dimensions,
             )
         else:
             return await self._forward_response(
                 target_url, forward_headers, body, _selected_frag_ids,
                 witness_context, provider, _recoverable_fragments, request_id,
                 extra_headers=control_headers,
+                usage_dimensions=usage_dimensions,
             )
 
     @staticmethod
@@ -2855,6 +2862,7 @@ class PromptCompilerProxy:
         recovery_depth: int = 0,
         request_id: str = "",
         extra_headers: dict[str, str] | None = None,
+        usage_dimensions: dict[str, str] | None = None,
     ) -> StreamingResponse | JSONResponse:
         """Buffer a streaming upstream response so WITNESS can enforce before display."""
         if not self._breaker.allow_request():
@@ -2906,6 +2914,7 @@ class PromptCompilerProxy:
                 request_id=accounting_request_id,
                 transcript=raw,
                 path=url,
+                usage_dimensions=usage_dimensions,
             )
 
         # ── Pre-flight: handle upstream errors before WITNESS ──
@@ -2976,6 +2985,7 @@ class PromptCompilerProxy:
                 recovery_depth=recovery_depth + 1,
                 request_id=request_id,
                 extra_headers=extra_headers,
+                usage_dimensions=usage_dimensions,
             )
             recovered_ok = (
                 recovered.status_code < 400
@@ -3230,6 +3240,7 @@ class PromptCompilerProxy:
         request_id: str = "",
         recovery_depth: int = 0,
         extra_headers: dict[str, str] | None = None,
+        usage_dimensions: dict[str, str] | None = None,
     ) -> StreamingResponse:
         """Forward a streaming request and proxy the SSE response.
 
@@ -3249,6 +3260,7 @@ class PromptCompilerProxy:
                 recovery_depth=recovery_depth,
                 request_id=request_id,
                 extra_headers=extra_headers,
+                usage_dimensions=usage_dimensions,
             )
 
         # Check circuit breaker
@@ -3344,6 +3356,7 @@ class PromptCompilerProxy:
                         request_id=request_id,
                         transcript=bytes(usage_tail),
                         path=url,
+                        usage_dimensions=usage_dimensions,
                     )
             except httpx.ReadError as e:
                 self._breaker.record_failure()
@@ -4100,6 +4113,7 @@ class PromptCompilerProxy:
         request_id: str = "",
         recovery_depth: int = 0,
         extra_headers: dict[str, str] | None = None,
+        usage_dimensions: dict[str, str] | None = None,
     ) -> JSONResponse:
         """Forward a non-streaming request with circuit breaker, retry on 429/5xx, and response validation.
 
@@ -4311,6 +4325,7 @@ class PromptCompilerProxy:
                 request_id=accounting_request_id,
                 payload=content,
                 path=url,
+                usage_dimensions=usage_dimensions,
             )
 
         # ── Signal 1: Assess non-streaming response for implicit feedback ──
@@ -4356,6 +4371,7 @@ class PromptCompilerProxy:
                             recoverable_fragments=[],
                             recovery_depth=recovery_depth + 1,
                             request_id=request_id,
+                            usage_dimensions=usage_dimensions,
                         )
                         recovered_ok = (
                             recovered.status_code < 400

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1050,6 +1050,10 @@ class PromptCompilerProxy:
         self._usage_recorded = 0
         self._usage_unpriced = 0
         self._usage_failures = 0
+        self._trust_usage_headers = (
+            os.environ.get("ENTROLY_TRUST_USAGE_HEADERS", "0").lower()
+            in {"1", "true", "yes", "on"}
+        )
         self._cache_route_stays = 0
         self._cache_route_switches = 0
         self._cache_route_blocked_unpriced = 0
@@ -1454,6 +1458,20 @@ class PromptCompilerProxy:
         }
         return redacted, headers
 
+    def _usage_dimensions(
+        self,
+        headers: dict[str, str],
+    ) -> dict[str, str]:
+        """Read bounded attribution only from an explicitly trusted ingress."""
+        if not self._trust_usage_headers:
+            return {}
+        dimensions: dict[str, str] = {}
+        for dimension in ("team", "project", "tool"):
+            value = headers.get(f"x-entroly-{dimension}", "").strip()
+            if value and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}", value):
+                dimensions[dimension] = value
+        return dimensions
+
     @staticmethod
     def _routing_conversation_id(
         body: dict[str, Any],
@@ -1691,6 +1709,7 @@ class PromptCompilerProxy:
         usage: TokenUsage,
         streaming: bool,
         path: str = "",
+        usage_dimensions: dict[str, str] | None = None,
     ) -> None:
         model = extract_model(body, path) or str(body.get("model", "unknown"))
         conversation_id = self._routing_conversation_id(body, provider)
@@ -1709,6 +1728,9 @@ class PromptCompilerProxy:
                 model=model,
                 usage=usage,
                 pricing=pricing,
+                team=(usage_dimensions or {}).get("team", ""),
+                tool=(usage_dimensions or {}).get("tool", ""),
+                project=(usage_dimensions or {}).get("project", ""),
                 conversation_id=conversation_id,
                 metadata={"streaming": streaming},
             )
@@ -1743,6 +1765,7 @@ class PromptCompilerProxy:
         request_id: str,
         payload: dict[str, Any],
         path: str = "",
+        usage_dimensions: dict[str, str] | None = None,
     ) -> None:
         usage_keys = {"usage", "usage_metadata", "usageMetadata"}
         if not usage_keys.intersection(payload):
@@ -1757,6 +1780,7 @@ class PromptCompilerProxy:
                 usage=usage,
                 streaming=False,
                 path=path,
+                usage_dimensions=usage_dimensions,
             )
         except Exception:
             with self._stats_lock:
@@ -1771,6 +1795,7 @@ class PromptCompilerProxy:
         request_id: str,
         transcript: bytes,
         path: str = "",
+        usage_dimensions: dict[str, str] | None = None,
     ) -> None:
         try:
             usage = parse_stream_usage(provider, transcript)
@@ -1784,6 +1809,7 @@ class PromptCompilerProxy:
                 usage=usage,
                 streaming=True,
                 path=path,
+                usage_dimensions=usage_dimensions,
             )
         except Exception:
             with self._stats_lock:

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -2679,6 +2679,14 @@ class PromptCompilerProxy:
             return JSONResponse({"error": "stream_error", "detail": str(e)[:200]}, status_code=502)
 
         raw = b"".join(chunks)
+        if status_code < 400:
+            await self._observe_stream_usage(
+                body=body,
+                provider=provider,
+                request_id=request_id,
+                transcript=raw,
+                path=url,
+            )
 
         # ── Pre-flight: handle upstream errors before WITNESS ──
         # Must check status BEFORE recording success to the circuit breaker.
@@ -4053,6 +4061,15 @@ class PromptCompilerProxy:
                 "status": response.status_code,
                 "body_preview": response.text[:500],
             }
+
+        if isinstance(content, dict) and response.status_code < 400:
+            await self._observe_json_usage(
+                body=body,
+                provider=provider,
+                request_id=request_id,
+                payload=content,
+                path=url,
+            )
 
         # ── Signal 1: Assess non-streaming response for implicit feedback ──
         # If verification rejects an answer produced from compressed context,

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1530,6 +1530,27 @@ class PromptCompilerProxy:
         return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
     @staticmethod
+    def _route_target_url(
+        url: str,
+        provider: str,
+        model: str,
+    ) -> str:
+        """Apply a routed model to providers that encode it in the URL."""
+        if provider != "gemini":
+            return url
+        if not re.fullmatch(r"[A-Za-z0-9._-]+", model):
+            raise ValueError("invalid URL-embedded model identifier")
+        routed, replacements = re.subn(
+            r"(/models/)[^/:?]+",
+            rf"\g<1>{model}",
+            url,
+            count=1,
+        )
+        if replacements != 1:
+            raise ValueError("Gemini target URL does not contain a model")
+        return routed
+
+    @staticmethod
     def _routing_token_estimates(
         body: dict[str, Any],
         user_message: str,
@@ -2287,6 +2308,11 @@ class PromptCompilerProxy:
                             from .ravs.router import swap_model_in_body
                             _ravs_original_model = _current_model
                             body = swap_model_in_body(body, decision.recommended_model)
+                            target_url = self._route_target_url(
+                                target_url,
+                                provider,
+                                decision.recommended_model,
+                            )
                             _ravs_swapped = True
                             logger.info(
                                 "RAVS: %s -> %s (%s; %s)",

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -4969,6 +4969,8 @@ async def _catch_all(request: Request) -> StreamingResponse | JSONResponse:
     """
     proxy = request.app.state.proxy
     headers = {k: v for k, v in request.headers.items()}
+    request_id = headers.get("x-request-id") or uuid.uuid4().hex[:12]
+    usage_dimensions = proxy._usage_dimensions(headers)
     provider = detect_provider(request.url.path, headers)
     target_url = proxy._resolve_target(provider, request.url.path)
     forward_headers = proxy._build_headers(headers, provider)
@@ -5022,15 +5024,27 @@ async def _catch_all(request: Request) -> StreamingResponse | JSONResponse:
                 forward_headers,
                 body,
                 provider=provider,
+                request_id=request_id,
                 extra_headers=_redaction_headers,
+                usage_dimensions=usage_dimensions,
             )
         response = await client.request(
             request.method, target_url, json=body, headers=forward_headers
         )
         content_type = response.headers.get("content-type", "")
         if "application/json" in content_type:
+            content = response.json()
+            if isinstance(body, dict) and isinstance(content, dict) and response.status_code < 400:
+                await proxy._observe_json_usage(
+                    body=body,
+                    provider=provider,
+                    request_id=request_id,
+                    payload=content,
+                    path=target_url,
+                    usage_dimensions=usage_dimensions,
+                )
             return JSONResponse(
-                content=response.json(),
+                content=content,
                 status_code=response.status_code,
                 headers=_redaction_headers,
             )

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -59,7 +59,7 @@ from .proxy_transform import (
     strip_anthropic_unsupported_params,
 )
 from .cache_aligner import CacheAligner
-from .cache_routing import CacheAwareRouter
+from .cache_routing import CacheAwareRouter, CachePrice, ModelCandidate
 from .control_plane import (
     ControlAudit,
     ControlPlaneDecision,
@@ -1050,6 +1050,10 @@ class PromptCompilerProxy:
         self._usage_recorded = 0
         self._usage_unpriced = 0
         self._usage_failures = 0
+        self._cache_route_stays = 0
+        self._cache_route_switches = 0
+        self._cache_route_blocked_unpriced = 0
+        self._cache_route_last: dict[str, Any] | None = None
 
         # Gap #29: Last optimization context (for transparency endpoint)
         self._last_context_fragments: list = []
@@ -1524,6 +1528,138 @@ class PromptCompilerProxy:
             default=str,
         )
         return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _routing_token_estimates(
+        body: dict[str, Any],
+        user_message: str,
+    ) -> tuple[int, int, int]:
+        """Estimate the cacheable prefix, new input, and expected output."""
+        input_surface = {
+            key: body[key]
+            for key in (
+                "system",
+                "systemInstruction",
+                "instructions",
+                "messages",
+                "contents",
+                "input",
+                "tools",
+            )
+            if key in body
+        }
+        serialized = json.dumps(
+            input_surface,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        total_input = max(1, len(serialized.encode("utf-8")) // 4)
+        new_input = max(1, len(user_message.encode("utf-8")) // 4)
+        prefix_tokens = max(0, total_input - new_input)
+
+        expected_output: Any = body.get("max_completion_tokens")
+        if expected_output is None:
+            expected_output = body.get("max_tokens")
+        if expected_output is None:
+            generation = body.get("generationConfig")
+            if isinstance(generation, dict):
+                expected_output = generation.get("maxOutputTokens")
+        try:
+            output_tokens = max(0, min(int(expected_output or 1024), 1_000_000))
+        except (TypeError, ValueError):
+            output_tokens = 1024
+        return prefix_tokens, new_input, output_tokens
+
+    def _cache_economics_allow_ravs(
+        self,
+        *,
+        body: dict[str, Any],
+        provider: str,
+        current_model: str,
+        recommended_model: str,
+        user_message: str,
+        risk: str,
+    ) -> tuple[bool, str]:
+        """Apply observed cache economics after RAVS has passed quality gates."""
+        if self._pricing_catalog is None:
+            return True, "pricing_catalog_not_configured"
+
+        current_pricing = self._pricing_catalog.resolve(provider, current_model)
+        recommended_pricing = self._pricing_catalog.resolve(
+            provider,
+            recommended_model,
+        )
+        if current_pricing is None or recommended_pricing is None:
+            with self._stats_lock:
+                self._cache_route_blocked_unpriced += 1
+                self._cache_route_last = {
+                    "current_model": current_model,
+                    "recommended_model": recommended_model,
+                    "reason": "stay:missing_pricing",
+                }
+            return False, "stay:missing_pricing"
+
+        def candidate(model: str, pricing: Any) -> ModelCandidate:
+            return ModelCandidate(
+                model=model,
+                provider=provider,
+                price=CachePrice(
+                    input_per_million=float(pricing.input_per_million),
+                    cache_read_per_million=float(
+                        pricing.cache_read_per_million
+                    ),
+                    output_per_million=float(pricing.output_per_million),
+                    cache_write_per_million=float(pricing.cache_write_rate),
+                ),
+                # RAVS has already enforced empirical quality/risk gates.
+                quality=1.0,
+            )
+
+        conversation_id = self._routing_conversation_id(body, provider)
+        if not conversation_id:
+            with self._stats_lock:
+                self._cache_route_last = {
+                    "current_model": current_model,
+                    "recommended_model": recommended_model,
+                    "reason": "stay:missing_conversation_identity",
+                }
+            return False, "stay:missing_conversation_identity"
+
+        prefix_tokens, new_input_tokens, output_tokens = (
+            self._routing_token_estimates(body, user_message)
+        )
+        route = self._cache_router.decide(
+            conversation_id,
+            current_model=current_model,
+            candidates=(
+                candidate(current_model, current_pricing),
+                candidate(recommended_model, recommended_pricing),
+            ),
+            prefix_hash=self._cache_prefix_hash(body, provider),
+            prefix_tokens=prefix_tokens,
+            new_input_tokens=new_input_tokens,
+            expected_output_tokens=output_tokens,
+            risk=risk,
+        )
+        allow = route.selected_model == recommended_model
+        with self._stats_lock:
+            if allow:
+                self._cache_route_switches += 1
+            else:
+                self._cache_route_stays += 1
+            self._cache_route_last = {
+                "current_model": current_model,
+                "recommended_model": recommended_model,
+                "selected_model": route.selected_model,
+                "reason": route.reason,
+                "cache_warm": route.cache_warm,
+                "stayed_for_cache": route.stayed_for_cache,
+                "switch_savings_usd": route.switch_savings_usd,
+                "projected_costs_usd": dict(route.projected_costs_usd),
+            }
+        return allow, route.reason
 
     def _record_provider_usage(
         self,
@@ -2124,13 +2260,35 @@ class PromptCompilerProxy:
                             )
 
                         if not _ece_blocked:
+                            cache_allows, cache_reason = (
+                                self._cache_economics_allow_ravs(
+                                    body=body,
+                                    provider=provider,
+                                    current_model=_current_model,
+                                    recommended_model=decision.recommended_model,
+                                    user_message=user_message,
+                                    risk=decision.risk_level,
+                                )
+                            )
+                            if not cache_allows:
+                                _ece_blocked = True
+                                logger.info(
+                                    "RAVS: kept %s after cache-economics gate (%s)",
+                                    _current_model,
+                                    cache_reason,
+                                )
+
+                        if not _ece_blocked:
                             from .ravs.router import swap_model_in_body
                             _ravs_original_model = _current_model
                             body = swap_model_in_body(body, decision.recommended_model)
                             _ravs_swapped = True
                             logger.info(
-                                "RAVS: %s -> %s (%s)",
-                                _current_model, decision.recommended_model, decision.reason,
+                                "RAVS: %s -> %s (%s; %s)",
+                                _current_model,
+                                decision.recommended_model,
+                                decision.reason,
+                                cache_reason,
                             )
 
                 # Store for next-request feedback attribution
@@ -4890,7 +5048,13 @@ async def _proxy_stats(request: Request) -> JSONResponse:
             "ladder_models": len(proxy._escalation_ladder),
         }
 
-    stats["provider_cache"] = proxy._cache_router.stats()
+    stats["provider_cache"] = {
+        **proxy._cache_router.stats(),
+        "routing_stays": proxy._cache_route_stays,
+        "routing_switches": proxy._cache_route_switches,
+        "blocked_unpriced": proxy._cache_route_blocked_unpriced,
+        "last_decision": proxy._cache_route_last,
+    }
     usage_accounting: dict[str, Any] = {
         "enabled": proxy._usage_ledger is not None,
         "pricing_catalog": (

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -2838,10 +2838,15 @@ class PromptCompilerProxy:
 
         raw = b"".join(chunks)
         if status_code < 400:
+            accounting_request_id = (
+                request_id
+                if recovery_depth == 0
+                else f"{request_id}:recovery:{recovery_depth}"
+            )
             await self._observe_stream_usage(
                 body=body,
                 provider=provider,
-                request_id=request_id,
+                request_id=accounting_request_id,
                 transcript=raw,
                 path=url,
             )
@@ -4238,10 +4243,15 @@ class PromptCompilerProxy:
             }
 
         if isinstance(content, dict) and response.status_code < 400:
+            accounting_request_id = (
+                request_id
+                if recovery_depth == 0
+                else f"{request_id}:recovery:{recovery_depth}"
+            )
             await self._observe_json_usage(
                 body=body,
                 provider=provider,
-                request_id=request_id,
+                request_id=accounting_request_id,
                 payload=content,
                 path=url,
             )

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1533,8 +1533,9 @@ class PromptCompilerProxy:
         request_id: str,
         usage: TokenUsage,
         streaming: bool,
+        path: str = "",
     ) -> None:
-        model = extract_model(body) or str(body.get("model", "unknown"))
+        model = extract_model(body, path) or str(body.get("model", "unknown"))
         conversation_id = self._routing_conversation_id(body, provider)
         prefix_hash = self._cache_prefix_hash(body, provider)
         cached_prefix_tokens = max(
@@ -1579,6 +1580,7 @@ class PromptCompilerProxy:
         provider: str,
         request_id: str,
         payload: dict[str, Any],
+        path: str = "",
     ) -> None:
         usage_keys = {"usage", "usage_metadata", "usageMetadata"}
         if not usage_keys.intersection(payload):
@@ -1592,6 +1594,7 @@ class PromptCompilerProxy:
                 request_id=request_id,
                 usage=usage,
                 streaming=False,
+                path=path,
             )
         except Exception:
             with self._stats_lock:
@@ -1605,6 +1608,7 @@ class PromptCompilerProxy:
         provider: str,
         request_id: str,
         transcript: bytes,
+        path: str = "",
     ) -> None:
         try:
             usage = parse_stream_usage(provider, transcript)
@@ -1617,6 +1621,7 @@ class PromptCompilerProxy:
                 request_id=request_id,
                 usage=usage,
                 streaming=True,
+                path=path,
             )
         except Exception:
             with self._stats_lock:

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -3046,12 +3046,18 @@ class PromptCompilerProxy:
         _witness_enabled = self._witness_enabled and bool(self._witness_analyzer)
         _frag_ids = selected_frag_ids or []
         _buffer_cap = ImplicitFeedbackTracker._MAX_BUFFER_BYTES
+        try:
+            _usage_tail_cap = int(os.environ.get("ENTROLY_USAGE_SSE_TAIL_BYTES", "262144"))
+        except ValueError:
+            _usage_tail_cap = 262144
+        _usage_tail_cap = max(16384, min(_usage_tail_cap, 1048576))
         # Capture selected fragments for per-variant utilization tracking (Change 4)
         _selected_frags = getattr(self, '_last_context_fragments', []) if _feedback_enabled else []
 
         async def event_generator():
             buffer = [] if (_feedback_enabled or _witness_enabled) else None
             buffer_size = 0
+            usage_tail = bytearray()
             try:
                 client = await self._ensure_client()
                 async with client.stream(
@@ -3106,8 +3112,19 @@ class PromptCompilerProxy:
                         if buffer is not None and buffer_size < _buffer_cap:
                             buffer.append(chunk)
                             buffer_size += len(chunk)
+                        usage_tail.extend(chunk)
+                        if len(usage_tail) > _usage_tail_cap:
+                            del usage_tail[:-_usage_tail_cap]
                         yield chunk
                 self._breaker.record_success()
+                if usage_tail:
+                    await self._observe_stream_usage(
+                        body=body,
+                        provider=provider,
+                        request_id=request_id,
+                        transcript=bytes(usage_tail),
+                        path=url,
+                    )
             except httpx.ReadError as e:
                 self._breaker.record_failure()
                 logger.warning(f"Upstream stream interrupted: {e}")

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1674,6 +1674,32 @@ class PromptCompilerProxy:
         model = extract_model(body, path) or str(body.get("model", "unknown"))
         conversation_id = self._routing_conversation_id(body, provider)
         prefix_hash = self._cache_prefix_hash(body, provider)
+        inserted = True
+
+        if self._usage_ledger is not None:
+            pricing = (
+                self._pricing_catalog.resolve(provider, model)
+                if self._pricing_catalog is not None
+                else None
+            )
+            event, inserted = self._usage_ledger.record_usage_with_status(
+                request_id=request_id or uuid.uuid4().hex,
+                provider=provider,
+                model=model,
+                usage=usage,
+                pricing=pricing,
+                conversation_id=conversation_id,
+                metadata={"streaming": streaming},
+            )
+            if inserted:
+                with self._stats_lock:
+                    self._usage_recorded += 1
+                    if event.pricing_source.startswith("unpriced:"):
+                        self._usage_unpriced += 1
+
+        if not inserted:
+            return
+
         cached_prefix_tokens = max(
             usage.cache_read_tokens,
             usage.cache_write_tokens,
@@ -1687,27 +1713,6 @@ class PromptCompilerProxy:
                 cached_prefix_tokens=cached_prefix_tokens,
                 cache_hit=usage.cache_read_tokens > 0,
             )
-
-        if self._usage_ledger is None:
-            return
-        pricing = (
-            self._pricing_catalog.resolve(provider, model)
-            if self._pricing_catalog is not None
-            else None
-        )
-        event = self._usage_ledger.record_usage(
-            request_id=request_id or uuid.uuid4().hex,
-            provider=provider,
-            model=model,
-            usage=usage,
-            pricing=pricing,
-            conversation_id=conversation_id,
-            metadata={"streaming": streaming},
-        )
-        with self._stats_lock:
-            self._usage_recorded += 1
-            if event.pricing_source.startswith("unpriced:"):
-                self._usage_unpriced += 1
 
     async def _observe_json_usage(
         self,

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -4889,6 +4889,27 @@ async def _proxy_stats(request: Request) -> JSONResponse:
             "last": proxy._escalation_last,
             "ladder_models": len(proxy._escalation_ladder),
         }
+
+    stats["provider_cache"] = proxy._cache_router.stats()
+    usage_accounting: dict[str, Any] = {
+        "enabled": proxy._usage_ledger is not None,
+        "pricing_catalog": (
+            proxy._pricing_catalog.source
+            if proxy._pricing_catalog is not None
+            else None
+        ),
+        "recorded": proxy._usage_recorded,
+        "unpriced": proxy._usage_unpriced,
+        "failures": proxy._usage_failures,
+    }
+    if proxy._usage_ledger is not None:
+        try:
+            usage_accounting["ledger"] = await asyncio.to_thread(
+                proxy._usage_ledger.summary
+            )
+        except Exception:
+            usage_accounting["ledger_error"] = "summary_unavailable"
+    stats["usage_accounting"] = usage_accounting
     return JSONResponse(stats)
 
 

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.37"
+version = "1.0.38"
 
 description = "Information-theoretic context optimization with deterministic hallucination detection and suppression. MCP server, HTTP proxy, and Python SDK for AI coding agents."
 readme = "README.md"
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 native = [
-    "entroly-core>=1.0.37,<2",
+    "entroly-core>=1.0.38,<2",
     "mcp>=1.0.0,<2",
 ]
 

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -4722,7 +4722,7 @@ def main():
     try:
         from entroly import __version__ as _version
     except Exception:
-        _version = "1.0.37"
+        _version = "1.0.38"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/entroly/usage_ledger.py
+++ b/entroly/usage_ledger.py
@@ -501,6 +501,51 @@ class UsageLedger:
             metadata=json.loads(row["metadata_json"]),
         )
 
+    def record_usage(
+        self,
+        *,
+        request_id: str,
+        provider: str,
+        model: str,
+        usage: TokenUsage,
+        pricing: UsagePricing | None,
+        occurred_at: float | None = None,
+        team: str = "",
+        tool: str = "",
+        project: str = "",
+        conversation_id: str = "",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> UsageEvent:
+        if pricing is None:
+            cost = 0
+            savings = 0
+            pricing_source = f"unpriced:{provider.lower()}:{model}"
+        else:
+            cost, savings = price_usage(usage, pricing)
+            pricing_source = pricing.source
+        event = UsageEvent(
+            request_id=request_id,
+            provider=provider,
+            model=model,
+            usage=usage,
+            cost_micro_usd=cost,
+            cache_savings_micro_usd=savings,
+            occurred_at=time.time() if occurred_at is None else occurred_at,
+            team=team,
+            tool=tool,
+            project=project,
+            conversation_id=conversation_id,
+            pricing_source=pricing_source,
+            metadata=dict(metadata or {}),
+        )
+        inserted = self.record(event)
+        if inserted:
+            return event
+        existing = self.get(request_id)
+        if existing is None:
+            raise RuntimeError("idempotent usage record is unavailable")
+        return existing
+
     def record_provider_payload(
         self,
         *,
@@ -517,29 +562,19 @@ class UsageLedger:
         metadata: Mapping[str, Any] | None = None,
     ) -> UsageEvent:
         usage = parse_provider_usage(provider, payload)
-        cost, savings = price_usage(usage, pricing)
-        event = UsageEvent(
+        return self.record_usage(
             request_id=request_id,
             provider=provider,
             model=model,
             usage=usage,
-            cost_micro_usd=cost,
-            cache_savings_micro_usd=savings,
-            occurred_at=time.time() if occurred_at is None else occurred_at,
+            pricing=pricing,
+            occurred_at=occurred_at,
             team=team,
             tool=tool,
             project=project,
             conversation_id=conversation_id,
-            pricing_source=pricing.source,
-            metadata=dict(metadata or {}),
+            metadata=metadata,
         )
-        inserted = self.record(event)
-        if inserted:
-            return event
-        existing = self.get(request_id)
-        if existing is None:
-            raise RuntimeError("idempotent usage record is unavailable")
-        return existing
 
     def summary(self, **filters: str) -> dict[str, int | float]:
         unknown = set(filters) - self._FILTER_COLUMNS
@@ -564,7 +599,11 @@ class UsageLedger:
                     COALESCE(SUM(output_tokens), 0) AS output_tokens,
                     COALESCE(SUM(cost_micro_usd), 0) AS cost_micro_usd,
                     COALESCE(SUM(cache_savings_micro_usd), 0)
-                        AS cache_savings_micro_usd
+                        AS cache_savings_micro_usd,
+                    COALESCE(SUM(
+                        CASE WHEN pricing_source LIKE 'unpriced:%'
+                        THEN 1 ELSE 0 END
+                    ), 0) AS unpriced_requests
                 FROM usage_events
                 {where}
                 """,

--- a/entroly/usage_ledger.py
+++ b/entroly/usage_ledger.py
@@ -95,7 +95,9 @@ class UsagePricing:
 
     @property
     def cache_write_rate(self) -> Decimal:
-        return self.cache_write_per_million or self.input_per_million
+        if self.cache_write_per_million is None:
+            return self.input_per_million
+        return self.cache_write_per_million
 
 
 @dataclass(frozen=True, slots=True)

--- a/entroly/usage_ledger.py
+++ b/entroly/usage_ledger.py
@@ -447,6 +447,10 @@ class UsageLedger:
             identity = (
                 existing["provider"],
                 existing["model"],
+                existing["team"],
+                existing["tool"],
+                existing["project"],
+                existing["conversation_id"],
                 existing["uncached_input_tokens"],
                 existing["cache_read_tokens"],
                 existing["cache_write_tokens"],
@@ -454,10 +458,15 @@ class UsageLedger:
                 existing["cost_micro_usd"],
                 existing["cache_savings_micro_usd"],
                 existing["pricing_source"],
+                existing["metadata_json"],
             )
             proposed = (
                 event.provider,
                 event.model,
+                event.team,
+                event.tool,
+                event.project,
+                event.conversation_id,
                 event.usage.uncached_input_tokens,
                 event.usage.cache_read_tokens,
                 event.usage.cache_write_tokens,
@@ -465,6 +474,13 @@ class UsageLedger:
                 event.cost_micro_usd,
                 event.cache_savings_micro_usd,
                 event.pricing_source,
+                json.dumps(
+                    dict(event.metadata),
+                    ensure_ascii=True,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ),
             )
             if identity != proposed:
                 raise ValueError(

--- a/entroly/usage_ledger.py
+++ b/entroly/usage_ledger.py
@@ -516,6 +516,37 @@ class UsageLedger:
         conversation_id: str = "",
         metadata: Mapping[str, Any] | None = None,
     ) -> UsageEvent:
+        event, _inserted = self.record_usage_with_status(
+            request_id=request_id,
+            provider=provider,
+            model=model,
+            usage=usage,
+            pricing=pricing,
+            occurred_at=occurred_at,
+            team=team,
+            tool=tool,
+            project=project,
+            conversation_id=conversation_id,
+            metadata=metadata,
+        )
+        return event
+
+    def record_usage_with_status(
+        self,
+        *,
+        request_id: str,
+        provider: str,
+        model: str,
+        usage: TokenUsage,
+        pricing: UsagePricing | None,
+        occurred_at: float | None = None,
+        team: str = "",
+        tool: str = "",
+        project: str = "",
+        conversation_id: str = "",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> tuple[UsageEvent, bool]:
+        """Record normalized usage and report whether this call inserted it."""
         if pricing is None:
             cost = 0
             savings = 0
@@ -540,11 +571,11 @@ class UsageLedger:
         )
         inserted = self.record(event)
         if inserted:
-            return event
+            return event, True
         existing = self.get(request_id)
         if existing is None:
             raise RuntimeError("idempotent usage record is unavailable")
-        return existing
+        return existing, False
 
     def record_provider_payload(
         self,

--- a/entroly/usage_ledger.py
+++ b/entroly/usage_ledger.py
@@ -99,6 +99,84 @@ class UsagePricing:
 
 
 @dataclass(frozen=True, slots=True)
+class UsagePricingCatalog:
+    """Validated model pricing keyed by provider:model."""
+
+    entries: Mapping[str, UsagePricing]
+    source: str
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        default_source: str = "explicit-catalog",
+    ) -> "UsagePricingCatalog":
+        source = str(payload.get("source") or default_source).strip()
+        if not source:
+            raise ValueError("pricing catalog source is required")
+        models = payload.get("models")
+        if not isinstance(models, Mapping) or not models:
+            raise ValueError("pricing catalog requires a non-empty models mapping")
+
+        entries: dict[str, UsagePricing] = {}
+        for raw_key, raw_rates in models.items():
+            key = str(raw_key).strip()
+            provider, separator, model = key.partition(":")
+            if not separator or not provider or not model:
+                raise ValueError(
+                    "pricing keys must use the provider:model form"
+                )
+            if not isinstance(raw_rates, Mapping):
+                raise ValueError(f"pricing entry {key!r} must be an object")
+            required = {
+                "input_per_million",
+                "output_per_million",
+                "cache_read_per_million",
+            }
+            missing = required - set(raw_rates)
+            if missing:
+                raise ValueError(
+                    f"pricing entry {key!r} is missing {sorted(missing)}"
+                )
+            normalized_key = f"{provider.lower()}:{model}"
+            if normalized_key in entries:
+                raise ValueError(f"duplicate pricing entry {normalized_key!r}")
+            entries[normalized_key] = UsagePricing.from_values(
+                input_per_million=raw_rates["input_per_million"],
+                output_per_million=raw_rates["output_per_million"],
+                cache_read_per_million=raw_rates["cache_read_per_million"],
+                cache_write_per_million=raw_rates.get(
+                    "cache_write_per_million"
+                ),
+                source=f"{source}:{normalized_key}",
+            )
+        return cls(entries=entries, source=source)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "UsagePricingCatalog":
+        catalog_path = Path(path)
+        try:
+            payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                f"cannot load pricing catalog {catalog_path}: {exc}"
+            ) from exc
+        if not isinstance(payload, Mapping):
+            raise ValueError("pricing catalog root must be an object")
+        return cls.from_mapping(
+            payload,
+            default_source=f"file:{catalog_path}",
+        )
+
+    def resolve(self, provider: str, model: str) -> UsagePricing | None:
+        provider_key = provider.lower().strip()
+        return self.entries.get(
+            f"{provider_key}:{model}"
+        ) or self.entries.get(f"{provider_key}:*")
+
+
+@dataclass(frozen=True, slots=True)
 class UsageEvent:
     request_id: str
     provider: str
@@ -128,6 +206,8 @@ def parse_provider_usage(provider: str, payload: Mapping[str, Any]) -> TokenUsag
     raw = payload.get("usage")
     if not isinstance(raw, Mapping):
         raw = payload.get("usage_metadata")
+    if not isinstance(raw, Mapping):
+        raw = payload.get("usageMetadata")
     if not isinstance(raw, Mapping):
         raw = payload
 
@@ -167,6 +247,76 @@ def parse_provider_usage(provider: str, payload: Mapping[str, Any]) -> TokenUsag
         )
 
     raise ValueError(f"unsupported provider usage format: {provider!r}")
+
+
+def parse_stream_usage(
+    provider: str,
+    payload: bytes | str,
+) -> TokenUsage | None:
+    """Extract cumulative provider usage from an SSE transcript.
+
+    Providers split usage across different events. Component-wise maxima merge
+    cumulative counters without double-counting repeated terminal frames.
+    """
+    text = (
+        payload.decode("utf-8", errors="replace")
+        if isinstance(payload, bytes)
+        else payload
+    )
+    aggregate = TokenUsage()
+    found = False
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("data:"):
+            continue
+        encoded = stripped[5:].strip()
+        if not encoded or encoded == "[DONE]":
+            continue
+        try:
+            event = json.loads(encoded)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, Mapping):
+            continue
+
+        candidates: list[Mapping[str, Any]] = []
+        if isinstance(event.get("usage"), Mapping):
+            candidates.append({"usage": event["usage"]})
+        if isinstance(event.get("usage_metadata"), Mapping):
+            candidates.append({"usage_metadata": event["usage_metadata"]})
+        if isinstance(event.get("usageMetadata"), Mapping):
+            candidates.append({"usageMetadata": event["usageMetadata"]})
+        for container_name in ("message", "response"):
+            container = event.get(container_name)
+            if isinstance(container, Mapping) and isinstance(
+                container.get("usage"), Mapping
+            ):
+                candidates.append({"usage": container["usage"]})
+
+        for candidate in candidates:
+            usage = parse_provider_usage(provider, candidate)
+            aggregate = TokenUsage(
+                uncached_input_tokens=max(
+                    aggregate.uncached_input_tokens,
+                    usage.uncached_input_tokens,
+                ),
+                cache_read_tokens=max(
+                    aggregate.cache_read_tokens,
+                    usage.cache_read_tokens,
+                ),
+                cache_write_tokens=max(
+                    aggregate.cache_write_tokens,
+                    usage.cache_write_tokens,
+                ),
+                output_tokens=max(
+                    aggregate.output_tokens,
+                    usage.output_tokens,
+                ),
+            )
+            found = True
+
+    return aggregate if found else None
 
 
 def _micro_cost(tokens: int, rate_per_million: Decimal) -> int:
@@ -286,7 +436,70 @@ class UsageLedger:
                 """,
                 row,
             )
-            return cursor.rowcount == 1
+            if cursor.rowcount == 1:
+                return True
+            existing = self._conn.execute(
+                "SELECT * FROM usage_events WHERE request_id = ?",
+                (event.request_id,),
+            ).fetchone()
+            if existing is None:
+                raise RuntimeError("idempotent usage insert lost its stored row")
+            identity = (
+                existing["provider"],
+                existing["model"],
+                existing["uncached_input_tokens"],
+                existing["cache_read_tokens"],
+                existing["cache_write_tokens"],
+                existing["output_tokens"],
+                existing["cost_micro_usd"],
+                existing["cache_savings_micro_usd"],
+                existing["pricing_source"],
+            )
+            proposed = (
+                event.provider,
+                event.model,
+                event.usage.uncached_input_tokens,
+                event.usage.cache_read_tokens,
+                event.usage.cache_write_tokens,
+                event.usage.output_tokens,
+                event.cost_micro_usd,
+                event.cache_savings_micro_usd,
+                event.pricing_source,
+            )
+            if identity != proposed:
+                raise ValueError(
+                    "request_id already has different provider usage"
+                )
+            return False
+
+    def get(self, request_id: str) -> UsageEvent | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM usage_events WHERE request_id = ?",
+                (request_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return UsageEvent(
+            request_id=row["request_id"],
+            provider=row["provider"],
+            model=row["model"],
+            usage=TokenUsage(
+                uncached_input_tokens=row["uncached_input_tokens"],
+                cache_read_tokens=row["cache_read_tokens"],
+                cache_write_tokens=row["cache_write_tokens"],
+                output_tokens=row["output_tokens"],
+            ),
+            cost_micro_usd=row["cost_micro_usd"],
+            cache_savings_micro_usd=row["cache_savings_micro_usd"],
+            occurred_at=row["occurred_at"],
+            team=row["team"],
+            tool=row["tool"],
+            project=row["project"],
+            conversation_id=row["conversation_id"],
+            pricing_source=row["pricing_source"],
+            metadata=json.loads(row["metadata_json"]),
+        )
 
     def record_provider_payload(
         self,
@@ -320,8 +533,13 @@ class UsageLedger:
             pricing_source=pricing.source,
             metadata=dict(metadata or {}),
         )
-        self.record(event)
-        return event
+        inserted = self.record(event)
+        if inserted:
+            return event
+        existing = self.get(request_id)
+        if existing is None:
+            raise RuntimeError("idempotent usage record is unavailable")
+        return existing
 
     def summary(self, **filters: str) -> dict[str, int | float]:
         unknown = set(filters) - self._FILTER_COLUMNS
@@ -375,6 +593,8 @@ __all__ = [
     "UsageEvent",
     "UsageLedger",
     "UsagePricing",
+    "UsagePricingCatalog",
     "parse_provider_usage",
+    "parse_stream_usage",
     "price_usage",
 ]

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -2,13 +2,13 @@
 
 The formula in this directory is the canonical source. To make `brew tap juyterman1000/entroly && brew install entroly` work, the formula must live in a separate repo named `juyterman1000/homebrew-entroly`.
 
-Current release example version: `1.0.37`.
+Current release example version: `1.0.38`.
 
 ## Release checklist
 
 1. Copy `packaging/homebrew/entroly.rb` into `juyterman1000/homebrew-entroly/Formula/entroly.rb`.
-2. Set `VER=1.0.37` when preparing this release.
-3. Download the matching PyPI sdist: `entroly-1.0.37.tar.gz`.
+2. Set `VER=1.0.38` when preparing this release.
+3. Download the matching PyPI sdist: `entroly-1.0.38.tar.gz`.
 4. Recalculate the `sha256` for that tarball before publishing the Homebrew tap update.
 5. Verify locally before pushing with `brew install --build-from-source ./Formula/entroly.rb`, `brew test entroly`, and `brew audit --new --strict entroly`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.37"
+version = "1.0.38"
 description = "Auditable context control plane for AI agents: Context Receipts, MCP tools, local optimization, and SDK helpers."
 readme = "README.md"
 license = "Apache-2.0"
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.6.0,<2",
-    "entroly-core>=1.0.37,<2",
+    "entroly-core>=1.0.38,<2",
 ]
 
 [project.optional-dependencies]
@@ -43,7 +43,7 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.37,<2",
+    "entroly-core>=1.0.38,<2",
 ]
 
 [project.scripts]

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Bump version across all Entroly manifests.
 
-Usage: python scripts/bump_version.py 1.0.37
+Usage: python scripts/bump_version.py 1.0.38
 """
 from __future__ import annotations
 import re

--- a/tests/test_live_gateway_accounting.py
+++ b/tests/test_live_gateway_accounting.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from entroly.proxy import PromptCompilerProxy
+from entroly.proxy_config import ProxyConfig
+from entroly.usage_ledger import (
+    TokenUsage,
+    UsageLedger,
+    UsagePricing,
+    UsagePricingCatalog,
+)
+
+
+def _catalog(*, include_recommended: bool = True) -> UsagePricingCatalog:
+    models: dict[str, dict[str, float]] = {
+        "openai:gpt-current": {
+            "input_per_million": 10.0,
+            "output_per_million": 2.0,
+            "cache_read_per_million": 0.1,
+            "cache_write_per_million": 10.0,
+        }
+    }
+    if include_recommended:
+        models["openai:gpt-cheap"] = {
+            "input_per_million": 1.0,
+            "output_per_million": 1.0,
+            "cache_read_per_million": 0.05,
+            "cache_write_per_million": 1.0,
+        }
+    return UsagePricingCatalog.from_mapping(
+        {"source": "test-catalog-v1", "models": models}
+    )
+
+
+def _proxy() -> PromptCompilerProxy:
+    proxy = PromptCompilerProxy(object(), ProxyConfig())
+    proxy._witness_enabled = False
+    proxy._witness_analyzer = None
+    proxy._enable_passive_feedback = False
+    proxy._usage_ledger = UsageLedger()
+    proxy._pricing_catalog = _catalog()
+    return proxy
+
+
+@pytest.mark.asyncio
+async def test_live_json_forward_records_usage_and_cache_observation() -> None:
+    async def upstream(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "id": "response-1",
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 7,
+                    "prompt_tokens_details": {"cached_tokens": 80},
+                },
+            },
+        )
+
+    proxy = _proxy()
+    proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+    body = {
+        "model": "gpt-current",
+        "messages": [
+            {"role": "system", "content": "stable policy"},
+            {"role": "user", "content": "answer this"},
+        ],
+    }
+    try:
+        response = await proxy._forward_response(
+            "https://provider.example/v1/chat/completions",
+            {},
+            body,
+            provider="openai",
+            request_id="request-json",
+        )
+        event = proxy._usage_ledger.get("request-json")
+        assert response.status_code == 200
+        assert event is not None
+        assert event.usage == TokenUsage(
+            uncached_input_tokens=20,
+            cache_read_tokens=80,
+            output_tokens=7,
+        )
+        assert event.cost_micro_usd > 0
+        assert proxy._cache_router.stats()["observed_hits"] == 1
+    finally:
+        await proxy._client.aclose()
+        proxy._usage_ledger.close()
+
+
+@pytest.mark.asyncio
+async def test_live_sse_forward_records_terminal_usage_without_rewriting_bytes() -> None:
+    transcript = (
+        b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+        b'data: {"usage":{"prompt_tokens":120,"completion_tokens":9,'
+        b'"prompt_tokens_details":{"cached_tokens":100}}}\n\n'
+        b"data: [DONE]\n\n"
+    )
+
+    async def upstream(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=transcript,
+        )
+
+    proxy = _proxy()
+    proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+    body = {
+        "model": "gpt-current",
+        "stream": True,
+        "messages": [
+            {"role": "system", "content": "stable policy"},
+            {"role": "user", "content": "stream this"},
+        ],
+    }
+    try:
+        response = await proxy._stream_response(
+            "https://provider.example/v1/chat/completions",
+            {},
+            body,
+            provider="openai",
+            request_id="request-stream",
+        )
+        forwarded = b"".join(
+            [chunk async for chunk in response.body_iterator]
+        )
+        event = proxy._usage_ledger.get("request-stream")
+        assert forwarded == transcript
+        assert event is not None
+        assert event.usage.cache_read_tokens == 100
+        assert event.usage.output_tokens == 9
+    finally:
+        await proxy._client.aclose()
+        proxy._usage_ledger.close()
+
+
+def test_cache_economics_keep_a_large_warm_prefix_on_current_model() -> None:
+    proxy = _proxy()
+    body = {
+        "model": "gpt-current",
+        "messages": [
+            {"role": "system", "content": "policy " * 60_000},
+            {"role": "user", "content": "continue"},
+        ],
+    }
+    conversation_id = proxy._routing_conversation_id(body, "openai")
+    proxy._cache_router.observe(
+        conversation_id,
+        model="gpt-current",
+        provider="openai",
+        prefix_hash=proxy._cache_prefix_hash(body, "openai"),
+        cached_prefix_tokens=100_000,
+        cache_hit=True,
+    )
+
+    allowed, reason = proxy._cache_economics_allow_ravs(
+        body=body,
+        provider="openai",
+        current_model="gpt-current",
+        recommended_model="gpt-cheap",
+        user_message="continue",
+        risk="standard",
+    )
+
+    assert not allowed
+    assert reason == "stay:warm_cache_economics"
+    assert proxy._cache_route_stays == 1
+    proxy._usage_ledger.close()
+
+
+def test_cache_economics_switch_when_cold_model_is_materially_cheaper() -> None:
+    proxy = _proxy()
+    body = {
+        "model": "gpt-current",
+        "messages": [
+            {"role": "system", "content": "policy " * 60_000},
+            {"role": "user", "content": "continue"},
+        ],
+    }
+
+    allowed, reason = proxy._cache_economics_allow_ravs(
+        body=body,
+        provider="openai",
+        current_model="gpt-current",
+        recommended_model="gpt-cheap",
+        user_message="continue",
+        risk="standard",
+    )
+
+    assert allowed
+    assert reason == "switch:projected_savings"
+    assert proxy._cache_route_switches == 1
+    proxy._usage_ledger.close()
+
+
+def test_cache_economics_fail_closed_when_catalog_is_incomplete() -> None:
+    proxy = _proxy()
+    proxy._pricing_catalog = _catalog(include_recommended=False)
+    body = {
+        "model": "gpt-current",
+        "messages": [{"role": "user", "content": "continue"}],
+    }
+
+    allowed, reason = proxy._cache_economics_allow_ravs(
+        body=body,
+        provider="openai",
+        current_model="gpt-current",
+        recommended_model="gpt-cheap",
+        user_message="continue",
+        risk="standard",
+    )
+
+    assert not allowed
+    assert reason == "stay:missing_pricing"
+    assert proxy._cache_route_blocked_unpriced == 1
+    proxy._usage_ledger.close()
+
+
+def test_usage_ledger_survives_reopen(tmp_path) -> None:
+    path = tmp_path / "usage.sqlite3"
+    pricing = UsagePricing.from_values(
+        input_per_million=3,
+        output_per_million=6,
+        cache_read_per_million=0.3,
+        source="durability-test",
+    )
+    with UsageLedger(path) as ledger:
+        ledger.record_usage(
+            request_id="durable-request",
+            provider="openai",
+            model="gpt-current",
+            usage=TokenUsage(
+                uncached_input_tokens=10,
+                cache_read_tokens=90,
+                output_tokens=5,
+            ),
+            pricing=pricing,
+        )
+
+    with UsageLedger(path) as reopened:
+        event = reopened.get("durable-request")
+        assert event is not None
+        assert event.pricing_source == "durability-test"
+        assert event.usage.cache_read_tokens == 90
+        assert json.loads(json.dumps(reopened.summary()))["requests"] == 1

--- a/tests/test_live_gateway_accounting.py
+++ b/tests/test_live_gateway_accounting.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import json
 
 import httpx
-import pytest
 
 from entroly.proxy import PromptCompilerProxy
 from entroly.proxy_config import ProxyConfig
@@ -46,101 +46,103 @@ def _proxy() -> PromptCompilerProxy:
     return proxy
 
 
-@pytest.mark.asyncio
-async def test_live_json_forward_records_usage_and_cache_observation() -> None:
-    async def upstream(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200,
-            headers={"content-type": "application/json"},
-            json={
-                "id": "response-1",
-                "choices": [{"message": {"content": "ok"}}],
-                "usage": {
-                    "prompt_tokens": 100,
-                    "completion_tokens": 7,
-                    "prompt_tokens_details": {"cached_tokens": 80},
+def test_live_json_forward_records_usage_and_cache_observation() -> None:
+    async def run() -> None:
+        async def upstream(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/json"},
+                json={
+                    "id": "response-1",
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {
+                        "prompt_tokens": 100,
+                        "completion_tokens": 7,
+                        "prompt_tokens_details": {"cached_tokens": 80},
+                    },
                 },
-            },
-        )
+            )
+    
+        proxy = _proxy()
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        body = {
+            "model": "gpt-current",
+            "messages": [
+                {"role": "system", "content": "stable policy"},
+                {"role": "user", "content": "answer this"},
+            ],
+        }
+        try:
+            response = await proxy._forward_response(
+                "https://provider.example/v1/chat/completions",
+                {},
+                body,
+                provider="openai",
+                request_id="request-json",
+            )
+            event = proxy._usage_ledger.get("request-json")
+            assert response.status_code == 200
+            assert event is not None
+            assert event.usage == TokenUsage(
+                uncached_input_tokens=20,
+                cache_read_tokens=80,
+                output_tokens=7,
+            )
+            assert event.cost_micro_usd > 0
+            assert proxy._cache_router.stats()["observed_hits"] == 1
+        finally:
+            await proxy._client.aclose()
+            proxy._usage_ledger.close()
 
-    proxy = _proxy()
-    proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
-    body = {
-        "model": "gpt-current",
-        "messages": [
-            {"role": "system", "content": "stable policy"},
-            {"role": "user", "content": "answer this"},
-        ],
-    }
-    try:
-        response = await proxy._forward_response(
-            "https://provider.example/v1/chat/completions",
-            {},
-            body,
-            provider="openai",
-            request_id="request-json",
-        )
-        event = proxy._usage_ledger.get("request-json")
-        assert response.status_code == 200
-        assert event is not None
-        assert event.usage == TokenUsage(
-            uncached_input_tokens=20,
-            cache_read_tokens=80,
-            output_tokens=7,
-        )
-        assert event.cost_micro_usd > 0
-        assert proxy._cache_router.stats()["observed_hits"] == 1
-    finally:
-        await proxy._client.aclose()
-        proxy._usage_ledger.close()
+    asyncio.run(run())
 
-
-@pytest.mark.asyncio
-async def test_live_sse_forward_records_terminal_usage_without_rewriting_bytes() -> None:
-    transcript = (
-        b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
-        b'data: {"usage":{"prompt_tokens":120,"completion_tokens":9,'
-        b'"prompt_tokens_details":{"cached_tokens":100}}}\n\n'
-        b"data: [DONE]\n\n"
-    )
-
-    async def upstream(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200,
-            headers={"content-type": "text/event-stream"},
-            content=transcript,
+def test_live_sse_forward_records_terminal_usage_without_rewriting_bytes() -> None:
+    async def run() -> None:
+        transcript = (
+            b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+            b'data: {"usage":{"prompt_tokens":120,"completion_tokens":9,'
+            b'"prompt_tokens_details":{"cached_tokens":100}}}\n\n'
+            b"data: [DONE]\n\n"
         )
+    
+        async def upstream(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=transcript,
+            )
+    
+        proxy = _proxy()
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        body = {
+            "model": "gpt-current",
+            "stream": True,
+            "messages": [
+                {"role": "system", "content": "stable policy"},
+                {"role": "user", "content": "stream this"},
+            ],
+        }
+        try:
+            response = await proxy._stream_response(
+                "https://provider.example/v1/chat/completions",
+                {},
+                body,
+                provider="openai",
+                request_id="request-stream",
+            )
+            forwarded = b"".join(
+                [chunk async for chunk in response.body_iterator]
+            )
+            event = proxy._usage_ledger.get("request-stream")
+            assert forwarded == transcript
+            assert event is not None
+            assert event.usage.cache_read_tokens == 100
+            assert event.usage.output_tokens == 9
+        finally:
+            await proxy._client.aclose()
+            proxy._usage_ledger.close()
 
-    proxy = _proxy()
-    proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
-    body = {
-        "model": "gpt-current",
-        "stream": True,
-        "messages": [
-            {"role": "system", "content": "stable policy"},
-            {"role": "user", "content": "stream this"},
-        ],
-    }
-    try:
-        response = await proxy._stream_response(
-            "https://provider.example/v1/chat/completions",
-            {},
-            body,
-            provider="openai",
-            request_id="request-stream",
-        )
-        forwarded = b"".join(
-            [chunk async for chunk in response.body_iterator]
-        )
-        event = proxy._usage_ledger.get("request-stream")
-        assert forwarded == transcript
-        assert event is not None
-        assert event.usage.cache_read_tokens == 100
-        assert event.usage.output_tokens == 9
-    finally:
-        await proxy._client.aclose()
-        proxy._usage_ledger.close()
-
+    asyncio.run(run())
 
 def test_cache_economics_keep_a_large_warm_prefix_on_current_model() -> None:
     proxy = _proxy()
@@ -253,39 +255,41 @@ def test_usage_ledger_survives_reopen(tmp_path) -> None:
         assert json.loads(json.dumps(reopened.summary()))["requests"] == 1
 
 
-@pytest.mark.asyncio
-async def test_duplicate_provider_observation_is_idempotent_everywhere() -> None:
-    proxy = _proxy()
-    body = {
-        "model": "gpt-current",
-        "messages": [
-            {"role": "system", "content": "stable policy"},
-            {"role": "user", "content": "answer this"},
-        ],
-    }
-    payload = {
-        "usage": {
-            "prompt_tokens": 100,
-            "completion_tokens": 7,
-            "prompt_tokens_details": {"cached_tokens": 80},
+def test_duplicate_provider_observation_is_idempotent_everywhere() -> None:
+    async def run() -> None:
+        proxy = _proxy()
+        body = {
+            "model": "gpt-current",
+            "messages": [
+                {"role": "system", "content": "stable policy"},
+                {"role": "user", "content": "answer this"},
+            ],
         }
-    }
-    try:
-        await proxy._observe_json_usage(
-            body=body,
-            provider="openai",
-            request_id="duplicate-request",
-            payload=payload,
-        )
-        await proxy._observe_json_usage(
-            body=body,
-            provider="openai",
-            request_id="duplicate-request",
-            payload=payload,
-        )
+        payload = {
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 7,
+                "prompt_tokens_details": {"cached_tokens": 80},
+            }
+        }
+        try:
+            await proxy._observe_json_usage(
+                body=body,
+                provider="openai",
+                request_id="duplicate-request",
+                payload=payload,
+            )
+            await proxy._observe_json_usage(
+                body=body,
+                provider="openai",
+                request_id="duplicate-request",
+                payload=payload,
+            )
+    
+            assert proxy._usage_ledger.summary()["requests"] == 1
+            assert proxy._usage_recorded == 1
+            assert proxy._cache_router.stats()["observed_hits"] == 1
+        finally:
+            proxy._usage_ledger.close()
 
-        assert proxy._usage_ledger.summary()["requests"] == 1
-        assert proxy._usage_recorded == 1
-        assert proxy._cache_router.stats()["observed_hits"] == 1
-    finally:
-        proxy._usage_ledger.close()
+    asyncio.run(run())

--- a/tests/test_live_gateway_accounting.py
+++ b/tests/test_live_gateway_accounting.py
@@ -295,3 +295,33 @@ def test_duplicate_provider_observation_is_idempotent_everywhere() -> None:
             proxy._usage_ledger.close()
 
     asyncio.run(run())
+
+
+def test_url_embedded_model_routing_updates_gemini_target_only() -> None:
+    gemini = PromptCompilerProxy._route_target_url(
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-1.5-pro:streamGenerateContent?alt=sse",
+        "gemini",
+        "gemini-2.0-flash",
+    )
+    openai = PromptCompilerProxy._route_target_url(
+        "https://api.openai.com/v1/chat/completions",
+        "openai",
+        "gpt-cheap",
+    )
+
+    assert "/models/gemini-2.0-flash:streamGenerateContent" in gemini
+    assert openai == "https://api.openai.com/v1/chat/completions"
+
+
+def test_url_embedded_model_routing_rejects_path_injection() -> None:
+    try:
+        PromptCompilerProxy._route_target_url(
+            "https://provider.example/v1beta/models/current:generateContent",
+            "gemini",
+            "../attacker",
+        )
+    except ValueError as exc:
+        assert "invalid URL-embedded model identifier" in str(exc)
+    else:
+        raise AssertionError("unsafe model identifier was accepted")

--- a/tests/test_live_gateway_accounting.py
+++ b/tests/test_live_gateway_accounting.py
@@ -251,3 +251,41 @@ def test_usage_ledger_survives_reopen(tmp_path) -> None:
         assert event.pricing_source == "durability-test"
         assert event.usage.cache_read_tokens == 90
         assert json.loads(json.dumps(reopened.summary()))["requests"] == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_provider_observation_is_idempotent_everywhere() -> None:
+    proxy = _proxy()
+    body = {
+        "model": "gpt-current",
+        "messages": [
+            {"role": "system", "content": "stable policy"},
+            {"role": "user", "content": "answer this"},
+        ],
+    }
+    payload = {
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 7,
+            "prompt_tokens_details": {"cached_tokens": 80},
+        }
+    }
+    try:
+        await proxy._observe_json_usage(
+            body=body,
+            provider="openai",
+            request_id="duplicate-request",
+            payload=payload,
+        )
+        await proxy._observe_json_usage(
+            body=body,
+            provider="openai",
+            request_id="duplicate-request",
+            payload=payload,
+        )
+
+        assert proxy._usage_ledger.summary()["requests"] == 1
+        assert proxy._usage_recorded == 1
+        assert proxy._cache_router.stats()["observed_hits"] == 1
+    finally:
+        proxy._usage_ledger.close()

--- a/tests/test_live_gateway_accounting.py
+++ b/tests/test_live_gateway_accounting.py
@@ -62,7 +62,7 @@ def test_live_json_forward_records_usage_and_cache_observation() -> None:
                     },
                 },
             )
-    
+
         proxy = _proxy()
         proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
         body = {
@@ -96,6 +96,7 @@ def test_live_json_forward_records_usage_and_cache_observation() -> None:
 
     asyncio.run(run())
 
+
 def test_live_sse_forward_records_terminal_usage_without_rewriting_bytes() -> None:
     async def run() -> None:
         transcript = (
@@ -104,14 +105,14 @@ def test_live_sse_forward_records_terminal_usage_without_rewriting_bytes() -> No
             b'"prompt_tokens_details":{"cached_tokens":100}}}\n\n'
             b"data: [DONE]\n\n"
         )
-    
+
         async def upstream(_request: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
                 headers={"content-type": "text/event-stream"},
                 content=transcript,
             )
-    
+
         proxy = _proxy()
         proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
         body = {
@@ -143,6 +144,7 @@ def test_live_sse_forward_records_terminal_usage_without_rewriting_bytes() -> No
             proxy._usage_ledger.close()
 
     asyncio.run(run())
+
 
 def test_cache_economics_keep_a_large_warm_prefix_on_current_model() -> None:
     proxy = _proxy()
@@ -285,7 +287,7 @@ def test_duplicate_provider_observation_is_idempotent_everywhere() -> None:
                 request_id="duplicate-request",
                 payload=payload,
             )
-    
+
             assert proxy._usage_ledger.summary()["requests"] == 1
             assert proxy._usage_recorded == 1
             assert proxy._cache_router.stats()["observed_hits"] == 1

--- a/tests/test_live_gateway_accounting.py
+++ b/tests/test_live_gateway_accounting.py
@@ -325,3 +325,57 @@ def test_url_embedded_model_routing_rejects_path_injection() -> None:
         assert "invalid URL-embedded model identifier" in str(exc)
     else:
         raise AssertionError("unsafe model identifier was accepted")
+
+
+def test_usage_attribution_headers_require_explicit_trust() -> None:
+    proxy = _proxy()
+    headers = {
+        "x-entroly-team": "platform",
+        "x-entroly-project": "gateway/v2",
+        "x-entroly-tool": "coding-agent",
+    }
+
+    assert proxy._usage_dimensions(headers) == {}
+    proxy._trust_usage_headers = True
+    assert proxy._usage_dimensions(headers) == {
+        "team": "platform",
+        "project": "gateway/v2",
+        "tool": "coding-agent",
+    }
+    headers["x-entroly-team"] = "../invalid team"
+    assert "team" not in proxy._usage_dimensions(headers)
+    proxy._usage_ledger.close()
+
+
+def test_live_usage_records_trusted_attribution_dimensions() -> None:
+    async def run() -> None:
+        proxy = _proxy()
+        try:
+            await proxy._observe_json_usage(
+                body={
+                    "model": "gpt-current",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+                provider="openai",
+                request_id="attributed-request",
+                payload={
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 2,
+                    }
+                },
+                usage_dimensions={
+                    "team": "platform",
+                    "project": "gateway",
+                    "tool": "agent",
+                },
+            )
+            assert proxy._usage_ledger.summary(team="platform")["requests"] == 1
+            event = proxy._usage_ledger.get("attributed-request")
+            assert event is not None
+            assert event.project == "gateway"
+            assert event.tool == "agent"
+        finally:
+            proxy._usage_ledger.close()
+
+    asyncio.run(run())

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from entroly.usage_ledger import (
     UsageLedger,
     UsagePricing,
+    UsagePricingCatalog,
     parse_provider_usage,
+    parse_stream_usage,
     price_usage,
 )
 
@@ -82,3 +84,124 @@ def test_ledger_is_durable_and_idempotent(tmp_path) -> None:
         assert summary["requests"] == 1
         assert summary["cache_read_tokens"] == 300
         assert summary["cache_hit_token_ratio"] == 0.6
+
+
+def test_gemini_usage_accepts_camel_case_usage_metadata() -> None:
+    usage = parse_provider_usage(
+        "gemini",
+        {
+            "usageMetadata": {
+                "promptTokenCount": 1_000,
+                "cachedContentTokenCount": 700,
+                "candidatesTokenCount": 80,
+            }
+        },
+    )
+
+    assert usage.uncached_input_tokens == 300
+    assert usage.cache_read_tokens == 700
+    assert usage.output_tokens == 80
+
+
+def test_stream_usage_reads_openai_terminal_frame() -> None:
+    transcript = (
+        'data: {"id":"x","choices":[{"delta":{"content":"hi"}}]}\n\n'
+        'data: {"id":"x","choices":[],"usage":{"prompt_tokens":1000,'
+        '"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":800}}}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+    usage = parse_stream_usage("openai", transcript)
+
+    assert usage is not None
+    assert usage.uncached_input_tokens == 200
+    assert usage.cache_read_tokens == 800
+    assert usage.output_tokens == 50
+
+
+def test_stream_usage_merges_anthropic_start_and_delta() -> None:
+    transcript = (
+        'data: {"type":"message_start","message":{"usage":{'
+        '"input_tokens":100,"cache_read_input_tokens":900,'
+        '"cache_creation_input_tokens":0,"output_tokens":1}}}\n\n'
+        'data: {"type":"message_delta","usage":{"output_tokens":75}}\n\n'
+    )
+
+    usage = parse_stream_usage("anthropic", transcript)
+
+    assert usage is not None
+    assert usage.uncached_input_tokens == 100
+    assert usage.cache_read_tokens == 900
+    assert usage.output_tokens == 75
+
+
+def test_pricing_catalog_resolves_exact_then_provider_default() -> None:
+    catalog = UsagePricingCatalog.from_mapping(
+        {
+            "source": "contract-2026-q2",
+            "models": {
+                "openai:gpt-test": {
+                    "input_per_million": "10",
+                    "output_per_million": "20",
+                    "cache_read_per_million": "1",
+                },
+                "anthropic:*": {
+                    "input_per_million": "8",
+                    "output_per_million": "16",
+                    "cache_read_per_million": "0.8",
+                    "cache_write_per_million": "10",
+                },
+            },
+        }
+    )
+
+    exact = catalog.resolve("openai", "gpt-test")
+    fallback = catalog.resolve("anthropic", "claude-future")
+
+    assert exact is not None
+    assert exact.input_per_million == 10
+    assert exact.source == "contract-2026-q2:openai:gpt-test"
+    assert fallback is not None
+    assert fallback.cache_write_rate == 10
+    assert catalog.resolve("gemini", "missing") is None
+
+
+def test_duplicate_request_id_rejects_conflicting_usage(tmp_path) -> None:
+    import pytest
+
+    pricing = UsagePricing.from_values(
+        input_per_million=10,
+        cache_read_per_million=1,
+        output_per_million=20,
+        source="catalog-v1",
+    )
+    with UsageLedger(tmp_path / "usage.sqlite3") as ledger:
+        first = ledger.record_provider_payload(
+            request_id="same-request",
+            provider="openai",
+            model="model",
+            payload={"usage": {"prompt_tokens": 100, "completion_tokens": 10}},
+            pricing=pricing,
+        )
+        repeated = ledger.record_provider_payload(
+            request_id="same-request",
+            provider="openai",
+            model="model",
+            payload={"usage": {"prompt_tokens": 100, "completion_tokens": 10}},
+            pricing=pricing,
+        )
+
+        assert repeated == first
+        with pytest.raises(ValueError, match="different provider usage"):
+            ledger.record_provider_payload(
+                request_id="same-request",
+                provider="openai",
+                model="model",
+                payload={
+                    "usage": {
+                        "prompt_tokens": 999,
+                        "completion_tokens": 10,
+                    }
+                },
+                pricing=pricing,
+            )

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -206,6 +206,21 @@ def test_duplicate_request_id_rejects_conflicting_usage(tmp_path) -> None:
                 pricing=pricing,
             )
 
+        with pytest.raises(ValueError, match="different provider usage"):
+            ledger.record_provider_payload(
+                request_id="same-request",
+                provider="openai",
+                model="model",
+                payload={
+                    "usage": {
+                        "prompt_tokens": 100,
+                        "completion_tokens": 10,
+                    }
+                },
+                pricing=pricing,
+                team="different-team",
+            )
+
 
 def test_unpriced_usage_preserves_tokens_and_surfaces_reconciliation_gap() -> None:
     from entroly.usage_ledger import TokenUsage

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -244,3 +244,14 @@ def test_unpriced_usage_preserves_tokens_and_surfaces_reconciliation_gap() -> No
     assert summary["requests"] == 1
     assert summary["cache_read_tokens"] == 900
     assert summary["unpriced_requests"] == 1
+
+
+def test_explicit_zero_cache_write_rate_is_not_replaced() -> None:
+    pricing = UsagePricing.from_values(
+        input_per_million=10,
+        output_per_million=20,
+        cache_read_per_million=1,
+        cache_write_per_million=0,
+    )
+
+    assert pricing.cache_write_rate == 0

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -205,3 +205,27 @@ def test_duplicate_request_id_rejects_conflicting_usage(tmp_path) -> None:
                 },
                 pricing=pricing,
             )
+
+
+def test_unpriced_usage_preserves_tokens_and_surfaces_reconciliation_gap() -> None:
+    from entroly.usage_ledger import TokenUsage
+
+    with UsageLedger() as ledger:
+        event = ledger.record_usage(
+            request_id="unpriced-request",
+            provider="openai",
+            model="future-model",
+            usage=TokenUsage(
+                uncached_input_tokens=100,
+                cache_read_tokens=900,
+                output_tokens=50,
+            ),
+            pricing=None,
+        )
+        summary = ledger.summary()
+
+    assert event.pricing_source == "unpriced:openai:future-model"
+    assert event.cost_micro_usd == 0
+    assert summary["requests"] == 1
+    assert summary["cache_read_tokens"] == 900
+    assert summary["unpriced_requests"] == 1


### PR DESCRIPTION
## Summary

Releases Entroly 1.0.38 and integrates the audited gateway primitives into the live proxy lifecycle.

- normalizes OpenAI, Anthropic, and Gemini JSON/SSE usage
- records durable, idempotent micro-USD cost events in SQLite
- supports versioned exact/wildcard pricing catalogs
- records unpriced usage without inventing cost
- propagates opt-in trusted team/project/tool attribution
- observes provider-reported cache hits and TTL-bound leases
- gates RAVS swaps on multi-turn cache economics after RAVS safety gates
- routes Gemini URL-embedded model changes correctly
- covers optimized, bypass, recovery, streaming, and catch-all POST paths
- exposes cache and spend metrics from the guarded stats endpoint
- bumps Python, Rust, WASM, npm, plugin, CLI/server, and lockfile versions to 1.0.38

## Safety invariants

- no inferred cache hit is recorded
- duplicate request IDs cannot double-count spend or cache telemetry
- conflicting usage or attribution under one request ID fails closed
- explicit zero cache-write pricing remains zero
- incomplete catalog pricing blocks a catalog-backed RAVS downgrade
- accounting failures do not alter provider responses
- streaming accounting runs only after successful completion
- normal SSE keeps only a bounded terminal accounting tail
- attribution headers are ignored unless the trusted-ingress flag is enabled
- URL-embedded model identifiers reject path injection

## Verification

Final head `324fab9e57686896e51420a287ea5ef6aa3f3ae1` passed:

- Python lint
- Rust tests and Clippy
- single-binary proxy build and end-to-end tests
- pure-Python fallback
- MemoryOS production gate
- wheel build, functional tests, and Python tests on 3.10 through 3.14
- Entroly Cost Check
- Entroly Context Index competitive benchmark

No unresolved review threads.