### PR TITLE
Trigger Entroly 1.0.47 publication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,4 @@ entroly-compression-mcp = "entroly.compression_mcp:main"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
-# one-time-release-trigger: 1.0.47-pr
+# one-time-release-trigger: 1.0.47-pr2


### PR DESCRIPTION
Launches the synchronized 1.0.47 release on a dedicated release branch, then dispatches the established native wheel, PyPI, npm, Docker, GitHub Release, and MCP publication pipeline.