### PR TITLE
Add Context Efficiency Frontier benchmark contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,16 @@ Reproduce: `python -m benchmarks.context_commit_conformance`.
 measure artifact integrity, replay, and recovery on the committed fixtures;
 they do not measure model-answer quality or claim identical Python/Rust selection.
 
+**Context Efficiency Frontier research:** Entroly is building a paired,
+model-neutral benchmark for the question token-savings tables cannot answer:
+does less context preserve real task quality? The preregistered protocol
+compares raw context, model-native compaction, Entroly, and their combination
+using provider-observed tokens, cost, latency, task success, evidence recall,
+and unsupported claims.
+
+[Read the preregistered protocol](docs/benchmarks/context-efficiency-frontier.md).
+No headline result will be claimed until the paired confidence bounds pass.
+
 Every number below is reproducible and backed by a committed JSON artifact you can audit — not a screenshot.
 
 **Token savings** (this repo, `entroly verify-claims`, local, no API):

--- a/benchmarks/context_efficiency_frontier.py
+++ b/benchmarks/context_efficiency_frontier.py
@@ -183,8 +183,16 @@ def _paired(trials: Iterable[Trial]) -> dict[tuple[Any, ...], dict[str, Trial]]:
     for key, conditions in pairs.items():
         if BASELINE not in conditions:
             raise ValueError(f"pair {key!r} is missing the raw baseline")
-    if not any(len(conditions) > 1 for conditions in pairs.values()):
+    expected_conditions = set().union(*(set(conditions) for conditions in pairs.values()))
+    if expected_conditions == {BASELINE}:
         raise ValueError("at least one paired non-baseline trial is required")
+    for key, conditions in pairs.items():
+        missing = expected_conditions.difference(conditions)
+        if missing:
+            raise ValueError(
+                f"pair {key!r} has an incomplete condition matrix; "
+                f"missing {sorted(missing)!r}"
+            )
     return pairs
 
 

