### PR TITLE
feat: add frontier Context Check quality layer

### DIFF
--- a/.github/actions/entroly-context-check/README.md
+++ b/.github/actions/entroly-context-check/README.md
@@ -1,0 +1,29 @@
+# Entroly Context Check action
+
+This composite action creates a replayable Context Commit, compares its selected
+files with files changed in a pull request, writes a bounded Markdown summary,
+and uploads the schema-defined JSON, Markdown, and Context Commit artifacts.
+
+```yaml
+jobs:
+  context-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: juyterman1000/entroly/.github/actions/entroly-context-check@main
+        with:
+          task: ${{ github.event.pull_request.title }}
+          token-budget: 8000
+          fail-on-risk: high
+```
+
+For non-pull-request events, pass a fetched `base-ref`. Without a comparison
+base, the action still creates a Context Commit but marks changed-file coverage
+as `not_measured` and risk as `unknown`. A configured threshold treats unknown
+risk conservatively.
+
+Changed-file recall is retrospective coverage evidence. It does not prove task
+correctness, identify every file that should have been read, or prove that a
+model used the selected context.

--- a/.github/actions/entroly-context-check/action.yml
+++ b/.github/actions/entroly-context-check/action.yml
@@ -1,0 +1,126 @@
+name: Entroly Context Check
+description: Audit selected context against files changed by an agent or pull request.
+author: juyterman1000
+
+branding:
+  icon: check-circle
+  color: purple
+
+inputs:
+  task:
+    description: Agent task or question used to select repository context.
+    required: true
+  token-budget:
+    description: Maximum tokens selected into the Context Commit.
+    required: false
+    default: "8000"
+  max-files:
+    description: Maximum supported repository files to index; 0 means unlimited.
+    required: false
+    default: "0"
+  repo-path:
+    description: Repository path relative to the workspace.
+    required: false
+    default: "."
+  base-ref:
+    description: Git base ref or SHA; pull requests default to the event base SHA.
+    required: false
+    default: ""
+  head-ref:
+    description: Git head ref or SHA.
+    required: false
+    default: HEAD
+  python-version:
+    description: Python version used to run Entroly.
+    required: false
+    default: "3.12"
+  fail-on-risk:
+    description: Fail at none, high, or medium Context Check risk.
+    required: false
+    default: none
+
+outputs:
+  check-id:
+    description: Content-addressed Context Check identifier.
+    value: ${{ steps.summarize.outputs.check_id }}
+  context-commit-id:
+    description: Replayable Context Commit identifier.
+    value: ${{ steps.summarize.outputs.context_commit_id }}
+  changed-file-recall:
+    description: Fraction of changed files represented in selected context.
+    value: ${{ steps.summarize.outputs.changed_file_recall }}
+  risk-level:
+    description: Conservative Context Check risk level.
+    value: ${{ steps.summarize.outputs.risk_level }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Entroly from action ref
+      shell: bash
+      env:
+        ENTROLY_ACTION_PATH: ${{ github.action_path }}
+      run: python -m pip install "$ENTROLY_ACTION_PATH/../../.."
+
+    - name: Resolve comparison base
+      id: base
+      shell: bash
+      env:
+        INPUT_BASE_REF: ${{ inputs.base-ref }}
+        EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        base="$INPUT_BASE_REF"
+        if [[ -z "$base" ]]; then base="$EVENT_BASE_SHA"; fi
+        if [[ -n "$base" ]] && ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+          echo "::error::Base ref '$base' is unavailable. Checkout full history or pass a fetched base-ref."
+          exit 2
+        fi
+        echo "base_ref=$base" >> "$GITHUB_OUTPUT"
+
+    - name: Run Context Check
+      shell: bash
+      env:
+        TASK: ${{ inputs.task }}
+        BUDGET: ${{ inputs.token-budget }}
+        MAX_FILES: ${{ inputs.max-files }}
+        REPO_PATH: ${{ inputs.repo-path }}
+        HEAD_REF: ${{ inputs.head-ref }}
+        BASE_REF: ${{ steps.base.outputs.base_ref }}
+        FAIL_ON_RISK: ${{ inputs.fail-on-risk }}
+      run: |
+        args=("$REPO_PATH" --task "$TASK" --budget "$BUDGET" --max-files "$MAX_FILES" --git-head "$HEAD_REF" --fail-on-risk "$FAIL_ON_RISK")
+        if [[ -n "$BASE_REF" ]]; then args+=(--git-base "$BASE_REF"); fi
+        python -m entroly.context_check "${args[@]}"
+
+    - name: Publish summary and outputs
+      id: summarize
+      shell: bash
+      run: |
+        python - <<'PY'
+        import json, os
+        check = json.load(open("entroly-context-check.json", encoding="utf-8"))
+        recall = check["metrics"].get("changed_file_recall")
+        values = {
+            "check_id": check["check_id"],
+            "context_commit_id": check["context_commit"]["commit_id"],
+            "changed_file_recall": "not_measured" if recall is None else str(recall),
+            "risk_level": check["risk"]["level"],
+        }
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+            for key, value in values.items(): out.write(f"{key}={value}\n")
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+            summary.write(open("entroly-context-check.md", encoding="utf-8").read())
+        PY
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: entroly-context-check
+        path: |
+          entroly-context-check.json
+          entroly-context-check.md
+          entroly-context-commit.json
+        retention-days: 30

--- a/docs/schemas/context-check-v1.schema.json
+++ b/docs/schemas/context-check-v1.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://entroly.dev/schemas/context-check-v1.schema.json",
+  "title": "Entroly Context Check v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task",
+    "context_commit",
+    "comparison",
+    "corpus",
+    "metrics",
+    "risk",
+    "warnings",
+    "interpretation",
+    "check_id"
+  ],
+  "properties": {
+    "schema_version": {"const": "entroly.context-check.v1"},
+    "task": {"type": "string", "minLength": 1},
+    "check_id": {"type": "string", "pattern": "^cck_[0-9a-f]{24}$"},
+    "context_commit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit_id", "schema_version", "receipt_id", "engine", "selected_context_digest", "recovery_bundle_digest"],
+      "properties": {
+        "commit_id": {"type": "string", "pattern": "^ctx_[0-9a-f]{24}$"},
+        "schema_version": {"const": "entroly.context-commit.v1"},
+        "receipt_id": {"type": "string", "pattern": "^cr_[0-9a-f]{12}$"},
+        "engine": {"type": "object", "additionalProperties": {"type": "string"}},
+        "selected_context_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "recovery_bundle_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "changed_files", "changed_files_selected", "changed_files_missing", "changed_files_not_indexed"],
+      "properties": {
+        "status": {"enum": ["measured", "not_measured"]},
+        "changed_files": {"$ref": "#/$defs/pathList"},
+        "changed_files_selected": {"$ref": "#/$defs/pathList"},
+        "changed_files_missing": {"$ref": "#/$defs/pathList"},
+        "changed_files_not_indexed": {"$ref": "#/$defs/pathList"}
+      }
+    },
+    "corpus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supported_files_found", "files_indexed", "indexed_files", "selected_files"],
+      "properties": {
+        "supported_files_found": {"type": "integer", "minimum": 0},
+        "files_indexed": {"type": "integer", "minimum": 0},
+        "indexed_files": {"$ref": "#/$defs/pathList"},
+        "selected_files": {"$ref": "#/$defs/pathList"}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["changed_file_recall", "indexed_changed_file_recall", "changed_file_precision", "selected_chunks", "omitted_chunks", "token_budget"],
+      "properties": {
+        "changed_file_recall": {"$ref": "#/$defs/nullableRatio"},
+        "indexed_changed_file_recall": {"$ref": "#/$defs/nullableRatio"},
+        "changed_file_precision": {"$ref": "#/$defs/nullableRatio"},
+        "selected_chunks": {"type": "integer", "minimum": 0},
+        "omitted_chunks": {"type": "integer", "minimum": 0},
+        "token_budget": {"type": "integer", "minimum": 1}
+      }
+    },
+    "risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "receipt_review_level", "flags"],
+      "properties": {
+        "level": {"enum": ["low", "medium", "high", "unknown"]},
+        "receipt_review_level": {"type": "string"},
+        "flags": {"type": "array", "items": {"$ref": "#/$defs/riskFlag"}}
+      }
+    },
+    "warnings": {"type": "array", "items": {"type": "string"}},
+    "interpretation": {"type": "string", "minLength": 1}
+  },
+  "$defs": {
+    "pathList": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "nullableRatio": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+    "riskFlag": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "message", "files"],
+      "properties": {
+        "code": {"type": "string", "minLength": 1},
+        "severity": {"enum": ["low", "medium", "high", "unknown"]},
+        "message": {"type": "string", "minLength": 1},
+        "files": {"$ref": "#/$defs/pathList"}
+      }
+    }
+  }
+}

