### PR TITLE
Trigger Entroly 1.0.47 publication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,4 @@ entroly-compression-mcp = "entroly.compression_mcp:main"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
-# one-time-release-trigger: 1.0.47
+# one-time-release-trigger: 1.0.47-pr


### PR DESCRIPTION
Starts the recognized release-preparation job. The job bumps all version surfaces to 1.0.47, commits the SimHash geometry release, removes temporary trigger metadata, and dispatches the established PyPI/native/npm/Docker/MCP publication workflow.