### PR TITLE
Fix P0-P2 session intelligence gaps

### DIFF
--- a/docs/releases/session-intelligence-next.md
+++ b/docs/releases/session-intelligence-next.md
@@ -1,0 +1,25 @@
+# Session intelligence hardening
+
+This draft release note covers the P0/P1/P2 session-intelligence hardening work.
+
+## Added
+
+- Retrieval-adjusted savings in `CompressionRetrievalStore`.
+- Per-span retrieval counts, retrieved token estimates, repeated expansion penalties, and net realized savings.
+- Confidence-tiered savings records via `SavingsTierLedger`.
+- Decision, failure, remaining-task, and modified-path extraction for compaction continuity.
+- Query-conditioned checkpoint scoring with a trust fence.
+- Forecast-only cache retention economics.
+- Behavioral loop telemetry for repeated errors, duplicate tool calls, retry loops, and model-switch churn.
+
+## Invariants
+
+- Gross compression savings are never treated as realized savings after omitted spans are retrieved.
+- Measured, estimated, and opportunity savings remain separate.
+- Checkpoint restoration is scored and fenced; untrusted checkpoints are discounted.
+- Cache retention is forecast-only and does not issue keep-warm network calls.
+- Behavioral telemetry is bounded by a sliding window.
+
+## Validation
+
+- `tests/test_session_intelligence.py` covers P0, P1, and P2 primitives.

--- a/docs/session-intelligence-validation.md
+++ b/docs/session-intelligence-validation.md
@@ -1,0 +1,37 @@
+# Session intelligence validation checklist
+
+Use this checklist before merging the P0/P1/P2 session-intelligence branch.
+
+## P0 retrieval-adjusted savings
+
+- Store a compression receipt with omitted spans.
+- Retrieve one span through `get_span`.
+- Verify `retrieved_tokens` increases.
+- Retrieve the same span again.
+- Verify `repeated_expansion_tokens` increases.
+- Verify `net_realized_saved_tokens < gross_saved_tokens`.
+- Reopen the store from disk and verify counters persist.
+
+## P0 confidence tiers
+
+- Record measured, estimated, and opportunity savings separately.
+- Verify summaries do not merge tiers.
+
+## P1 checkpoint continuity
+
+- Extract a digest from a transcript containing decisions, failures, remaining work, and modified paths.
+- Put that digest under checkpoint metadata key `continuity`.
+- Rank checkpoints for a query.
+- Verify the relevant trusted checkpoint outranks stale or untrusted checkpoints.
+
+## P2 cache retention
+
+- Feed short pause samples to the forecaster.
+- Verify short or long cache retention is selected only when expected savings clears the threshold.
+- Verify `none` is selected when savings is not material.
+
+## P2 behavior loops
+
+- Record duplicate errors, duplicate tool calls, retries, and model switches.
+- Verify the waste report counts each class and computes a positive waste score.
+- Advance time past the configured window and verify old events are evicted.

--- a/docs/session-intelligence.md
+++ b/docs/session-intelligence.md
@@ -1,0 +1,77 @@
+# Session intelligence rollout
+
+This release adds license-clean session intelligence primitives inspired by external optimizer workflows, implemented independently for Entroly.
+
+## P0: retrieval-adjusted savings
+
+`CompressionRetrievalStore` now records when omitted spans are retrieved. Each receipt reports:
+
+- `gross_saved_tokens`
+- `retrieved_tokens`
+- `repeated_expansion_tokens`
+- `net_realized_saved_tokens`
+- `confidence`
+
+This prevents inflated compression claims. A context block that is later re-expanded is netted against savings.
+
+```python
+from entroly.compression_retrieval_store import CompressionRetrievalStore
+
+store = CompressionRetrievalStore(".entroly/compression-store.json")
+summary = store.realized_savings_summary()
+```
+
+## P0: confidence-tiered savings
+
+`SavingsTierLedger` separates savings into three buckets:
+
+- `measured`: provider or retrieval-store backed numbers
+- `estimated`: locally estimated but plausible values
+- `opportunity`: what could be saved if a policy were enabled
+
+These tiers must not be mixed in invoice-grade reporting.
+
+```python
+from entroly.session_intelligence import SavingsTierLedger, RealizedSavingsRecord
+```
+
+## P1: checkpoint relevance and decision preservation
+
+`extract_decision_digest()` extracts compact continuity facts before compaction:
+
+- decisions
+- modified paths
+- failures
+- remaining tasks
+
+`CheckpointRelevanceScorer` ranks checkpoints by query relevance, continuity hits, freshness, coverage, and a trust fence. Untrusted checkpoints are still searchable but heavily discounted.
+
+```python
+from entroly.session_intelligence import extract_decision_digest, CheckpointRelevanceScorer
+```
+
+## P2: forecast-only cache retention
+
+`CacheRetentionForecaster` estimates whether no retention, short retention, or long retention is economically best given observed pause distributions. It deliberately does not issue keep-warm calls. The caller must decide whether a provider-specific retention mechanism is allowed.
+
+```python
+from entroly.session_intelligence import CacheRetentionForecaster
+```
+
+## P2: behavior-loop telemetry
+
+`BehavioralWasteDetector` tracks repeated errors, repeated tool calls, retry loops, and model-switch churn inside a bounded window. The result is a normalized `waste_score` for dashboards and routing diagnostics.
+
+```python
+from entroly.session_intelligence import BehavioralWasteDetector
+```
+
+## Production invariant
+
+Savings are reported in this order of trust:
+
+```text
+invoice-grade provider usage > retrieval-adjusted measured savings > estimated local savings > opportunity savings
+```
+
+External optimizer source code was not copied. These are independent Entroly primitives designed to plug into the existing ELC retrieval store, checkpoint system, cache router, and gateway dashboards.

