### PR TITLE
Add replayable Context Commit proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
   <img src="docs/assets/entroly_wordmark.svg" width="820" alt="Entroly">
 </p>
 
-<p align="center"><b>The local context OS for AI coding agents.</b><br>
-Give Claude, OpenAI, Gemini, Cursor, Codex, and Aider the right evidence with fewer tokens, recoverable context, receipts, memory, gateway controls, and a <b>$0 hallucination guard</b>.</p>
+<p align="center"><b>Know exactly what your AI agent saw.</b><br>
+Entroly creates replayable <b>Context Commits</b>: content-addressed proof of the evidence selected, omitted, and kept recoverable for each model request.</p>
 
 <p align="center">
   <sub>Drop-in for <b>Cursor, Claude Code, Codex, Aider + 34 more</b> and custom providers — 60s, no code changes.</sub>
@@ -35,6 +35,7 @@ Give Claude, OpenAI, Gemini, Cursor, Codex, and Aider the right evidence with fe
   <img src="https://img.shields.io/badge/Token_Savings-workload_dependent-brightgreen" alt="Token savings">
   <img src="https://img.shields.io/badge/Hallucination-HaluEval--QA_0.844_AUROC_·_%240-blueviolet" alt="Hallucination guard">
   <img src="https://img.shields.io/badge/Engine-Rust_+_WASM-orange?logo=rust" alt="Rust + WASM">
+  <img src="https://img.shields.io/badge/Context_Commits-128%2F128_replayed_+_768%2F768_tamper_detected-0A7B83" alt="Context Commit conformance">
 </p>
 
 <p align="center">
@@ -95,7 +96,7 @@ Entroly ships as a full local runtime, not one proxy command:
 
 | Surface | What users get |
 |---|---|
-| **CLI** | `verify-claims`, `simulate`, `perf`, `wrap`, `proxy`, `serve`, `daemon`, `benchmark`, `witness`, `receipt`, `audit`, `doctor`, `health`, `batch`, `learn`, `ravs`, `cache`, and more |
+| **CLI** | `context-commit`, `verify-claims`, `simulate`, `perf`, `wrap`, `proxy`, `serve`, `daemon`, `benchmark`, `witness`, `receipt`, `audit`, `doctor`, `health`, `batch`, `learn`, `ravs`, `cache`, and more |
 | **SDK** | `compress`, `compress_messages`, `optimize`, `verify`, hallucination detection, Context Receipts, localizers, cache alignment, cost cortex, Memory OS |
 | **MCP server** | Context optimization, exact retrieval, receipts, recovery, feedback, security scans, codebase health, smart reads, belief verification, response verification |
 | **Proxy** | Anthropic/OpenAI-compatible local optimization path for API-key users and custom apps |
@@ -215,6 +216,39 @@ If your repo is tiny or already under budget, Entroly should say so and pass thr
 
 ---
 
+## Context Commits
+
+A Context Commit is a portable JSON artifact for the exact context selected for
+an agent request. It binds the ordered selected text, omitted evidence, exact
+recovery data, engine/version identity, and optional parent lineage to one
+content-addressed `ctx_...` identifier.
+
+```bash
+entroly context-commit ./repo --query "Where is token rotation enforced?" \
+  --budget 8000 --out context-commit.json
+entroly context-commit --verify context-commit.json
+```
+
+```python
+from entroly import create_context_commit, replay_context, verify_context_commit
+
+commit = create_context_commit(
+    [("auth.py", open("auth.py", encoding="utf-8").read())],
+    query="Where is token rotation enforced?",
+    token_budget=8000,
+)
+assert verify_context_commit(commit).valid
+exact_context = replay_context(commit)
+```
+
+The artifact is self-contained and therefore may contain source text in its
+recovery bundle. Keep it under the same access and retention policy as the
+source repository. Content addressing proves mutation, not signer identity;
+use Entroly's optional Ed25519 attestation and Merkle-log APIs when custody or
+operator identity matters. [Contract and threat model](docs/context-commits.md).
+
+---
+
 ## Context Receipts
 
 Entroly gives every AI answer a context receipt: what was used, what was omitted, why, and what risks remain. This is built for hard multi-document work such as contracts, policies, addenda, code reviews, and audit evidence where "top-k chunks" is not enough.
@@ -244,6 +278,20 @@ Examples:
 ---
 
 ## Proof
+
+**Context Commit conformance** (synthetic deterministic code fixtures, local,
+no model or network calls):
+
+| Integrity property | Committed result |
+|---|---:|
+| Deterministic replay across Python + Rust modes | **128 / 128** |
+| Exact recovery of omitted chunks | **576 / 576** |
+| Tamper mutations detected | **768 / 768** |
+
+Reproduce: `python -m benchmarks.context_commit_conformance`.
+[Raw JSON](benchmarks/results/context_commit_conformance.json). These numbers
+measure artifact integrity, replay, and recovery on the committed fixtures;
+they do not measure model-answer quality or claim identical Python/Rust selection.
 
 Every number below is reproducible and backed by a committed JSON artifact you can audit — not a screenshot.
 
