### PR TITLE
Generate synchronized Entroly 1.0.49 release branch

### DIFF
--- a/docs/releases/.prepare-1.0.49
+++ b/docs/releases/.prepare-1.0.49
@@ -1,0 +1,1 @@
+Generate the synchronized Entroly 1.0.49 release branch from current main.


### PR DESCRIPTION
Opening this same-repository PR triggers the dedicated preparation workflow. The workflow checks out current `main`, runs `scripts/bump_version.py 1.0.49`, removes all temporary release triggers, validates release synchronization and Context Commit tests, and pushes `release/1.0.49`.

This PR itself should not be merged; it is only the event source for release branch generation.