### PR TITLE
Fix MCP Registry manifest validation

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.juyterman1000/entroly",
   "title": "Entroly",
-  "description": "Local context OS for AI coding agents with token optimization, receipts, exact recovery, memory, and verification.",
+  "description": "Local context OS for AI agents with token optimization, receipts, memory, and verification.",
   "repository": {
     "url": "https://github.com/juyterman1000/entroly",
     "source": "github"

--- a/tests/test_mcp_registry_manifest.py
+++ b/tests/test_mcp_registry_manifest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_mcp_registry_manifest_respects_schema_bounds() -> None:
+    manifest = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+
+    assert 3 <= len(manifest["name"]) <= 200
+    assert 1 <= len(manifest["title"]) <= 100
+    assert 1 <= len(manifest["description"]) <= 100
+    assert 1 <= len(manifest["version"]) <= 255
+
+
+def test_mcp_registry_package_ownership_contract() -> None:
+    manifest = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+    expected_name = "io.github.juyterman1000/entroly"
+
+    assert manifest["name"] == expected_name
+    packages = {package["registryType"]: package for package in manifest["packages"]}
+    assert packages["pypi"]["identifier"] == "entroly"
+    assert packages["npm"]["identifier"] == "entroly-mcp"
+
+    npm_manifest = json.loads(
+        (ROOT / "entroly" / "npm" / "package.json").read_text(encoding="utf-8")
+    )
+    assert npm_manifest["mcpName"] == expected_name
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert f"mcp-name: {expected_name}" in readme


### PR DESCRIPTION
## Root cause

The live `server.json` description was 114 characters, while the MCP Registry schema permits at most 100 characters. That causes `mcp-publisher publish` package/server validation to fail before the listing-verification step.

## Fix

- shorten the description to 91 characters without changing product meaning
- add focused schema-bound assertions for MCP Registry metadata
- add ownership-contract tests for the PyPI README marker and npm `mcpName`

After merge, rerun **Publish Entroly to MCP Registry** with `workflow_dispatch`; no version bump is required because the underlying PyPI/npm 1.0.50 packages are already published.