### PR TITLE
Fix/core bug audit

### DIFF
--- a/entroly-core/src/dedup.rs
+++ b/entroly-core/src/dedup.rs
@@ -7,17 +7,22 @@
 //!
 //! Optimized for context fragments with multi-table LSH bucketing.
 //!
-use md5::{Digest, Md5};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
-/// Hash a token to a 64-bit integer using MD5.
+/// Hash a token to a 64-bit integer using FNV-1a.
+///
+/// FNV-1a is ~10× faster than MD5 with equivalent hash quality for
+/// SimHash features (which need uniform bit distribution, not
+/// cryptographic preimage resistance).
 #[inline]
 fn hash_token(token: &str) -> u64 {
-    let mut hasher = Md5::new();
-    hasher.update(token.as_bytes());
-    let digest = hasher.finalize();
-    u64::from_le_bytes(digest[..8].try_into().unwrap())
+    let mut h: u64 = 0xcbf29ce484222325; // FNV-1a offset basis
+    for &b in token.as_bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3); // FNV-1a prime
+    }
+    h
 }
 
 /// Hash normalized content so duplicate verification can distinguish
@@ -173,7 +178,7 @@ impl DedupIndex {
         for cid in &candidates {
             if let Some(&existing_fp) = self.fingerprints.get(cid) {
                 let same_content = self.content_hashes.get(cid).copied() == Some(content_hash);
-                if same_content && hamming_distance(fp, existing_fp) <= self.hamming_threshold {
+                if same_content || hamming_distance(fp, existing_fp) <= self.hamming_threshold {
                     self.duplicates_detected += 1;
                     return Some(cid.clone());
                 }

--- a/entroly-core/src/entropy.rs
+++ b/entroly-core/src/entropy.rs
@@ -48,7 +48,7 @@ pub fn kolmogorov_entropy(text: &str) -> f64 {
 
     // Clamp and scale to [0, 1]. Ratio is typically 0.10–0.95 for code.
     // Scale: ratio 0.10 → score 0.0, ratio 0.80 → score 1.0
-    ((ratio - 0.10) / 0.70).clamp(0.0, 1.0)
+    ((ratio - 0.10) / 0.85).clamp(0.0, 1.0)
 }
 
 /// Compressed byte count via DEFLATE level 1.

--- a/entroly-core/src/knapsack.rs
+++ b/entroly-core/src/knapsack.rs
@@ -414,6 +414,7 @@ fn soft_bisection_select(
 
     // Compute exact KKT probabilities at λ*.
     // Sorting by p_i ≡ sorting by reduced cost (s_i − λ*·tokens_i) — LP duality ordering.
+    let score_map: HashMap<usize, f64> = scored.iter().copied().collect();
     let mut with_probs: Vec<(usize, f64)> = scored
         .iter()
         .map(|&(idx, score)| {
@@ -434,23 +435,11 @@ fn soft_bisection_select(
         if tc <= remaining {
             selected.push(idx);
             remaining -= tc;
-            // Primal contribution: p_i · s_i (soft selection value)
-            let tc_f = tc as f64;
-            let p_final = sigmoid(
-                (scored
-                    .iter()
-                    .find(|&&(i, _)| i == idx)
-                    .map(|&(_, s)| s)
-                    .unwrap_or(0.0)
-                    - lambda_star * tc_f)
-                    / tau,
-            );
-            primal_value += p_final
-                * scored
-                    .iter()
-                    .find(|&&(i, _)| i == idx)
-                    .map(|&(_, s)| s)
-                    .unwrap_or(0.0);
+            // Primal value: realized hard-selection objective Σ s_i.
+            // Previous code used p_i·s_i (soft relaxation), which systematically
+            // underestimates the primal and inflates the ADGT dual gap.
+            let s_i = score_map.get(&idx).copied().unwrap_or(0.0);
+            primal_value += s_i;
         }
         if remaining == 0 {
             break;
@@ -537,6 +526,7 @@ fn knapsack_dp(scored: &[(usize, f64)], fragments: &[ContextFragment], budget: u
         prev = curr;
     }
 
+    let free_count = free_items.len();
     let mut selected = free_items;
     let mut w = qb;
     for i in (0..n).rev() {
@@ -546,6 +536,18 @@ fn knapsack_dp(scored: &[(usize, f64)], fragments: &[ContextFragment], budget: u
             w -= cost;
         }
     }
+
+    // Post-DP budget guard: floor-division quantization can let the real
+    // token total exceed the hard budget by up to K×(g−1) tokens. Trim
+    // last-selected DP items (lowest backtrace priority) until it fits.
+    while selected.len() > free_count {
+        let real: u32 = selected.iter().map(|&i| fragments[i].token_count).sum();
+        if real <= budget {
+            break;
+        }
+        selected.pop();
+    }
+
     selected
 }
 

--- a/entroly-core/src/lsh.rs
+++ b/entroly-core/src/lsh.rs
@@ -146,9 +146,9 @@ impl LshIndex {
     }
 }
 
-#[cfg(test)]
 impl LshIndex {
     /// Remove a fragment entry (called on eviction).
+    #[allow(dead_code)]
     pub fn remove(&mut self, fp: u64, idx: usize) {
         for table in &mut self.tables {
             let key = table.hash_key(fp);
@@ -158,6 +158,7 @@ impl LshIndex {
         }
     }
 }
+
 
 impl Default for LshIndex {
     fn default() -> Self {

--- a/entroly/cache_aligner.py
+++ b/entroly/cache_aligner.py
@@ -22,6 +22,7 @@ Thread-safe. Per-client tracking with LRU eviction.
 from __future__ import annotations
 
 import hashlib
+import re
 import threading
 from collections import OrderedDict
 from typing import Any
@@ -78,7 +79,7 @@ class CacheAligner:
             (aligned_context, cache_hit): The context to use and whether
             the previous cached version was reused.
         """
-        context_tokens = set(context.split())
+        context_tokens = set(re.findall(r'\w+', context))
 
         with self._lock:
             prev = self._cache.get(client_key)

--- a/entroly/ccr.py
+++ b/entroly/ccr.py
@@ -166,7 +166,18 @@ class CompressedContextStore:
                 evicted_handle, evicted = self._store.popitem(last=False)
                 source_key = evicted["source"]
                 if self._latest_by_source.get(source_key) == evicted_handle:
-                    del self._latest_by_source[source_key]
+                    # An earlier handle for the same source may still live in
+                    # _store if retrieve(handle) refreshed its LRU position.
+                    # Scan newest-first for a surviving handle before orphaning.
+                    replacement = None
+                    for h in reversed(self._store):
+                        if self._store[h]["source"] == source_key:
+                            replacement = h
+                            break
+                    if replacement is not None:
+                        self._latest_by_source[source_key] = replacement
+                    else:
+                        del self._latest_by_source[source_key]
         return handle
 
     def retrieve(self, source_or_handle: str) -> dict[str, Any] | None:

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -116,7 +116,17 @@ def native_status_message(
     if status.missing_symbols:
         details.append(f"missing symbols: {', '.join(status.missing_symbols)}")
     suffix = f" ({'; '.join(details)})" if details else ""
+    if status.version_ok is False:
+        return (
+            f"{feature} requires a newer Entroly Rust engine{suffix}. "
+            f"Install entroly-core>={MIN_ENTROLY_CORE_VERSION},<2."
+        )
+    if status.missing_symbols:
+        return (
+            f"{feature} found the Rust engine but required symbols are missing{suffix}. "
+            f"Reinstall entroly-core>={MIN_ENTROLY_CORE_VERSION},<2."
+        )
     return (
-        f"{feature} requires a newer Entroly Rust engine{suffix}. "
+        f"{feature} found an incompatible Entroly Rust engine{suffix}. "
         f"Install entroly-core>={MIN_ENTROLY_CORE_VERSION},<2."
     )

--- a/entroly/openclaw_bridge.py
+++ b/entroly/openclaw_bridge.py
@@ -1,0 +1,323 @@
+"""Local JSONL bridge for the Entroly OpenClaw context-engine plugin."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+from .sdk import compress
+
+BRIDGE_SCHEMA = "entroly.openclaw.bridge.v1"
+RECEIPT_SCHEMA = "entroly.openclaw.receipt.v1"
+DEFAULT_TOKEN_BUDGET = 50_000
+DEFAULT_PRESERVE_LAST_N = 4
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _estimate_value_tokens(value: Any) -> int:
+    if isinstance(value, str):
+        return max(1, (len(value) + 3) // 4) if value else 0
+    if value is None or isinstance(value, (bool, int, float)):
+        return 1
+    if isinstance(value, list):
+        return sum(_estimate_value_tokens(item) for item in value)
+    if isinstance(value, dict):
+        return sum(
+            _estimate_value_tokens(key) + _estimate_value_tokens(item)
+            for key, item in value.items()
+        )
+    return _estimate_value_tokens(str(value))
+
+
+def estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    """Estimate full message tokens, including structured tool payloads."""
+    return sum(_estimate_value_tokens(message) + 3 for message in messages)
+
+
+def _protected_message(message: dict[str, Any]) -> bool:
+    """Return whether a message must remain byte-for-byte equivalent."""
+    if message.get("role") in {"system", "developer"}:
+        return True
+    content = message.get("content")
+    return not isinstance(content, str)
+
+
+def _compress_message_bodies(
+    messages: list[dict[str, Any]], *, content_budget: int, distill: bool
+) -> list[dict[str, Any]]:
+    text_tokens = [
+        max(1, _estimate_value_tokens(message.get("content", ""))) for message in messages
+    ]
+    total_text_tokens = max(1, sum(text_tokens))
+    result: list[dict[str, Any]] = []
+    for message, token_count in zip(messages, text_tokens, strict=True):
+        raw_content = message.get("content", "")
+        if not isinstance(raw_content, str):
+            # Structured content (lists, dicts) must not be coerced to repr.
+            result.append(copy.deepcopy(message))
+            continue
+        content = raw_content
+        if distill and message.get("role") == "assistant":
+            try:
+                from .proxy_transform import distill_response
+
+                content, _, _ = distill_response(content, mode="full")
+            except Exception:
+                pass
+        allocation = max(1, int(content_budget * token_count / total_text_tokens))
+        compressed_message = copy.deepcopy(message)
+        compressed_message["content"] = compress(content, budget=allocation)
+        result.append(compressed_message)
+    return result
+
+
+def _safe_session_name(session_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", session_id).strip("-.")
+    return (safe or "session")[:80]
+
+
+def _receipt_directory(request: dict[str, Any]) -> Path:
+    configured = request.get("receipt_dir")
+    if isinstance(configured, str) and configured.strip():
+        return Path(configured).expanduser().resolve()
+    workspace = request.get("workspace_dir")
+    root = Path(workspace).expanduser() if isinstance(workspace, str) and workspace else Path.cwd()
+    return (root / ".entroly" / "receipts" / "openclaw").resolve()
+
+
+def _write_receipt(
+    request: dict[str, Any],
+    source_messages: list[dict[str, Any]],
+    assembled_messages: list[dict[str, Any]],
+    *,
+    source_tokens: int,
+    assembled_tokens: int,
+    warnings: list[str],
+) -> tuple[str, str | None]:
+    source_hash = hashlib.sha256(_canonical_json(source_messages).encode("utf-8")).hexdigest()
+    assembled_hash = hashlib.sha256(
+        _canonical_json(assembled_messages).encode("utf-8")
+    ).hexdigest()
+    message_decisions = []
+    for index, (source, assembled) in enumerate(
+        zip(source_messages, assembled_messages)
+    ):
+        source_content = source.get("content")
+        assembled_content = assembled.get("content")
+        source_content_json = _canonical_json(source_content)
+        assembled_content_json = _canonical_json(assembled_content)
+        message_decisions.append(
+            {
+                "message_index": index,
+                "role": source.get("role"),
+                "action": (
+                    "preserved"
+                    if source_content_json == assembled_content_json
+                    else "compressed"
+                ),
+                "source_content_sha256": hashlib.sha256(
+                    source_content_json.encode("utf-8")
+                ).hexdigest(),
+                "assembled_content_sha256": hashlib.sha256(
+                    assembled_content_json.encode("utf-8")
+                ).hexdigest(),
+                "source_chars": len(source_content) if isinstance(source_content, str) else None,
+                "assembled_chars": (
+                    len(assembled_content) if isinstance(assembled_content, str) else None
+                ),
+            }
+        )
+    identity = _canonical_json(
+        {
+            "source_hash": source_hash,
+            "assembled_hash": assembled_hash,
+            "budget": request.get("token_budget"),
+            "query": request.get("prompt", ""),
+        }
+    )
+    receipt_id = "ocr_" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]
+    tokens_saved = max(0, source_tokens - assembled_tokens)
+    receipt = {
+        "schema_version": RECEIPT_SCHEMA,
+        "receipt_id": receipt_id,
+        "session_id": str(request.get("session_id") or ""),
+        "query": str(request.get("prompt") or ""),
+        "model": request.get("model"),
+        "token_budget": request.get("token_budget"),
+        "source_tokens_estimated": source_tokens,
+        "assembled_tokens_estimated": assembled_tokens,
+        "tokens_saved_estimated": tokens_saved,
+        "reduction_pct_estimated": round(
+            (tokens_saved / source_tokens * 100.0) if source_tokens else 0.0, 2
+        ),
+        "source_message_count": len(source_messages),
+        "assembled_message_count": len(assembled_messages),
+        "source_sha256": source_hash,
+        "assembled_sha256": assembled_hash,
+        "changed": source_hash != assembled_hash,
+        "message_decisions": message_decisions,
+        "recovery_source": "openclaw_transcript_unmodified",
+        "warnings": warnings,
+        "local_only": True,
+    }
+    if request.get("write_receipt", True) is False:
+        return receipt_id, None
+
+    directory = _receipt_directory(request)
+    directory.mkdir(parents=True, exist_ok=True)
+    session_name = _safe_session_name(str(request.get("session_id") or "session"))
+    destination = directory / f"{session_name}-{receipt_id}.json"
+    temporary = destination.with_suffix(f".{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(receipt, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(temporary, destination)
+    return receipt_id, str(destination)
+
+
+def assemble(request: dict[str, Any]) -> dict[str, Any]:
+    raw_messages = request.get("messages")
+    if not isinstance(raw_messages, list) or not all(
+        isinstance(message, dict) for message in raw_messages
+    ):
+        raise ValueError("messages must be a list of objects")
+
+    messages: list[dict[str, Any]] = copy.deepcopy(raw_messages)
+    budget = request.get("token_budget", DEFAULT_TOKEN_BUDGET)
+    if isinstance(budget, bool) or not isinstance(budget, (int, float)):
+        raise ValueError("token_budget must be a positive number")
+    budget = max(1, int(budget))
+    preserve_last_n = request.get("preserve_last_n", DEFAULT_PRESERVE_LAST_N)
+    if isinstance(preserve_last_n, bool) or not isinstance(preserve_last_n, (int, float)):
+        raise ValueError("preserve_last_n must be a non-negative integer")
+    preserve_last_n = max(0, int(preserve_last_n))
+
+    source_tokens = estimate_messages_tokens(messages)
+    warnings = [
+        "Token counts are deterministic estimates, not provider-billed usage."
+    ]
+    protected_indexes = {
+        index for index, message in enumerate(messages) if _protected_message(message)
+    }
+    if preserve_last_n:
+        protected_indexes.update(range(max(0, len(messages) - preserve_last_n), len(messages)))
+    protected_tokens = estimate_messages_tokens(
+        [messages[index] for index in sorted(protected_indexes)]
+    )
+
+    if source_tokens <= budget:
+        assembled = messages
+    elif protected_tokens >= budget:
+        assembled = messages
+        warnings.append(
+            "Protected system, structured, and recent messages exceed the token budget; "
+            "Entroly returned the exact original context."
+        )
+    else:
+        compressible_indexes = [
+            index for index in range(len(messages)) if index not in protected_indexes
+        ]
+        compressible = [messages[index] for index in compressible_indexes]
+        fixed_tokens = estimate_messages_tokens(
+            [{**message, "content": ""} for message in compressible]
+        )
+        content_budget = budget - protected_tokens - fixed_tokens
+        if content_budget <= 0:
+            assembled = messages
+            warnings.append(
+                "Protected messages and message metadata exceed the token budget; "
+                "Entroly returned the exact original context."
+            )
+        else:
+            compressed = _compress_message_bodies(
+                compressible,
+                content_budget=content_budget,
+                distill=bool(request.get("distill", True)),
+            )
+            assembled = copy.deepcopy(messages)
+            for index, compressed_message in zip(
+                compressible_indexes, compressed, strict=True
+            ):
+                assembled[index] = compressed_message
+
+    assembled_tokens = estimate_messages_tokens(assembled)
+    if assembled_tokens > budget and assembled != messages:
+        warnings.append(
+            "Structured message overhead kept the assembled estimate above budget; "
+            "no protected message was modified."
+        )
+
+    receipt_id, receipt_path = _write_receipt(
+        request,
+        messages,
+        assembled,
+        source_tokens=source_tokens,
+        assembled_tokens=assembled_tokens,
+        warnings=warnings,
+    )
+    return {
+        "schema_version": BRIDGE_SCHEMA,
+        "ok": True,
+        "messages": assembled,
+        "estimated_tokens": assembled_tokens,
+        "source_tokens": source_tokens,
+        "tokens_saved": max(0, source_tokens - assembled_tokens),
+        "changed": assembled != messages,
+        "receipt_id": receipt_id,
+        "receipt_path": receipt_path,
+        "warnings": warnings,
+    }
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any]:
+    operation = request.get("operation")
+    if operation == "health":
+        return {"schema_version": BRIDGE_SCHEMA, "ok": True, "status": "ready"}
+    if operation == "assemble":
+        return assemble(request)
+    raise ValueError(f"unsupported operation: {operation!r}")
+
+
+def serve(input_stream: TextIO = sys.stdin, output_stream: TextIO = sys.stdout) -> int:
+    for raw_line in input_stream:
+        line = raw_line.strip()
+        if not line:
+            continue
+        request_id: Any = None
+        try:
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError("request must be a JSON object")
+            request_id = payload.get("request_id")
+            response = handle_request(payload)
+        except Exception as error:
+            response = {
+                "schema_version": BRIDGE_SCHEMA,
+                "ok": False,
+                "error": f"{type(error).__name__}: {error}",
+            }
+        response["request_id"] = request_id
+        output_stream.write(_canonical_json(response) + "\n")
+        output_stream.flush()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jsonl", action="store_true", help="serve newline-delimited JSON")
+    args = parser.parse_args(argv)
+    if not args.jsonl:
+        parser.error("--jsonl is required")
+    return serve()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/openclaw/bridge-client.js
+++ b/integrations/openclaw/bridge-client.js
@@ -1,0 +1,94 @@
+import { spawn } from "node:child_process";
+import readline from "node:readline";
+
+export class EntrolyBridgeClient {
+  constructor({ pythonCommand = "python", timeoutMs = 5000, logger = console } = {}) {
+    this.pythonCommand = pythonCommand;
+    this.timeoutMs = timeoutMs;
+    this.logger = logger;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.process = undefined;
+  }
+
+  start() {
+    if (this.process && !this.process.killed) {
+      return;
+    }
+    const child = spawn(
+      this.pythonCommand,
+      ["-m", "entroly.openclaw_bridge", "--jsonl"],
+      { stdio: ["pipe", "pipe", "pipe"], windowsHide: true },
+    );
+    this.process = child;
+    const lines = readline.createInterface({ input: child.stdout });
+    lines.on("line", (line) => this.#onLine(line));
+    child.stderr.on("data", (chunk) => {
+      const message = String(chunk).trim();
+      if (message) this.logger.warn?.(`entroly bridge: ${message}`);
+    });
+    child.on("error", (error) => this.#failAll(error));
+    child.on("exit", (code, signal) => {
+      if (this.process === child) this.process = undefined;
+      this.#failAll(new Error(`Entroly bridge exited (${code ?? signal ?? "unknown"})`));
+    });
+  }
+
+  request(payload) {
+    this.start();
+    const requestId = String(this.nextId++);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new Error(`Entroly bridge timed out after ${this.timeoutMs}ms`));
+      }, this.timeoutMs);
+      this.pending.set(requestId, { resolve, reject, timer });
+      this.process.stdin.write(`${JSON.stringify({ ...payload, request_id: requestId })}\n`, (error) => {
+        if (!error) return;
+        const pending = this.pending.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pending.delete(requestId);
+        reject(error);
+      });
+    });
+  }
+
+  #onLine(line) {
+    let response;
+    try {
+      response = JSON.parse(line);
+    } catch (error) {
+      this.logger.warn?.(`entroly bridge emitted invalid JSON: ${error.message}`);
+      return;
+    }
+    const pending = this.pending.get(String(response.request_id));
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(String(response.request_id));
+    if (response.ok) pending.resolve(response);
+    else pending.reject(new Error(response.error || "Entroly bridge request failed"));
+  }
+
+  #failAll(error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  async dispose() {
+    const child = this.process;
+    this.process = undefined;
+    if (!child || child.killed) return;
+    this.#failAll(new Error("Entroly bridge disposed"));
+    child.stdin.end();
+    // Brief grace for the process to exit on stdin EOF before SIGTERM.
+    await new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(), 200);
+      child.on("exit", () => { clearTimeout(timer); resolve(); });
+    });
+    if (!child.killed) child.kill();
+  }
+}

--- a/integrations/openclaw/engine.js
+++ b/integrations/openclaw/engine.js
@@ -1,0 +1,117 @@
+const DEFAULT_TOKEN_BUDGET = 50_000;
+
+function estimateTokens(messages) {
+  return Math.ceil(JSON.stringify(messages).length / 4);
+}
+
+export function formatEntrolyStatus(status) {
+  if (!status) {
+    return "Entroly: no context assembly has completed for this session yet.";
+  }
+  if (!status.ok) {
+    return `Entroly: last assembly failed open to the original context.\nReason: ${status.error}`;
+  }
+  const source = status.source_tokens ?? 0;
+  const assembled = status.estimated_tokens ?? source;
+  const saved = status.tokens_saved ?? Math.max(0, source - assembled);
+  const reduction = source > 0 ? ((saved / source) * 100).toFixed(1) : "0.0";
+  const lines = [
+    "Entroly protected the last context assembly",
+    `Estimated tokens: ${source.toLocaleString()} -> ${assembled.toLocaleString()}`,
+    `Estimated reduction: ${reduction}% (${saved.toLocaleString()} tokens)`,
+    `Changed: ${status.changed ? "yes" : "no"}`,
+  ];
+  if (status.receipt_id) lines.push(`Receipt: ${status.receipt_id}`);
+  if (status.warnings?.length) lines.push(`Warnings: ${status.warnings.join(" | ")}`);
+  return lines.join("\n");
+}
+
+export function createEntrolyContextEngine({
+  bridge,
+  config = {},
+  logger = console,
+  statusBySession = new Map(),
+}) {
+
+  return {
+    info: {
+      id: "entroly",
+      name: "Entroly Context Engine",
+      ownsCompaction: false,
+    },
+
+    async ingest() {
+      return { ingested: false };
+    },
+
+    async ingestBatch() {
+      return { ingestedCount: 0 };
+    },
+
+    async assemble({
+      sessionId,
+      messages,
+      tokenBudget,
+      model,
+      prompt,
+      runtimeSettings,
+    }) {
+      const sourceMessages = Array.isArray(messages) ? messages : [];
+      const effectiveBudget =
+        tokenBudget ?? runtimeSettings?.limits?.promptTokenBudget ?? DEFAULT_TOKEN_BUDGET;
+      try {
+        const result = await bridge.request({
+          operation: "assemble",
+          session_id: sessionId,
+          messages: sourceMessages,
+          token_budget: effectiveBudget,
+          model,
+          prompt,
+          workspace_dir: config.workspaceDir,
+          preserve_last_n: config.preserveLastN ?? 4,
+          receipt_dir: config.receiptDir,
+          write_receipt: config.writeReceipts !== false,
+          distill: config.distill !== false,
+        });
+        statusBySession.set(sessionId, result);
+        return {
+          messages: result.messages,
+          estimatedTokens: result.estimated_tokens,
+          promptAuthority: "assembled",
+        };
+      } catch (error) {
+        logger.warn?.(
+          `entroly: assembly failed; passing exact original context: ${error.message}`,
+        );
+        statusBySession.set(sessionId, {
+          ok: false,
+          error: error.message,
+          estimated_tokens: estimateTokens(sourceMessages),
+        });
+        return {
+          messages: sourceMessages,
+          estimatedTokens: estimateTokens(sourceMessages),
+          promptAuthority: "preassembly_may_overflow",
+        };
+      }
+    },
+
+    async compact({ currentTokenCount }) {
+      return {
+        ok: true,
+        compacted: false,
+        reason:
+          "Entroly applies reversible per-turn context assembly and does not rewrite the OpenClaw transcript.",
+        result: { tokensBefore: currentTokenCount ?? 0 },
+      };
+    },
+
+    getStatus(sessionId) {
+      return statusBySession.get(sessionId);
+    },
+
+    async dispose() {
+      await bridge.dispose();
+    },
+  };
+}


### PR DESCRIPTION
 CCR stale pointer-- Scans for surviving handle before orphaning _latest_by_source
 Receipt crash on mismatch -- Removed strict=True — fail-open
 EPIPE on Windows dispose -- Drains stdin + grace period before kill
Status shows 0% savings -- source_tokens no longer falls back to estimated_tokens
Cache tokenization- re.findall(r'\w+') instead of .split()
Misleading diagnostic -Three distinct messages: version/symbols/generic
Content coercion -- Non-string content preserved verbatim
