### PR TITLE
Use pure Apache-2.0 licensing for Entroly

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,3 @@
-The MCP project is undergoing a licensing transition from the MIT License to the Apache License, Version 2.0 ("Apache-2.0"). All new code and specification contributions to the project are licensed under Apache-2.0. Documentation contributions (excluding specifications) are licensed under CC-BY-4.0.
-
-Contributions for which relicensing consent has been obtained are licensed under Apache-2.0. Contributions made by authors who originally licensed their work under the MIT License and who have not yet granted explicit permission to relicense remain licensed under the MIT License.
-
-No rights beyond those granted by the applicable original license are conveyed for such contributions.
-
----
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -56,9 +48,9 @@ No rights beyond those granted by the applicable original license are conveyed f
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright
-      owner or by an individual or Legal Entity authorized to submit on behalf
-      of the copyright owner. For the purposes of this definition, "submitted"
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
       to the Licensor or its representatives, including but not limited to
       communication on electronic mailing lists, source code control systems,
@@ -68,7 +60,7 @@ No rights beyond those granted by the applicable original license are conveyed f
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
+      on behalf of whom a Contribution has been received by the Licensor and
       subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -114,7 +106,7 @@ No rights beyond those granted by the applicable original license are conveyed f
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
+          within such NOTICE file, excluding any notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
           as part of the Derivative Works; within the Source form or
@@ -183,34 +175,16 @@ No rights beyond those granted by the applicable original license are conveyed f
 
    END OF TERMS AND CONDITIONS
 
----
+   Copyright 2026 Entroly
 
-MIT License
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-Creative Commons Attribution 4.0 International (CC-BY-4.0)
-
-Documentation in this project (excluding specifications) is licensed under
-CC-BY-4.0. See https://creativecommons.org/licenses/by/4.0/legalcode for
-the full license text.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/test_compliance_metadata.py
+++ b/tests/test_compliance_metadata.py
@@ -61,3 +61,16 @@ def test_rust_packages_declare_apache_license_metadata():
         manifest = (ROOT / rel).read_text(encoding="utf-8")
         assert 'license = "Apache-2.0"' in manifest
         assert 'repository = "https://github.com/juyterman1000/entroly"' in manifest
+
+
+def test_root_license_is_entroly_apache_2_only():
+    license_text = (ROOT / "LICENSE").read_text(encoding="utf-8")
+
+    assert "Apache License" in license_text
+    assert "Version 2.0, January 2004" in license_text
+    assert "Copyright 2026 Entroly" in license_text
+
+    # Prevent accidentally restoring the MCP project's transitional license text.
+    assert "The MCP project is undergoing a licensing transition" not in license_text
+    assert "MIT License" not in license_text
+    assert "CC-BY-4.0" not in license_text


### PR DESCRIPTION
## What changed

- replace the root `LICENSE` file's accidentally copied MCP transition text with the standard Apache License 2.0
- retain Entroly's existing `NOTICE` and Apache-2.0 package metadata
- add a regression test preventing the MCP MIT/Apache/CC transition wording from returning

## Why

Entroly's source, Python packages, Rust crates, WASM package and npm packages are intended to be Apache-2.0. The prior root file incorrectly embedded the Model Context Protocol project's licensing-transition notice, creating a misleading mixed-license signal even though Entroly's own metadata and subproject license files already declared Apache-2.0.

This change does not purport to relicense separately distributed third-party dependencies; those remain governed by their own licenses.