### PR TITLE
Trigger Entroly 1.0.48 release preparation

### DIFF
--- a/.github/workflows/prepare-release-1.0.48.yml
+++ b/.github/workflows/prepare-release-1.0.48.yml
@@ -1,6 +1,6 @@
 name: Prepare Entroly 1.0.48 Release
 
-# Second push intentionally triggers the release preparation job.
+# A merged PR intentionally triggers this release preparation job.
 on:
   push:
     branches:


### PR DESCRIPTION
Triggers the canonical 1.0.48 version synchronization on the dedicated release branch after Context Commit proofs were merged into main.