### PR TITLE
Run clean Entroly 1.0.48 release preparation

### DIFF
--- a/.github/workflows/prepare-release-1.0.48.yml
+++ b/.github/workflows/prepare-release-1.0.48.yml
@@ -1,6 +1,6 @@
 name: Prepare Entroly 1.0.48 Release
 
-# Second main-branch merge intentionally starts the registered workflow.
+# Final clean trigger after resetting the release branch onto current main.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Final one-line trigger after resetting `release/1.0.48` to current `main`. The registered workflow will regenerate the synchronized release branch and run the focused release and Context Commit tests.