### PR TITLE
Trigger registered Entroly 1.0.48 preparation

### DIFF
--- a/.github/workflows/prepare-release-1.0.48.yml
+++ b/.github/workflows/prepare-release-1.0.48.yml
@@ -1,5 +1,6 @@
 name: Prepare Entroly 1.0.48 Release
 
+# Second main-branch merge intentionally starts the registered workflow.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
One-line trigger change now that the one-time release workflow is already present on `main`. Its merge starts the synchronized release-branch build and focused validation.