### PR TITLE
Release v1.0.51: Frontier Context Quality Layer

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/.github/workflows/sync-release-version.yml
+++ b/.github/workflows/sync-release-version.yml
@@ -1,0 +1,70 @@
+name: Synchronize Release Version
+
+on:
+  push:
+    branches:
+      - 'release/v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semantic release version, for example 1.0.51
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  synchronize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Resolve target version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME#release/v}"
+          fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release branch or version: $version"
+            exit 2
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Synchronize tracked release surfaces
+        run: python scripts/sync_release_version.py "${{ steps.version.outputs.version }}"
+
+      - name: Validate release contract
+        run: |
+          python -m pip install pytest
+          python -m pytest tests/test_release_surface.py -q
+          python -m compileall -q scripts/sync_release_version.py entroly
+
+      - name: Commit synchronized surfaces
+        shell: bash
+        run: |
+          if git diff --quiet && git diff --cached --quiet && [[ -z "$(git status --porcelain)" ]]; then
+            echo "Release surfaces are already synchronized."
+            exit 0
+          fi
+          git config user.name "juyterman1000"
+          git config user.email "208309368+juyterman1000@users.noreply.github.com"
+          git add -A
+          git commit -m "Synchronize release version ${{ steps.version.outputs.version }}"
+          git push origin HEAD