--- a/entroly/compression_retrieval_store.py
+++ b/entroly/compression_retrieval_store.py
@@ -7,6 +7,9 @@ Headroom-style reversible compression requires two pieces:
 
 This module provides the second piece for Entroly. It is deterministic,
 dependency-free, local-first, and intentionally small enough to audit.
+
+The store also records omitted-span retrievals so Entroly reports net realized
+savings rather than inflated gross compression savings.
 """
 
 from __future__ import annotations
@@ -28,6 +31,18 @@ class StoredSpan:
     content: str
     reason: str = "budget"
     created_ns: int = field(default_factory=time.time_ns)
+    retrieval_count: int = 0
+    retrieved_tokens: int = 0
+    last_retrieved_ns: int = 0
+
+    @property
+    def token_estimate(self) -> int:
+        return _estimate_tokens(self.content)
+
+    def record_retrieval(self, *, tokens: int | None = None, retrieved_ns: int | None = None) -> None:
+        self.retrieval_count += 1
+        self.retrieved_tokens += max(0, self.token_estimate if tokens is None else int(tokens))
+        self.last_retrieved_ns = time.time_ns() if retrieved_ns is None else int(retrieved_ns)
 
     def as_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -42,6 +57,43 @@ class StoredCompression:
     spans: list[StoredSpan]
     metadata: dict[str, object] = field(default_factory=dict)
     created_ns: int = field(default_factory=time.time_ns)
+
+    @property
+    def gross_saved_tokens(self) -> int:
+        return max(0, self.original_tokens - self.compressed_tokens)
+
+    @property
+    def retrieved_tokens(self) -> int:
+        return sum(max(0, span.retrieved_tokens) for span in self.spans)
+
+    @property
+    def repeated_expansion_tokens(self) -> int:
+        return sum(
+            max(0, span.retrieval_count - 1) * span.token_estimate
+            for span in self.spans
+        )
+
+    @property
+    def net_realized_saved_tokens(self) -> int:
+        return max(
+            0,
+            self.gross_saved_tokens
+            - self.retrieved_tokens
+            - self.repeated_expansion_tokens,
+        )
+
+    def savings_record(self) -> dict[str, object]:
+        confidence = str(self.metadata.get("savings_confidence", "measured"))
+        return {
+            "receipt_id": self.receipt_id,
+            "original_tokens": self.original_tokens,
+            "compressed_tokens": self.compressed_tokens,
+            "gross_saved_tokens": self.gross_saved_tokens,
+            "retrieved_tokens": self.retrieved_tokens,
+            "repeated_expansion_tokens": self.repeated_expansion_tokens,
+            "net_realized_saved_tokens": self.net_realized_saved_tokens,
+            "confidence": confidence,
+        }
 
     def as_dict(self) -> dict[str, object]:
         data = asdict(self)
@@ -103,7 +155,7 @@ class CompressionRetrievalStore:
             original_tokens=int(receipt.get("original_tokens", 0)),
             compressed_tokens=int(receipt.get("compressed_tokens", 0)),
             spans=spans,
-            metadata=dict(metadata or {}),
+            metadata={"savings_confidence": "measured", **dict(metadata or {})},
         )
         self._items[receipt_id] = stored
         self._persist()
@@ -112,16 +164,31 @@ class CompressionRetrievalStore:
     def get_receipt(self, receipt_id: str) -> StoredCompression | None:
         return self._items.get(receipt_id)
 
-    def get_span(self, receipt_id: str, span_id: str) -> StoredSpan | None:
+    def get_span(
+        self,
+        receipt_id: str,
+        span_id: str,
+        *,
+        record_retrieval: bool = True,
+    ) -> StoredSpan | None:
         item = self._items.get(receipt_id)
         if item is None:
             return None
         for span in item.spans:
             if span.span_id == span_id:
+                if record_retrieval:
+                    span.record_retrieval()
+                    self._persist()
                 return span
         return None
 
-    def search(self, query: str, *, limit: int = 5) -> list[StoredSpan]:
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        record_retrieval: bool = True,
+    ) -> list[StoredSpan]:
         terms = {part.lower() for part in query.split() if len(part) >= 3}
         scored: list[tuple[int, StoredSpan]] = []
         for item in self._items.values():
@@ -131,7 +198,55 @@ class CompressionRetrievalStore:
                 if score:
                     scored.append((score, span))
         scored.sort(key=lambda pair: (pair[0], pair[1].created_ns), reverse=True)
-        return [span for _score, span in scored[:limit]]
+        spans = [span for _score, span in scored[:limit]]
+        if record_retrieval:
+            for span in spans:
+                span.record_retrieval()
+            if spans:
+                self._persist()
+        return spans
+
+    def realized_savings(self, receipt_id: str) -> dict[str, object] | None:
+        item = self._items.get(receipt_id)
+        if item is None:
+            return None
+        return item.savings_record()
+
+    def realized_savings_summary(self) -> dict[str, object]:
+        records = [item.savings_record() for item in self._items.values()]
+        total = {
+            "receipts": len(records),
+            "gross_saved_tokens": 0,
+            "retrieved_tokens": 0,
+            "repeated_expansion_tokens": 0,
+            "net_realized_saved_tokens": 0,
+            "by_confidence": {},
+        }
+        by_confidence: dict[str, dict[str, int]] = {}
+        for record in records:
+            confidence = str(record["confidence"])
+            bucket = by_confidence.setdefault(
+                confidence,
+                {
+                    "receipts": 0,
+                    "gross_saved_tokens": 0,
+                    "retrieved_tokens": 0,
+                    "repeated_expansion_tokens": 0,
+                    "net_realized_saved_tokens": 0,
+                },
+            )
+            bucket["receipts"] += 1
+            for key in (
+                "gross_saved_tokens",
+                "retrieved_tokens",
+                "repeated_expansion_tokens",
+                "net_realized_saved_tokens",
+            ):
+                value = int(record[key])
+                total[key] = int(total[key]) + value
+                bucket[key] += value
+        total["by_confidence"] = by_confidence
+        return total
 
     def list_receipts(self) -> list[dict[str, object]]:
         return [
@@ -139,6 +254,10 @@ class CompressionRetrievalStore:
                 "receipt_id": item.receipt_id,
                 "original_tokens": item.original_tokens,
                 "compressed_tokens": item.compressed_tokens,
+                "gross_saved_tokens": item.gross_saved_tokens,
+                "retrieved_tokens": item.retrieved_tokens,
+                "repeated_expansion_tokens": item.repeated_expansion_tokens,
+                "net_realized_saved_tokens": item.net_realized_saved_tokens,
                 "span_count": len(item.spans),
                 "created_ns": item.created_ns,
                 "metadata": item.metadata,
@@ -170,6 +289,10 @@ class CompressionRetrievalStore:
         tmp = self.path.with_suffix(self.path.suffix + ".tmp")
         tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
         tmp.replace(self.path)
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len((text or "").encode("utf-8")) // 4)
 
 
 def _sha256_text(text: str) -> str:

--- a/entroly/session_intelligence.py
+++ b/entroly/session_intelligence.py
@@ -1,0 +1,395 @@
+"""Session intelligence primitives for realized savings and continuity.
+
+This module separates exact savings from estimates, nets omitted-span retrievals
+against gross compression savings, scores checkpoints by query relevance, extracts
+compact decision state before compaction, forecasts cache-retention value without
+issuing network calls, and detects repeated waste loops in a bounded window.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Mapping, Sequence
+
+_WORD_RE = re.compile(r"[A-Za-z0-9_./:-]{3,}")
+_DECISION_RE = re.compile(
+    r"(?im)^\s*(?:[-*]\s*)?(?:decision|decided|choose|chosen|selected|use|ship|fix|root cause|remaining|next|todo|failure|failed|blocked)\b[:\-]?\s*(.+)$"
+)
+_PATH_RE = re.compile(r"(?<![A-Za-z0-9_])(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+")
+
+
+class SavingsConfidence(str, Enum):
+    MEASURED = "measured"
+    ESTIMATED = "estimated"
+    OPPORTUNITY = "opportunity"
+
+
+@dataclass(frozen=True, slots=True)
+class RealizedSavingsRecord:
+    receipt_id: str
+    original_tokens: int
+    compressed_tokens: int
+    retrieved_tokens: int = 0
+    repeated_expansion_tokens: int = 0
+    confidence: SavingsConfidence = SavingsConfidence.MEASURED
+
+    @property
+    def gross_saved_tokens(self) -> int:
+        return max(0, self.original_tokens - self.compressed_tokens)
+
+    @property
+    def net_realized_saved_tokens(self) -> int:
+        return max(
+            0,
+            self.gross_saved_tokens
+            - max(0, self.retrieved_tokens)
+            - max(0, self.repeated_expansion_tokens),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_id": self.receipt_id,
+            "original_tokens": self.original_tokens,
+            "compressed_tokens": self.compressed_tokens,
+            "gross_saved_tokens": self.gross_saved_tokens,
+            "retrieved_tokens": self.retrieved_tokens,
+            "repeated_expansion_tokens": self.repeated_expansion_tokens,
+            "net_realized_saved_tokens": self.net_realized_saved_tokens,
+            "confidence": self.confidence.value,
+        }
+
+
+@dataclass(slots=True)
+class SavingsTierLedger:
+    _records: list[RealizedSavingsRecord] = field(default_factory=list)
+
+    def add(self, record: RealizedSavingsRecord) -> None:
+        self._records.append(record)
+
+    def summary(self) -> dict[str, Any]:
+        by_tier = {
+            tier.value: {
+                "records": 0,
+                "gross_saved_tokens": 0,
+                "retrieved_tokens": 0,
+                "repeated_expansion_tokens": 0,
+                "net_realized_saved_tokens": 0,
+            }
+            for tier in SavingsConfidence
+        }
+        for record in self._records:
+            bucket = by_tier[record.confidence.value]
+            bucket["records"] += 1
+            bucket["gross_saved_tokens"] += record.gross_saved_tokens
+            bucket["retrieved_tokens"] += max(0, record.retrieved_tokens)
+            bucket["repeated_expansion_tokens"] += max(0, record.repeated_expansion_tokens)
+            bucket["net_realized_saved_tokens"] += record.net_realized_saved_tokens
+        return {"records": len(self._records), "by_confidence": by_tier}
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionDigest:
+    decisions: tuple[str, ...] = ()
+    modified_paths: tuple[str, ...] = ()
+    failures: tuple[str, ...] = ()
+    remaining_tasks: tuple[str, ...] = ()
+
+    def as_metadata(self) -> dict[str, list[str]]:
+        return {
+            "decisions": list(self.decisions),
+            "modified_paths": list(self.modified_paths),
+            "failures": list(self.failures),
+            "remaining_tasks": list(self.remaining_tasks),
+        }
+
+
+def extract_decision_digest(text: str, *, max_items: int = 12) -> DecisionDigest:
+    decisions: list[str] = []
+    failures: list[str] = []
+    remaining: list[str] = []
+    for match in _DECISION_RE.finditer(text or ""):
+        raw = _clean_line(match.group(0))
+        lower = raw.lower()
+        if any(word in lower for word in ("failure", "failed", "blocked", "root cause")):
+            failures.append(raw)
+        elif any(word in lower for word in ("remaining", "next", "todo")):
+            remaining.append(raw)
+        else:
+            decisions.append(raw)
+    paths = sorted(set(_PATH_RE.findall(text or "")))
+    return DecisionDigest(
+        decisions=tuple(_dedupe(decisions)[:max_items]),
+        modified_paths=tuple(paths[:max_items]),
+        failures=tuple(_dedupe(failures)[:max_items]),
+        remaining_tasks=tuple(_dedupe(remaining)[:max_items]),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointScore:
+    checkpoint_id: str
+    score: float
+    matched_terms: tuple[str, ...]
+    age_seconds: float
+    decision_hits: int
+    path_hits: int
+    is_trusted: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "checkpoint_id": self.checkpoint_id,
+            "score": round(self.score, 6),
+            "matched_terms": list(self.matched_terms),
+            "age_seconds": round(self.age_seconds, 3),
+            "decision_hits": self.decision_hits,
+            "path_hits": self.path_hits,
+            "is_trusted": self.is_trusted,
+        }
+
+
+class CheckpointRelevanceScorer:
+    def __init__(self, *, half_life_seconds: float = 86400.0) -> None:
+        if half_life_seconds <= 0:
+            raise ValueError("half_life_seconds must be positive")
+        self.half_life_seconds = half_life_seconds
+
+    def score(self, checkpoint: Any, query: str, *, now: float | None = None) -> CheckpointScore:
+        timestamp = time.time() if now is None else float(now)
+        created = float(getattr(checkpoint, "timestamp", timestamp) or timestamp)
+        age = max(0.0, timestamp - created)
+        terms = _terms(query)
+        metadata = getattr(checkpoint, "metadata", {}) or {}
+        stats = getattr(checkpoint, "stats", {}) or {}
+        fragments = getattr(checkpoint, "fragments", []) or []
+        text_parts: list[str] = []
+        for key in ("task", "query", "summary", "current_step"):
+            value = metadata.get(key)
+            if value:
+                text_parts.append(str(value))
+        continuity = metadata.get("continuity")
+        if isinstance(continuity, Mapping):
+            for value in continuity.values():
+                if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                    text_parts.extend(str(item) for item in value)
+                else:
+                    text_parts.append(str(value))
+        for fragment in fragments[:50]:
+            if isinstance(fragment, Mapping):
+                text_parts.append(str(fragment.get("source", "")))
+                text_parts.append(str(fragment.get("content", ""))[:500])
+        haystack = "\n".join(text_parts).lower()
+        matched = tuple(sorted(term for term in terms if term in haystack))
+        decision_hits = _count_hits(continuity, "decisions", terms)
+        path_hits = _count_hits(continuity, "modified_paths", terms)
+        freshness = 0.5 ** (age / self.half_life_seconds)
+        fragment_strength = min(1.0, math.log1p(len(fragments)) / math.log(101))
+        try:
+            stats_strength = min(1.0, float(stats.get("coverage_pct", 0.0)) / 100.0) if isinstance(stats, Mapping) else 0.0
+        except (TypeError, ValueError):
+            stats_strength = 0.0
+        is_trusted = not bool(metadata.get("untrusted", False))
+        trust = 1.0 if is_trusted else 0.35
+        term_score = len(matched) / max(1, len(terms))
+        continuity_score = min(1.0, 0.2 * decision_hits + 0.25 * path_hits)
+        score = trust * (0.55 * term_score + 0.20 * continuity_score + 0.15 * freshness + 0.05 * fragment_strength + 0.05 * stats_strength)
+        return CheckpointScore(str(getattr(checkpoint, "checkpoint_id", "")), score, matched, age, decision_hits, path_hits, is_trusted)
+
+    def rank(self, checkpoints: Iterable[Any], query: str, *, now: float | None = None, limit: int = 5) -> list[CheckpointScore]:
+        scored = [self.score(checkpoint, query, now=now) for checkpoint in checkpoints]
+        scored.sort(key=lambda item: (item.score, -item.age_seconds, item.checkpoint_id), reverse=True)
+        return scored[: max(0, limit)]
+
+
+@dataclass(frozen=True, slots=True)
+class CacheRetentionOption:
+    name: str
+    ttl_seconds: float
+    write_multiplier: float
+    read_multiplier: float
+
+
+@dataclass(frozen=True, slots=True)
+class CacheRetentionDecision:
+    selected: str
+    expected_cost_usd: Mapping[str, float]
+    expected_savings_usd: Mapping[str, float]
+    reason: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "selected": self.selected,
+            "expected_cost_usd": {k: round(v, 9) for k, v in self.expected_cost_usd.items()},
+            "expected_savings_usd": {k: round(v, 9) for k, v in self.expected_savings_usd.items()},
+            "reason": self.reason,
+        }
+
+
+class CacheRetentionForecaster:
+    def __init__(self, options: Iterable[CacheRetentionOption] | None = None) -> None:
+        self.options = tuple(options or (
+            CacheRetentionOption("none", 0.0, 1.0, 1.0),
+            CacheRetentionOption("short", 300.0, 1.0, 0.1),
+            CacheRetentionOption("long", 3600.0, 1.25, 0.1),
+        ))
+        if not self.options:
+            raise ValueError("at least one cache option is required")
+
+    def decide(self, *, prefix_tokens: int, input_price_per_million: float, pause_samples_seconds: Sequence[float], expected_future_turns: int = 1, min_savings_usd: float = 0.0) -> CacheRetentionDecision:
+        if prefix_tokens < 0 or input_price_per_million < 0:
+            raise ValueError("prefix tokens and price must be non-negative")
+        turns = max(1, int(expected_future_turns))
+        pauses = [max(0.0, float(pause)) for pause in pause_samples_seconds] or [float("inf")]
+        base_write = prefix_tokens * input_price_per_million / 1_000_000.0
+        expected_cost: dict[str, float] = {}
+        expected_savings: dict[str, float] = {}
+        for option in self.options:
+            hit_probability = sum(1 for pause in pauses if pause <= option.ttl_seconds) / len(pauses)
+            write_cost = base_write * option.write_multiplier
+            read_cost = base_write * option.read_multiplier * hit_probability * turns
+            miss_cost = base_write * (1.0 - hit_probability) * turns
+            total = write_cost + read_cost + miss_cost
+            no_cache_total = base_write * (1 + turns)
+            expected_cost[option.name] = total
+            expected_savings[option.name] = max(0.0, no_cache_total - total)
+        selected = min(expected_cost, key=lambda name: (expected_cost[name], name))
+        if expected_savings.get(selected, 0.0) < min_savings_usd:
+            selected = "none" if "none" in expected_cost else selected
+            reason = "forecast:no_material_savings"
+        else:
+            reason = "forecast:lowest_expected_cost"
+        return CacheRetentionDecision(selected, expected_cost, expected_savings, reason)
+
+
+@dataclass(frozen=True, slots=True)
+class BehaviorEvent:
+    kind: str
+    key: str
+    timestamp: float = field(default_factory=time.time)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class BehaviorWasteReport:
+    repeated_errors: int
+    repeated_tool_calls: int
+    retry_loops: int
+    model_switch_churn: int
+    total_events: int
+
+    @property
+    def waste_score(self) -> float:
+        weighted = 1.5 * self.repeated_errors + self.repeated_tool_calls + 1.25 * self.retry_loops + 1.25 * self.model_switch_churn
+        return round(min(1.0, weighted / max(1, self.total_events)), 6)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "repeated_errors": self.repeated_errors,
+            "repeated_tool_calls": self.repeated_tool_calls,
+            "retry_loops": self.retry_loops,
+            "model_switch_churn": self.model_switch_churn,
+            "total_events": self.total_events,
+            "waste_score": self.waste_score,
+        }
+
+
+class BehavioralWasteDetector:
+    def __init__(self, *, window_seconds: float = 300.0) -> None:
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self.window_seconds = window_seconds
+        self._events: list[BehaviorEvent] = []
+
+    def record(self, kind: str, key: str, *, timestamp: float | None = None, metadata: Mapping[str, Any] | None = None) -> BehaviorWasteReport:
+        ts = time.time() if timestamp is None else float(timestamp)
+        self._events.append(BehaviorEvent(kind, key, ts, dict(metadata or {})))
+        self._evict(ts)
+        return self.report(now=ts)
+
+    def report(self, *, now: float | None = None) -> BehaviorWasteReport:
+        ts = time.time() if now is None else float(now)
+        self._evict(ts)
+        repeated_errors = _repeat_count(self._events, "error")
+        repeated_tool_calls = _repeat_count(self._events, "tool_call")
+        retry_loops = _repeat_count(self._events, "retry")
+        model_switch_churn = _churn_count([event for event in self._events if event.kind == "model"])
+        return BehaviorWasteReport(repeated_errors, repeated_tool_calls, retry_loops, model_switch_churn, len(self._events))
+
+    def _evict(self, now: float) -> None:
+        cutoff = now - self.window_seconds
+        self._events = [event for event in self._events if event.timestamp >= cutoff]
+
+
+def _terms(text: str) -> set[str]:
+    return {match.group(0).lower() for match in _WORD_RE.finditer(text or "")}
+
+
+def _clean_line(text: str) -> str:
+    return " ".join((text or "").strip().split())[:300]
+
+
+def _dedupe(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        key = item.lower()
+        if key and key not in seen:
+            seen.add(key)
+            result.append(item)
+    return result
+
+
+def _count_hits(continuity: Any, key: str, terms: set[str]) -> int:
+    if not isinstance(continuity, Mapping):
+        return 0
+    values = continuity.get(key, ())
+    if isinstance(values, str):
+        values = (values,)
+    if not isinstance(values, Sequence):
+        return 0
+    count = 0
+    for value in values:
+        lowered = str(value).lower()
+        if any(term in lowered for term in terms):
+            count += 1
+    return count
+
+
+def _repeat_count(events: Sequence[BehaviorEvent], kind: str) -> int:
+    counts: dict[str, int] = {}
+    for event in events:
+        if event.kind == kind:
+            counts[event.key] = counts.get(event.key, 0) + 1
+    return sum(max(0, count - 1) for count in counts.values())
+
+
+def _churn_count(events: Sequence[BehaviorEvent]) -> int:
+    if len(events) < 2:
+        return 0
+    switches = 0
+    previous = events[0].key
+    for event in events[1:]:
+        if event.key != previous:
+            switches += 1
+            previous = event.key
+    return switches
+
+
+__all__ = [
+    "BehaviorEvent",
+    "BehaviorWasteReport",
+    "BehavioralWasteDetector",
+    "CacheRetentionDecision",
+    "CacheRetentionForecaster",
+    "CacheRetentionOption",
+    "CheckpointRelevanceScorer",
+    "CheckpointScore",
+    "DecisionDigest",
+    "RealizedSavingsRecord",
+    "SavingsConfidence",
+    "SavingsTierLedger",
+    "extract_decision_digest",
+]

--- a/tests/test_session_intelligence.py
+++ b/tests/test_session_intelligence.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from entroly.compression_retrieval_store import CompressionRetrievalStore
+from entroly.session_intelligence import (
+    BehavioralWasteDetector,
+    CacheRetentionForecaster,
+    CheckpointRelevanceScorer,
+    RealizedSavingsRecord,
+    SavingsConfidence,
+    SavingsTierLedger,
+    extract_decision_digest,
+)
+
+
+def test_realized_savings_nets_retrieval_and_repeated_expansion() -> None:
+    record = RealizedSavingsRecord(
+        receipt_id="r1",
+        original_tokens=1000,
+        compressed_tokens=300,
+        retrieved_tokens=120,
+        repeated_expansion_tokens=80,
+        confidence=SavingsConfidence.MEASURED,
+    )
+
+    assert record.gross_saved_tokens == 700
+    assert record.net_realized_saved_tokens == 500
+    assert record.as_dict()["confidence"] == "measured"
+
+
+def test_savings_tier_ledger_keeps_measured_estimated_opportunity_separate() -> None:
+    ledger = SavingsTierLedger()
+    ledger.add(RealizedSavingsRecord("measured", 100, 40, confidence=SavingsConfidence.MEASURED))
+    ledger.add(RealizedSavingsRecord("estimated", 100, 50, confidence=SavingsConfidence.ESTIMATED))
+    ledger.add(RealizedSavingsRecord("opportunity", 100, 70, confidence=SavingsConfidence.OPPORTUNITY))
+
+    summary = ledger.summary()
+
+    assert summary["records"] == 3
+    assert summary["by_confidence"]["measured"]["net_realized_saved_tokens"] == 60
+    assert summary["by_confidence"]["estimated"]["net_realized_saved_tokens"] == 50
+    assert summary["by_confidence"]["opportunity"]["net_realized_saved_tokens"] == 30
+
+
+def test_retrieval_store_records_net_realized_savings(tmp_path) -> None:
+    store_path = tmp_path / "compression-store.json"
+    store = CompressionRetrievalStore(store_path)
+    original = "\n".join(f"line {i} important evidence" for i in range(1, 11))
+    stored = store.put(
+        original_text=original,
+        compressed_text="line 1 important evidence\n[omitted]",
+        receipt={
+            "original_tokens": 100,
+            "compressed_tokens": 20,
+            "omitted_spans": [{"start_line": 3, "end_line": 5, "reason": "budget"}],
+        },
+    )
+    span_id = stored.spans[0].span_id
+
+    span = store.get_span(stored.receipt_id, span_id)
+    assert span is not None
+    assert span.retrieval_count == 1
+    again = store.get_span(stored.receipt_id, span_id)
+    assert again is not None
+    assert again.retrieval_count == 2
+
+    realized = store.realized_savings(stored.receipt_id)
+    assert realized is not None
+    assert realized["gross_saved_tokens"] == 80
+    assert realized["retrieved_tokens"] > 0
+    assert realized["repeated_expansion_tokens"] > 0
+    assert realized["net_realized_saved_tokens"] < 80
+
+    reopened = CompressionRetrievalStore(store_path)
+    persisted = reopened.get_span(stored.receipt_id, span_id, record_retrieval=False)
+    assert persisted is not None
+    assert persisted.retrieval_count == 2
+    assert reopened.realized_savings_summary()["receipts"] == 1
+
+
+def test_search_records_retrieved_spans_once_per_result(tmp_path) -> None:
+    store = CompressionRetrievalStore(tmp_path / "store.json")
+    stored = store.put(
+        original_text="alpha beta gamma\nneedle evidence here\nplain tail",
+        compressed_text="alpha beta gamma",
+        receipt={
+            "original_tokens": 60,
+            "compressed_tokens": 15,
+            "omitted_spans": [{"start_line": 2, "end_line": 2}],
+        },
+    )
+
+    hits = store.search("needle", limit=5)
+
+    assert len(hits) == 1
+    assert hits[0].retrieval_count == 1
+    assert store.realized_savings(stored.receipt_id)["retrieved_tokens"] == hits[0].retrieved_tokens
+
+
+def test_extract_decision_digest_preserves_decisions_paths_failures_and_next_tasks() -> None:
+    digest = extract_decision_digest(
+        """
+        Decision: use cache-aware routing before model switch
+        failed: provider returned timeout
+        next: wire ledger into proxy
+        modified entroly/proxy.py and tests/test_proxy.py
+        """
+    )
+
+    assert any("cache-aware routing" in item for item in digest.decisions)
+    assert any("provider returned timeout" in item for item in digest.failures)
+    assert any("wire ledger" in item for item in digest.remaining_tasks)
+    assert "entroly/proxy.py" in digest.modified_paths
+    assert "tests/test_proxy.py" in digest.modified_paths
+
+
+@dataclass
+class FakeCheckpoint:
+    checkpoint_id: str
+    timestamp: float
+    fragments: list[dict]
+    metadata: dict
+    stats: dict
+
+
+def test_checkpoint_relevance_scores_query_and_continuity_with_trust_fence() -> None:
+    scorer = CheckpointRelevanceScorer(half_life_seconds=1000)
+    relevant = FakeCheckpoint(
+        checkpoint_id="relevant",
+        timestamp=1000,
+        fragments=[{"source": "entroly/proxy.py", "content": "cache routing ledger"}],
+        metadata={
+            "continuity": {
+                "decisions": ["Decision: use cache-aware routing"],
+                "modified_paths": ["entroly/proxy.py"],
+            }
+        },
+        stats={"coverage_pct": 80},
+    )
+    stale_untrusted = FakeCheckpoint(
+        checkpoint_id="stale",
+        timestamp=1,
+        fragments=[{"source": "notes.txt", "content": "cache routing ledger"}],
+        metadata={"untrusted": True},
+        stats={},
+    )
+
+    ranked = scorer.rank([stale_untrusted, relevant], "cache routing proxy", now=1100)
+
+    assert ranked[0].checkpoint_id == "relevant"
+    assert ranked[0].is_trusted is True
+    assert ranked[1].is_trusted is False
+
+
+def test_cache_retention_forecaster_selects_long_when_pauses_fit_long_ttl() -> None:
+    decision = CacheRetentionForecaster().decide(
+        prefix_tokens=100_000,
+        input_price_per_million=10.0,
+        pause_samples_seconds=[600, 900, 1200],
+        expected_future_turns=2,
+    )
+
+    assert decision.selected == "long"
+    assert decision.expected_savings_usd["long"] > decision.expected_savings_usd["short"]
+    assert decision.reason == "forecast:lowest_expected_cost"
+
+
+def test_cache_retention_forecaster_returns_none_when_savings_not_material() -> None:
+    decision = CacheRetentionForecaster().decide(
+        prefix_tokens=10,
+        input_price_per_million=0.01,
+        pause_samples_seconds=[10, 20],
+        min_savings_usd=1.0,
+    )
+
+    assert decision.selected == "none"
+    assert decision.reason == "forecast:no_material_savings"
+
+
+def test_behavioral_waste_detector_counts_repeats_and_model_churn() -> None:
+    detector = BehavioralWasteDetector(window_seconds=60)
+    detector.record("error", "timeout", timestamp=10)
+    detector.record("error", "timeout", timestamp=11)
+    detector.record("tool_call", "grep:foo", timestamp=12)
+    detector.record("tool_call", "grep:foo", timestamp=13)
+    detector.record("retry", "request-1", timestamp=14)
+    detector.record("retry", "request-1", timestamp=15)
+    detector.record("model", "gpt-a", timestamp=16)
+    detector.record("model", "gpt-b", timestamp=17)
+    report = detector.record("model", "gpt-a", timestamp=18)
+
+    assert report.repeated_errors == 1
+    assert report.repeated_tool_calls == 1
+    assert report.retry_loops == 1
+    assert report.model_switch_churn == 2
+    assert report.waste_score > 0
+
+
+def test_behavioral_waste_detector_evicts_old_events() -> None:
+    detector = BehavioralWasteDetector(window_seconds=5)
+    detector.record("error", "old", timestamp=1)
+    detector.record("error", "old", timestamp=2)
+    report = detector.record("error", "new", timestamp=10)
+
+    assert report.repeated_errors == 0
+    assert report.total_events == 1


### PR DESCRIPTION
## Summary

Implements the P0/P1/P2 session-intelligence gaps identified from the token-optimizer review, without copying external source code.

## P0

- Track omitted-span retrievals inside `CompressionRetrievalStore`.
- Report gross saved tokens, retrieved tokens, repeated expansion tokens, and net realized saved tokens.
- Preserve retrieval counters across store reloads.
- Add confidence-tiered savings records and summaries.

## P1

- Add decision digest extraction for decisions, failures, remaining tasks, and modified paths.
- Add query-conditioned checkpoint scoring with freshness, continuity hits, coverage, fragment strength, and a trust fence.

## P2

- Add forecast-only cache-retention economics. This does not issue keep-warm calls.
- Add bounded behavioral waste telemetry for repeated errors, repeated tool calls, retry loops, and model-switch churn.

## Validation

- Adds `tests/test_session_intelligence.py` covering all P0/P1/P2 primitives.
- Adds rollout docs, release-note draft, and a validation checklist.

## Notes

The stable public import path is `entroly.session_intelligence`. I avoided a full `entroly/__init__.py` rewrite because that file contains unrelated security text and the connector blocked the replacement. The feature is still directly importable and test-covered.