### PR TITLE
Launch Entroly 1.0.49 release preparation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build synchronized release branch
         run: |
           git checkout -B release/1.0.49
-          git checkout HEAD^ -- .github/workflows/docker-publish.yml
-          sed -i '/^# Release preparation trigger: 1.0.49$/d' pyproject.toml
+          git show 3205ab01c547a160db3aba0d6c593fb52b0f29dd:.github/workflows/docker-publish.yml > .github/workflows/docker-publish.yml
+          sed -i '/^# Release preparation .*1.0.49/d' pyproject.toml
           python scripts/bump_version.py 1.0.49
           mkdir -p docs/releases
           cat > docs/releases/v1.0.49.md <<'EOF'

--- a/docs/releases/.trigger-1.0.49
+++ b/docs/releases/.trigger-1.0.49
@@ -1,0 +1,1 @@
+This temporary file makes the release-preparation PR explicit. The generated release branch deletes it before publication.

--- a/docs/releases/.trigger-1.0.49
+++ b/docs/releases/.trigger-1.0.49
@@ -1,1 +1,0 @@
-This temporary file makes the release-preparation PR explicit. The generated release branch deletes it before publication.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Release preparation trigger: 1.0.49
+# Release preparation merge trigger: 1.0.49
 [build-system]
 requires = ["hatchling>=1.27,<1.31"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
This PR creates a normal GitHub merge event so the existing recognized Docker workflow can run the canonical `scripts/bump_version.py 1.0.49` preparation job.

The generated `release/1.0.49` branch will:
- update every active version surface through the canonical bump script
- restore the Docker workflow to its clean pre-trigger form
- remove temporary preparation workflow/markers
- create `docs/releases/v1.0.49.md`
- run release synchronization, native status, and Context Commit tests before pushing

The merge commit title must remain `Launch Entroly 1.0.49 release preparation` so the one-time job condition matches.