### PR TITLE
Release 1.0.39 with live canonical provider routing

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/docs/provider-adapter-live-gateway.md
+++ b/docs/provider-adapter-live-gateway.md
@@ -1,0 +1,48 @@
+# Production provider adapter seam
+
+The cache-aware gateway control plane is provider-neutral, while the live proxy receives provider-specific JSON payloads and forwards them to provider-specific endpoints. `entroly/provider_adapters.py` is the boundary between those worlds.
+
+## Adapter responsibilities
+
+The adapter converts supported request bodies into `CanonicalGatewayRequest` for:
+
+- OpenAI Chat Completions
+- OpenAI Responses API
+- Anthropic Messages API
+- Gemini generate and stream-generate endpoints
+
+The canonical view keeps only fields the control plane can reason about safely:
+
+- model
+- messages
+- tools
+- streaming requirement
+- response schema requirement
+- portable attribution metadata
+- vision requirement
+- reasoning-control requirement
+
+It also computes the estimates used by cache-aware routing:
+
+- cacheable prefix tokens
+- new input tokens
+- expected output tokens
+
+## Same-provider routing
+
+If the target provider is unchanged, the live proxy can preserve the original body and replace only the model. `apply_target_same_provider(...)` validates the target and performs that rewrite. For Gemini, the model is validated and rewritten in the `/models/{model}` path segment.
+
+## Cross-provider failover
+
+A cross-provider failover target must not reuse the original provider body. Provider-specific generation controls and tool formats are not interchangeable.
+
+For that reason, cross-provider execution must render from the canonical request using `render_canonical_request(...)`. That renderer emits only portable fields with equivalent semantics. Provider-specific fields are deliberately dropped unless a future explicit adapter implements a verified translation.
+
+## Production invariant
+
+```text
+same provider  -> preserve body + validated model rewrite
+cross provider -> render from canonical request only
+```
+
+This prevents silent semantic drift while still allowing a future enterprise transport layer to execute capability-safe cross-provider failover.

--- a/docs/provider-adapter-live-gateway.md
+++ b/docs/provider-adapter-live-gateway.md
@@ -36,7 +36,7 @@ If the target provider is unchanged, the live proxy can preserve the original bo
 
 A cross-provider failover target must not reuse the original provider body. Provider-specific generation controls and tool formats are not interchangeable.
 
-For that reason, cross-provider execution must render from the canonical request using `render_canonical_request(...)`. That renderer emits only portable fields with equivalent semantics. Provider-specific fields are deliberately dropped unless a future explicit adapter implements a verified translation.
+For that reason, cross-provider execution must render from the canonical request using `render_canonical_request(...)`. The current renderer accepts only text chat with portable system, user, and assistant roles. It fails closed for tools, tool-call history, vision, reasoning controls, and response schemas until a dedicated adapter proves equivalent semantics. Provider-specific controls are never silently dropped.
 
 ## Production invariant
 

