### PR TITLE
Add receipt proof layer for Context Receipts

### DIFF
--- a/docs/receipt-proof-layer.md
+++ b/docs/receipt-proof-layer.md
@@ -1,0 +1,29 @@
+# Receipt proof layer
+
+This branch adds a small proof layer on top of Context Receipts.
+
+## Included
+
+- `receipt_attestation.py`: signed receipt custody chain.
+- `receipt_merkle.py`: Merkle inclusion and prefix proofs for receipt roots.
+- `receipt_disclosure.py`: salted commitments for opening one provenance atom at a time.
+- `receipt_witness.py`: witness signatures for signed tree heads.
+- `auditable_receipts.py`: facade that records context receipts and returns portable proofs.
+- `examples/demo_receipt_proof.py`: minimal demo.
+
+## Excluded
+
+The uploaded review package also included edits to `cli.py`, `server.py`, `proxy.py`, and self-healing logic. Those are intentionally excluded from this branch because they touch runtime behavior and should be reviewed separately.
+
+## Usage
+
+```python
+from entroly.auditable_receipts import AuditableReceiptLog
+
+log = AuditableReceiptLog(prefer_rust=False)
+recorded = log.record_receipt({"receipt_id": "example", "selected_context": []})
+proof = log.prove(recorded.index)
+assert proof.verify(operator_public_key=log.public_key)
+```
+
+The root package exports are intentionally not changed in this PR. Use explicit module imports.