--- a/benchmarks/context_efficiency_frontier.py
+++ b/benchmarks/context_efficiency_frontier.py
@@ -1,0 +1,392 @@
+"""Analyze paired quality-cost trials for context-control systems.
+
+The runner is deliberately model-neutral. Provider adapters write one JSONL
+record per task and condition; this module validates pairing, computes paired
+bootstrap intervals, and reports the quality/context Pareto frontier.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+SCHEMA_VERSION = "entroly.context-efficiency-trial.v1"
+REPORT_VERSION = "entroly.context-efficiency-frontier.v1"
+BASELINE = "raw"
+CONDITIONS = ("raw", "native_compaction", "entroly", "combined")
+
+
+def _number(payload: dict[str, Any], name: str, *, minimum: float = 0.0) -> float:
+    value = payload.get(name)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be a number")
+    value = float(value)
+    if not math.isfinite(value) or value < minimum:
+        raise ValueError(f"{name} must be finite and >= {minimum}")
+    return value
+
+
+def _text(payload: dict[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _integer(payload: dict[str, Any], name: str, *, minimum: int = 0) -> int:
+    value = payload.get(name)
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+@dataclass(frozen=True)
+class Trial:
+    workload: str
+    workload_version: str
+    task_id: str
+    provider: str
+    model: str
+    replicate: int
+    condition: str
+    scorer: str
+    task_score: float
+    evidence_recall: float
+    unsupported_claim_rate: float
+    context_tokens: int
+    reasoning_tokens: int
+    output_tokens: int
+    billed_cost_usd: float
+    latency_ms: float
+    context_commit_id: str | None = None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> Trial:
+        if payload.get("schema_version") != SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+        condition = _text(payload, "condition")
+        if condition not in CONDITIONS:
+            raise ValueError(f"condition must be one of {CONDITIONS}")
+
+        replicate = payload.get("replicate")
+        if isinstance(replicate, bool) or not isinstance(replicate, int) or replicate < 0:
+            raise ValueError("replicate must be a non-negative integer")
+
+        commit_id = payload.get("context_commit_id")
+        if commit_id is not None and (
+            not isinstance(commit_id, str) or not commit_id.startswith("ctx_")
+        ):
+            raise ValueError("context_commit_id must start with 'ctx_'")
+        if condition in {"entroly", "combined"} and commit_id is None:
+            raise ValueError(f"{condition} trials require context_commit_id")
+
+        scores = {
+            name: _number(payload, name)
+            for name in ("task_score", "evidence_recall", "unsupported_claim_rate")
+        }
+        for name, value in scores.items():
+            if value > 1.0:
+                raise ValueError(f"{name} must be <= 1.0")
+
+        return cls(
+            workload=_text(payload, "workload"),
+            workload_version=_text(payload, "workload_version"),
+            task_id=_text(payload, "task_id"),
+            provider=_text(payload, "provider"),
+            model=_text(payload, "model"),
+            replicate=replicate,
+            condition=condition,
+            scorer=_text(payload, "scorer"),
+            task_score=scores["task_score"],
+            evidence_recall=scores["evidence_recall"],
+            unsupported_claim_rate=scores["unsupported_claim_rate"],
+            context_tokens=_integer(payload, "context_tokens", minimum=1),
+            reasoning_tokens=_integer(payload, "reasoning_tokens"),
+            output_tokens=_integer(payload, "output_tokens"),
+            billed_cost_usd=_number(payload, "billed_cost_usd"),
+            latency_ms=_number(payload, "latency_ms"),
+            context_commit_id=commit_id,
+        )
+
+    @property
+    def pair_key(self) -> tuple[str, str, str, str, str, int, str]:
+        return (
+            self.workload,
+            self.workload_version,
+            self.task_id,
+            self.provider,
+            self.model,
+            self.replicate,
+            self.scorer,
+        )
+
+    def as_record(self) -> dict[str, Any]:
+        return {"schema_version": SCHEMA_VERSION, **asdict(self)}
+
+
+def load_trials(path: Path) -> list[Trial]:
+    trials: list[Trial] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError("record must be a JSON object")
+            trials.append(Trial.from_dict(payload))
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(f"{path}:{line_number}: {exc}") from exc
+    if not trials:
+        raise ValueError(f"{path}: no trial records")
+    return trials
+
+
+def _paired(trials: Iterable[Trial]) -> dict[tuple[Any, ...], dict[str, Trial]]:
+    pairs: dict[tuple[Any, ...], dict[str, Trial]] = {}
+    for trial in trials:
+        conditions = pairs.setdefault(trial.pair_key, {})
+        if trial.condition in conditions:
+            raise ValueError(
+                f"duplicate {trial.condition!r} trial for pair {trial.pair_key!r}"
+            )
+        conditions[trial.condition] = trial
+    for key, conditions in pairs.items():
+        if BASELINE not in conditions:
+            raise ValueError(f"pair {key!r} is missing the raw baseline")
+    if not any(len(conditions) > 1 for conditions in pairs.values()):
+        raise ValueError("at least one paired non-baseline trial is required")
+    return pairs
+
+
+def _mean(values: Iterable[float]) -> float:
+    materialized = list(values)
+    return sum(materialized) / len(materialized)
+
+
+def _percentile(sorted_values: list[float], probability: float) -> float:
+    index = probability * (len(sorted_values) - 1)
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return sorted_values[lower]
+    weight = index - lower
+    return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
+
+
+def _bootstrap_mean_ci(
+    values: list[float], *, samples: int, rng: random.Random
+) -> list[float]:
+    if samples < 1:
+        raise ValueError("bootstrap_samples must be positive")
+    estimates = [
+        _mean(values[rng.randrange(len(values))] for _ in values)
+        for _ in range(samples)
+    ]
+    estimates.sort()
+    return [
+        round(_percentile(estimates, 0.025), 6),
+        round(_percentile(estimates, 0.975), 6),
+    ]
+
+
+def _reduction(candidate: float, baseline: float) -> float:
+    if baseline <= 0:
+        return 0.0
+    return 1.0 - candidate / baseline
+
+
+def _aggregate(trials: list[Trial]) -> dict[str, Any]:
+    return {
+        "trials": len(trials),
+        "mean_task_score": round(_mean(t.task_score for t in trials), 6),
+        "mean_evidence_recall": round(_mean(t.evidence_recall for t in trials), 6),
+        "mean_unsupported_claim_rate": round(
+            _mean(t.unsupported_claim_rate for t in trials), 6
+        ),
+        "mean_context_tokens": round(_mean(t.context_tokens for t in trials), 3),
+        "mean_reasoning_tokens": round(_mean(t.reasoning_tokens for t in trials), 3),
+        "mean_output_tokens": round(_mean(t.output_tokens for t in trials), 3),
+        "mean_billed_cost_usd": round(_mean(t.billed_cost_usd for t in trials), 8),
+        "mean_latency_ms": round(_mean(t.latency_ms for t in trials), 3),
+    }
+
+
+def _dominates(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    no_worse = (
+        left["mean_task_score"] >= right["mean_task_score"]
+        and left["mean_evidence_recall"] >= right["mean_evidence_recall"]
+        and left["mean_unsupported_claim_rate"]
+        <= right["mean_unsupported_claim_rate"]
+        and left["mean_context_tokens"] <= right["mean_context_tokens"]
+        and left["mean_billed_cost_usd"] <= right["mean_billed_cost_usd"]
+    )
+    strictly_better = any(
+        (
+            left[name] > right[name]
+            if name in {"mean_task_score", "mean_evidence_recall"}
+            else left[name] < right[name]
+        )
+        for name in (
+            "mean_task_score",
+            "mean_evidence_recall",
+            "mean_unsupported_claim_rate",
+            "mean_context_tokens",
+            "mean_billed_cost_usd",
+        )
+    )
+    return no_worse and strictly_better
+
+
+def analyze_frontier(
+    trials: Iterable[Trial],
+    *,
+    bootstrap_samples: int = 2_000,
+    seed: int = 42,
+    quality_tolerance: float = 0.01,
+) -> dict[str, Any]:
+    if not 0.0 <= quality_tolerance <= 1.0:
+        raise ValueError("quality_tolerance must be between 0 and 1")
+    materialized = list(trials)
+    pairs = _paired(materialized)
+    by_condition = {
+        condition: [trial for trial in materialized if trial.condition == condition]
+        for condition in CONDITIONS
+        if any(trial.condition == condition for trial in materialized)
+    }
+    aggregates = {
+        condition: _aggregate(condition_trials)
+        for condition, condition_trials in by_condition.items()
+    }
+
+    comparisons: dict[str, Any] = {}
+    rng = random.Random(seed)
+    for condition in CONDITIONS:
+        if condition == BASELINE:
+            continue
+        paired_rows = [
+            (conditions[BASELINE], conditions[condition])
+            for conditions in pairs.values()
+            if condition in conditions
+        ]
+        if not paired_rows:
+            continue
+        quality_delta = [candidate.task_score - raw.task_score for raw, candidate in paired_rows]
+        evidence_delta = [
+            candidate.evidence_recall - raw.evidence_recall
+            for raw, candidate in paired_rows
+        ]
+        unsupported_delta = [
+            candidate.unsupported_claim_rate - raw.unsupported_claim_rate
+            for raw, candidate in paired_rows
+        ]
+        context_reduction = [
+            _reduction(candidate.context_tokens, raw.context_tokens)
+            for raw, candidate in paired_rows
+        ]
+        latency_reduction = [
+            _reduction(candidate.latency_ms, raw.latency_ms)
+            for raw, candidate in paired_rows
+        ]
+        cost_reduction = [
+            _reduction(candidate.billed_cost_usd, raw.billed_cost_usd)
+            for raw, candidate in paired_rows
+            if raw.billed_cost_usd > 0
+        ]
+        quality_ci = _bootstrap_mean_ci(quality_delta, samples=bootstrap_samples, rng=rng)
+        evidence_ci = _bootstrap_mean_ci(evidence_delta, samples=bootstrap_samples, rng=rng)
+        context_ci = _bootstrap_mean_ci(
+            context_reduction, samples=bootstrap_samples, rng=rng
+        )
+        unsupported_ci = _bootstrap_mean_ci(
+            unsupported_delta, samples=bootstrap_samples, rng=rng
+        )
+        comparisons[condition] = {
+            "paired_trials": len(paired_rows),
+            "mean_quality_delta": round(_mean(quality_delta), 6),
+            "quality_delta_95ci": quality_ci,
+            "mean_evidence_recall_delta": round(_mean(evidence_delta), 6),
+            "evidence_recall_delta_95ci": evidence_ci,
+            "mean_unsupported_claim_rate_delta": round(_mean(unsupported_delta), 6),
+            "unsupported_claim_rate_delta_95ci": unsupported_ci,
+            "mean_context_reduction": round(_mean(context_reduction), 6),
+            "context_reduction_95ci": context_ci,
+            "mean_latency_reduction": round(_mean(latency_reduction), 6),
+            "mean_billed_cost_reduction": (
+                round(_mean(cost_reduction), 6) if cost_reduction else None
+            ),
+            "quality_preserving_context_win": (
+                quality_ci[0] >= -quality_tolerance
+                and evidence_ci[0] >= -quality_tolerance
+                and unsupported_ci[1] <= quality_tolerance
+                and context_ci[0] > 0.0
+            ),
+        }
+
+    frontier = [
+        condition
+        for condition, aggregate in aggregates.items()
+        if not any(
+            other != condition and _dominates(other_aggregate, aggregate)
+            for other, other_aggregate in aggregates.items()
+        )
+    ]
+    return {
+        "schema_version": REPORT_VERSION,
+        "methodology": {
+            "baseline": BASELINE,
+            "pairing_unit": [
+                "workload",
+                "workload_version",
+                "task_id",
+                "provider",
+                "model",
+                "replicate",
+                "scorer",
+            ],
+            "bootstrap_samples": bootstrap_samples,
+            "bootstrap_seed": seed,
+            "confidence_interval": "paired percentile bootstrap 95%",
+            "quality_tolerance": quality_tolerance,
+        },
+        "pair_count": len(pairs),
+        "aggregates": aggregates,
+        "comparisons_to_raw": comparisons,
+        "pareto_frontier": frontier,
+        "caveats": [
+            "A frontier win applies only to the recorded models, workloads, and scorer.",
+            "Provider token and cost fields must come from actual response usage or invoices.",
+            "Context Commit IDs prove artifact integrity, not task-score validity or signer identity.",
+            "A non-dominated point is not necessarily statistically better than every alternative.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="JSONL file containing paired trials")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--bootstrap-samples", type=int, default=2_000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--quality-tolerance", type=float, default=0.01)
+    args = parser.parse_args()
+    report = analyze_frontier(
+        load_trials(args.input),
+        bootstrap_samples=args.bootstrap_samples,
+        seed=args.seed,
+        quality_tolerance=args.quality_tolerance,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/context_efficiency_frontier.py
+++ b/benchmarks/context_efficiency_frontier.py
@@ -19,6 +19,18 @@ SCHEMA_VERSION = "entroly.context-efficiency-trial.v1"
 REPORT_VERSION = "entroly.context-efficiency-frontier.v1"
 BASELINE = "raw"
 CONDITIONS = ("raw", "native_compaction", "entroly", "combined")
+USAGE_SOURCES = (
+    "provider_response",
+    "provider_log",
+    "provider_ledger",
+    "deterministic_fixture",
+)
+COST_SOURCES = (
+    "provider_invoice",
+    "provider_ledger",
+    "pricing_snapshot",
+    "zero_cost_fixture",
+)
 
 
 def _number(payload: dict[str, Any], name: str, *, minimum: float = 0.0) -> float:
@@ -52,6 +64,9 @@ class Trial:
     task_id: str
     provider: str
     model: str
+    provider_request_id: str
+    usage_source: str
+    cost_source: str
     replicate: int
     condition: str
     scorer: str
@@ -85,6 +100,13 @@ class Trial:
         if condition in {"entroly", "combined"} and commit_id is None:
             raise ValueError(f"{condition} trials require context_commit_id")
 
+        usage_source = _text(payload, "usage_source")
+        if usage_source not in USAGE_SOURCES:
+            raise ValueError(f"usage_source must be one of {USAGE_SOURCES}")
+        cost_source = _text(payload, "cost_source")
+        if cost_source not in COST_SOURCES:
+            raise ValueError(f"cost_source must be one of {COST_SOURCES}")
+
         scores = {
             name: _number(payload, name)
             for name in ("task_score", "evidence_recall", "unsupported_claim_rate")
@@ -99,6 +121,9 @@ class Trial:
             task_id=_text(payload, "task_id"),
             provider=_text(payload, "provider"),
             model=_text(payload, "model"),
+            provider_request_id=_text(payload, "provider_request_id"),
+            usage_source=usage_source,
+            cost_source=cost_source,
             replicate=replicate,
             condition=condition,
             scorer=_text(payload, "scorer"),
@@ -354,6 +379,13 @@ def analyze_frontier(
             "quality_tolerance": quality_tolerance,
         },
         "pair_count": len(pairs),
+        "provenance": {
+            "workloads": sorted({t.workload for t in materialized}),
+            "providers": sorted({t.provider for t in materialized}),
+            "models": sorted({t.model for t in materialized}),
+            "usage_sources": sorted({t.usage_source for t in materialized}),
+            "cost_sources": sorted({t.cost_source for t in materialized}),
+        },
         "aggregates": aggregates,
         "comparisons_to_raw": comparisons,
         "pareto_frontier": frontier,

--- a/benchmarks/context_efficiency_report.py
+++ b/benchmarks/context_efficiency_report.py
@@ -1,0 +1,144 @@
+"""Render an honest public report from a Context Efficiency Frontier JSON file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from benchmarks.context_efficiency_frontier import REPORT_VERSION
+
+
+def _percent(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.1%}"
+
+
+def _interval(value: list[float]) -> str:
+    return f"[{value[0]:.1%}, {value[1]:.1%}]"
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    if report.get("schema_version") != REPORT_VERSION:
+        raise ValueError(f"schema_version must be {REPORT_VERSION!r}")
+    methodology = report.get("methodology")
+    aggregates = report.get("aggregates")
+    comparisons = report.get("comparisons_to_raw")
+    caveats = report.get("caveats")
+    if not isinstance(methodology, dict):
+        raise ValueError("report is missing methodology")
+    if not isinstance(aggregates, dict) or not aggregates:
+        raise ValueError("report is missing aggregates")
+    if not isinstance(comparisons, dict):
+        raise ValueError("report is missing comparisons_to_raw")
+    if not isinstance(caveats, list):
+        raise ValueError("report is missing caveats")
+
+    lines = [
+        "# Context Efficiency Frontier",
+        "",
+        "Paired evaluation of task quality, evidence retention, provider-observed context usage, cost, and latency.",
+        "",
+        "## Operating Points",
+        "",
+        "| Condition | Trials | Task score | Evidence recall | Unsupported claims | Context tokens | Cost (USD) | Latency (ms) | Pareto |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    frontier = set(report.get("pareto_frontier", []))
+    for condition, aggregate in aggregates.items():
+        lines.append(
+            "| {condition} | {trials} | {score:.3f} | {evidence:.3f} | "
+            "{unsupported:.3f} | {context:,.0f} | {cost:.6f} | {latency:,.1f} | {pareto} |".format(
+                condition=condition,
+                trials=aggregate["trials"],
+                score=aggregate["mean_task_score"],
+                evidence=aggregate["mean_evidence_recall"],
+                unsupported=aggregate["mean_unsupported_claim_rate"],
+                context=aggregate["mean_context_tokens"],
+                cost=aggregate["mean_billed_cost_usd"],
+                latency=aggregate["mean_latency_ms"],
+                pareto="yes" if condition in frontier else "no",
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Paired Results Versus Raw Context",
+            "",
+            "`PASS` requires the 95% paired-bootstrap bounds to preserve task score and evidence recall, avoid excess unsupported claims, and reduce context beyond zero.",
+            "",
+            "| Condition | Pairs | Quality delta (95% CI) | Evidence delta (95% CI) | Context reduction (95% CI) | Cost reduction | Result |",
+            "|---|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for condition, comparison in comparisons.items():
+        lines.append(
+            "| {condition} | {pairs} | {quality} {quality_ci} | {evidence} "
+            "{evidence_ci} | {context} {context_ci} | {cost} | **{result}** |".format(
+                condition=condition,
+                pairs=comparison["paired_trials"],
+                quality=_percent(comparison["mean_quality_delta"]),
+                quality_ci=_interval(comparison["quality_delta_95ci"]),
+                evidence=_percent(comparison["mean_evidence_recall_delta"]),
+                evidence_ci=_interval(comparison["evidence_recall_delta_95ci"]),
+                context=_percent(comparison["mean_context_reduction"]),
+                context_ci=_interval(comparison["context_reduction_95ci"]),
+                cost=_percent(comparison["mean_billed_cost_reduction"]),
+                result=(
+                    "PASS"
+                    if comparison["quality_preserving_context_win"]
+                    else "NO CLAIM"
+                ),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Methodology",
+            "",
+            f"- Baseline: `{methodology['baseline']}`",
+            f"- Pair count: {report['pair_count']}",
+            f"- Confidence interval: {methodology['confidence_interval']}",
+            f"- Bootstrap samples: {methodology['bootstrap_samples']}",
+            f"- Quality tolerance: {_percent(methodology['quality_tolerance'])}",
+            "",
+            "## Caveats",
+            "",
+        ]
+    )
+    lines.extend(f"- {caveat}" for caveat in caveats)
+    lines.extend(
+        [
+            "",
+            "## Reproduce",
+            "",
+            "```bash",
+            "python -m benchmarks.context_efficiency_frontier trials.jsonl --output report.json",
+            "python -m benchmarks.context_efficiency_report report.json --output report.md",
+            "```",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Frontier report JSON")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("report must be a JSON object")
+    rendered = render_markdown(payload)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/context_efficiency_report.py
+++ b/benchmarks/context_efficiency_report.py
@@ -103,6 +103,8 @@ def render_markdown(report: dict[str, Any]) -> str:
             f"- Confidence interval: {methodology['confidence_interval']}",
             f"- Bootstrap samples: {methodology['bootstrap_samples']}",
             f"- Quality tolerance: {_percent(methodology['quality_tolerance'])}",
+            f"- Usage sources: {', '.join(report['provenance']['usage_sources'])}",
+            f"- Cost sources: {', '.join(report['provenance']['cost_sources'])}",
             "",
             "## Caveats",
             "",

--- a/benchmarks/context_efficiency_trial.schema.json
+++ b/benchmarks/context_efficiency_trial.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://entroly.com/schemas/context-efficiency-trial.v1.json",
+  "title": "Entroly Context Efficiency Trial",
+  "description": "One provider-observed task trial in a paired context-efficiency experiment.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "workload",
+    "workload_version",
+    "task_id",
+    "provider",
+    "model",
+    "replicate",
+    "condition",
+    "scorer",
+    "task_score",
+    "evidence_recall",
+    "unsupported_claim_rate",
+    "context_tokens",
+    "reasoning_tokens",
+    "output_tokens",
+    "billed_cost_usd",
+    "latency_ms",
+    "context_commit_id"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "entroly.context-efficiency-trial.v1"
+    },
+    "workload": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workload_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1
+    },
+    "replicate": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "condition": {
+      "enum": [
+        "raw",
+        "native_compaction",
+        "entroly",
+        "combined"
+      ]
+    },
+    "scorer": {
+      "type": "string",
+      "minLength": 1
+    },
+    "task_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "evidence_recall": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "unsupported_claim_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "context_tokens": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "reasoning_tokens": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "output_tokens": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "billed_cost_usd": {
+      "type": "number",
+      "minimum": 0
+    },
+    "latency_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "context_commit_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^ctx_"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "condition": {
+            "enum": [
+              "entroly",
+              "combined"
+            ]
+          }
+        },
+        "required": [
+          "condition"
+        ]
+      },
+      "then": {
+        "properties": {
+          "context_commit_id": {
+            "type": "string",
+            "pattern": "^ctx_"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/benchmarks/context_efficiency_trial.schema.json
+++ b/benchmarks/context_efficiency_trial.schema.json
@@ -12,6 +12,9 @@
     "task_id",
     "provider",
     "model",
+    "provider_request_id",
+    "usage_source",
+    "cost_source",
     "replicate",
     "condition",
     "scorer",
@@ -48,6 +51,27 @@
     "model": {
       "type": "string",
       "minLength": 1
+    },
+    "provider_request_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Provider request ID or a stable redacted hash of it."
+    },
+    "usage_source": {
+      "enum": [
+        "provider_response",
+        "provider_log",
+        "provider_ledger",
+        "deterministic_fixture"
+      ]
+    },
+    "cost_source": {
+      "enum": [
+        "provider_invoice",
+        "provider_ledger",
+        "pricing_snapshot",
+        "zero_cost_fixture"
+      ]
     },
     "replicate": {
       "type": "integer",

--- a/docs/benchmarks/context-efficiency-frontier.md
+++ b/docs/benchmarks/context-efficiency-frontier.md
@@ -59,6 +59,8 @@ Each invocation writes one JSON object conforming to
   provider response or an auditable provider log, not a local tokenizer.
 - `billed_cost_usd` comes from an invoice, provider usage ledger, or a declared
   immutable pricing snapshot. Reports must identify which source was used.
+- `usage_source`, `cost_source`, and `provider_request_id` make that provenance
+  machine-readable. A request ID may be replaced by a stable redacted hash.
 - `latency_ms` is wall-clock request latency measured at the same boundary for
   all conditions.
 - `task_score`, `evidence_recall`, and `unsupported_claim_rate` are bounded in

--- a/docs/benchmarks/context-efficiency-frontier.md
+++ b/docs/benchmarks/context-efficiency-frontier.md
@@ -67,6 +67,8 @@ Each invocation writes one JSON object conforming to
   `[0, 1]` and use the scorer named in the pairing key.
 - Failures, timeouts, refusals, and malformed tool calls remain in the sample
   and receive the preregistered failure score. They are not silently discarded.
+- Every task-replicate must contain the same condition matrix. The analyzer
+  rejects incomplete matrices rather than comparing unequal task subsets.
 
 ## Initial workload matrix
 

--- a/docs/benchmarks/context-efficiency-frontier.md
+++ b/docs/benchmarks/context-efficiency-frontier.md
@@ -1,0 +1,147 @@
+# Entroly Context Efficiency Frontier
+
+The Context Efficiency Frontier (CEF) measures whether a context-control system
+reduces model input while preserving task outcomes. It does not treat token
+savings alone as a product win.
+
+This document preregisters the public protocol before results are collected.
+Changing a threshold, workload, scorer, or exclusion after inspecting results
+requires a new protocol version and a written reason.
+
+## Research question
+
+For a fixed model, task, prompt, tool set, and sampling configuration, does
+Entroly reduce provider-observed context usage without a material loss in task
+quality, evidence recall, or grounding?
+
+The benchmark reports a Pareto frontier. It does not collapse quality, cost,
+and latency into a promotional composite score.
+
+## Conditions
+
+Every experimental result is paired with `raw` on the same workload version,
+task, provider, model, replicate, and scorer.
+
+| Condition | Context behavior |
+|---|---|
+| `raw` | Complete unmodified task context. This is the required baseline. |
+| `native_compaction` | Only the model or agent's documented native context management is enabled. |
+| `entroly` | Entroly controls context; model-native compaction is disabled where the provider exposes that control. |
+| `combined` | Entroly and documented model-native context management are both enabled. |
+
+Entroly and combined trials must retain the `ctx_...` Context Commit ID for the
+exact selected context. The artifact is integrity evidence, not proof that a
+task score or model answer is correct.
+
+## Primary hypotheses
+
+The default non-inferiority tolerance is one percentage point.
+
+- **H1 task quality:** lower bound of the paired 95% bootstrap interval for
+  task-score delta is at least `-0.01`.
+- **H2 evidence:** lower bound of the paired 95% bootstrap interval for
+  answer-critical evidence-recall delta is at least `-0.01`.
+- **H3 grounding:** upper bound of the paired 95% bootstrap interval for the
+  unsupported-claim-rate delta is at most `0.01`.
+- **H4 context:** lower bound of the paired 95% bootstrap interval for context
+  reduction is greater than zero.
+
+The analyzer emits `quality_preserving_context_win: true` only when all four
+hypotheses pass. Larger minimum savings thresholds may be declared by a
+workload-specific preregistration, but cannot be lowered after results are seen.
+
+## Measurement contract
+
+Each invocation writes one JSON object conforming to
+[`context_efficiency_trial.schema.json`](../../benchmarks/context_efficiency_trial.schema.json).
+
+- `context_tokens`, `reasoning_tokens`, and `output_tokens` come from the
+  provider response or an auditable provider log, not a local tokenizer.
+- `billed_cost_usd` comes from an invoice, provider usage ledger, or a declared
+  immutable pricing snapshot. Reports must identify which source was used.
+- `latency_ms` is wall-clock request latency measured at the same boundary for
+  all conditions.
+- `task_score`, `evidence_recall`, and `unsupported_claim_rate` are bounded in
+  `[0, 1]` and use the scorer named in the pairing key.
+- Failures, timeouts, refusals, and malformed tool calls remain in the sample
+  and receive the preregistered failure score. They are not silently discarded.
+
+## Initial workload matrix
+
+The first public report should include all completed suites, not only favorable
+ones.
+
+| Capability | Initial suite | Primary score |
+|---|---|---|
+| Long-context QA | LongBench HotpotQA and 2WikiMultihopQA | official answer score |
+| Tool use | Berkeley Function Calling Leaderboard subset | executable call accuracy |
+| Repository coding | SWE-bench Verified or a version-pinned public subset | resolved task rate |
+| Long-running agents | Versioned OpenClaw and Hermes traces | terminal task success plus evidence recall |
+| Structured operations | Versioned JSON, logs, and API traces | exact field or incident recovery |
+
+Every suite needs enough independent tasks for a meaningful paired interval.
+Synthetic needle tests and deterministic conformance fixtures remain useful CI
+gates, but they are labeled separately and cannot support the headline product
+claim.
+
+## Experimental controls
+
+- Pin model identifiers, provider API versions, workload revisions, prompts,
+  tool schemas, temperatures, token limits, and stop conditions.
+- Use identical task order and replicate IDs across conditions. Randomize the
+  condition execution order within each task to reduce time-of-day bias.
+- Preserve provider request IDs and usage records privately when licenses or
+  customer data prevent publishing the full trace.
+- Score automatically where an executable or exact-answer oracle exists.
+  Human or model judging must be blinded to condition and use a frozen rubric.
+- Bootstrap over paired task-replicate units with a fixed seed. Do not treat
+  multiple tokens, claims, or judge votes from one task as independent samples.
+- Report each model and workload separately before any aggregate. An aggregate
+  must not hide a failed workload.
+
+## Falsification and exclusions
+
+The claim fails for a condition when any primary hypothesis fails. A point can
+remain on the descriptive Pareto frontier while still receiving `NO CLAIM` from
+the statistical gate.
+
+Allowed exclusions are limited to failures proven to be benchmark-infrastructure
+errors affecting all paired conditions, such as a missing dataset file. Model
+timeouts, context-limit errors, tool failures, and safety refusals are outcomes.
+All exclusions must be listed with task IDs before analysis.
+
+## Reproduce the analysis
+
+```bash
+python -m benchmarks.context_efficiency_frontier trials.jsonl \
+  --bootstrap-samples 2000 \
+  --quality-tolerance 0.01 \
+  --output report.json
+
+python -m benchmarks.context_efficiency_report report.json \
+  --output report.md
+```
+
+The JSON report is the source of truth. The Markdown table is generated from
+that artifact and shows failed conditions and caveats alongside passing ones.
+
+## Publication requirements
+
+A public Entroly CEF result must include:
+
+1. Protocol version and any workload-specific preregistration.
+2. Trial JSONL or a license-safe manifest with hashes and provider request IDs.
+3. Generated JSON and Markdown reports.
+4. Model, provider, scorer, dependency, and Entroly versions.
+5. Context Commit artifacts for Entroly-controlled trials, subject to source
+   retention and privacy policy.
+6. Per-workload results, uncertainty intervals, failures, exclusions, and cost
+   provenance.
+
+The preferred headline has this form:
+
+> On the named model and workload, Entroly retained the preregistered quality
+> bound while reducing provider-observed context by X% (paired 95% CI: L-U,
+> N tasks).
+
+Do not generalize beyond the evaluated models, workloads, budgets, and scorer.

--- a/tests/test_context_efficiency_frontier.py
+++ b/tests/test_context_efficiency_frontier.py
@@ -10,6 +10,7 @@ from benchmarks.context_efficiency_frontier import (
     analyze_frontier,
     load_trials,
 )
+from benchmarks.context_efficiency_report import render_markdown
 
 
 def _record(task: int, condition: str, **overrides):
@@ -107,3 +108,24 @@ def test_load_trials_reports_the_invalid_line(tmp_path):
 
     with pytest.raises(ValueError, match=r"trials\.jsonl:2"):
         load_trials(path)
+
+
+def test_public_report_exposes_pass_rule_and_caveats():
+    trials = [
+        Trial.from_dict(_record(task, condition))
+        for task in range(4)
+        for condition in ("raw", "entroly")
+    ]
+    report = analyze_frontier(trials, bootstrap_samples=50)
+
+    markdown = render_markdown(report)
+
+    assert "| entroly | 4 |" in markdown
+    assert "**PASS**" in markdown
+    assert "95% paired-bootstrap bounds" in markdown
+    assert "Context Commit IDs prove artifact integrity" in markdown
+
+
+def test_public_report_rejects_unknown_schema():
+    with pytest.raises(ValueError, match="schema_version"):
+        render_markdown({"schema_version": "future"})

--- a/tests/test_context_efficiency_frontier.py
+++ b/tests/test_context_efficiency_frontier.py
@@ -111,6 +111,17 @@ def test_analyzer_rejects_unpaired_or_duplicate_trials():
         analyze_frontier([raw, raw, entroly_only], bootstrap_samples=10)
 
 
+def test_analyzer_rejects_incomplete_condition_matrix():
+    trials = [
+        Trial.from_dict(_record(1, "raw")),
+        Trial.from_dict(_record(1, "entroly")),
+        Trial.from_dict(_record(2, "raw")),
+    ]
+
+    with pytest.raises(ValueError, match="incomplete condition matrix"):
+        analyze_frontier(trials, bootstrap_samples=10)
+
+
 def test_load_trials_reports_the_invalid_line(tmp_path):
     path = tmp_path / "trials.jsonl"
     path.write_text(

--- a/tests/test_context_efficiency_frontier.py
+++ b/tests/test_context_efficiency_frontier.py
@@ -21,6 +21,9 @@ def _record(task: int, condition: str, **overrides):
         "task_id": f"task-{task}",
         "provider": "fixture",
         "model": "fixture-model",
+        "provider_request_id": f"fixture-request-{task}-{condition}",
+        "usage_source": "deterministic_fixture",
+        "cost_source": "zero_cost_fixture",
         "replicate": 0,
         "condition": condition,
         "scorer": "exact-match-v1",
@@ -54,6 +57,7 @@ def test_frontier_reports_paired_quality_preserving_win():
     assert comparison["mean_billed_cost_reduction"] == 0.5
     assert comparison["quality_preserving_context_win"] is True
     assert report["pareto_frontier"] == ["entroly"]
+    assert report["provenance"]["usage_sources"] == ["deterministic_fixture"]
 
 
 def test_frontier_refuses_to_call_context_savings_a_quality_win():
@@ -86,6 +90,14 @@ def test_trial_rejects_fractional_token_counts():
     payload["context_tokens"] = 999.5
 
     with pytest.raises(ValueError, match="context_tokens must be an integer"):
+        Trial.from_dict(payload)
+
+
+def test_trial_rejects_unverifiable_usage_provenance():
+    payload = _record(1, "raw")
+    payload["usage_source"] = "local_estimate"
+
+    with pytest.raises(ValueError, match="usage_source must be one of"):
         Trial.from_dict(payload)
 
 
@@ -123,6 +135,7 @@ def test_public_report_exposes_pass_rule_and_caveats():
     assert "| entroly | 4 |" in markdown
     assert "**PASS**" in markdown
     assert "95% paired-bootstrap bounds" in markdown
+    assert "Usage sources: deterministic_fixture" in markdown
     assert "Context Commit IDs prove artifact integrity" in markdown
 
 

--- a/tests/test_context_efficiency_frontier.py
+++ b/tests/test_context_efficiency_frontier.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchmarks.context_efficiency_frontier import (
+    SCHEMA_VERSION,
+    Trial,
+    analyze_frontier,
+    load_trials,
+)
+
+
+def _record(task: int, condition: str, **overrides):
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "workload": "fixture-agent-tasks",
+        "workload_version": "1",
+        "task_id": f"task-{task}",
+        "provider": "fixture",
+        "model": "fixture-model",
+        "replicate": 0,
+        "condition": condition,
+        "scorer": "exact-match-v1",
+        "task_score": 1.0,
+        "evidence_recall": 1.0,
+        "unsupported_claim_rate": 0.0,
+        "context_tokens": 1_000 if condition == "raw" else 400,
+        "reasoning_tokens": 100,
+        "output_tokens": 50,
+        "billed_cost_usd": 0.01 if condition == "raw" else 0.005,
+        "latency_ms": 1_000 if condition == "raw" else 800,
+        "context_commit_id": "ctx_fixture" if condition in {"entroly", "combined"} else None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_frontier_reports_paired_quality_preserving_win():
+    trials = [
+        Trial.from_dict(_record(task, condition))
+        for task in range(8)
+        for condition in ("raw", "entroly")
+    ]
+
+    report = analyze_frontier(trials, bootstrap_samples=200, seed=7)
+    comparison = report["comparisons_to_raw"]["entroly"]
+
+    assert report["pair_count"] == 8
+    assert comparison["mean_quality_delta"] == 0.0
+    assert comparison["mean_context_reduction"] == 0.6
+    assert comparison["mean_billed_cost_reduction"] == 0.5
+    assert comparison["quality_preserving_context_win"] is True
+    assert report["pareto_frontier"] == ["entroly"]
+
+
+def test_frontier_refuses_to_call_context_savings_a_quality_win():
+    trials = [
+        Trial.from_dict(_record(task, "raw"))
+        for task in range(6)
+    ] + [
+        Trial.from_dict(
+            _record(task, "entroly", task_score=0.8, evidence_recall=0.8)
+        )
+        for task in range(6)
+    ]
+
+    report = analyze_frontier(trials, bootstrap_samples=100)
+
+    assert report["comparisons_to_raw"]["entroly"]["quality_preserving_context_win"] is False
+    assert set(report["pareto_frontier"]) == {"raw", "entroly"}
+
+
+def test_trial_requires_context_commit_for_entroly_conditions():
+    payload = _record(1, "entroly")
+    payload["context_commit_id"] = None
+
+    with pytest.raises(ValueError, match="require context_commit_id"):
+        Trial.from_dict(payload)
+
+
+def test_trial_rejects_fractional_token_counts():
+    payload = _record(1, "raw")
+    payload["context_tokens"] = 999.5
+
+    with pytest.raises(ValueError, match="context_tokens must be an integer"):
+        Trial.from_dict(payload)
+
+
+def test_analyzer_rejects_unpaired_or_duplicate_trials():
+    entroly_only = Trial.from_dict(_record(1, "entroly"))
+    with pytest.raises(ValueError, match="missing the raw baseline"):
+        analyze_frontier([entroly_only], bootstrap_samples=10)
+
+    raw = Trial.from_dict(_record(1, "raw"))
+    with pytest.raises(ValueError, match="duplicate 'raw'"):
+        analyze_frontier([raw, raw, entroly_only], bootstrap_samples=10)
+
+
+def test_load_trials_reports_the_invalid_line(tmp_path):
+    path = tmp_path / "trials.jsonl"
+    path.write_text(
+        json.dumps(_record(1, "raw")) + "\n" + "{not-json}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"trials\.jsonl:2"):
+        load_trials(path)

--- a/tests/test_context_efficiency_frontier.py
+++ b/tests/test_context_efficiency_frontier.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
 from benchmarks.context_efficiency_frontier import (
+    CONDITIONS,
+    COST_SOURCES,
     SCHEMA_VERSION,
+    USAGE_SOURCES,
     Trial,
     analyze_frontier,
     load_trials,
@@ -153,3 +157,17 @@ def test_public_report_exposes_pass_rule_and_caveats():
 def test_public_report_rejects_unknown_schema():
     with pytest.raises(ValueError, match="schema_version"):
         render_markdown({"schema_version": "future"})
+
+
+def test_public_json_schema_matches_python_trial_contract():
+    root = Path(__file__).resolve().parents[1]
+    schema = json.loads(
+        (root / "benchmarks/context_efficiency_trial.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert set(schema["required"]) == {"schema_version", *Trial.__dataclass_fields__}
+    assert tuple(schema["properties"]["condition"]["enum"]) == CONDITIONS
+    assert tuple(schema["properties"]["usage_source"]["enum"]) == USAGE_SOURCES
+    assert tuple(schema["properties"]["cost_source"]["enum"]) == COST_SOURCES


### PR DESCRIPTION
## Summary
- add a model-neutral paired Context Efficiency Frontier analyzer
- report paired bootstrap confidence intervals, quality/context gates, and Pareto operating points
- require Context Commit IDs for Entroly-controlled trials
- publish a strict JSONL schema and generated Markdown report
- require provider usage/cost provenance and reject incomplete condition matrices
- preregister workload, scoring, anti-cherry-picking, and publication rules before collecting headline numbers

## Why
Token savings alone do not establish product value. This creates a falsifiable contract for testing raw context, model-native compaction, Entroly, and the combined path on identical tasks while measuring task quality, evidence recall, unsupported claims, provider-observed tokens, cost, and latency.

## Validation
- `python -m pytest tests -q`: 1759 passed, 46 skipped, 1 xfailed
- `python -m pytest tests/test_release_version_sync.py tests/test_release_surface.py tests/test_bump_version.py tests/test_context_efficiency_frontier.py -q`: 23 passed
- `python -m ruff check entroly benchmarks tests`: passed
- `python scripts/verify_readme.py`: 28/28 passed
- pre-push `cargo clippy`: passed
- pre-push `cargo test --lib`: 531 passed

## Release state
Built on current `main` release 1.0.50. Live PyPI verification confirms both `entroly==1.0.50` and `entroly-core==1.0.50` are available.