--- a/docs/releases/v1.0.39.md
+++ b/docs/releases/v1.0.39.md
@@ -1,0 +1,27 @@
+# Entroly v1.0.39
+
+Entroly v1.0.39 connects the canonical provider adapter seam to live routing.
+
+## Provider adapters
+
+- Canonicalizes OpenAI Chat, OpenAI Responses, Anthropic Messages, and Gemini
+  generate/stream requests before routing.
+- Preserves provider-specific controls for same-provider model changes.
+- Validates Gemini URL-embedded model identifiers and rewrites.
+- Detects streaming, tools, schemas, vision, and reasoning requirements.
+
+## Routing safety
+
+- Applies live RAVS targets through the provider adapter.
+- Keeps requests on the original model when model-level capability
+  compatibility is not proven.
+- Restricts cross-provider rendering to text-only portable chat.
+- Fails closed for unproven tool, tool-history, vision, reasoning, and response
+  schema translations.
+
+## Verification
+
+- Adds provider canonicalization, rendering, injection rejection, and
+  fail-closed translation tests.
+- Retains the v1.0.38 spend ledger, cache-aware routing, redaction, and
+  recoverable compression lifecycle.

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "1.0.38"
+version = "1.0.39"
 dependencies = [
  "entroly-qccr",
  "flate2",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.38"
+version = "1.0.39"
 dependencies = [
  "regex",
  "serde",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "1.0.38"
+version = "1.0.39"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=1.0.38"
+python -m pip install --no-cache-dir -U "entroly-core>=1.0.39"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "1.0.38"
+version = "1.0.39"
 description = "Rust core for Entroly: Context Receipts, deterministic ingestion/ranking, dependency audits, and local context optimization"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-qccr/Cargo.lock
+++ b/entroly-qccr/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.38"
+version = "1.0.39"
 dependencies = [
  "regex",
  "regex-lite",

--- a/entroly-qccr/Cargo.toml
+++ b/entroly-qccr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-qccr"
-version = "1.0.38"
+version = "1.0.39"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.38"
+version = "1.0.39"
 dependencies = [
  "regex-lite",
  "serde",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "1.0.38"
+version = "1.0.39"
 dependencies = [
  "entroly-qccr",
  "flate2",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "1.0.38"
+version = "1.0.39"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Auditable context control plane for AI agents: context receipts, local optimization, MCP, and app SDK helpers. Pure WebAssembly, no Python dependency.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "1.0.38"
+__version__ = "1.0.39"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -50,7 +50,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "1.0.38"
+    __version__ = "1.0.39"
 
 from entroly.config import (
     load_active_tuning_config as _load_active_tuning_config,
@@ -3051,7 +3051,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.38\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.39\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -4220,7 +4220,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.38\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.39\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -4263,7 +4263,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.38\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.39\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -69,7 +69,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "1.0.38"
+    version: str = "1.0.39"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -7,7 +7,7 @@ from importlib import metadata
 from types import ModuleType
 
 
-MIN_ENTROLY_CORE_VERSION = "1.0.38"
+MIN_ENTROLY_CORE_VERSION = "1.0.39"
 QCCR_SYMBOLS = (
     "py_qccr_expand_query",
     "py_qccr_rank_files",

--- a/entroly/npm-alias/package.json
+++ b/entroly/npm-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Compatibility alias for Entroly's Node/WASM runtime. Installs and delegates to entroly-wasm.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "dependencies": {
-    "entroly-wasm": "1.0.38"
+    "entroly-wasm": "1.0.39"
   },
   "repository": {
     "type": "git",

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "NPX bridge for Entroly, an auditable context control plane with MCP tools, Context Receipts, and local optimization for AI agents.",
   "main": "index.js",
   "bin": {

--- a/entroly/provider_adapters.py
+++ b/entroly/provider_adapters.py
@@ -1,0 +1,342 @@
+"""Provider adapters for the production gateway control plane.
+
+The cache-aware control plane is provider-neutral; the live proxy is not.  This
+module is the narrow seam between both worlds.  It converts OpenAI, Anthropic,
+and Gemini request bodies into one canonical shape, and can render a canonical
+request back to a provider body when an enterprise gateway explicitly elects to
+execute a capability-safe failover target.
+
+The adapter is deliberately conservative:
+- it preserves generation controls from the original body only for the same
+  provider;
+- cross-provider rendering only emits portable fields that have equivalent
+  semantics;
+- model identifiers embedded in Gemini URLs are validated before rewrite;
+- opaque provider-specific fields are never silently translated.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .provider_policy import CanonicalGatewayRequest, ProviderTarget
+
+_SAFE_MODEL_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRequestAdapterResult:
+    """Canonical view plus token estimates needed by the router."""
+
+    provider: str
+    canonical: CanonicalGatewayRequest
+    prefix_tokens_estimate: int
+    new_input_tokens_estimate: int
+    expected_output_tokens: int
+
+
+def _text_from_content(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(part for part in (_text_from_content(v) for v in value) if part)
+    if isinstance(value, Mapping):
+        for key in ("text", "content", "input"):
+            nested = value.get(key)
+            if isinstance(nested, (str, list, Mapping)):
+                text = _text_from_content(nested)
+                if text:
+                    return text
+        parts = value.get("parts")
+        if isinstance(parts, list):
+            return _text_from_content(parts)
+        return ""
+    return str(value)
+
+
+def _token_estimate(value: Any) -> int:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+    return max(1, len(raw.encode("utf-8")) // 4)
+
+
+def _has_vision(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        if any(key in value for key in ("image_url", "image", "inline_data", "file_data")):
+            return True
+        mime = value.get("mime_type") or value.get("mimeType")
+        if isinstance(mime, str) and mime.startswith("image/"):
+            return True
+        return any(_has_vision(child) for child in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_has_vision(child) for child in value)
+    return False
+
+
+def _portable_metadata(headers: Mapping[str, str] | None) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    if not headers:
+        return metadata
+    for key, value in headers.items():
+        lower = key.lower()
+        if lower in {"x-request-id", "x-entroly-team", "x-entroly-project", "x-entroly-tool"}:
+            metadata[lower] = str(value)[:256]
+    return metadata
+
+
+def _last_user_text(messages: tuple[Mapping[str, Any], ...]) -> str:
+    for message in reversed(messages):
+        if message.get("role") == "user":
+            return _text_from_content(message.get("content"))
+    return ""
+
+
+def _normalize_openai_messages(body: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    if isinstance(body.get("messages"), list):
+        return tuple(dict(m) for m in body["messages"] if isinstance(m, Mapping))
+
+    # Responses API: preserve a system-like instruction separately and convert
+    # input items into user messages so conversation identity remains stable.
+    messages: list[Mapping[str, Any]] = []
+    instructions = body.get("instructions")
+    if isinstance(instructions, str) and instructions.strip():
+        messages.append({"role": "system", "content": instructions})
+    raw_input = body.get("input")
+    if isinstance(raw_input, str):
+        messages.append({"role": "user", "content": raw_input})
+    elif isinstance(raw_input, list):
+        for item in raw_input:
+            if isinstance(item, Mapping):
+                role = str(item.get("role") or "user")
+                content = item.get("content", item.get("text", ""))
+                messages.append({"role": role, "content": content})
+            elif isinstance(item, str):
+                messages.append({"role": "user", "content": item})
+    return tuple(messages)
+
+
+def _normalize_anthropic_messages(body: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    messages: list[Mapping[str, Any]] = []
+    system = body.get("system")
+    if isinstance(system, str) and system.strip():
+        messages.append({"role": "system", "content": system})
+    raw_messages = body.get("messages")
+    if isinstance(raw_messages, list):
+        messages.extend(dict(m) for m in raw_messages if isinstance(m, Mapping))
+    return tuple(messages)
+
+
+def _normalize_gemini_messages(body: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    messages: list[Mapping[str, Any]] = []
+    system = body.get("systemInstruction")
+    if isinstance(system, Mapping):
+        messages.append({"role": "system", "content": _text_from_content(system)})
+    elif isinstance(system, str) and system.strip():
+        messages.append({"role": "system", "content": system})
+
+    contents = body.get("contents")
+    if isinstance(contents, list):
+        for item in contents:
+            if not isinstance(item, Mapping):
+                continue
+            role = str(item.get("role") or "user")
+            if role == "model":
+                role = "assistant"
+            messages.append({"role": role, "content": item.get("parts", item.get("content", ""))})
+    return tuple(messages)
+
+
+def canonical_request_from_provider_body(
+    provider: str,
+    body: Mapping[str, Any],
+    *,
+    headers: Mapping[str, str] | None = None,
+    path: str = "",
+) -> ProviderRequestAdapterResult:
+    """Convert a provider-specific request body into canonical gateway form."""
+
+    provider = provider.lower()
+    if provider in {"openai", "responses"}:
+        messages = _normalize_openai_messages(body)
+        tools = tuple(dict(t) for t in body.get("tools", ()) if isinstance(t, Mapping)) if isinstance(body.get("tools"), list) else ()
+        schema = None
+        response_format = body.get("response_format")
+        if isinstance(response_format, Mapping) and response_format.get("type") in {"json_schema", "json_object"}:
+            schema = response_format
+        model = str(body.get("model") or "")
+        stream = bool(body.get("stream", False))
+    elif provider == "anthropic":
+        messages = _normalize_anthropic_messages(body)
+        tools = tuple(dict(t) for t in body.get("tools", ()) if isinstance(t, Mapping)) if isinstance(body.get("tools"), list) else ()
+        schema = body.get("response_schema") if isinstance(body.get("response_schema"), Mapping) else None
+        model = str(body.get("model") or "")
+        stream = bool(body.get("stream", False))
+    elif provider == "gemini":
+        messages = _normalize_gemini_messages(body)
+        tools = tuple(dict(t) for t in body.get("tools", ()) if isinstance(t, Mapping)) if isinstance(body.get("tools"), list) else ()
+        generation = body.get("generationConfig") if isinstance(body.get("generationConfig"), Mapping) else {}
+        schema = generation.get("responseSchema") if isinstance(generation, Mapping) else None
+        model = str(body.get("model") or _model_from_gemini_path(path) or "")
+        stream = bool(body.get("stream", False) or "streamGenerateContent" in path)
+    else:
+        raise ValueError(f"unsupported provider: {provider}")
+
+    if not model:
+        raise ValueError("provider request does not identify a model")
+
+    portable_input = {
+        key: body[key]
+        for key in ("system", "systemInstruction", "instructions", "messages", "contents", "input", "tools")
+        if key in body
+    }
+    total_input = _token_estimate(portable_input)
+    new_input = max(1, len(_last_user_text(messages).encode("utf-8")) // 4)
+    prefix = max(0, total_input - new_input)
+
+    expected_output: Any = body.get("max_completion_tokens")
+    if expected_output is None:
+        expected_output = body.get("max_tokens")
+    generation = body.get("generationConfig")
+    if expected_output is None and isinstance(generation, Mapping):
+        expected_output = generation.get("maxOutputTokens")
+    try:
+        output_tokens = max(0, min(int(expected_output or 1024), 1_000_000))
+    except (TypeError, ValueError):
+        output_tokens = 1024
+
+    canonical = CanonicalGatewayRequest(
+        model=model,
+        messages=messages,
+        tools=tools,
+        stream=stream,
+        response_schema=schema if isinstance(schema, Mapping) else None,
+        metadata=_portable_metadata(headers),
+        requires_vision=_has_vision(messages),
+        requires_reasoning=any(key in body for key in ("thinking", "reasoning_effort", "effort")),
+    )
+    return ProviderRequestAdapterResult(
+        provider=provider,
+        canonical=canonical,
+        prefix_tokens_estimate=prefix,
+        new_input_tokens_estimate=new_input,
+        expected_output_tokens=output_tokens,
+    )
+
+
+def _model_from_gemini_path(path: str) -> str:
+    match = re.search(r"/models/([^/:?]+)", path or "")
+    return match.group(1) if match else ""
+
+
+def rewrite_gemini_model_in_url(url: str, model: str) -> str:
+    if not _SAFE_MODEL_RE.fullmatch(model):
+        raise ValueError("invalid URL-embedded model identifier")
+    rewritten, count = re.subn(r"(/models/)[^/:?]+", rf"\g<1>{model}", url, count=1)
+    if count != 1:
+        raise ValueError("Gemini target URL does not contain a model")
+    return rewritten
+
+
+def apply_target_same_provider(
+    *,
+    provider: str,
+    target: ProviderTarget,
+    body: Mapping[str, Any],
+    url: str,
+) -> tuple[dict[str, Any], str]:
+    """Apply a selected target to an existing provider request body.
+
+    This is the safe path for the current live proxy: it can change model within
+    the same provider while preserving all provider-specific generation controls.
+    Cross-provider execution must use ``render_canonical_request`` because it
+    cannot safely reuse opaque provider-specific fields.
+    """
+
+    provider = provider.lower()
+    if target.provider.lower() != provider:
+        raise ValueError("same-provider rewrite received a cross-provider target")
+    if not _SAFE_MODEL_RE.fullmatch(target.model):
+        raise ValueError("invalid model identifier")
+    output = copy.deepcopy(dict(body))
+    if provider == "gemini":
+        output.pop("model", None)
+        return output, rewrite_gemini_model_in_url(url, target.model)
+    output["model"] = target.model
+    return output, url
+
+
+def render_canonical_request(
+    request: CanonicalGatewayRequest,
+    target: ProviderTarget,
+) -> dict[str, Any]:
+    """Render canonical request to a provider body using only portable fields."""
+
+    if not _SAFE_MODEL_RE.fullmatch(target.model):
+        raise ValueError("invalid model identifier")
+    provider = target.provider.lower()
+    messages = [dict(message) for message in request.messages]
+
+    if provider == "openai":
+        body: dict[str, Any] = {
+            "model": target.model,
+            "messages": messages,
+        }
+        if request.tools:
+            body["tools"] = [dict(tool) for tool in request.tools]
+        if request.stream:
+            body["stream"] = True
+        if request.response_schema is not None:
+            body["response_format"] = request.response_schema
+        return body
+
+    if provider == "anthropic":
+        system_parts: list[str] = []
+        anthropic_messages: list[dict[str, Any]] = []
+        for message in messages:
+            if message.get("role") == "system":
+                system_parts.append(_text_from_content(message.get("content")))
+            else:
+                anthropic_messages.append(message)
+        body = {"model": target.model, "messages": anthropic_messages}
+        if system_parts:
+            body["system"] = "\n\n".join(part for part in system_parts if part)
+        if request.tools:
+            body["tools"] = [dict(tool) for tool in request.tools]
+        if request.stream:
+            body["stream"] = True
+        return body
+
+    if provider == "gemini":
+        contents: list[dict[str, Any]] = []
+        system_text = ""
+        for message in messages:
+            role = str(message.get("role") or "user")
+            if role == "system":
+                system_text = (system_text + "\n\n" + _text_from_content(message.get("content"))).strip()
+                continue
+            gemini_role = "model" if role == "assistant" else "user"
+            content = message.get("content", "")
+            parts = content if isinstance(content, list) else [{"text": _text_from_content(content)}]
+            contents.append({"role": gemini_role, "parts": parts})
+        body = {"contents": contents}
+        if system_text:
+            body["systemInstruction"] = {"parts": [{"text": system_text}]}
+        if request.tools:
+            body["tools"] = [dict(tool) for tool in request.tools]
+        return body
+
+    raise ValueError(f"unsupported provider target: {target.provider}")
+
+
+__all__ = [
+    "ProviderRequestAdapterResult",
+    "apply_target_same_provider",
+    "canonical_request_from_provider_body",
+    "render_canonical_request",
+    "rewrite_gemini_model_in_url",
+]

--- a/entroly/provider_adapters.py
+++ b/entroly/provider_adapters.py
@@ -26,6 +26,7 @@ from typing import Any, Mapping
 from .provider_policy import CanonicalGatewayRequest, ProviderTarget
 
 _SAFE_MODEL_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+_SAFE_GEMINI_MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -234,7 +235,7 @@ def _model_from_gemini_path(path: str) -> str:
 
 
 def rewrite_gemini_model_in_url(url: str, model: str) -> str:
-    if not _SAFE_MODEL_RE.fullmatch(model):
+    if not _SAFE_GEMINI_MODEL_RE.fullmatch(model):
         raise ValueError("invalid URL-embedded model identifier")
     rewritten, count = re.subn(r"(/models/)[^/:?]+", rf"\g<1>{model}", url, count=1)
     if count != 1:

--- a/entroly/provider_adapters.py
+++ b/entroly/provider_adapters.py
@@ -274,12 +274,38 @@ def render_canonical_request(
     request: CanonicalGatewayRequest,
     target: ProviderTarget,
 ) -> dict[str, Any]:
-    """Render canonical request to a provider body using only portable fields."""
+    """Render the text-only portable subset of a canonical request.
+
+    Cross-provider transport fails closed until a dedicated adapter proves
+    semantic equivalence for vision, reasoning, schemas, tools, and tool-call
+    history. Dropping those controls would change the request contract.
+    """
 
     if not _SAFE_MODEL_RE.fullmatch(target.model):
         raise ValueError("invalid model identifier")
+    required = request.required_capabilities()
+    if not target.supports(required):
+        raise ValueError("target does not satisfy canonical request capabilities")
+    if request.requires_vision:
+        raise ValueError("cross-provider vision translation is not implemented")
+    if request.requires_reasoning:
+        raise ValueError("cross-provider reasoning translation is not implemented")
+    if request.response_schema is not None:
+        raise ValueError("cross-provider response schema translation is not implemented")
+    if request.tools:
+        raise ValueError("cross-provider tool translation is not implemented")
+
+    messages: list[dict[str, Any]] = []
+    for message in request.messages:
+        role = str(message.get("role") or "")
+        content = message.get("content", "")
+        if role not in {"system", "user", "assistant"}:
+            raise ValueError("cross-provider message role is not portable")
+        if not isinstance(content, str):
+            raise ValueError("cross-provider message content is not text-only")
+        messages.append({"role": role, "content": content})
+
     provider = target.provider.lower()
-    messages = [dict(message) for message in request.messages]
 
     if provider == "openai":
         body: dict[str, Any] = {

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -67,7 +67,16 @@ from .control_plane import (
     plan_request,
     stable_request_fingerprint,
 )
-from .provider_policy import GatewayRedactionPolicy
+from .provider_adapters import (
+    apply_target_same_provider,
+    canonical_request_from_provider_body,
+    rewrite_gemini_model_in_url,
+)
+from .provider_policy import (
+    Capability,
+    GatewayRedactionPolicy,
+    ProviderTarget,
+)
 from .stable_prefix import conversation_anchor
 from .usage_ledger import (
     TokenUsage,
@@ -1556,17 +1565,7 @@ class PromptCompilerProxy:
         """Apply a routed model to providers that encode it in the URL."""
         if provider != "gemini":
             return url
-        if not re.fullmatch(r"[A-Za-z0-9._-]+", model):
-            raise ValueError("invalid URL-embedded model identifier")
-        routed, replacements = re.subn(
-            r"(/models/)[^/:?]+",
-            rf"\g<1>{model}",
-            url,
-            count=1,
-        )
-        if replacements != 1:
-            raise ValueError("Gemini target URL does not contain a model")
-        return routed
+        return rewrite_gemini_model_in_url(url, model)
 
     @staticmethod
     def _routing_token_estimates(
@@ -1856,6 +1855,16 @@ class PromptCompilerProxy:
         request_id = headers.get("x-request-id") or uuid.uuid4().hex[:12]
         usage_dimensions = self._usage_dimensions(headers)
         provider = detect_provider(path, headers, body)
+        gateway_adapter = None
+        try:
+            gateway_adapter = canonical_request_from_provider_body(
+                provider,
+                body,
+                headers=headers,
+                path=path,
+            )
+        except ValueError as exc:
+            logger.debug("Canonical provider adapter unavailable: %s", exc)
         # Authoritative subscription-auth guard — fail fast with actionable guidance
         # before any forwarding, instead of a confusing upstream 401/429.
         _sub_block = self._subscription_guard(provider, headers)
@@ -2316,6 +2325,21 @@ class PromptCompilerProxy:
                                 "RAVS: kept original model because request has model-specific controls"
                             )
 
+                        if gateway_adapter is None:
+                            _ece_blocked = True
+                            logger.info(
+                                "RAVS: kept original model because canonical adaptation failed"
+                            )
+                        elif (
+                            gateway_adapter.canonical.required_capabilities()
+                            - {Capability.CHAT, Capability.STREAMING}
+                        ):
+                            _ece_blocked = True
+                            logger.info(
+                                "RAVS: kept original model because model-level "
+                                "capability compatibility is unproven"
+                            )
+
                         if not _ece_blocked:
                             cache_allows, cache_reason = (
                                 self._cache_economics_allow_ravs(
@@ -2336,13 +2360,19 @@ class PromptCompilerProxy:
                                 )
 
                         if not _ece_blocked:
-                            from .ravs.router import swap_model_in_body
                             _ravs_original_model = _current_model
-                            body = swap_model_in_body(body, decision.recommended_model)
-                            target_url = self._route_target_url(
-                                target_url,
-                                provider,
-                                decision.recommended_model,
+                            target = ProviderTarget(
+                                provider=provider,
+                                model=decision.recommended_model,
+                                capabilities=(
+                                    gateway_adapter.canonical.required_capabilities()
+                                ),
+                            )
+                            body, target_url = apply_target_same_provider(
+                                provider=provider,
+                                target=target,
+                                body=body,
+                                url=target_url,
                             )
                             _ravs_swapped = True
                             logger.info(

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.38"
+version = "1.0.39"
 
 description = "Information-theoretic context optimization with deterministic hallucination detection and suppression. MCP server, HTTP proxy, and Python SDK for AI coding agents."
 readme = "README.md"
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 native = [
-    "entroly-core>=1.0.38,<2",
+    "entroly-core>=1.0.39,<2",
     "mcp>=1.0.0,<2",
 ]
 

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -4722,7 +4722,7 @@ def main():
     try:
         from entroly import __version__ as _version
     except Exception:
-        _version = "1.0.38"
+        _version = "1.0.39"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -2,13 +2,13 @@
 
 The formula in this directory is the canonical source. To make `brew tap juyterman1000/entroly && brew install entroly` work, the formula must live in a separate repo named `juyterman1000/homebrew-entroly`.
 
-Current release example version: `1.0.38`.
+Current release example version: `1.0.39`.
 
 ## Release checklist
 
 1. Copy `packaging/homebrew/entroly.rb` into `juyterman1000/homebrew-entroly/Formula/entroly.rb`.
-2. Set `VER=1.0.38` when preparing this release.
-3. Download the matching PyPI sdist: `entroly-1.0.38.tar.gz`.
+2. Set `VER=1.0.39` when preparing this release.
+3. Download the matching PyPI sdist: `entroly-1.0.39.tar.gz`.
 4. Recalculate the `sha256` for that tarball before publishing the Homebrew tap update.
 5. Verify locally before pushing with `brew install --build-from-source ./Formula/entroly.rb`, `brew test entroly`, and `brew audit --new --strict entroly`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.38"
+version = "1.0.39"
 description = "Auditable context control plane for AI agents: Context Receipts, MCP tools, local optimization, and SDK helpers."
 readme = "README.md"
 license = "Apache-2.0"
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.6.0,<2",
-    "entroly-core>=1.0.38,<2",
+    "entroly-core>=1.0.39,<2",
 ]
 
 [project.optional-dependencies]
@@ -43,7 +43,7 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.38,<2",
+    "entroly-core>=1.0.39,<2",
 ]
 
 [project.scripts]

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Bump version across all Entroly manifests.
 
-Usage: python scripts/bump_version.py 1.0.38
+Usage: python scripts/bump_version.py 1.0.39
 """
 from __future__ import annotations
 import re

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -154,6 +154,11 @@ def test_same_provider_gemini_rewrite_validates_url_embedded_model() -> None:
             "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent",
             "../bad",
         )
+    with pytest.raises(ValueError):
+        rewrite_gemini_model_in_url(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent",
+            "gemini-safe:alternateAction",
+        )
 
 
 def test_cross_provider_same_body_rewrite_is_rejected() -> None:

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import pytest
+
+from entroly.provider_adapters import (
+    apply_target_same_provider,
+    canonical_request_from_provider_body,
+    render_canonical_request,
+    rewrite_gemini_model_in_url,
+)
+from entroly.provider_policy import Capability, ProviderTarget
+
+
+FULL_CAPS = frozenset(
+    {
+        Capability.CHAT,
+        Capability.STREAMING,
+        Capability.TOOLS,
+        Capability.JSON_SCHEMA,
+        Capability.VISION,
+        Capability.REASONING,
+    }
+)
+
+
+def _target(provider: str, model: str) -> ProviderTarget:
+    return ProviderTarget(provider=provider, model=model, capabilities=FULL_CAPS)
+
+
+def test_openai_chat_canonicalization_detects_tools_schema_vision_and_reasoning() -> None:
+    body = {
+        "model": "gpt-4.1",
+        "stream": True,
+        "reasoning_effort": "medium",
+        "max_completion_tokens": 77,
+        "messages": [
+            {"role": "system", "content": "stable policy"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect this"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}},
+                ],
+            },
+        ],
+        "tools": [{"type": "function", "function": {"name": "lookup"}}],
+        "response_format": {"type": "json_schema", "json_schema": {"name": "answer"}},
+    }
+
+    result = canonical_request_from_provider_body(
+        "openai",
+        body,
+        headers={"x-request-id": "req-1", "authorization": "Bearer secret"},
+    )
+
+    assert result.canonical.model == "gpt-4.1"
+    assert result.canonical.stream is True
+    assert result.canonical.tools
+    assert result.canonical.response_schema == body["response_format"]
+    assert result.canonical.requires_vision is True
+    assert result.canonical.requires_reasoning is True
+    assert result.expected_output_tokens == 77
+    assert result.new_input_tokens_estimate > 0
+    assert result.prefix_tokens_estimate >= 0
+    assert result.canonical.metadata == {"x-request-id": "req-1"}
+
+
+def test_openai_responses_api_is_canonicalized_without_losing_instructions() -> None:
+    result = canonical_request_from_provider_body(
+        "openai",
+        {
+            "model": "gpt-4.1-mini",
+            "instructions": "answer as JSON",
+            "input": [
+                {"role": "user", "content": "summarize"},
+                "include action items",
+            ],
+        },
+    )
+
+    assert [m["role"] for m in result.canonical.messages] == ["system", "user", "user"]
+    assert result.canonical.messages[0]["content"] == "answer as JSON"
+    assert result.canonical.messages[-1]["content"] == "include action items"
+
+
+def test_anthropic_system_field_becomes_stable_system_message() -> None:
+    result = canonical_request_from_provider_body(
+        "anthropic",
+        {
+            "model": "claude-sonnet-4-5",
+            "system": "stable enterprise policy",
+            "messages": [{"role": "user", "content": "debug"}],
+            "max_tokens": 123,
+        },
+    )
+
+    assert result.canonical.messages[0] == {
+        "role": "system",
+        "content": "stable enterprise policy",
+    }
+    assert result.canonical.messages[1]["role"] == "user"
+    assert result.expected_output_tokens == 123
+
+
+def test_gemini_path_model_and_streaming_are_canonicalized() -> None:
+    result = canonical_request_from_provider_body(
+        "gemini",
+        {
+            "systemInstruction": {"parts": [{"text": "stable"}]},
+            "contents": [
+                {"role": "user", "parts": [{"text": "hello"}]},
+                {"role": "model", "parts": [{"text": "hi"}]},
+            ],
+            "generationConfig": {
+                "maxOutputTokens": 321,
+                "responseSchema": {"type": "object"},
+            },
+        },
+        path="/v1beta/models/gemini-2.0-flash:streamGenerateContent",
+    )
+
+    assert result.canonical.model == "gemini-2.0-flash"
+    assert result.canonical.stream is True
+    assert result.canonical.messages[0]["role"] == "system"
+    assert result.canonical.messages[2]["role"] == "assistant"
+    assert result.canonical.response_schema == {"type": "object"}
+    assert result.expected_output_tokens == 321
+
+
+def test_same_provider_openai_rewrite_preserves_provider_specific_controls() -> None:
+    body, url = apply_target_same_provider(
+        provider="openai",
+        target=_target("openai", "gpt-4.1-mini"),
+        body={"model": "gpt-4.1", "messages": [], "temperature": 0.2},
+        url="https://api.openai.com/v1/chat/completions",
+    )
+
+    assert body == {"model": "gpt-4.1-mini", "messages": [], "temperature": 0.2}
+    assert url == "https://api.openai.com/v1/chat/completions"
+
+
+def test_same_provider_gemini_rewrite_validates_url_embedded_model() -> None:
+    body, url = apply_target_same_provider(
+        provider="gemini",
+        target=_target("gemini", "gemini-2.0-flash"),
+        body={"contents": []},
+        url="https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent",
+    )
+
+    assert body == {"contents": []}
+    assert "/models/gemini-2.0-flash:generateContent" in url
+    with pytest.raises(ValueError):
+        rewrite_gemini_model_in_url(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent",
+            "../bad",
+        )
+
+
+def test_cross_provider_same_body_rewrite_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        apply_target_same_provider(
+            provider="openai",
+            target=_target("anthropic", "claude-haiku"),
+            body={"model": "gpt-4.1", "messages": []},
+            url="https://api.openai.com/v1/chat/completions",
+        )
+
+
+def test_render_canonical_request_to_anthropic_uses_only_portable_fields() -> None:
+    canonical = canonical_request_from_provider_body(
+        "openai",
+        {
+            "model": "gpt-4.1",
+            "messages": [
+                {"role": "system", "content": "policy"},
+                {"role": "user", "content": "question"},
+            ],
+            "tools": [{"name": "lookup"}],
+            "temperature": 0.99,
+        },
+    ).canonical
+
+    rendered = render_canonical_request(canonical, _target("anthropic", "claude-haiku"))
+
+    assert rendered == {
+        "model": "claude-haiku",
+        "messages": [{"role": "user", "content": "question"}],
+        "system": "policy",
+        "tools": [{"name": "lookup"}],
+    }
+    assert "temperature" not in rendered
+
+
+def test_render_canonical_request_to_gemini_maps_assistant_to_model() -> None:
+    canonical = canonical_request_from_provider_body(
+        "openai",
+        {
+            "model": "gpt-4.1",
+            "messages": [
+                {"role": "system", "content": "policy"},
+                {"role": "assistant", "content": "old answer"},
+                {"role": "user", "content": "next"},
+            ],
+        },
+    ).canonical
+
+    rendered = render_canonical_request(canonical, _target("gemini", "gemini-2.0-flash"))
+
+    assert rendered["systemInstruction"] == {"parts": [{"text": "policy"}]}
+    assert rendered["contents"][0]["role"] == "model"
+    assert rendered["contents"][1]["role"] == "user"
+
+
+def test_canonicalization_fails_without_model() -> None:
+    with pytest.raises(ValueError):
+        canonical_request_from_provider_body("openai", {"messages": []})
+
+
+def test_unsupported_provider_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        canonical_request_from_provider_body("unknown", {"model": "x"})

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -175,7 +175,6 @@ def test_render_canonical_request_to_anthropic_uses_only_portable_fields() -> No
                 {"role": "system", "content": "policy"},
                 {"role": "user", "content": "question"},
             ],
-            "tools": [{"name": "lookup"}],
             "temperature": 0.99,
         },
     ).canonical
@@ -186,9 +185,30 @@ def test_render_canonical_request_to_anthropic_uses_only_portable_fields() -> No
         "model": "claude-haiku",
         "messages": [{"role": "user", "content": "question"}],
         "system": "policy",
-        "tools": [{"name": "lookup"}],
     }
     assert "temperature" not in rendered
+
+
+def test_cross_provider_render_rejects_unproven_tool_translation() -> None:
+    canonical = canonical_request_from_provider_body(
+        "openai",
+        {
+            "model": "gpt-4.1",
+            "messages": [{"role": "user", "content": "use a tool"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        },
+    ).canonical
+
+    with pytest.raises(ValueError, match="tool translation"):
+        render_canonical_request(canonical, _target("anthropic", "claude-haiku"))
 
 
 def test_render_canonical_request_to_gemini_maps_assistant_to_model() -> None:


### PR DESCRIPTION
## Summary

Releases Entroly 1.0.39 and connects the canonical provider adapter seam to the live proxy routing lifecycle.

## Implemented

- Canonicalize OpenAI Chat, OpenAI Responses, Anthropic Messages, and Gemini requests before routing.
- Detect tools, response schemas, streaming, vision, reasoning controls, portable attribution metadata, and routing token estimates.
- Apply same-provider RAVS targets through a validated adapter that preserves provider-specific controls.
- Validate and rewrite Gemini URL-embedded model identifiers.
- Keep requests on the original model when model-level capability compatibility is unproven.
- Restrict cross-provider rendering to text-only portable chat.
- Fail closed for unproven tools, tool-call history, vision, reasoning, and response-schema translations.
- Add focused adapter tests and production invariant documentation.
- Bump Python, Rust, WASM, npm, plugin, CLI/server, and lockfile versions to 1.0.39.

## Production invariants

- Same provider: preserve the original body and apply only a validated model target.
- Cross provider: render only from canonical form.
- Provider-specific controls are never silently dropped.
- Unsupported semantic translation keeps the original route or raises before transport.
- RAVS quality evidence remains the first gate; cache economics and capability compatibility are additional gates.
- Gemini model IDs cannot inject a path or endpoint action delimiter.

## Verification

Final head `ee7b3d0b4be7ddc0b6940a53c087e3c1a8b90ace` passed:

- Python lint
- Rust tests and Clippy
- single-binary proxy build and end-to-end tests
- pure-Python fallback
- MemoryOS production gate
- wheel build, functional tests, and Python tests on 3.10 through 3.14
- Entroly Cost Check
- Entroly Context Index competitive benchmark

No unresolved review threads.