--- a/entroly/context_check.py
+++ b/entroly/context_check.py
@@ -1,0 +1,277 @@
+"""Deterministic, replayable retrospective context-quality checks.
+
+A Context Check measures whether files changed by an agent or pull request were
+represented in the verified Context Commit that preceded the change.  The
+result is evidence about context coverage, not proof of task correctness or
+model behaviour.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections.abc import Iterable, Mapping
+from pathlib import Path, PurePath
+from typing import Any
+
+from .context_commit import create_context_commit, verify_context_commit
+from .context_receipts.ingest import read_documents_from_path
+from .context_receipts.models import stable_hash
+
+CONTEXT_CHECK_SCHEMA = "entroly.context-check.v1"
+_RISK_RANK = {"low": 0, "medium": 1, "high": 2, "unknown": 2}
+_SENSITIVE_MARKERS = (
+    "/auth", "auth.", "security", "permission", "secret", "crypto",
+    ".github/workflows/", "migration", "dockerfile", "pyproject.toml",
+    "package.json", "cargo.toml",
+)
+
+
+def _path_text(value: object) -> str:
+    return PurePath(str(value).replace("\\", "/")).as_posix().removeprefix("./")
+
+
+def _relative_path(value: object, root: Path) -> str:
+    candidate = Path(str(value))
+    if candidate.is_absolute():
+        try:
+            return candidate.resolve().relative_to(root).as_posix()
+        except ValueError as exc:
+            raise ValueError(f"path is outside the checked root: {value}") from exc
+    normalized = _path_text(value)
+    if normalized in {"", ".", ".."} or normalized.startswith("../"):
+        raise ValueError(f"path is outside the checked root: {value}")
+    return normalized
+
+
+def _normalize_paths(values: Iterable[str | Path], root: Path | None = None) -> list[str]:
+    result: set[str] = set()
+    for value in values:
+        normalized = _relative_path(value, root.resolve()) if root else _path_text(value)
+        if normalized:
+            result.add(normalized)
+    return sorted(result)
+
+
+def _is_sensitive(path: str) -> bool:
+    lowered = "/" + path.casefold().lstrip("/")
+    return any(marker in lowered for marker in _SENSITIVE_MARKERS)
+
+
+def _max_risk(receipt_level: object, flags: list[dict[str, Any]]) -> str:
+    level = str(receipt_level).casefold()
+    if level not in {"low", "medium", "high"}:
+        level = "low"
+    for flag in flags:
+        candidate = str(flag.get("severity", "low"))
+        if _RISK_RANK.get(candidate, 0) > _RISK_RANK[level]:
+            level = candidate
+    return level
+
+
+def _commit_summary(commit: Mapping[str, Any]) -> dict[str, Any]:
+    receipt = commit.get("receipt", {})
+    receipt = receipt if isinstance(receipt, Mapping) else {}
+    engine = commit.get("engine", {})
+    return {
+        "commit_id": str(commit.get("commit_id", "")),
+        "schema_version": str(commit.get("schema_version", "")),
+        "receipt_id": str(receipt.get("receipt_id", "")),
+        "engine": dict(engine) if isinstance(engine, Mapping) else {},
+        "selected_context_digest": str(commit.get("selected_context_digest", "")),
+        "recovery_bundle_digest": str(commit.get("recovery_bundle_digest", "")),
+    }
+
+
+def assess_context_commit(
+    commit: Mapping[str, Any],
+    *,
+    changed_files: Iterable[str | Path] | None = None,
+    corpus_total_files: int | None = None,
+    corpus_included_files: int | None = None,
+) -> dict[str, Any]:
+    """Create a stable Context Check from a verified Context Commit."""
+    verification = verify_context_commit(commit)
+    if not verification.valid:
+        raise ValueError("Context Commit verification failed: " + ", ".join(verification.errors))
+
+    receipt_raw = commit.get("receipt", {})
+    receipt = receipt_raw if isinstance(receipt_raw, Mapping) else {}
+    fingerprints = receipt.get("source_fingerprints", {})
+    indexed = sorted(str(path) for path in fingerprints) if isinstance(fingerprints, Mapping) else []
+    selected_context = receipt.get("selected_context", [])
+    selected = sorted({
+        str(item.get("source_path"))
+        for item in selected_context
+        if isinstance(item, Mapping) and item.get("source_path")
+    }) if isinstance(selected_context, list) else []
+
+    measured = changed_files is not None
+    changed = _normalize_paths(changed_files or ())
+    selected_set, indexed_set = set(selected), set(indexed)
+    covered = [path for path in changed if path in selected_set]
+    missing = [path for path in changed if path not in selected_set]
+    unsupported = [path for path in changed if path not in indexed_set]
+    indexed_changed = [path for path in changed if path in indexed_set]
+
+    recall = round(len(covered) / len(changed), 4) if measured and changed else (1.0 if measured else None)
+    indexed_recall = round(len(covered) / len(indexed_changed), 4) if measured and indexed_changed else None
+    precision = round(len(covered) / len(selected), 4) if measured and selected else None
+
+    flags: list[dict[str, Any]] = []
+    if not measured:
+        flags.append({"code": "comparison_evidence_missing", "severity": "unknown", "message": "No changed-file evidence was supplied; coverage was not measured.", "files": []})
+    elif missing:
+        sensitive = [path for path in missing if _is_sensitive(path)]
+        flags.append({"code": "changed_files_not_selected", "severity": "high" if sensitive else "medium", "message": f"{len(missing)} changed file(s) were absent from selected context.", "files": missing})
+        if sensitive:
+            flags.append({"code": "sensitive_changed_files_not_selected", "severity": "high", "message": "Sensitive, dependency, workflow, or configuration changes were absent from selected context.", "files": sensitive})
+    if unsupported:
+        flags.append({"code": "changed_files_not_indexed", "severity": "high", "message": f"{len(unsupported)} changed file(s) were outside the indexed corpus.", "files": unsupported})
+
+    total = len(indexed) if corpus_total_files is None else corpus_total_files
+    included = len(indexed) if corpus_included_files is None else corpus_included_files
+    if total > included:
+        flags.append({"code": "corpus_truncated", "severity": "medium", "message": f"The bounded scan indexed {included} of {total} supported files.", "files": []})
+
+    receipt_risk_raw = receipt.get("risk_summary", {})
+    receipt_risk = receipt_risk_raw if isinstance(receipt_risk_raw, Mapping) else {}
+    level = "unknown" if not measured else _max_risk(receipt_risk.get("review_level", "low"), flags)
+    warnings = [str(item) for item in receipt.get("warnings", [])] if isinstance(receipt.get("warnings"), list) else []
+    warnings.extend(str(flag["message"]) for flag in flags)
+
+    payload: dict[str, Any] = {
+        "schema_version": CONTEXT_CHECK_SCHEMA,
+        "task": str(receipt.get("query", "")),
+        "context_commit": _commit_summary(commit),
+        "comparison": {
+            "status": "measured" if measured else "not_measured",
+            "changed_files": changed,
+            "changed_files_selected": covered,
+            "changed_files_missing": missing,
+            "changed_files_not_indexed": unsupported,
+        },
+        "corpus": {"supported_files_found": total, "files_indexed": included, "indexed_files": indexed, "selected_files": selected},
+        "metrics": {
+            "changed_file_recall": recall,
+            "indexed_changed_file_recall": indexed_recall,
+            "changed_file_precision": precision,
+            "selected_chunks": verification.selected_chunks,
+            "omitted_chunks": verification.omitted_chunks,
+            "token_budget": int(receipt.get("token_budget", 0) or 0),
+        },
+        "risk": {"level": level, "receipt_review_level": str(receipt_risk.get("review_level", "unknown")), "flags": flags},
+        "warnings": list(dict.fromkeys(warnings)),
+        "interpretation": "Changed-file recall is retrospective coverage evidence. It does not prove task correctness, complete task knowledge, or that a model used the selected context.",
+    }
+    payload["check_id"] = "cck_" + stable_hash(payload)[:24]
+    return payload
+
+
+def _documents(path: str | Path, max_files: int) -> tuple[list[tuple[str, str]], int, Path]:
+    source = Path(path).resolve()
+    root = source.parent if source.is_file() else source
+    documents = [(_relative_path(name, root), text) for name, text in read_documents_from_path(source)]
+    documents.sort(key=lambda item: item[0])
+    total = len(documents)
+    return (documents[:max_files] if max_files > 0 else documents), total, root
+
+
+def create_context_check_from_path(
+    path: str | Path,
+    *,
+    task: str,
+    token_budget: int = 8000,
+    changed_files: Iterable[str | Path] | None = None,
+    max_files: int = 0,
+    chunk_tokens: int = 360,
+    overlap_tokens: int = 32,
+    prefer_rust: bool = True,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not task.strip():
+        raise ValueError("task must not be empty")
+    if token_budget <= 0:
+        raise ValueError("token_budget must be positive")
+    if max_files < 0:
+        raise ValueError("max_files must be zero or positive")
+    documents, total, root = _documents(path, max_files)
+    if not documents:
+        raise ValueError("no supported documents found")
+    normalized = None if changed_files is None else _normalize_paths(changed_files, root)
+    commit = create_context_commit(documents, query=task.strip(), token_budget=token_budget, chunk_tokens=chunk_tokens, overlap_tokens=overlap_tokens, prefer_rust=prefer_rust)
+    return assess_context_commit(commit, changed_files=normalized, corpus_total_files=total, corpus_included_files=len(documents)), commit
+
+
+def git_changed_files(path: str | Path, *, base: str, head: str = "HEAD") -> list[str]:
+    if not base.strip() or base.startswith("-") or not head.strip() or head.startswith("-"):
+        raise ValueError("git refs must be non-empty and must not start with '-'")
+    source = Path(path).resolve()
+    root = source.parent if source.is_file() else source
+    try:
+        result = subprocess.run(["git", "-C", str(root), "diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...{head}", "--"], capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"unable to compare git refs: {exc}") from exc
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git diff failed")
+    return _normalize_paths(result.stdout.splitlines())
+
+
+def context_check_markdown(check: Mapping[str, Any]) -> str:
+    comparison = check.get("comparison", {}) if isinstance(check.get("comparison"), Mapping) else {}
+    metrics = check.get("metrics", {}) if isinstance(check.get("metrics"), Mapping) else {}
+    risk = check.get("risk", {}) if isinstance(check.get("risk"), Mapping) else {}
+    commit = check.get("context_commit", {}) if isinstance(check.get("context_commit"), Mapping) else {}
+    fmt = lambda name: "not measured" if metrics.get(name) is None else f"{float(metrics[name]):.1%}"
+    lines = [
+        "# Entroly Context Check", "",
+        f"- Check: `{check.get('check_id', '')}`", f"- Task: {check.get('task', '')}",
+        f"- Context Commit: `{commit.get('commit_id', '')}`", f"- Risk: **{risk.get('level', 'unknown')}**",
+        f"- Comparison: {comparison.get('status', 'not_measured')}",
+        f"- Changed-file recall: {fmt('changed_file_recall')}",
+        f"- Indexed changed-file recall: {fmt('indexed_changed_file_recall')}",
+        f"- Changed-file precision: {fmt('changed_file_precision')}", "", "## Changed-file evidence", "",
+    ]
+    for label, key in (("Selected", "changed_files_selected"), ("Missing", "changed_files_missing"), ("Not indexed", "changed_files_not_indexed")):
+        values = comparison.get(key, [])
+        rendered = ", ".join(f"`{value}`" for value in values) if values else "none"
+        lines.append(f"- {label}: {rendered}")
+    lines.extend(["", "## Risk flags", ""])
+    flags = risk.get("flags", [])
+    if isinstance(flags, list) and flags:
+        lines.extend(f"- **{flag.get('severity', 'unknown')}** `{flag.get('code', '')}`: {flag.get('message', '')}" for flag in flags if isinstance(flag, Mapping))
+    else:
+        lines.append("- No additional changed-file risk flags.")
+    lines.extend(["", "## Interpretation", "", str(check.get("interpretation", "")), ""])
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit selected context against changed files")
+    parser.add_argument("path", nargs="?", default=".")
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--budget", type=int, default=8000)
+    parser.add_argument("--max-files", type=int, default=0)
+    parser.add_argument("--git-base")
+    parser.add_argument("--git-head", default="HEAD")
+    parser.add_argument("--out", default="entroly-context-check.json")
+    parser.add_argument("--report", default="entroly-context-check.md")
+    parser.add_argument("--commit-out", default="entroly-context-commit.json")
+    parser.add_argument("--fail-on-risk", choices=("none", "medium", "high"), default="none")
+    args = parser.parse_args(argv)
+    changed = git_changed_files(args.path, base=args.git_base, head=args.git_head) if args.git_base else None
+    check, commit = create_context_check_from_path(args.path, task=args.task, token_budget=args.budget, changed_files=changed, max_files=args.max_files)
+    Path(args.out).write_text(json.dumps(check, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    Path(args.report).write_text(context_check_markdown(check), encoding="utf-8")
+    Path(args.commit_out).write_text(json.dumps(commit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"check_id": check["check_id"], "context_commit_id": check["context_commit"]["commit_id"], "risk": check["risk"]["level"]}, sort_keys=True))
+    rank = _RISK_RANK.get(str(check["risk"]["level"]), 2)
+    threshold = {"none": 99, "medium": 1, "high": 2}[args.fail_on_risk]
+    return 1 if rank >= threshold else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["CONTEXT_CHECK_SCHEMA", "assess_context_commit", "context_check_markdown", "create_context_check_from_path", "git_changed_files", "main"]

--- a/tests/test_context_check.py
+++ b/tests/test_context_check.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from entroly.context_check import (
+    CONTEXT_CHECK_SCHEMA,
+    assess_context_commit,
+    context_check_markdown,
+    create_context_check_from_path,
+    git_changed_files,
+)
+from entroly.context_commit import create_context_commit, verify_context_commit
+
+DOCUMENTS = [
+    ("src/handler.py", "def handle_timeout(request):\n    return request.retry_after\n"),
+    ("src/auth.py", "def rotate_secret(user):\n    return user.rotate_credentials()\n"),
+    ("tests/test_handler.py", "def test_timeout():\n    assert handle_timeout(fake_request()) == 30\n"),
+]
+
+
+def _commit():
+    return create_context_commit(DOCUMENTS, query="handle_timeout request retry_after", token_budget=18, prefer_rust=False)
+
+
+def test_context_check_measures_changed_file_coverage():
+    check = assess_context_commit(_commit(), changed_files=["src/handler.py", "src/auth.py"])
+    assert check["schema_version"] == CONTEXT_CHECK_SCHEMA
+    assert check["check_id"].startswith("cck_")
+    assert check["comparison"]["status"] == "measured"
+    assert "src/handler.py" in check["comparison"]["changed_files_selected"]
+    assert check["metrics"]["changed_file_recall"] < 1.0
+    assert check["risk"]["level"] == "high"
+    assert any(flag["code"] == "sensitive_changed_files_not_selected" for flag in check["risk"]["flags"])
+
+
+def test_context_check_is_content_addressed_and_deterministic():
+    first = assess_context_commit(_commit(), changed_files=["src/auth.py", "src/handler.py"])
+    second = assess_context_commit(_commit(), changed_files=["src/handler.py", "src/auth.py", "src/auth.py"])
+    assert first == second
+
+
+def test_missing_comparison_is_unknown_not_false_success():
+    check = assess_context_commit(_commit())
+    assert check["comparison"]["status"] == "not_measured"
+    assert check["metrics"]["changed_file_recall"] is None
+    assert check["risk"]["level"] == "unknown"
+
+
+def test_empty_change_set_is_measured_full_recall():
+    check = assess_context_commit(_commit(), changed_files=[])
+    assert check["comparison"]["status"] == "measured"
+    assert check["metrics"]["changed_file_recall"] == 1.0
+
+
+def test_unindexed_changed_file_is_high_risk():
+    check = assess_context_commit(_commit(), changed_files=["generated/unknown.bin"])
+    assert check["risk"]["level"] == "high"
+    assert check["comparison"]["changed_files_not_indexed"] == ["generated/unknown.bin"]
+
+
+def test_truncated_corpus_is_explicit():
+    check = assess_context_commit(_commit(), changed_files=[], corpus_total_files=10, corpus_included_files=3)
+    assert any(flag["code"] == "corpus_truncated" for flag in check["risk"]["flags"])
+
+
+def test_markdown_is_bounded_and_contains_key_evidence():
+    report = context_check_markdown(assess_context_commit(_commit(), changed_files=["src/auth.py"]))
+    assert "# Entroly Context Check" in report
+    assert "Changed-file recall" in report
+    assert "sensitive_changed_files_not_selected" in report
+    assert len(report) < 20_000
+
+
+def test_create_from_path_writes_replayable_commit(tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "handler.py").write_text(DOCUMENTS[0][1], encoding="utf-8")
+    (tmp_path / "src" / "auth.py").write_text(DOCUMENTS[1][1], encoding="utf-8")
+    check, commit = create_context_check_from_path(
+        tmp_path,
+        task="handle_timeout request retry_after",
+        token_budget=18,
+        changed_files=["src/handler.py"],
+        prefer_rust=False,
+    )
+    assert check["context_commit"]["commit_id"] == commit["commit_id"]
+    assert verify_context_commit(commit).valid
+
+
+def test_create_from_path_rejects_traversal(tmp_path: Path):
+    (tmp_path / "main.py").write_text("print('ok')\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="outside the checked root"):
+        create_context_check_from_path(tmp_path, task="main", changed_files=["../secret.py"], prefer_rust=False)
+
+
+def test_git_changed_files_uses_merge_base_comparison(tmp_path: Path):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    tracked = tmp_path / "main.py"
+    tracked.write_text("print('one')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "main.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=tmp_path, check=True, capture_output=True)
+    base = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True).strip()
+    tracked.write_text("print('two')\n", encoding="utf-8")
+    subprocess.run(["git", "commit", "-am", "change"], cwd=tmp_path, check=True, capture_output=True)
+    assert git_changed_files(tmp_path, base=base) == ["main.py"]
+
+
+def test_module_cli_emits_artifacts(tmp_path: Path):
+    (tmp_path / "main.py").write_text("def answer():\n    return 42\n", encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "-m", "entroly.context_check", str(tmp_path), "--task", "answer", "--budget", "32", "--out", str(tmp_path / "check.json"), "--report", str(tmp_path / "check.md"), "--commit-out", str(tmp_path / "commit.json")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    check = json.loads((tmp_path / "check.json").read_text(encoding="utf-8"))
+    assert check["risk"]["level"] == "unknown"
+    assert (tmp_path / "check.md").exists()
+    assert (tmp_path / "commit.json").exists()


### PR DESCRIPTION
## Summary

Adds a deterministic, replayable Context Check quality layer that audits whether changed files were represented in the verified Context Commit used for a task.

### Included
- `entroly.context_check` engine and standalone module CLI
- content-addressed `cck_...` artifacts
- changed-file recall, indexed recall, and precision
- conservative risk escalation for sensitive, unsupported, and truncated context
- verified Context Commit linkage and recovery digests
- strict JSON Schema contract
- reusable GitHub composite action with artifacts and risk gating
- deterministic, traversal, git comparison, CLI, and risk tests

## Architectural decisions

- Keeps the engine independent of the large central CLI to reduce merge and release risk. It runs as `python -m entroly.context_check` and can later be exposed through the main dispatcher with a very small adapter.
- Treats missing comparison evidence as `unknown`, never as a false success.
- Explicitly frames recall as retrospective coverage evidence, not a model-quality or correctness score.
- Uses verified Context Commits as the trust root and stable hashes for reproducible check identifiers.

## Validation

CI should run the added test suite. The implementation was developed against the current `main` Context Commit and Context Receipt interfaces; direct local repository execution was unavailable in this environment, so the PR remains draft until CI confirms integration.