### PR TITLE
Trigger Entroly 1.0.47 geometry release

### DIFF
--- a/.github/workflows/release-geometry-1.0.47.yml
+++ b/.github/workflows/release-geometry-1.0.47.yml
@@ -1,7 +1,6 @@
 name: Release Entroly 1.0.47 Geometry Fix
 
-# This second commit intentionally triggers the workflow after its definition
-# already exists on the default branch.
+# A merged PR intentionally triggers this workflow as a normal main-branch push.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

- trigger the one-time 1.0.47 release through a normal merged PR push
- synchronize all release surfaces with `scripts/bump_version.py`
- dispatch the existing PyPI, native wheel, npm, Docker, and MCP Registry pipelines
- calculate and commit the real Homebrew sdist SHA after PyPI publication

This PR only changes the trigger comment in the temporary release workflow; the workflow removes itself in the generated release commit.