--- a/entroly/auditable_receipts.py
+++ b/entroly/auditable_receipts.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from entroly.context_receipts import run_receipt_pipeline
+from entroly.receipt_attestation import AttestationKey
+from entroly.receipt_disclosure import ReceiptCommitment
+from entroly.receipt_merkle import ReceiptMerkleLog, verify_inclusion
+
+
+@dataclass(frozen=True)
+class RecordedReceipt:
+    receipt: dict[str, Any]
+    index: int
+
+    @property
+    def receipt_id(self) -> str:
+        return str(self.receipt.get("receipt_id", ""))
+
+
+@dataclass(frozen=True)
+class ReceiptProof:
+    index: int
+    leaf_hex: str
+    audit_path: list[str]
+    tree_size: int
+    root_hash: str
+    operator_signature: str
+    operator_public_key: str
+
+    def verify(self, *, operator_public_key: str | None = None) -> bool:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        if operator_public_key is not None and operator_public_key != self.operator_public_key:
+            return False
+        try:
+            Ed25519PublicKey.from_public_bytes(bytes.fromhex(self.operator_public_key)).verify(
+                bytes.fromhex(self.operator_signature),
+                f"{self.tree_size}|{self.root_hash}".encode(),
+            )
+        except (InvalidSignature, ValueError):
+            return False
+        return verify_inclusion(
+            self.index,
+            self.tree_size,
+            bytes.fromhex(self.leaf_hex),
+            [bytes.fromhex(item) for item in self.audit_path],
+            bytes.fromhex(self.root_hash),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "leaf_hex": self.leaf_hex,
+            "audit_path": list(self.audit_path),
+            "tree_size": self.tree_size,
+            "root_hash": self.root_hash,
+            "operator_signature": self.operator_signature,
+            "operator_public_key": self.operator_public_key,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ReceiptProof":
+        return cls(
+            index=int(data["index"]),
+            leaf_hex=str(data["leaf_hex"]),
+            audit_path=[str(item) for item in data.get("audit_path", [])],
+            tree_size=int(data["tree_size"]),
+            root_hash=str(data["root_hash"]),
+            operator_signature=str(data["operator_signature"]),
+            operator_public_key=str(data["operator_public_key"]),
+        )
+
+
+class AuditableReceiptLog:
+    def __init__(self, key: AttestationKey | None = None, *, prefer_rust: bool = True) -> None:
+        self._key = key or AttestationKey.generate()
+        self._log = ReceiptMerkleLog(self._key)
+        self._prefer_rust = prefer_rust
+
+    @property
+    def public_key(self) -> str:
+        return self._key.public_hex()
+
+    @property
+    def size(self) -> int:
+        return self._log.size
+
+    def record(
+        self,
+        documents: Iterable[tuple[str, str]],
+        *,
+        query: str,
+        token_budget: int,
+        chunk_tokens: int = 360,
+        overlap_tokens: int = 32,
+    ) -> RecordedReceipt:
+        receipt = run_receipt_pipeline(
+            documents,
+            query=query,
+            token_budget=token_budget,
+            chunk_tokens=chunk_tokens,
+            overlap_tokens=overlap_tokens,
+            prefer_rust=self._prefer_rust,
+        )
+        return self.record_receipt(receipt)
+
+    def record_receipt(self, receipt: dict[str, Any]) -> RecordedReceipt:
+        index = self._log.append(receipt)
+        return RecordedReceipt(receipt=receipt, index=index)
+
+    def record_commitment(self, receipt: dict[str, Any]) -> tuple[RecordedReceipt, ReceiptCommitment]:
+        commitment = ReceiptCommitment.from_receipt(receipt)
+        public_receipt = {
+            "receipt_id": receipt.get("receipt_id", ""),
+            "commitment_root": commitment.root_hex(),
+            "schema_version": receipt.get("schema_version", ""),
+            "token_budget": receipt.get("token_budget"),
+            "selected_count": len(receipt.get("selected_context", []) or []),
+            "omitted_count": len(receipt.get("omitted_context", []) or []),
+        }
+        return self.record_receipt(public_receipt), commitment
+
+    def prove(self, index: int) -> ReceiptProof:
+        head = self._log.signed_tree_head()
+        return ReceiptProof(
+            index=index,
+            leaf_hex=self._log.leaf_at(index).hex(),
+            audit_path=[item.hex() for item in self._log.prove_inclusion(index)],
+            tree_size=head.tree_size,
+            root_hash=head.root_hash,
+            operator_signature=head.signature,
+            operator_public_key=head.public_key,
+        )
+
+    def signed_tree_head(self):
+        return self._log.signed_tree_head()
+
+    def consistency_proof(self, old_size: int) -> list[bytes]:
+        return self._log.prove_consistency(old_size)
+
+
+__all__ = ["AuditableReceiptLog", "RecordedReceipt", "ReceiptProof"]

--- a/entroly/receipt_attestation.py
+++ b/entroly/receipt_attestation.py
@@ -1,0 +1,193 @@
+"""Receipt attestation primitives for context receipts.
+
+This module keeps the cryptography optional at import time. When the
+``cryptography`` package is available, receipts can be signed with Ed25519 and
+verified as an append-only hash chain. The chain is useful for local custody;
+Merkle transparency proofs live in ``merkle_transparency``.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from entroly.context_receipts.models import stable_hash
+
+_GENESIS = "0" * 64
+
+
+def _crypto():
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+            Ed25519PublicKey,
+        )
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            NoEncryption,
+            PrivateFormat,
+            PublicFormat,
+        )
+    except ImportError as exc:  # pragma: no cover - optional dependency guard
+        raise RuntimeError("receipt attestation requires cryptography") from exc
+    return (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+        InvalidSignature,
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        PublicFormat,
+    )
+
+
+class AttestationKey:
+    """Ed25519 key wrapper used to sign receipt custody records."""
+
+    def __init__(self, private_key: Any) -> None:
+        self._private_key = private_key
+
+    @classmethod
+    def generate(cls) -> "AttestationKey":
+        return cls(_crypto()[0].generate())
+
+    @classmethod
+    def from_private_hex(cls, value: str) -> "AttestationKey":
+        return cls(_crypto()[0].from_private_bytes(bytes.fromhex(value)))
+
+    def private_hex(self) -> str:
+        _, _, _, encoding, no_encryption, private_format, _ = _crypto()
+        return self._private_key.private_bytes(
+            encoding.Raw, private_format.Raw, no_encryption()
+        ).hex()
+
+    def public_hex(self) -> str:
+        _, _, _, encoding, _, _, public_format = _crypto()
+        return self._private_key.public_key().public_bytes(
+            encoding.Raw, public_format.Raw
+        ).hex()
+
+    def sign(self, message: bytes) -> str:
+        return self._private_key.sign(message).hex()
+
+
+@dataclass(frozen=True)
+class AttestedReceipt:
+    receipt: dict[str, Any]
+    sequence: int
+    prev_hash: str
+    content_hash: str
+    signature: str
+    public_key: str
+    signed_at: float
+
+    def signing_message(self) -> bytes:
+        return f"{self.sequence}|{self.prev_hash}|{self.content_hash}".encode()
+
+    def attestation_hash(self) -> str:
+        return stable_hash(
+            {
+                "sequence": self.sequence,
+                "prev_hash": self.prev_hash,
+                "content_hash": self.content_hash,
+                "signature": self.signature,
+                "public_key": self.public_key,
+                "signed_at": self.signed_at,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AttestedReceipt":
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    valid: bool
+    entries_checked: int
+    broken_at: int | None = None
+    reason: str = ""
+
+
+class AttestationLog:
+    """In-memory append-only hash chain for signed receipts."""
+
+    def __init__(self, key: AttestationKey) -> None:
+        self._key = key
+        self._entries: list[AttestedReceipt] = []
+
+    @property
+    def entries(self) -> list[AttestedReceipt]:
+        return list(self._entries)
+
+    @property
+    def head_hash(self) -> str:
+        return self._entries[-1].attestation_hash() if self._entries else _GENESIS
+
+    def append(self, receipt: dict[str, Any]) -> AttestedReceipt:
+        sequence = len(self._entries)
+        content_hash = stable_hash(receipt)
+        prev_hash = self.head_hash
+        message = f"{sequence}|{prev_hash}|{content_hash}".encode()
+        entry = AttestedReceipt(
+            receipt=receipt,
+            sequence=sequence,
+            prev_hash=prev_hash,
+            content_hash=content_hash,
+            signature=self._key.sign(message),
+            public_key=self._key.public_hex(),
+            signed_at=time.time(),
+        )
+        self._entries.append(entry)
+        return entry
+
+
+def _signature_valid(entry: AttestedReceipt) -> bool:
+    _, public_key_cls, invalid_signature, *_ = _crypto()
+    try:
+        public_key_cls.from_public_bytes(bytes.fromhex(entry.public_key)).verify(
+            bytes.fromhex(entry.signature), entry.signing_message()
+        )
+        return True
+    except (ValueError, invalid_signature):
+        return False
+
+
+def verify_attestation(
+    entry: AttestedReceipt, *, public_key: str | None = None
+) -> bool:
+    if public_key is not None and entry.public_key != public_key:
+        return False
+    if stable_hash(entry.receipt) != entry.content_hash:
+        return False
+    return _signature_valid(entry)
+
+
+def verify_chain(
+    entries: list[AttestedReceipt], *, public_key: str | None = None
+) -> VerificationResult:
+    prev_hash = _GENESIS
+    for index, entry in enumerate(entries):
+        if entry.sequence != index:
+            return VerificationResult(False, index, index, "sequence out of order")
+        if entry.prev_hash != prev_hash:
+            return VerificationResult(False, index, index, "broken previous hash")
+        if not verify_attestation(entry, public_key=public_key):
+            return VerificationResult(False, index, index, "invalid attestation")
+        prev_hash = entry.attestation_hash()
+    return VerificationResult(True, len(entries))
+
+
+__all__ = [
+    "AttestationKey",
+    "AttestedReceipt",
+    "AttestationLog",
+    "VerificationResult",
+    "verify_attestation",
+    "verify_chain",
+]

--- a/entroly/receipt_disclosure.py
+++ b/entroly/receipt_disclosure.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from typing import Any
+
+from entroly.context_receipts.models import stable_json
+from entroly.receipt_merkle import inclusion_proof, leaf_hash, merkle_root, verify_inclusion
+
+
+@dataclass(frozen=True)
+class ProvenanceAtom:
+    kind: str
+    identifier: str
+    content_hash: str
+    status: str
+    detail: str = ""
+
+    def canonical(self) -> bytes:
+        return stable_json(
+            {
+                "kind": self.kind,
+                "identifier": self.identifier,
+                "content_hash": self.content_hash,
+                "status": self.status,
+                "detail": self.detail,
+            }
+        ).encode("utf-8")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "kind": self.kind,
+            "identifier": self.identifier,
+            "content_hash": self.content_hash,
+            "status": self.status,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]) -> "ProvenanceAtom":
+        return cls(
+            str(data["kind"]),
+            str(data["identifier"]),
+            str(data["content_hash"]),
+            str(data["status"]),
+            str(data.get("detail", "")),
+        )
+
+
+def _atom_leaf(atom: ProvenanceAtom, salt_hex: str) -> bytes:
+    return leaf_hash(bytes.fromhex(salt_hex) + atom.canonical())
+
+
+def receipt_atoms(receipt: dict[str, Any]) -> list[ProvenanceAtom]:
+    atoms: list[ProvenanceAtom] = []
+    for chunk in receipt.get("selected_context", []) or []:
+        if isinstance(chunk, dict):
+            atoms.append(
+                ProvenanceAtom(
+                    kind="source",
+                    identifier=str(chunk.get("source_path") or chunk.get("chunk_id") or ""),
+                    content_hash=str(chunk.get("fingerprint") or chunk.get("content_hash") or ""),
+                    status="selected",
+                    detail="; ".join(str(v) for v in (chunk.get("reasons") or [])[:2])[:160],
+                )
+            )
+    for chunk in receipt.get("omitted_context", []) or []:
+        if isinstance(chunk, dict):
+            atoms.append(
+                ProvenanceAtom(
+                    kind="source",
+                    identifier=str(chunk.get("source_path") or chunk.get("chunk_id") or ""),
+                    content_hash=str(chunk.get("fingerprint") or chunk.get("content_hash") or ""),
+                    status="omitted",
+                    detail=str(chunk.get("reason") or "")[:160],
+                )
+            )
+    return atoms
+
+
+@dataclass(frozen=True)
+class AtomDisclosure:
+    atom: ProvenanceAtom
+    salt: str
+    index: int
+    tree_size: int
+    audit_path: list[str]
+    commitment_root: str
+
+    def verify(self, *, commitment_root: str | None = None) -> bool:
+        if commitment_root is not None and commitment_root != self.commitment_root:
+            return False
+        return verify_inclusion(
+            self.index,
+            self.tree_size,
+            _atom_leaf(self.atom, self.salt),
+            [bytes.fromhex(item) for item in self.audit_path],
+            bytes.fromhex(self.commitment_root),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "atom": self.atom.to_dict(),
+            "salt": self.salt,
+            "index": self.index,
+            "tree_size": self.tree_size,
+            "audit_path": list(self.audit_path),
+            "commitment_root": self.commitment_root,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AtomDisclosure":
+        return cls(
+            atom=ProvenanceAtom.from_dict(data["atom"]),
+            salt=str(data["salt"]),
+            index=int(data["index"]),
+            tree_size=int(data["tree_size"]),
+            audit_path=[str(item) for item in data.get("audit_path", [])],
+            commitment_root=str(data["commitment_root"]),
+        )
+
+
+class ReceiptCommitment:
+    def __init__(self, atoms: list[ProvenanceAtom], salts: list[str] | None = None) -> None:
+        self._atoms = list(atoms)
+        self._salts = list(salts) if salts is not None else [secrets.token_bytes(16).hex() for _ in self._atoms]
+        if len(self._atoms) != len(self._salts):
+            raise ValueError("atoms and salts must have the same length")
+        self._leaves = [_atom_leaf(atom, salt) for atom, salt in zip(self._atoms, self._salts)]
+        self._root = merkle_root(self._leaves)
+
+    @classmethod
+    def from_receipt(cls, receipt: dict[str, Any]) -> "ReceiptCommitment":
+        return cls(receipt_atoms(receipt))
+
+    @property
+    def atoms(self) -> list[ProvenanceAtom]:
+        return list(self._atoms)
+
+    def root_hex(self) -> str:
+        return self._root.hex()
+
+    def disclose(self, index: int) -> AtomDisclosure:
+        return AtomDisclosure(
+            atom=self._atoms[index],
+            salt=self._salts[index],
+            index=index,
+            tree_size=len(self._leaves),
+            audit_path=[item.hex() for item in inclusion_proof(self._leaves, index)],
+            commitment_root=self.root_hex(),
+        )
+
+    def disclose_where(self, *, identifier: str | None = None, status: str | None = None) -> list[AtomDisclosure]:
+        result: list[AtomDisclosure] = []
+        for index, atom in enumerate(self._atoms):
+            if identifier is not None and atom.identifier != identifier:
+                continue
+            if status is not None and atom.status != status:
+                continue
+            result.append(self.disclose(index))
+        return result
+
+
+ReceiptDisclosure = ReceiptCommitment
+
+__all__ = [
+    "AtomDisclosure",
+    "ProvenanceAtom",
+    "ReceiptCommitment",
+    "ReceiptDisclosure",
+    "receipt_atoms",
+]

--- a/entroly/receipt_merkle.py
+++ b/entroly/receipt_merkle.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from entroly.context_receipts.models import stable_json
+from entroly.receipt_attestation import AttestationKey
+
+_LEAF = b"\x00"
+_NODE = b"\x01"
+
+
+def _sha(data: bytes) -> bytes:
+    return hashlib.sha256(data).digest()
+
+
+def leaf_hash(data: bytes) -> bytes:
+    return _sha(_LEAF + data)
+
+
+def _node_hash(left: bytes, right: bytes) -> bytes:
+    return _sha(_NODE + left + right)
+
+
+def receipt_leaf(receipt: dict[str, Any]) -> bytes:
+    return leaf_hash(stable_json(receipt).encode("utf-8"))
+
+
+def _split(size: int) -> int:
+    if size <= 1:
+        raise ValueError("size must be greater than one")
+    k = 1
+    while (k << 1) < size:
+        k <<= 1
+    return k
+
+
+def merkle_root(leaves: list[bytes]) -> bytes:
+    size = len(leaves)
+    if size == 0:
+        return _sha(b"")
+    if size == 1:
+        return leaves[0]
+    pivot = _split(size)
+    return _node_hash(merkle_root(leaves[:pivot]), merkle_root(leaves[pivot:]))
+
+
+def inclusion_proof(leaves: list[bytes], index: int) -> list[bytes]:
+    size = len(leaves)
+    if not 0 <= index < size:
+        raise IndexError("index out of range")
+    if size == 1:
+        return []
+    pivot = _split(size)
+    if index < pivot:
+        return inclusion_proof(leaves[:pivot], index) + [merkle_root(leaves[pivot:])]
+    return inclusion_proof(leaves[pivot:], index - pivot) + [merkle_root(leaves[:pivot])]
+
+
+def _rebuild(index: int, size: int, leaf: bytes, proof: list[bytes]) -> bytes:
+    if size == 1:
+        if proof:
+            raise ValueError("proof too long")
+        return leaf
+    pivot = _split(size)
+    sibling = proof.pop()
+    if index < pivot:
+        return _node_hash(_rebuild(index, pivot, leaf, proof), sibling)
+    return _node_hash(sibling, _rebuild(index - pivot, size - pivot, leaf, proof))
+
+
+def verify_inclusion(index: int, size: int, leaf: bytes, proof: list[bytes], root: bytes) -> bool:
+    if not 0 <= index < size:
+        return False
+    try:
+        return _rebuild(index, size, leaf, list(proof)) == root
+    except (IndexError, ValueError):
+        return False
+
+
+def consistency_proof(leaves: list[bytes], old_size: int) -> list[bytes]:
+    size = len(leaves)
+    if not 0 < old_size <= size:
+        raise ValueError("old_size must be in range")
+    if old_size == size:
+        return []
+    return _subproof(old_size, leaves, True)
+
+
+def _subproof(old_size: int, leaves: list[bytes], on_old_path: bool) -> list[bytes]:
+    size = len(leaves)
+    if old_size == size:
+        return [] if on_old_path else [merkle_root(leaves)]
+    pivot = _split(size)
+    if old_size <= pivot:
+        return _subproof(old_size, leaves[:pivot], on_old_path) + [merkle_root(leaves[pivot:])]
+    return _subproof(old_size - pivot, leaves[pivot:], False) + [merkle_root(leaves[:pivot])]
+
+
+def verify_consistency(old_size: int, new_size: int, proof: list[bytes], old_root: bytes, new_root: bytes) -> bool:
+    if old_size < 0 or new_size < 0 or old_size > new_size:
+        return False
+    if old_size == new_size:
+        return old_root == new_root and not proof
+    if old_size == 0:
+        return not proof
+    path = list(proof)
+    if old_size & (old_size - 1) == 0:
+        path = [old_root] + path
+    node = old_size - 1
+    last = new_size - 1
+    while node & 1:
+        node >>= 1
+        last >>= 1
+    if not path:
+        return False
+    old_acc = path[0]
+    new_acc = path[0]
+    for sibling in path[1:]:
+        if last == 0:
+            return False
+        if (node & 1) or node == last:
+            old_acc = _node_hash(sibling, old_acc)
+            new_acc = _node_hash(sibling, new_acc)
+            if not (node & 1):
+                while (node & 1) == 0 and node != 0:
+                    node >>= 1
+                    last >>= 1
+        else:
+            new_acc = _node_hash(new_acc, sibling)
+        node >>= 1
+        last >>= 1
+    return old_acc == old_root and new_acc == new_root and last == 0
+
+
+@dataclass(frozen=True)
+class SignedTreeHead:
+    tree_size: int
+    root_hash: str
+    signature: str
+    public_key: str
+    timestamp: float
+
+    def signing_message(self) -> bytes:
+        return f"{self.tree_size}|{self.root_hash}".encode()
+
+    def verify(self, *, public_key: str | None = None) -> bool:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        if public_key is not None and public_key != self.public_key:
+            return False
+        try:
+            Ed25519PublicKey.from_public_bytes(bytes.fromhex(self.public_key)).verify(bytes.fromhex(self.signature), self.signing_message())
+            return True
+        except (InvalidSignature, ValueError):
+            return False
+
+
+class ReceiptMerkleLog:
+    def __init__(self, key: AttestationKey | None = None) -> None:
+        self._key = key
+        self._leaves: list[bytes] = []
+
+    @property
+    def size(self) -> int:
+        return len(self._leaves)
+
+    def leaf_at(self, index: int) -> bytes:
+        return self._leaves[index]
+
+    def append(self, receipt: dict[str, Any]) -> int:
+        self._leaves.append(receipt_leaf(receipt))
+        return len(self._leaves) - 1
+
+    def root(self) -> bytes:
+        return merkle_root(self._leaves)
+
+    def root_hex(self) -> str:
+        return self.root().hex()
+
+    def prove_inclusion(self, index: int) -> list[bytes]:
+        return inclusion_proof(self._leaves, index)
+
+    def prove_consistency(self, old_size: int) -> list[bytes]:
+        return consistency_proof(self._leaves, old_size)
+
+    def signed_tree_head(self) -> SignedTreeHead:
+        if self._key is None:
+            raise RuntimeError("a signing key is required")
+        root_hex = self.root_hex()
+        message = f"{self.size}|{root_hex}".encode()
+        return SignedTreeHead(self.size, root_hex, self._key.sign(message), self._key.public_hex(), time.time())
+
+
+# Backward-friendly alias for the design package name.
+MerkleTransparencyLog = ReceiptMerkleLog
+
+__all__ = [
+    "SignedTreeHead",
+    "ReceiptMerkleLog",
+    "MerkleTransparencyLog",
+    "leaf_hash",
+    "receipt_leaf",
+    "merkle_root",
+    "inclusion_proof",
+    "verify_inclusion",
+    "consistency_proof",
+    "verify_consistency",
+]

--- a/entroly/receipt_witness.py
+++ b/entroly/receipt_witness.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from entroly.receipt_attestation import AttestationKey
+from entroly.receipt_merkle import SignedTreeHead, verify_consistency
+
+
+class WitnessRejection(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class WitnessSignature:
+    witness_id: str
+    tree_size: int
+    root_hash: str
+    signature: str
+    public_key: str
+
+    def message(self) -> bytes:
+        return f"{self.witness_id}|{self.tree_size}|{self.root_hash}".encode()
+
+    def verify(self) -> bool:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        try:
+            Ed25519PublicKey.from_public_bytes(bytes.fromhex(self.public_key)).verify(
+                bytes.fromhex(self.signature), self.message()
+            )
+            return True
+        except (InvalidSignature, ValueError):
+            return False
+
+
+class ReceiptWitness:
+    def __init__(self, *, name: str = "", key: AttestationKey | None = None) -> None:
+        self._key = key or AttestationKey.generate()
+        self.name = name or self._key.public_hex()[:16]
+        self.witness_id = self.name
+        self._last_size = 0
+        self._last_root = b""
+
+    def cosign(
+        self,
+        head: SignedTreeHead,
+        *,
+        operator_key: str,
+        consistency_proof: list[bytes] | None = None,
+    ) -> WitnessSignature:
+        if not head.verify(public_key=operator_key):
+            raise WitnessRejection("operator signature did not verify")
+        root = bytes.fromhex(head.root_hash)
+        if self._last_size:
+            proof = consistency_proof or []
+            if not verify_consistency(self._last_size, head.tree_size, proof, self._last_root, root):
+                raise WitnessRejection("tree head is not a verified extension")
+        self._last_size = head.tree_size
+        self._last_root = root
+        msg = f"{self.witness_id}|{head.tree_size}|{head.root_hash}".encode()
+        return WitnessSignature(
+            witness_id=self.witness_id,
+            tree_size=head.tree_size,
+            root_hash=head.root_hash,
+            signature=self._key.sign(msg),
+            public_key=self._key.public_hex(),
+        )
+
+
+@dataclass(frozen=True)
+class CosignedTreeHead:
+    head: SignedTreeHead
+    signatures: tuple[WitnessSignature, ...] = field(default_factory=tuple)
+
+    def verify(self, *, operator_key: str, trusted_witnesses: Iterable[str], threshold: int) -> bool:
+        if threshold < 0:
+            return False
+        if not self.head.verify(public_key=operator_key):
+            return False
+        trusted = set(trusted_witnesses)
+        seen: set[str] = set()
+        for signature in self.signatures:
+            if signature.witness_id not in trusted or signature.witness_id in seen:
+                continue
+            if signature.tree_size != self.head.tree_size or signature.root_hash != self.head.root_hash:
+                continue
+            if signature.verify():
+                seen.add(signature.witness_id)
+        return len(seen) >= threshold
+
+
+Witness = ReceiptWitness
+Cosignature = WitnessSignature
+
+__all__ = [
+    "ReceiptWitness",
+    "Witness",
+    "WitnessSignature",
+    "Cosignature",
+    "CosignedTreeHead",
+    "WitnessRejection",
+]

--- a/examples/demo_receipt_proof.py
+++ b/examples/demo_receipt_proof.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from entroly.auditable_receipts import AuditableReceiptLog
+from entroly.receipt_witness import CosignedTreeHead, ReceiptWitness
+
+
+DOCS = [
+    ("contract:section-7", "Indemnification survives termination of the Agreement."),
+    ("contract:section-12", "Total liability is capped at fees paid in the prior year."),
+    ("policy:data", "Customer data remains in EU regions unless approved in writing."),
+]
+
+
+def main() -> None:
+    log = AuditableReceiptLog(prefer_rust=False)
+    recorded = log.record(DOCS, query="does indemnification survive termination", token_budget=40)
+    proof = log.prove(recorded.index)
+    head = log.signed_tree_head()
+    witnesses = [ReceiptWitness(name=f"witness-{idx}") for idx in range(3)]
+    signatures = tuple(w.cosign(head, operator_key=log.public_key) for w in witnesses)
+    cosigned = CosignedTreeHead(head, signatures)
+    trusted = {w.witness_id for w in witnesses}
+
+    print("receipt_id:", recorded.receipt_id)
+    print("tree_size:", proof.tree_size)
+    print("proof_valid:", proof.verify(operator_public_key=log.public_key))
+    print("witness_quorum_valid:", cosigned.verify(operator_key=log.public_key, trusted_witnesses=trusted, threshold=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auditable_receipts_layer.py
+++ b/tests/test_auditable_receipts_layer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from entroly.auditable_receipts import AuditableReceiptLog, ReceiptProof, RecordedReceipt
+from entroly.receipt_attestation import AttestationKey
+
+pytest.importorskip("cryptography")
+
+
+RECEIPT = {
+    "receipt_id": "cr_manual",
+    "selected_context": [{"source_path": "income.pdf", "fingerprint": "sha256:aaa", "reasons": ["match"]}],
+    "omitted_context": [{"source_path": "other.pdf", "fingerprint": "sha256:bbb", "reason": "not relevant"}],
+}
+
+
+def test_recorded_receipt_has_portable_proof() -> None:
+    log = AuditableReceiptLog(prefer_rust=False)
+    recorded = log.record_receipt(RECEIPT)
+    assert isinstance(recorded, RecordedReceipt)
+    proof = log.prove(recorded.index)
+    assert proof.verify(operator_public_key=log.public_key)
+    restored = ReceiptProof.from_dict(proof.to_dict())
+    assert restored.verify(operator_public_key=log.public_key)
+
+
+def test_operator_key_check() -> None:
+    log = AuditableReceiptLog(prefer_rust=False)
+    recorded = log.record_receipt(RECEIPT)
+    proof = log.prove(recorded.index)
+    other = AttestationKey.generate()
+    assert not proof.verify(operator_public_key=other.public_hex())
+
+
+def test_record_commitment_logs_public_summary() -> None:
+    log = AuditableReceiptLog(prefer_rust=False)
+    recorded, commitment = log.record_commitment(RECEIPT)
+    assert recorded.receipt["commitment_root"] == commitment.root_hex()
+    assert recorded.receipt["selected_count"] == 1
+    assert recorded.receipt["omitted_count"] == 1
+    assert log.prove(recorded.index).verify(operator_public_key=log.public_key)

--- a/tests/test_receipt_attestation_layer.py
+++ b/tests/test_receipt_attestation_layer.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from entroly.receipt_attestation import AttestationKey, AttestationLog, verify_attestation, verify_chain
+
+pytest.importorskip("cryptography")
+
+
+def _receipt(index: int = 1) -> dict:
+    return {"receipt_id": f"cr_{index}", "selected_context": ["chunk"], "token_budget": 40}
+
+
+def test_attestation_chain_validates() -> None:
+    key = AttestationKey.generate()
+    log = AttestationLog(key)
+    for idx in range(4):
+        log.append(_receipt(idx))
+    result = verify_chain(log.entries, public_key=key.public_hex())
+    assert result.valid
+    assert result.entries_checked == 4
+
+
+def test_attestation_detects_changed_receipt_body() -> None:
+    key = AttestationKey.generate()
+    log = AttestationLog(key)
+    entry = log.append(_receipt())
+    changed = dataclasses.replace(entry, receipt={**entry.receipt, "token_budget": 999})
+    assert not verify_attestation(changed, public_key=key.public_hex())
+
+
+def test_attestation_rejects_unexpected_key() -> None:
+    key = AttestationKey.generate()
+    other = AttestationKey.generate()
+    entry = AttestationLog(key).append(_receipt())
+    assert verify_attestation(entry, public_key=key.public_hex())
+    assert not verify_attestation(entry, public_key=other.public_hex())

--- a/tests/test_receipt_disclosure_layer.py
+++ b/tests/test_receipt_disclosure_layer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import dataclasses
+
+from entroly.receipt_disclosure import ProvenanceAtom, ReceiptCommitment, receipt_atoms
+
+
+RECEIPT = {
+    "receipt_id": "cr",
+    "selected_context": [
+        {"source_path": "income.pdf", "fingerprint": "sha256:aaa", "reasons": ["match"]},
+    ],
+    "omitted_context": [
+        {"source_path": "protected.pdf", "fingerprint": "sha256:bbb", "reason": "not relevant"},
+    ],
+}
+
+
+def test_receipt_atoms_cover_selected_and_omitted_sources() -> None:
+    atoms = receipt_atoms(RECEIPT)
+    assert {atom.status for atom in atoms} == {"selected", "omitted"}
+    assert {atom.identifier for atom in atoms} == {"income.pdf", "protected.pdf"}
+
+
+def test_disclosure_verifies_for_one_atom() -> None:
+    commitment = ReceiptCommitment.from_receipt(RECEIPT)
+    disclosure = commitment.disclose_where(identifier="protected.pdf")[0]
+    assert disclosure.verify(commitment_root=commitment.root_hex())
+    assert disclosure.atom.identifier == "protected.pdf"
+
+
+def test_disclosure_serialization_roundtrip() -> None:
+    commitment = ReceiptCommitment.from_receipt(RECEIPT)
+    disclosure = commitment.disclose(0)
+    from entroly.receipt_disclosure import AtomDisclosure
+    restored = AtomDisclosure.from_dict(disclosure.to_dict())
+    assert restored.verify(commitment_root=commitment.root_hex())
+
+
+def test_disclosure_is_bound_to_committed_atom() -> None:
+    commitment = ReceiptCommitment.from_receipt(RECEIPT)
+    disclosure = commitment.disclose(0)
+    changed = dataclasses.replace(
+        disclosure,
+        atom=ProvenanceAtom("source", "other.pdf", "sha256:zzz", "selected", ""),
+    )
+    assert not changed.verify(commitment_root=commitment.root_hex())
+
+
+def test_same_atoms_have_different_roots_with_fresh_salts() -> None:
+    assert ReceiptCommitment.from_receipt(RECEIPT).root_hex() != ReceiptCommitment.from_receipt(RECEIPT).root_hex()

--- a/tests/test_receipt_merkle_layer.py
+++ b/tests/test_receipt_merkle_layer.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import hashlib
+
+from entroly.receipt_merkle import (
+    consistency_proof,
+    inclusion_proof,
+    leaf_hash,
+    merkle_root,
+    verify_consistency,
+    verify_inclusion,
+)
+
+
+def _leaves(count: int) -> list[bytes]:
+    return [leaf_hash(f"leaf-{idx}".encode()) for idx in range(count)]
+
+
+def test_roots_match_expected_hashes() -> None:
+    assert merkle_root([]) == hashlib.sha256(b"").digest()
+    one = leaf_hash(b"x")
+    assert merkle_root([one]) == one
+    two = [leaf_hash(b"a"), leaf_hash(b"b")]
+    assert merkle_root(two) == hashlib.sha256(b"\x01" + two[0] + two[1]).digest()
+
+
+def test_inclusion_proofs_for_small_trees() -> None:
+    for count in range(1, 18):
+        leaves = _leaves(count)
+        root = merkle_root(leaves)
+        for index, leaf in enumerate(leaves):
+            proof = inclusion_proof(leaves, index)
+            assert verify_inclusion(index, count, leaf, proof, root)
+            assert not verify_inclusion(index, count, leaf_hash(b"other"), proof, root)
+
+
+def test_consistency_proofs_for_prefixes() -> None:
+    leaves = _leaves(20)
+    new_root = merkle_root(leaves)
+    for old_size in range(1, 20):
+        old_root = merkle_root(leaves[:old_size])
+        proof = consistency_proof(leaves, old_size)
+        assert verify_consistency(old_size, 20, proof, old_root, new_root)
+
+
+def test_consistency_false_for_different_old_root() -> None:
+    leaves = _leaves(20)
+    proof = consistency_proof(leaves, 7)
+    assert not verify_consistency(7, 20, proof, leaf_hash(b"other"), merkle_root(leaves))

--- a/tests/test_receipt_witness_layer.py
+++ b/tests/test_receipt_witness_layer.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from entroly.receipt_attestation import AttestationKey
+from entroly.receipt_merkle import ReceiptMerkleLog
+from entroly.receipt_witness import CosignedTreeHead, ReceiptWitness, WitnessRejection
+
+pytest.importorskip("cryptography")
+
+
+def test_witness_cosigns_valid_extension() -> None:
+    operator = AttestationKey.generate()
+    log = ReceiptMerkleLog(operator)
+    for idx in range(3):
+        log.append({"receipt_id": f"cr_{idx}"})
+    old_head = log.signed_tree_head()
+    witness = ReceiptWitness(name="w1")
+    first = witness.cosign(old_head, operator_key=operator.public_hex())
+    assert first.verify()
+
+    log.append({"receipt_id": "cr_3"})
+    new_head = log.signed_tree_head()
+    second = witness.cosign(
+        new_head,
+        operator_key=operator.public_hex(),
+        consistency_proof=log.prove_consistency(old_head.tree_size),
+    )
+    assert second.verify()
+
+
+def test_witness_requires_valid_extension() -> None:
+    operator = AttestationKey.generate()
+    log = ReceiptMerkleLog(operator)
+    for idx in range(3):
+        log.append({"receipt_id": f"cr_{idx}"})
+    old_head = log.signed_tree_head()
+    witness = ReceiptWitness(name="w1")
+    witness.cosign(old_head, operator_key=operator.public_hex())
+
+    other = ReceiptMerkleLog(operator)
+    for idx in range(4):
+        other.append({"receipt_id": f"different_{idx}"})
+    with pytest.raises(WitnessRejection):
+        witness.cosign(
+            other.signed_tree_head(),
+            operator_key=operator.public_hex(),
+            consistency_proof=other.prove_consistency(old_head.tree_size),
+        )
+
+
+def test_cosigned_threshold() -> None:
+    operator = AttestationKey.generate()
+    log = ReceiptMerkleLog(operator)
+    log.append({"receipt_id": "cr"})
+    head = log.signed_tree_head()
+    witnesses = [ReceiptWitness(name=f"w{idx}") for idx in range(3)]
+    signatures = tuple(w.cosign(head, operator_key=operator.public_hex()) for w in witnesses)
+    cosigned = CosignedTreeHead(head, signatures)
+    trusted = {w.witness_id for w in witnesses}
+    assert cosigned.verify(operator_key=operator.public_hex(), trusted_witnesses=trusted, threshold=2)
+    assert not cosigned.verify(operator_key=operator.public_hex(), trusted_witnesses=trusted, threshold=4)


### PR DESCRIPTION
## Summary

Adds an additive receipt proof layer on top of Context Receipts.

## Added

- `receipt_attestation.py`
- `receipt_merkle.py`
- `receipt_disclosure.py`
- `receipt_witness.py`
- `auditable_receipts.py`
- `examples/demo_receipt_proof.py`
- focused tests
- `docs/receipt-proof-layer.md`

## Scope

This PR does not edit `cli.py`, `server.py`, `proxy.py`, `__init__.py`, release manifests, or package metadata.

## Validation

CI requested. New tests cover receipt signing, Merkle proofs, disclosure commitments, the facade API, and witness quorum checks.