@@ -497,6 +545,7 @@ This is the important distinction: Entroly does not just remember context. It ca
 | `entroly demo` | Before/after token + cost estimate on your repo |
 | `entroly ingest` | Ingest documents into a local Context Receipt index |
 | `entroly select` | Select context under budget and write a Context Receipt |
+| `entroly context-commit` | Create or verify a replayable, recoverable context artifact |
 | `entroly receipt` | Render a Context Receipt as a Markdown report |
 | `entroly explain` | Explain why a chunk was selected or omitted |
 | `entroly simulate` | Local no-LLM savings estimate with an explicit baseline |

--- a/benchmarks/context_commit_conformance.py
+++ b/benchmarks/context_commit_conformance.py
@@ -1,0 +1,225 @@
+"""Falsification benchmark for the Entroly Context Commit contract."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import platform
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+from entroly.context_commit import (
+    create_context_commit,
+    replay_context,
+    verify_context_commit,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = ROOT / "benchmarks" / "results" / "context_commit_conformance.json"
+
+
+def _case(case_id: int) -> tuple[list[tuple[str, str]], str]:
+    documents: list[tuple[str, str]] = []
+    target_doc = case_id % 6
+    target_window = 15 + (case_id % 17)
+    target_retries = 2 + (case_id % 5)
+    for doc_id in range(6):
+        lines = [f"# Service {doc_id} case {case_id}"]
+        for fact_id in range(12):
+            value = (case_id + 3) * (doc_id + 5) + fact_id
+            lines.append(
+                f"service_{doc_id}_fact_{fact_id} = {value}  # deterministic fixture"
+            )
+        if doc_id == target_doc:
+            lines.extend(
+                [
+                    f"DEPLOYMENT_WINDOW_MINUTES = {target_window}",
+                    f"PAYMENT_RETRY_LIMIT = {target_retries}",
+                    "FAIL_CLOSED_ON_MISSING_EVIDENCE = True",
+                ]
+            )
+        documents.append((f"services/service_{doc_id}.py", "\n".join(lines) + "\n"))
+    query = (
+        f"For service {target_doc}, what are DEPLOYMENT_WINDOW_MINUTES and "
+        "PAYMENT_RETRY_LIMIT?"
+    )
+    return documents, query
+
+
+def _tampered_variants(commit: dict[str, Any]) -> list[dict[str, Any]]:
+    variants: list[dict[str, Any]] = []
+
+    selected = copy.deepcopy(commit)
+    selected_items = selected["receipt"]["selected_context"]
+    if selected_items:
+        selected_items[0]["text"] += "\nTAMPERED = True"
+    else:
+        selected["receipt"]["token_budget"] += 1
+    variants.append(selected)
+
+    recovery = copy.deepcopy(commit)
+    recovery_chunk = next(iter(recovery["recovery_bundle"]["chunks"].values()))
+    recovery_chunk["text"] += "\nTAMPERED = True"
+    variants.append(recovery)
+
+    receipt = copy.deepcopy(commit)
+    receipt["receipt"]["token_budget"] += 1
+    variants.append(receipt)
+
+    engine = copy.deepcopy(commit)
+    engine["engine"]["implementation"] = "tampered"
+    variants.append(engine)
+
+    lineage = copy.deepcopy(commit)
+    lineage["parent_commit_id"] = "not-a-context-commit"
+    variants.append(lineage)
+
+    identity = copy.deepcopy(commit)
+    identity["commit_id"] += "0"
+    variants.append(identity)
+    return variants
+
+
+def _mode_benchmark(cases: int, *, prefer_rust: bool) -> dict[str, Any]:
+    deterministic = 0
+    valid = 0
+    replay_exact = 0
+    omitted = 0
+    recovered = 0
+    tamper_trials = 0
+    tamper_detected = 0
+    artifact_sizes: list[int] = []
+    elapsed_ms: list[float] = []
+    actual_engine = ""
+
+    for case_id in range(cases):
+        documents, query = _case(case_id)
+        started = time.perf_counter()
+        first = create_context_commit(
+            documents,
+            query=query,
+            token_budget=120,
+            chunk_tokens=80,
+            overlap_tokens=12,
+            prefer_rust=prefer_rust,
+        )
+        elapsed_ms.append((time.perf_counter() - started) * 1000)
+        second = create_context_commit(
+            reversed(documents),
+            query=query,
+            token_budget=120,
+            chunk_tokens=80,
+            overlap_tokens=12,
+            prefer_rust=prefer_rust,
+        )
+        actual_engine = str(first["engine"]["implementation"])
+        verification = verify_context_commit(first)
+        valid += int(verification.valid)
+        deterministic += int(first["commit_id"] == second["commit_id"])
+        replay_exact += int(replay_context(first) == first["receipt"]["selected_context"])
+        omitted += verification.omitted_chunks
+        recovered += verification.recovered_omitted_chunks
+        artifact_sizes.append(
+            len(json.dumps(first, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        )
+
+        for tampered in _tampered_variants(first):
+            tamper_trials += 1
+            tamper_detected += int(not verify_context_commit(tampered).valid)
+
+    return {
+        "requested_engine": "rust" if prefer_rust else "python",
+        "actual_engine": actual_engine,
+        "cases": cases,
+        "valid_commits": valid,
+        "deterministic_replays": deterministic,
+        "exact_context_replays": replay_exact,
+        "omitted_chunks": omitted,
+        "exact_omission_recoveries": recovered,
+        "tamper_trials": tamper_trials,
+        "tamper_detections": tamper_detected,
+        "median_create_ms": round(statistics.median(elapsed_ms), 3),
+        "median_artifact_bytes": int(statistics.median(artifact_sizes)),
+    }
+
+
+def run_benchmark(cases: int = 64) -> dict[str, Any]:
+    modes = [_mode_benchmark(cases, prefer_rust=False)]
+    rust = _mode_benchmark(cases, prefer_rust=True)
+    if rust["actual_engine"] == "rust":
+        modes.append(rust)
+
+    total_cases = sum(mode["cases"] for mode in modes)
+    total_omitted = sum(mode["omitted_chunks"] for mode in modes)
+    total_tamper = sum(mode["tamper_trials"] for mode in modes)
+    aggregate = {
+        "engine_modes": len(modes),
+        "cases": total_cases,
+        "valid_commit_rate": sum(mode["valid_commits"] for mode in modes)
+        / max(1, total_cases),
+        "deterministic_replay_rate": sum(
+            mode["deterministic_replays"] for mode in modes
+        )
+        / max(1, total_cases),
+        "exact_context_replay_rate": sum(
+            mode["exact_context_replays"] for mode in modes
+        )
+        / max(1, total_cases),
+        "exact_omission_recovery_rate": sum(
+            mode["exact_omission_recoveries"] for mode in modes
+        )
+        / max(1, total_omitted),
+        "tamper_detection_rate": sum(
+            mode["tamper_detections"] for mode in modes
+        )
+        / max(1, total_tamper),
+        "omitted_chunks_verified": total_omitted,
+        "tamper_trials": total_tamper,
+    }
+    return {
+        "benchmark": "entroly-context-commit-conformance",
+        "schema_version": "entroly.benchmark.context-commit.v1",
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+        },
+        "configuration": {
+            "cases_per_engine": cases,
+            "token_budget": 120,
+            "chunk_tokens": 80,
+            "overlap_tokens": 12,
+            "tamper_mutations_per_case": 6,
+        },
+        "aggregate": aggregate,
+        "modes": modes,
+        "caveats": [
+            "Synthetic deterministic code fixtures; no LLM or network calls.",
+            "Measures artifact integrity, replay, and recovery, not answer quality.",
+            "Does not claim Python and Rust select identical context.",
+            "Content addressing detects mutation; signer identity requires optional attestation APIs.",
+            "Recovery bundles contain source text and must follow the user's data-retention policy.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", type=int, default=64)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+    if args.cases < 1:
+        parser.error("--cases must be positive")
+    result = run_benchmark(args.cases)
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/results/context_commit_conformance.json
+++ b/benchmarks/results/context_commit_conformance.json
@@ -1,0 +1,63 @@
+{
+  "aggregate": {
+    "cases": 128,
+    "deterministic_replay_rate": 1.0,
+    "engine_modes": 2,
+    "exact_context_replay_rate": 1.0,
+    "exact_omission_recovery_rate": 1.0,
+    "omitted_chunks_verified": 576,
+    "tamper_detection_rate": 1.0,
+    "tamper_trials": 768,
+    "valid_commit_rate": 1.0
+  },
+  "benchmark": "entroly-context-commit-conformance",
+  "caveats": [
+    "Synthetic deterministic code fixtures; no LLM or network calls.",
+    "Measures artifact integrity, replay, and recovery, not answer quality.",
+    "Does not claim Python and Rust select identical context.",
+    "Content addressing detects mutation; signer identity requires optional attestation APIs.",
+    "Recovery bundles contain source text and must follow the user's data-retention policy."
+  ],
+  "configuration": {
+    "cases_per_engine": 64,
+    "chunk_tokens": 80,
+    "overlap_tokens": 12,
+    "tamper_mutations_per_case": 6,
+    "token_budget": 120
+  },
+  "environment": {
+    "platform": "Windows-11-10.0.26200-SP0",
+    "python": "3.13.8"
+  },
+  "modes": [
+    {
+      "actual_engine": "python",
+      "cases": 64,
+      "deterministic_replays": 64,
+      "exact_context_replays": 64,
+      "exact_omission_recoveries": 320,
+      "median_artifact_bytes": 18207,
+      "median_create_ms": 9.719,
+      "omitted_chunks": 320,
+      "requested_engine": "python",
+      "tamper_detections": 384,
+      "tamper_trials": 384,
+      "valid_commits": 64
+    },
+    {
+      "actual_engine": "rust",
+      "cases": 64,
+      "deterministic_replays": 64,
+      "exact_context_replays": 64,
+      "exact_omission_recoveries": 256,
+      "median_artifact_bytes": 17544,
+      "median_create_ms": 113.051,
+      "omitted_chunks": 256,
+      "requested_engine": "rust",
+      "tamper_detections": 384,
+      "tamper_trials": 384,
+      "valid_commits": 64
+    }
+  ],
+  "schema_version": "entroly.benchmark.context-commit.v1"
+}

--- a/docs/context-commits.md
+++ b/docs/context-commits.md
@@ -1,0 +1,95 @@
+# Context Commits
+
+A Context Commit is a portable, content-addressed record of the context Entroly
+selected for an agent request. It turns context assembly into an artifact that
+can be replayed, inspected, recovered, and independently checked for mutation.
+
+## Contract
+
+`entroly.context-commit.v1` binds these fields to one `ctx_...` identifier:
+
+- the complete Context Receipt;
+- exact ordered selected context and its digest;
+- omitted-context metadata and a fingerprint-verified recovery bundle;
+- the Python or Rust receipt engine and package versions;
+- an optional parent Context Commit identifier for session lineage.
+
+Creation is deterministic for the same normalized documents, configuration,
+query, engine, and parent. Input document order does not affect the identifier.
+
+## CLI
+
+```bash
+entroly context-commit ./repo --query "Where is token rotation enforced?" \
+  --budget 8000 --out context-commit.json
+entroly context-commit --verify context-commit.json
+```
+
+Use `--python` to force the reference receipt implementation. Without it,
+Entroly uses the Rust receipt engine when the installed native package exposes
+the required symbols and otherwise records the Python fallback explicitly.
+
+## Python
+
+```python
+from entroly import create_context_commit, replay_context, verify_context_commit
+
+commit = create_context_commit(
+    [("policy.md", policy_text), ("service.py", service_source)],
+    query="Which policy controls deployment approval?",
+    token_budget=4000,
+    parent_commit_id=previous_commit_id,
+)
+
+verification = verify_context_commit(commit)
+if not verification.valid:
+    raise RuntimeError(verification.errors)
+
+selected_context = replay_context(commit)
+```
+
+Verification fails closed when the commit identifier, receipt hash, selected
+text, recovery text, engine metadata, or lineage is mutated. Every omitted
+chunk must recover with matching chunk and content fingerprints.
+
+## Threat Model
+
+Context Commits detect mutation after creation. They do not by themselves prove
+who created the artifact or whether an untrusted creator omitted evidence before
+Entroly received the documents.
+
+For operator identity and custody, use `AttestationLog` with Ed25519 keys. For
+append-only publication and inclusion proofs, use `AuditableReceiptLog`. For
+selective disclosure without exposing all source identifiers, use
+`ReceiptCommitment`.
+
+Recovery bundles contain source text. Store them under the same access,
+retention, and deletion policy as the original source. Do not publish a commit
+artifact merely because its hashes verify.
+
+## Conformance Benchmark
+
+The committed benchmark runs 64 deterministic cases per available receipt
+engine. Each case creates the same commit from normal and reversed input order,
+replays selected context, verifies every omitted chunk, and applies six distinct
+mutations.
+
+| Measurement | Result |
+|---|---:|
+| Engine modes | 2 (Python and Rust) |
+| Valid commits | 128 / 128 |
+| Deterministic replays | 128 / 128 |
+| Exact selected-context replays | 128 / 128 |
+| Exact omitted-chunk recoveries | 576 / 576 |
+| Tamper mutations detected | 768 / 768 |
+
+```bash
+python -m benchmarks.context_commit_conformance
+```
+
+Raw evidence:
+[`benchmarks/results/context_commit_conformance.json`](../benchmarks/results/context_commit_conformance.json).
+
+The benchmark is synthetic, local, and uses no model calls. It measures artifact
+integrity, replay, and recoverability. It does not measure downstream answer
+quality and does not claim that Python and Rust select identical context.

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -39,6 +39,17 @@ try:
 except ImportError:
     pass  # Graceful degradation if dependencies missing
 
+# Context Commit: portable, content-addressed proof of what an agent received.
+try:
+    from .context_commit import (  # noqa: F401
+        ContextCommitVerification,
+        create_context_commit,
+        replay_context,
+        verify_context_commit,
+    )
+except ImportError:
+    pass
+
 # engine_s6 — public file-localization API (used internally by SDK / MCP /
 # proxy / CLI; also callable directly for advanced agent integrations).
 try:

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -3930,6 +3930,73 @@ def cmd_receipt(args):
         print(report, end="")
 
 
+def cmd_context_commit(args):
+    """Create or verify a portable Context Commit artifact."""
+    from entroly.context_commit import create_context_commit, verify_context_commit
+    from entroly.context_receipts.ingest import (
+        read_documents_from_path,
+        supported_documents_hint,
+    )
+    from entroly.context_receipts.store import read_json, write_json
+
+    if args.verify:
+        commit = read_json(args.verify)
+        result = verify_context_commit(commit)
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0 if result.valid else 1
+
+    if not args.path or not args.query:
+        print(
+            f"  {C.RED}PATH and --query are required when creating a Context Commit.{C.RESET}",
+            file=sys.stderr,
+        )
+        return 2
+    docs = read_documents_from_path(args.path)
+    if not docs:
+        print(
+            f"  {C.RED}No supported documents found.{C.RESET} "
+            f"{supported_documents_hint()}",
+            file=sys.stderr,
+        )
+        return 1
+    commit = create_context_commit(
+        docs,
+        query=args.query,
+        token_budget=args.budget,
+        chunk_tokens=args.chunk_tokens,
+        overlap_tokens=args.overlap_tokens,
+        parent_commit_id=args.parent,
+        prefer_rust=not args.python,
+    )
+    verification = verify_context_commit(commit)
+    if not verification.valid:
+        print(
+            f"  {C.RED}Context Commit self-verification failed:{C.RESET} "
+            + ", ".join(verification.errors),
+            file=sys.stderr,
+        )
+        return 1
+    output = (
+        Path(args.out)
+        if args.out
+        else Path(".entroly") / "context-commits" / f"{commit['commit_id']}.json"
+    )
+    write_json(output, commit)
+    if args.json:
+        print(json.dumps(commit, indent=2, sort_keys=True, ensure_ascii=False))
+    else:
+        print(f"  {C.GREEN}Context Commit {commit['commit_id']} created.{C.RESET}")
+        print(
+            "  Selected: {selected}; omitted and recoverable: {omitted}; engine: {engine}".format(
+                selected=verification.selected_chunks,
+                omitted=verification.omitted_chunks,
+                engine=commit["engine"]["implementation"],
+            )
+        )
+        print(f"  JSON: {output}")
+    return 0
+
+
 def _load_session_taint(path: str | None, chain_path: Path):
     from entroly.session_intelligence import HallucinationTaintTracker
 
@@ -5079,6 +5146,27 @@ def main():
     receipt_parser.add_argument("--json", action="store_true", help="Print normalized receipt JSON instead of Markdown")
     receipt_parser.add_argument("--python", action="store_true", help="Force the Python reference implementation")
 
+    context_commit_parser = subparsers.add_parser(
+        "context-commit",
+        help="Create or verify a portable proof of the exact selected context",
+    )
+    context_commit_parser.add_argument(
+        "path", nargs="?", default=None, help="Document file or directory"
+    )
+    context_commit_parser.add_argument(
+        "--query", "-q", default=None, help="Question/task to select context for"
+    )
+    context_commit_parser.add_argument(
+        "--budget", "-b", type=int, default=8000, help="Token budget (default: 8000)"
+    )
+    context_commit_parser.add_argument("--out", type=str, default=None, help="Commit JSON output path")
+    context_commit_parser.add_argument("--parent", type=str, default=None, help="Parent Context Commit ID")
+    context_commit_parser.add_argument("--verify", type=str, default=None, help="Verify an existing commit JSON")
+    context_commit_parser.add_argument("--chunk-tokens", type=int, default=360)
+    context_commit_parser.add_argument("--overlap-tokens", type=int, default=32)
+    context_commit_parser.add_argument("--python", action="store_true", help="Force the Python reference implementation")
+    context_commit_parser.add_argument("--json", action="store_true", help="Print the created JSON artifact")
+
     # entroly audit
     audit_parser = subparsers.add_parser(
         "audit",
@@ -5661,6 +5749,7 @@ def main():
         "ingest": cmd_ingest,
         "select": cmd_select,
         "receipt": cmd_receipt,
+        "context-commit": cmd_context_commit,
         "audit": cmd_audit,
         "explain": cmd_explain,
         "status": cmd_status,

--- a/entroly/context_commit.py
+++ b/entroly/context_commit.py
@@ -1,0 +1,222 @@
+"""Portable, content-addressed commits for the context an agent received."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass
+from importlib import metadata
+from typing import Any
+
+from .context_receipts import ingest_documents, recover_omitted, select_from_index
+from .context_receipts.models import stable_hash, text_fingerprint
+from .context_receipts.recover import build_recovery_bundle
+
+CONTEXT_COMMIT_SCHEMA = "entroly.context-commit.v1"
+
+
+def _package_version(name: str) -> str:
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return "source"
+
+
+def _rust_receipts_available() -> bool:
+    try:
+        core = importlib.import_module("entroly_core")
+    except Exception:
+        return False
+    return all(
+        hasattr(core, symbol)
+        for symbol in ("context_receipts_ingest", "context_receipts_select")
+    )
+
+
+def _engine_identity(*, prefer_rust: bool) -> dict[str, str]:
+    use_rust = prefer_rust and _rust_receipts_available()
+    return {
+        "implementation": "rust" if use_rust else "python",
+        "entroly_version": _package_version("entroly"),
+        "engine_version": _package_version("entroly-core") if use_rust else "python",
+    }
+
+
+def _selected_context_digest(receipt: Mapping[str, Any]) -> str:
+    selected = receipt.get("selected_context", [])
+    canonical = []
+    if isinstance(selected, list):
+        for item in selected:
+            if isinstance(item, Mapping):
+                canonical.append(
+                    {
+                        "chunk_id": str(item.get("chunk_id", "")),
+                        "fingerprint": str(item.get("fingerprint", "")),
+                        "source_path": str(item.get("source_path", "")),
+                        "text": str(item.get("text", "")),
+                    }
+                )
+    return stable_hash(canonical)
+
+
+def _commit_payload(commit: Mapping[str, Any]) -> dict[str, Any]:
+    payload = copy.deepcopy(dict(commit))
+    payload.pop("commit_id", None)
+    return payload
+
+
+@dataclass(frozen=True)
+class ContextCommitVerification:
+    valid: bool
+    checks: dict[str, bool]
+    errors: tuple[str, ...]
+    selected_chunks: int
+    omitted_chunks: int
+    recovered_omitted_chunks: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def create_context_commit(
+    documents: Iterable[tuple[str, str]],
+    *,
+    query: str,
+    token_budget: int,
+    chunk_tokens: int = 360,
+    overlap_tokens: int = 32,
+    parent_commit_id: str | None = None,
+    prefer_rust: bool = True,
+) -> dict[str, Any]:
+    """Create a self-contained commit for selected and omitted context."""
+
+    docs = [(str(path), str(text)) for path, text in documents]
+    index = ingest_documents(
+        docs,
+        chunk_tokens=chunk_tokens,
+        overlap_tokens=overlap_tokens,
+        prefer_rust=prefer_rust,
+    )
+    receipt = select_from_index(
+        index,
+        query=query,
+        token_budget=token_budget,
+        prefer_rust=prefer_rust,
+    )
+    recovery = build_recovery_bundle(index)
+    payload: dict[str, Any] = {
+        "schema_version": CONTEXT_COMMIT_SCHEMA,
+        "parent_commit_id": parent_commit_id,
+        "engine": _engine_identity(prefer_rust=prefer_rust),
+        "receipt": receipt,
+        "selected_context_digest": _selected_context_digest(receipt),
+        "recovery_bundle_digest": stable_hash(recovery),
+        "recovery_bundle": recovery,
+    }
+    return {"commit_id": "ctx_" + stable_hash(payload)[:24], **payload}
+
+
+def replay_context(commit: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return an exact, ordered copy of the context selected for the model."""
+
+    receipt = commit.get("receipt", {})
+    if not isinstance(receipt, Mapping):
+        return []
+    selected = receipt.get("selected_context", [])
+    if not isinstance(selected, list):
+        return []
+    return [copy.deepcopy(dict(item)) for item in selected if isinstance(item, Mapping)]
+
+
+def verify_context_commit(commit: Mapping[str, Any] | object) -> ContextCommitVerification:
+    """Fail closed unless the commit, receipt, replay, and recovery all verify."""
+
+    if not isinstance(commit, Mapping):
+        return ContextCommitVerification(
+            False, {}, ("commit is not a mapping",), 0, 0, 0
+        )
+
+    data = dict(commit)
+    receipt = data.get("receipt", {})
+    recovery = data.get("recovery_bundle", {})
+    receipt_map = receipt if isinstance(receipt, Mapping) else {}
+    recovery_map = recovery if isinstance(recovery, Mapping) else {}
+    selected = replay_context(data)
+    omitted_raw = receipt_map.get("omitted_context", [])
+    omitted = omitted_raw if isinstance(omitted_raw, list) else []
+
+    expected_commit_id = "ctx_" + stable_hash(_commit_payload(data))[:24]
+    receipt_payload = {
+        key: value
+        for key, value in receipt_map.items()
+        if key not in {"receipt_id", "reproducibility_hash"}
+    }
+    expected_receipt_hash = stable_hash(receipt_payload)
+    expected_receipt_id = "cr_" + expected_receipt_hash[:12]
+
+    chunks_raw = recovery_map.get("chunks", {})
+    chunks = chunks_raw if isinstance(chunks_raw, Mapping) else {}
+    chunk_integrity = True
+    for entry in chunks.values():
+        if not isinstance(entry, Mapping):
+            chunk_integrity = False
+            break
+        text = str(entry.get("text", ""))
+        if text_fingerprint(text) != str(entry.get("content_sha", "")):
+            chunk_integrity = False
+            break
+
+    selected_integrity = True
+    for item in selected:
+        chunk_id = str(item.get("chunk_id", ""))
+        entry = chunks.get(chunk_id)
+        if not isinstance(entry, Mapping):
+            selected_integrity = False
+            break
+        if (
+            str(entry.get("text", "")) != str(item.get("text", ""))
+            or str(entry.get("fingerprint", ""))
+            != str(item.get("fingerprint", ""))
+        ):
+            selected_integrity = False
+            break
+
+    recovered = recover_omitted(dict(receipt_map), bundle=dict(recovery_map))
+    recovered_count = sum(bool(item.get("verified")) for item in recovered)
+    omitted_integrity = recovered_count == len(omitted)
+
+    checks = {
+        "schema": data.get("schema_version") == CONTEXT_COMMIT_SCHEMA,
+        "commit_id": data.get("commit_id") == expected_commit_id,
+        "receipt_hash": receipt_map.get("reproducibility_hash")
+        == expected_receipt_hash,
+        "receipt_id": receipt_map.get("receipt_id") == expected_receipt_id,
+        "selected_context_digest": data.get("selected_context_digest")
+        == _selected_context_digest(receipt_map),
+        "recovery_bundle_digest": data.get("recovery_bundle_digest")
+        == stable_hash(recovery_map),
+        "recovery_chunk_integrity": chunk_integrity,
+        "selected_context_integrity": selected_integrity,
+        "omitted_context_recovery": omitted_integrity,
+        "parent_lineage": data.get("parent_commit_id") is None
+        or str(data.get("parent_commit_id", "")).startswith("ctx_"),
+    }
+    errors = tuple(name for name, passed in checks.items() if not passed)
+    return ContextCommitVerification(
+        valid=not errors,
+        checks=checks,
+        errors=errors,
+        selected_chunks=len(selected),
+        omitted_chunks=len(omitted),
+        recovered_omitted_chunks=recovered_count,
+    )
+
+
+__all__ = [
+    "CONTEXT_COMMIT_SCHEMA",
+    "ContextCommitVerification",
+    "create_context_commit",
+    "replay_context",
+    "verify_context_commit",
+]

--- a/tests/test_context_commit.py
+++ b/tests/test_context_commit.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import copy
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 from entroly.context_commit import (
     CONTEXT_COMMIT_SCHEMA,
@@ -99,3 +104,55 @@ def test_context_commit_verification_fails_closed_on_non_mapping():
 
     assert result.valid is False
     assert result.errors == ("commit is not a mapping",)
+
+
+def test_context_commit_cli_create_and_verify(tmp_path: Path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    for path, text in DOCUMENTS:
+        (docs / path).write_text(text, encoding="utf-8")
+    output = tmp_path / "commit.json"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+
+    created = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "entroly.cli",
+            "context-commit",
+            str(docs),
+            "--query",
+            "How often should credentials rotate?",
+            "--budget",
+            "25",
+            "--python",
+            "--out",
+            str(output),
+        ],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    assert created.returncode == 0, created.stderr + created.stdout
+    assert output.exists()
+
+    verified = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "entroly.cli",
+            "context-commit",
+            "--verify",
+            str(output),
+        ],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    assert verified.returncode == 0, verified.stderr + verified.stdout
+    assert json.loads(verified.stdout)["valid"] is True

--- a/tests/test_context_commit.py
+++ b/tests/test_context_commit.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import copy
+
+from entroly.context_commit import (
+    CONTEXT_COMMIT_SCHEMA,
+    create_context_commit,
+    replay_context,
+    verify_context_commit,
+)
+
+
+DOCUMENTS = [
+    (
+        "auth.py",
+        "def validate_token(token):\n"
+        "    return token.startswith('sk-')\n\n"
+        "ROTATION_DAYS = 30\n",
+    ),
+    (
+        "billing.py",
+        "def charge(amount):\n"
+        "    return gateway.capture(amount)\n\n"
+        "RETRY_LIMIT = 3\n",
+    ),
+    (
+        "runbook.md",
+        "# Incident runbook\n"
+        "Rotate credentials every 30 days.\n"
+        "Retry failed charges three times.\n",
+    ),
+]
+
+
+def _commit(*, prefer_rust: bool = False, parent: str | None = None):
+    return create_context_commit(
+        DOCUMENTS,
+        query="How often should credentials rotate and charges retry?",
+        token_budget=25,
+        chunk_tokens=40,
+        overlap_tokens=8,
+        parent_commit_id=parent,
+        prefer_rust=prefer_rust,
+    )
+
+
+def test_context_commit_is_deterministic_replayable_and_recoverable():
+    first = _commit()
+    second = _commit()
+    verification = verify_context_commit(first)
+
+    assert first == second
+    assert first["schema_version"] == CONTEXT_COMMIT_SCHEMA
+    assert first["commit_id"].startswith("ctx_")
+    assert replay_context(first) == first["receipt"]["selected_context"]
+    assert verification.valid is True
+    assert verification.omitted_chunks > 0
+    assert verification.recovered_omitted_chunks == verification.omitted_chunks
+
+
+def test_context_commit_detects_receipt_and_recovery_tampering():
+    original = _commit()
+    receipt_tamper = copy.deepcopy(original)
+    receipt_tamper["receipt"]["selected_context"][0]["text"] += " tampered"
+    recovery_tamper = copy.deepcopy(original)
+    chunk = next(iter(recovery_tamper["recovery_bundle"]["chunks"].values()))
+    chunk["text"] += " tampered"
+
+    receipt_result = verify_context_commit(receipt_tamper)
+    recovery_result = verify_context_commit(recovery_tamper)
+
+    assert receipt_result.valid is False
+    assert "commit_id" in receipt_result.errors
+    assert "receipt_hash" in receipt_result.errors
+    assert "selected_context_integrity" in receipt_result.errors
+    assert recovery_result.valid is False
+    assert "recovery_bundle_digest" in recovery_result.errors
+    assert "recovery_chunk_integrity" in recovery_result.errors
+
+
+def test_context_commit_binds_parent_lineage_and_engine_identity():
+    parent = _commit()
+    child = _commit(parent=parent["commit_id"])
+
+    assert child["parent_commit_id"] == parent["commit_id"]
+    assert child["engine"]["implementation"] == "python"
+    assert verify_context_commit(child).valid is True
+
+
+def test_context_commit_uses_native_receipt_engine_when_available():
+    commit = _commit(prefer_rust=True)
+
+    assert commit["engine"]["implementation"] in {"python", "rust"}
+    assert verify_context_commit(commit).valid is True
+
+
+def test_context_commit_verification_fails_closed_on_non_mapping():
+    result = verify_context_commit(None)
+
+    assert result.valid is False
+    assert result.errors == ("commit is not a mapping",)

--- a/tests/test_context_commit_benchmark.py
+++ b/tests/test_context_commit_benchmark.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from benchmarks.context_commit_conformance import run_benchmark
+
+
+def test_context_commit_conformance_benchmark_falsification_gate():
+    result = run_benchmark(cases=3)
+    aggregate = result["aggregate"]
+
+    assert aggregate["cases"] >= 3
+    assert aggregate["valid_commit_rate"] == 1.0
+    assert aggregate["deterministic_replay_rate"] == 1.0
+    assert aggregate["exact_context_replay_rate"] == 1.0
+    assert aggregate["exact_omission_recovery_rate"] == 1.0
+    assert aggregate["tamper_detection_rate"] == 1.0
+    assert aggregate["omitted_chunks_verified"] > 0
+    assert aggregate["tamper_trials"] >= 18

--- a/tests/test_context_commit_benchmark.py
+++ b/tests/test_context_commit_benchmark.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from benchmarks.context_commit_conformance import run_benchmark
 
 
@@ -15,3 +18,20 @@ def test_context_commit_conformance_benchmark_falsification_gate():
     assert aggregate["tamper_detection_rate"] == 1.0
     assert aggregate["omitted_chunks_verified"] > 0
     assert aggregate["tamper_trials"] >= 18
+
+
+def test_committed_context_commit_claims_match_readme():
+    root = Path(__file__).resolve().parents[1]
+    result = json.loads(
+        (root / "benchmarks/results/context_commit_conformance.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    aggregate = result["aggregate"]
+
+    assert f"**{aggregate['cases']} / {aggregate['cases']}**" in readme
+    recovered = aggregate["omitted_chunks_verified"]
+    assert f"**{recovered} / {recovered}**" in readme
+    tampered = aggregate["tamper_trials"]
+    assert f"**{tampered} / {tampered}**" in readme


### PR DESCRIPTION
## Product thesis

Position Entroly around one portable primitive: a **Context Commit** that records and content-addresses the exact selected context, omitted evidence, recovery bundle, engine identity, and optional parent lineage.

## What changed

- add public `create_context_commit`, `replay_context`, and fail-closed `verify_context_commit` APIs
- add `entroly context-commit` create/verify CLI
- add a two-engine falsification benchmark and committed raw JSON
- replace the README feature-soup opening with the Context Commit category statement
- document the contract, threat model, retention risk, and attestation boundary
- add a claim-drift test tying README denominators to the committed result

## Committed benchmark

Synthetic deterministic code fixtures, local, no model or network calls:

- 128/128 valid and deterministic replays across Python and Rust receipt modes
- 576/576 omitted chunks recovered exactly
- 768/768 tamper mutations detected

Caveats: this measures artifact integrity, replay, and recovery. It does not measure downstream answer quality, does not claim Python/Rust selection parity, and content addressing does not prove signer identity.

## Validation

- `pytest tests/ -q --tb=short --timeout=60`: 1,718 passed, 29 skipped, 1 xfailed
- `ruff check entroly tests benchmarks/context_commit_conformance.py`
- 12 release/version tests
- 28/28 README claim checks
- clean wheel build; wheel contains `entroly/context_commit.py` and updated CLI
- pre-push: Clippy and 525 Rust tests