--- a/.mcpb-build/manifest.json
+++ b/.mcpb-build/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "entroly",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Open-source context control plane for AI coding agents. Compresses prompts 70-95%, stabilizes KV-cache prefixes, routes tasks to cheaper models, and verifies answers locally with WITNESS.",
   "author": {
     "name": "juyterman1000",

--- a/docs/releases/v1.0.51.md
+++ b/docs/releases/v1.0.51.md
@@ -1,0 +1,22 @@
+# Entroly 1.0.51
+
+Entroly 1.0.51 introduces the Frontier Context Quality Layer and completes
+its first production release across the Python, Rust, npm, MCP, OpenClaw,
+WASM, plugin, Docker, and GitHub release surfaces.
+
+Highlights:
+
+- deterministic, content-addressed Context Checks linked to verified Context
+  Commits;
+- retrospective changed-file recall, indexed recall, and precision evidence;
+- conservative risk escalation for sensitive, unsupported, truncated, and
+  unmeasured context;
+- replayable JSON and Markdown artifacts with a strict schema contract;
+- reusable GitHub Action integration with artifact publication and CI risk
+  gating;
+- synchronized release metadata across Python, Rust, QCCR, WASM, npm, MCP,
+  OpenClaw, plugins, manifests, lockfiles, Homebrew, and release verification
+  tests.
+
+Changed-file coverage is evidence about context selection. It is not presented
+as proof of model correctness or complete task knowledge.

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "1.0.50"
+version = "1.0.51"
 dependencies = [
  "entroly-qccr",
  "flate2",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.50"
+version = "1.0.51"
 dependencies = [
  "regex",
  "serde",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "1.0.50"
+version = "1.0.51"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=1.0.50"
+python -m pip install --no-cache-dir -U "entroly-core>=1.0.51"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "1.0.50"
+version = "1.0.51"
 description = "Rust core for Entroly: Context Receipts, deterministic ingestion/ranking, dependency audits, and local context optimization"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-qccr/Cargo.lock
+++ b/entroly-qccr/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.50"
+version = "1.0.51"
 dependencies = [
  "regex",
  "regex-lite",

--- a/entroly-qccr/Cargo.toml
+++ b/entroly-qccr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-qccr"
-version = "1.0.50"
+version = "1.0.51"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.50"
+version = "1.0.51"
 dependencies = [
  "regex-lite",
  "serde",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "1.0.50"
+version = "1.0.51"
 dependencies = [
  "entroly-qccr",
  "flate2",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "1.0.50"
+version = "1.0.51"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Pure WebAssembly local context OS for AI agents: context receipts, local optimization, MCP, app SDK helpers, and no Python dependency.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "1.0.50"
+__version__ = "1.0.51"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -51,7 +51,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "1.0.50"
+    __version__ = "1.0.51"
 
 from entroly.config import (
     load_active_tuning_config as _load_active_tuning_config,
@@ -3107,7 +3107,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.50\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.51\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -4625,7 +4625,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.50\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.51\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -4668,7 +4668,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.50\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.51\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -69,7 +69,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "1.0.50"
+    version: str = "1.0.51"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -7,7 +7,7 @@ from importlib import metadata
 from types import ModuleType
 
 
-MIN_ENTROLY_CORE_VERSION = "1.0.50"
+MIN_ENTROLY_CORE_VERSION = "1.0.51"
 QCCR_SYMBOLS = (
     "py_qccr_expand_query",
     "py_qccr_rank_files",

--- a/entroly/npm-alias/package.json
+++ b/entroly/npm-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Node/WASM Entroly runtime: local context optimization, MCP server tools, receipts, recovery, and verification without Python.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "dependencies": {
-    "entroly-wasm": "1.0.50"
+    "entroly-wasm": "1.0.51"
   },
   "repository": {
     "type": "git",

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "mcpName": "io.github.juyterman1000/entroly",
   "description": "NPX MCP bridge for Entroly, the local context OS with receipts, recovery, verification, and token optimization for AI coding agents.",
   "main": "index.js",

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.50"
+version = "1.0.51"
 
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, HTTP proxy, and Python SDK."
 readme = "README.md"
@@ -42,14 +42,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.50,<2",
+    "entroly-core>=1.0.51,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.50,<2",
+    "entroly-core>=1.0.51,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -4912,7 +4912,7 @@ def main():
     try:
         from entroly import __version__ as _version
     except Exception:
-        _version = "1.0.50"
+        _version = "1.0.51"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-openclaw",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Auditable, budget-aware Entroly context engine for OpenClaw",
   "type": "module",
   "license": "Apache-2.0",

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -2,13 +2,13 @@
 
 The formula in this directory is the canonical source. To make `brew tap juyterman1000/entroly && brew install entroly` work, the formula must live in a separate repo named `juyterman1000/homebrew-entroly`.
 
-Current release example version: `1.0.50`.
+Current release example version: `1.0.51`.
 
 ## Release checklist
 
 1. Copy `packaging/homebrew/entroly.rb` into `juyterman1000/homebrew-entroly/Formula/entroly.rb`.
-2. Set `VER=1.0.50` when preparing this release.
-3. Download the matching PyPI sdist: `entroly-1.0.50.tar.gz`.
+2. Set `VER=1.0.51` when preparing this release.
+3. Download the matching PyPI sdist: `entroly-1.0.51.tar.gz`.
 4. Recalculate the `sha256` for that tarball before publishing the Homebrew tap update.
 5. Verify locally before pushing with `brew install --build-from-source ./Formula/entroly.rb`, `brew test entroly`, and `brew audit --new --strict entroly`.
 

--- a/packaging/homebrew/entroly.rb
+++ b/packaging/homebrew/entroly.rb
@@ -21,7 +21,7 @@ class Entroly < Formula
 
   desc "Token-saving proxy and context compression engine for AI coding agents"
   homepage "https://github.com/juyterman1000/entroly"
-  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-1.0.50.tar.gz"
+  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-1.0.51.tar.gz"
   sha256 "94e54692b4e677e9261d2c667a30ecaec3c0f871729c1cc84256854361d9ec1e"
   license "Apache-2.0"
   head "https://github.com/juyterman1000/entroly.git", branch: "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.50"
+version = "1.0.51"
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, and SDK helpers."
 readme = "README.md"
 license = "Apache-2.0"
@@ -42,14 +42,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.50,<2",
+    "entroly-core>=1.0.51,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.50,<2",
+    "entroly-core>=1.0.51,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Synchronize Entroly release versions across tracked release surfaces.
+
+The script intentionally preserves historical release notes while updating every
+other tracked text file that advertises the current release. It is idempotent,
+validates the requested semantic version, and fails if stale current-version
+references remain outside ``docs/releases``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+SEMVER_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+PROJECT_VERSION_RE = re.compile(r'(?m)^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"')
+
+
+def _tracked_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return [root / item.decode("utf-8") for item in result.stdout.split(b"\0") if item]
+
+
+def _release_note(version: str) -> str:
+    return f"""# Entroly {version}
+
+Entroly {version} introduces the Frontier Context Quality Layer and completes
+its first production release across the Python, Rust, npm, MCP, OpenClaw,
+WASM, plugin, Docker, and GitHub release surfaces.
+
+Highlights:
+
+- deterministic, content-addressed Context Checks linked to verified Context
+  Commits;
+- retrospective changed-file recall, indexed recall, and precision evidence;
+- conservative risk escalation for sensitive, unsupported, truncated, and
+  unmeasured context;
+- replayable JSON and Markdown artifacts with a strict schema contract;
+- reusable GitHub Action integration with artifact publication and CI risk
+  gating;
+- synchronized release metadata across Python, Rust, QCCR, WASM, npm, MCP,
+  OpenClaw, plugins, manifests, lockfiles, Homebrew, and release verification
+  tests.
+
+Changed-file coverage is evidence about context selection. It is not presented
+as proof of model correctness or complete task knowledge.
+"""
+
+
+def synchronize(root: Path, target: str) -> list[str]:
+    if not SEMVER_RE.fullmatch(target):
+        raise ValueError(f"invalid semantic version: {target!r}")
+
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    match = PROJECT_VERSION_RE.search(pyproject)
+    if not match:
+        raise RuntimeError("unable to resolve current version from pyproject.toml")
+    current = match.group(1)
+
+    changed: list[str] = []
+    old_identifier = current.replace(".", "_")
+    new_identifier = target.replace(".", "_")
+
+    for path in _tracked_files(root):
+        relative = path.relative_to(root)
+        if relative.parts[:2] == ("docs", "releases"):
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        if b"\0" in data:
+            continue
+        updated = data.replace(current.encode(), target.encode())
+        updated = updated.replace(old_identifier.encode(), new_identifier.encode())
+        if updated != data:
+            path.write_bytes(updated)
+            changed.append(relative.as_posix())
+
+    note = root / "docs" / "releases" / f"v{target}.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    rendered_note = _release_note(target)
+    if not note.exists() or note.read_text(encoding="utf-8") != rendered_note:
+        note.write_text(rendered_note, encoding="utf-8")
+        changed.append(note.relative_to(root).as_posix())
+
+    stale: list[str] = []
+    for path in _tracked_files(root):
+        relative = path.relative_to(root)
+        if relative.parts[:2] == ("docs", "releases"):
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        if b"\0" not in data and current.encode() in data:
+            stale.append(relative.as_posix())
+    if current != target and stale:
+        raise RuntimeError("stale release references remain: " + ", ".join(stale))
+
+    return sorted(set(changed))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument("--root", default=".")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    changed = synchronize(root, args.version)
+    if changed:
+        print("Synchronized release surfaces:")
+        for path in changed:
+            print(f"  {path}")
+    else:
+        print(f"Release surfaces already synchronized at {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/juyterman1000/entroly",
     "source": "github"
   },
-  "version": "1.0.50",
+  "version": "1.0.51",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "entroly",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "transport": {
         "type": "stdio"
       }
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "entroly-mcp",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-RELEASE_VERSION = "1.0.50"
+RELEASE_VERSION = "1.0.51"
 
 
 def _read_json(path: str) -> dict:
@@ -59,7 +59,7 @@ def _read_project_metadata(path: str) -> dict[str, object]:
     return metadata
 
 
-def test_public_package_versions_are_1_0_50() -> None:
+def test_public_package_versions_are_1_0_51() -> None:
     assert _read_project_metadata("pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_project_metadata("entroly/pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_json("entroly/npm/package.json")["version"] == RELEASE_VERSION


### PR DESCRIPTION
## Release 1.0.51

Synchronizes Entroly 1.0.51 across every active release surface and prepares the full publication pipeline.

### Included
- Python package metadata, optional native dependency ranges, and runtime fallback versions
- Rust core, QCCR, and WASM manifests and lockfiles
- npm alias, MCP, WASM, and OpenClaw package versions
- MCP registry and Claude/MCPB plugin manifests
- Homebrew version references
- release contract tests
- `docs/releases/v1.0.51.md`
- deterministic reusable release-surface synchronization tooling

### Feature release
- Frontier Context Check quality layer
- deterministic Context Commit linkage and content-addressed checks
- changed-file recall, indexed recall, precision, and conservative risk gating
- strict JSON/Markdown artifacts and GitHub Action support

The squash merge title intentionally starts with `Release v1.0.51` so the existing publication workflow launches native wheels, PyPI, npm packages, GitHub Release, binaries, and container publication from the synchronized commit.