### PR TITLE
Secure canonical MCP Registry publishing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Canonical package and MCP Registry identity.
+# Enforce owner review for these paths in the main branch protection rule.
+/server.json @juyterman1000
+/PYPI_README.md @juyterman1000
+/pyproject.toml @juyterman1000
+/entroly/npm/package.json @juyterman1000
+/.github/workflows/publish-mcp-registry.yml @juyterman1000
+/.github/workflows/entroly-publish.yml @juyterman1000
+/.github/workflows/publish-core-wheels.yml @juyterman1000
+/scripts/sync_release_version.py @juyterman1000
+/tests/test_release_surface.py @juyterman1000

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -4,33 +4,56 @@ on:
   workflow_run:
     workflows: ["Build and Push Entroly Docker Image"]
     types: [completed]
-  workflow_dispatch:
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: mcp-registry-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: mcp-registry-production
   cancel-in-progress: false
 
 jobs:
   publish:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main' &&
-       (startsWith(github.event.workflow_run.head_commit.message, 'Release v') ||
-        startsWith(github.event.workflow_run.head_commit.message, 'Release ')))
+      github.repository == 'juyterman1000/entroly' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == 'juyterman1000/entroly' &&
+      github.event.workflow_run.actor.login == 'juyterman1000' &&
+      (startsWith(github.event.workflow_run.head_commit.message, 'Release v') ||
+       startsWith(github.event.workflow_run.head_commit.message, 'Release '))
     runs-on: ubuntu-latest
+    environment:
+      name: mcp-registry-production
+      url: https://registry.modelcontextprotocol.io/?q=io.github.juyterman1000%2Fentroly
 
     steps:
-      - name: Checkout released source
+      - name: Checkout exact released source
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Validate published package metadata
+      - name: Assert canonical publisher and immutable release source
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+          RELEASE_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "juyterman1000/entroly"
+          test "$GITHUB_REPOSITORY_OWNER" = "juyterman1000"
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$SOURCE_SHA" origin/main
+          case "$RELEASE_MESSAGE" in
+            "Release v"*|"Release "*) ;;
+            *) echo "::error::Refusing non-release commit: $RELEASE_MESSAGE"; exit 2 ;;
+          esac
+
+      - name: Validate canonical MCP identity and published packages
         shell: bash
         run: |
           python - <<'PY'
@@ -43,84 +66,122 @@ jobs:
           import urllib.request
 
           root = pathlib.Path('.')
-          with (root / 'pyproject.toml').open('rb') as fh:
-              version = tomllib.load(fh)['project']['version']
-          server = json.loads((root / 'server.json').read_text(encoding='utf-8'))
-          expected_name = 'io.github.juyterman1000/entroly'
+          canonical_repo = 'https://github.com/juyterman1000/entroly'
+          canonical_name = 'io.github.juyterman1000/entroly'
+          expected_packages = {
+              ('pypi', 'entroly'): ('uvx', ['serve']),
+              ('npm', 'entroly-mcp'): ('npx', ['serve']),
+          }
 
-          if server.get('name') != expected_name:
-              raise SystemExit(f"server.json name must be {expected_name!r}")
+          with (root / 'pyproject.toml').open('rb') as fh:
+              project = tomllib.load(fh)['project']
+          version = project['version']
+          if project.get('readme') != 'PYPI_README.md':
+              raise SystemExit('PyPI must publish the dedicated canonical MCP README')
+
+          marker = f'mcp-name: {canonical_name}'
+          pypi_readme = (root / 'PYPI_README.md').read_text(encoding='utf-8')
+          if marker not in pypi_readme:
+              raise SystemExit(f'PYPI_README.md is missing {marker!r}')
+
+          server = json.loads((root / 'server.json').read_text(encoding='utf-8'))
+          if server.get('name') != canonical_name:
+              raise SystemExit(f'server name must be {canonical_name!r}')
+          repository = server.get('repository') or {}
+          if repository.get('url') != canonical_repo or repository.get('source') != 'github':
+              raise SystemExit('server repository identity is not canonical')
+          if server.get('websiteUrl') != canonical_repo:
+              raise SystemExit('server websiteUrl is not canonical')
           if server.get('version') != version:
-              raise SystemExit(
-                  f"server.json version {server.get('version')!r} does not match project version {version!r}"
-              )
+              raise SystemExit('server.json and pyproject.toml versions differ')
+
+          actual_packages = {}
           for package in server.get('packages', []):
+              key = (package.get('registryType'), package.get('identifier'))
+              args = [item.get('value') for item in package.get('packageArguments', [])]
+              actual_packages[key] = (package.get('runtimeHint'), args)
               if package.get('version') != version:
-                  raise SystemExit(
-                      f"{package.get('identifier')} version {package.get('version')!r} "
-                      f"does not match project version {version!r}"
-                  )
+                  raise SystemExit(f'{key} does not match release version {version}')
+          if actual_packages != expected_packages:
+              raise SystemExit(
+                  f'canonical package set changed: {actual_packages!r}; '
+                  f'expected {expected_packages!r}'
+              )
+
+          npm_manifest = json.loads(
+              (root / 'entroly/npm/package.json').read_text(encoding='utf-8')
+          )
+          if npm_manifest.get('name') != 'entroly-mcp':
+              raise SystemExit('unexpected npm MCP package name')
+          if npm_manifest.get('mcpName') != canonical_name:
+              raise SystemExit('npm mcpName does not match canonical registry identity')
+          if npm_manifest.get('version') != version:
+              raise SystemExit('npm MCP package version does not match release')
 
           def read_json(url: str) -> dict:
               request = urllib.request.Request(
                   url,
-                  headers={'User-Agent': 'entroly-mcp-registry-publisher'},
+                  headers={'User-Agent': 'entroly-canonical-mcp-publisher'},
               )
               with urllib.request.urlopen(request, timeout=30) as response:
                   return json.load(response)
 
-          errors = []
           for attempt in range(1, 21):
               errors = []
               try:
                   pypi = read_json(
-                      f"https://pypi.org/pypi/entroly/{urllib.parse.quote(version)}/json"
+                      f'https://pypi.org/pypi/entroly/{urllib.parse.quote(version)}/json'
                   )
                   description = pypi.get('info', {}).get('description') or ''
-                  marker = f"mcp-name: {expected_name}"
                   if marker not in description:
-                      errors.append(f"PyPI README is missing {marker!r}")
+                      errors.append(f'PyPI README is missing {marker!r}')
               except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
-                  errors.append(f"PyPI entroly {version} is unavailable: {exc}")
+                  errors.append(f'PyPI entroly {version} is unavailable: {exc}')
 
               try:
                   npm = read_json(
-                      f"https://registry.npmjs.org/entroly-mcp/{urllib.parse.quote(version)}"
+                      f'https://registry.npmjs.org/entroly-mcp/{urllib.parse.quote(version)}'
                   )
-                  if npm.get('mcpName') != expected_name:
-                      errors.append(
-                          f"npm mcpName is {npm.get('mcpName')!r}, expected {expected_name!r}"
-                      )
+                  if npm.get('mcpName') != canonical_name:
+                      errors.append('npm package is missing the canonical mcpName')
+                  repository_url = (npm.get('repository') or {}).get('url', '')
+                  if canonical_repo not in repository_url:
+                      errors.append('npm package repository is not canonical')
               except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
-                  errors.append(f"npm entroly-mcp {version} is unavailable: {exc}")
+                  errors.append(f'npm entroly-mcp {version} is unavailable: {exc}')
 
               if not errors:
-                  print(f"Validated Entroly {version} on PyPI and npm.")
+                  print(f'Validated canonical Entroly {version} packages.')
                   break
               if attempt == 20:
                   raise SystemExit('\n'.join(errors))
               print(
-                  f"Package metadata not ready (attempt {attempt}/20): "
+                  f'Package metadata not ready (attempt {attempt}/20): '
                   + '; '.join(errors)
               )
               time.sleep(15)
           PY
 
-      - name: Install MCP Registry publisher
+      - name: Install pinned MCP Registry publisher
         shell: bash
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.9
         run: |
-          curl --fail --location --silent --show-error \
-            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
-            | tar xz mcp-publisher
-          ./mcp-publisher --help
+          set -euo pipefail
+          platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          url="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${platform}_${arch}.tar.gz"
+          curl --fail --location --silent --show-error "$url" | tar xz mcp-publisher
+          test -x ./mcp-publisher
+          ./mcp-publisher --help >/dev/null
 
-      - name: Authenticate with GitHub OIDC
+      - name: Authenticate canonical GitHub repository with OIDC
         run: ./mcp-publisher login github-oidc
 
-      - name: Publish Entroly
+      - name: Publish canonical Entroly identity
         run: ./mcp-publisher publish
 
-      - name: Verify registry listing
+      - name: Verify exact registry ownership and listing
         shell: bash
         run: |
           python - <<'PY'
@@ -130,28 +191,43 @@ jobs:
           import urllib.request
 
           name = 'io.github.juyterman1000/entroly'
+          repository = 'https://github.com/juyterman1000/entroly'
+          expected_packages = {('pypi', 'entroly'), ('npm', 'entroly-mcp')}
           version = json.load(open('server.json', encoding='utf-8'))['version']
           url = (
               'https://registry.modelcontextprotocol.io/v0.1/servers?search='
               + urllib.parse.quote(name, safe='')
           )
 
-          for attempt in range(1, 11):
+          for attempt in range(1, 16):
               request = urllib.request.Request(
                   url,
-                  headers={'User-Agent': 'entroly-mcp-registry-publisher'},
+                  headers={'User-Agent': 'entroly-canonical-mcp-publisher'},
               )
               with urllib.request.urlopen(request, timeout=30) as response:
                   payload = json.load(response)
-              servers = payload.get('servers', [])
-              if any(
-                  item.get('server', item).get('name') == name
-                  and item.get('server', item).get('version') == version
-                  for item in servers
-              ):
-                  print(f"Verified {name} {version} in the MCP Registry.")
+
+              match = None
+              for item in payload.get('servers', []):
+                  server = item.get('server', item)
+                  if server.get('name') == name and server.get('version') == version:
+                      match = server
+                      break
+
+              if match is not None:
+                  repo = match.get('repository') or {}
+                  packages = {
+                      (package.get('registryType'), package.get('identifier'))
+                      for package in match.get('packages', [])
+                  }
+                  if repo.get('url') != repository:
+                      raise SystemExit('registry listing points to a non-canonical repository')
+                  if packages != expected_packages:
+                      raise SystemExit(f'registry package set is unexpected: {packages!r}')
+                  print(f'Verified exclusive canonical listing {name} {version}.')
                   break
-              if attempt == 10:
-                  raise SystemExit(f"Registry listing for {name} {version} was not visible")
+
+              if attempt == 15:
+                  raise SystemExit(f'Registry listing for {name} {version} was not visible')
               time.sleep(10)
           PY

--- a/.github/workflows/sync-release-version.yml
+++ b/.github/workflows/sync-release-version.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Semantic release version, for example 1.0.51
+        description: 'Semantic release version, for example 1.2.3'
         required: true
         type: string
 
@@ -47,8 +47,17 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Synchronize tracked release surfaces
+      - name: Synchronize approved release surfaces
         run: python scripts/sync_release_version.py "${{ steps.version.outputs.version }}"
+
+      - name: Assert workflow definitions were not rewritten
+        shell: bash
+        run: |
+          if ! git diff --quiet -- .github/workflows/; then
+            echo "::error::Release synchronization must never modify workflow definitions."
+            git diff -- .github/workflows/
+            exit 1
+          fi
 
       - name: Validate release contract
         run: |

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,0 +1,103 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/entroly_wordmark.svg" width="760" alt="Entroly">
+</p>
+
+<p align="center"><b>Know exactly what your AI agent saw.</b></p>
+
+Entroly is a local context control plane for AI coding agents. It selects the
+highest-value evidence under a token budget, records what was selected and
+omitted, keeps compressed context recoverable, and produces verifiable Context
+Commits and receipts.
+
+## Install
+
+```bash
+pip install -U entroly
+```
+
+Run the local, no-key verification path:
+
+```bash
+entroly verify-claims
+entroly simulate
+```
+
+## MCP server
+
+Start the stdio MCP server directly:
+
+```bash
+entroly serve
+```
+
+Or use a package runner:
+
+```bash
+uvx --from entroly entroly serve
+npx -y entroly-mcp serve
+```
+
+Entroly works with GitHub Copilot in VS Code, Claude Code, Cursor, Windsurf,
+Cline, Continue, Zed, and other MCP-compatible clients.
+
+### GitHub Copilot / VS Code
+
+Create `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "entroly": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "entroly", "entroly", "serve"]
+    }
+  }
+}
+```
+
+Or install through the MCP gallery after the official registry listing becomes
+available by searching for **Entroly**.
+
+### Claude Code
+
+```bash
+claude mcp add entroly -- uvx --from entroly entroly serve
+```
+
+### Generic MCP configuration
+
+```json
+{
+  "mcpServers": {
+    "entroly": {
+      "command": "uvx",
+      "args": ["--from", "entroly", "entroly", "serve"]
+    }
+  }
+}
+```
+
+## What Entroly adds
+
+- **Context selection** under explicit token and cost budgets
+- **Context Commits** linking selected, omitted, and recoverable evidence
+- **Context Receipts** for replay, audit, and omission explanations
+- **Exact recovery** of compressed fragments through stable handles
+- **Local verification** through WITNESS and receipt checks
+- **Context Check** coverage evidence for changed files and CI risk gates
+- **Rust and WASM engines** with a pure-Python fallback
+- **Local-first operation** with no outbound analytics by default
+
+## Links
+
+- Repository: https://github.com/juyterman1000/entroly
+- Documentation: https://juyterman1000.github.io/entroly/
+- PyPI: https://pypi.org/project/entroly/
+- npm MCP bridge: https://www.npmjs.com/package/entroly-mcp
+
+## MCP Registry identity
+
+`mcp-name: io.github.juyterman1000/entroly`
+
+Apache-2.0 licensed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "entroly"
 version = "1.0.51"
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, and SDK helpers."
-readme = "README.md"
+readme = "PYPI_README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 logo = { file = "docs/assets/logo.png", content-type = "image/png" }
@@ -16,7 +16,7 @@ authors = [
 ]
 keywords = [
     "context-receipts", "context-control-plane", "local-context-os", "token-saving", "context-compression", "reduce-llm-costs", "llm-proxy",
-    "mcp", "agentic-ai", "cursor", "claude-code", "copilot", "llm",
+    "mcp", "mcp-server", "github-copilot", "agentic-ai", "cursor", "claude-code", "copilot", "llm",
     "knapsack", "entropy", "context-optimization", "token-reduction", "hallucination-detection"
 ]
 classifiers = [

--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -1,55 +1,62 @@
 #!/usr/bin/env python3
-"""Synchronize Entroly release versions across tracked release surfaces.
+"""Synchronize Entroly release versions across approved release surfaces.
 
-The script intentionally preserves historical release notes while updating every
-other tracked text file that advertises the current release. It is idempotent,
-validates the requested semantic version, and fails if stale current-version
-references remain outside ``docs/releases``.
+The release version is security-sensitive metadata. This tool updates only the
+explicit allowlist below; it never rewrites workflow definitions, historical
+release notes, arbitrary documentation, or unreviewed files. The narrow scope
+prevents an Actions token from accidentally modifying its own workflow and
+makes release drift reviewable.
 """
 
 from __future__ import annotations
 
 import argparse
 import re
-import subprocess
 from pathlib import Path
 
 SEMVER_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 PROJECT_VERSION_RE = re.compile(r'(?m)^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"')
 
-
-def _tracked_files(root: Path) -> list[Path]:
-    result = subprocess.run(
-        ["git", "-C", str(root), "ls-files", "-z"],
-        check=True,
-        capture_output=True,
-    )
-    return [root / item.decode("utf-8") for item in result.stdout.split(b"\0") if item]
+# Every active file that intentionally embeds the current public release.
+# Keep this list explicit: adding a new package or manifest must be reviewed.
+RELEASE_SURFACES: tuple[str, ...] = (
+    ".claude-plugin/manifest.json",
+    ".mcpb-build/manifest.json",
+    "entroly-core/Cargo.lock",
+    "entroly-core/Cargo.toml",
+    "entroly-core/README.md",
+    "entroly-core/pyproject.toml",
+    "entroly-qccr/Cargo.lock",
+    "entroly-qccr/Cargo.toml",
+    "entroly-wasm/Cargo.lock",
+    "entroly-wasm/Cargo.toml",
+    "entroly-wasm/package.json",
+    "entroly/__init__.py",
+    "entroly/cli.py",
+    "entroly/daemon.py",
+    "entroly/native_status.py",
+    "entroly/npm-alias/package.json",
+    "entroly/npm/package.json",
+    "entroly/pyproject.toml",
+    "entroly/server.py",
+    "integrations/openclaw/package.json",
+    "packaging/homebrew/README.md",
+    "packaging/homebrew/entroly.rb",
+    "pyproject.toml",
+    "server.json",
+    "tests/test_release_surface.py",
+)
 
 
 def _release_note(version: str) -> str:
     return f"""# Entroly {version}
 
-Entroly {version} introduces the Frontier Context Quality Layer and completes
-its first production release across the Python, Rust, npm, MCP, OpenClaw,
-WASM, plugin, Docker, and GitHub release surfaces.
+Release metadata for Entroly {version} is synchronized across Python, Rust,
+npm, MCP, OpenClaw, WASM, plugin, Docker, Homebrew, and GitHub release
+surfaces.
 
-Highlights:
-
-- deterministic, content-addressed Context Checks linked to verified Context
-  Commits;
-- retrospective changed-file recall, indexed recall, and precision evidence;
-- conservative risk escalation for sensitive, unsupported, truncated, and
-  unmeasured context;
-- replayable JSON and Markdown artifacts with a strict schema contract;
-- reusable GitHub Action integration with artifact publication and CI risk
-  gating;
-- synchronized release metadata across Python, Rust, QCCR, WASM, npm, MCP,
-  OpenClaw, plugins, manifests, lockfiles, Homebrew, and release verification
-  tests.
-
-Changed-file coverage is evidence about context selection. It is not presented
-as proof of model correctness or complete task knowledge.
+See the GitHub release and merged pull requests for the complete feature,
+security, compatibility, and migration notes.
 """
 
 
@@ -57,54 +64,54 @@ def synchronize(root: Path, target: str) -> list[str]:
     if not SEMVER_RE.fullmatch(target):
         raise ValueError(f"invalid semantic version: {target!r}")
 
-    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    pyproject_path = root / "pyproject.toml"
+    pyproject = pyproject_path.read_text(encoding="utf-8")
     match = PROJECT_VERSION_RE.search(pyproject)
     if not match:
         raise RuntimeError("unable to resolve current version from pyproject.toml")
     current = match.group(1)
 
+    if current == target:
+        return []
+
     changed: list[str] = []
+    missing: list[str] = []
+    stale: list[str] = []
     old_identifier = current.replace(".", "_")
     new_identifier = target.replace(".", "_")
 
-    for path in _tracked_files(root):
-        relative = path.relative_to(root)
-        if relative.parts[:2] == ("docs", "releases"):
+    for relative_name in RELEASE_SURFACES:
+        path = root / relative_name
+        if not path.is_file():
+            missing.append(relative_name)
             continue
-        try:
-            data = path.read_bytes()
-        except OSError:
+
+        data = path.read_bytes()
+        if current.encode() not in data and old_identifier.encode() not in data:
+            stale.append(relative_name)
             continue
-        if b"\0" in data:
-            continue
+
         updated = data.replace(current.encode(), target.encode())
         updated = updated.replace(old_identifier.encode(), new_identifier.encode())
         if updated != data:
             path.write_bytes(updated)
-            changed.append(relative.as_posix())
+            changed.append(relative_name)
+
+    if missing:
+        raise RuntimeError("release surfaces are missing: " + ", ".join(missing))
+    if stale:
+        raise RuntimeError(
+            "release surfaces no longer contain the current version; review the allowlist: "
+            + ", ".join(stale)
+        )
 
     note = root / "docs" / "releases" / f"v{target}.md"
-    note.parent.mkdir(parents=True, exist_ok=True)
-    rendered_note = _release_note(target)
-    if not note.exists() or note.read_text(encoding="utf-8") != rendered_note:
-        note.write_text(rendered_note, encoding="utf-8")
+    if not note.exists():
+        note.parent.mkdir(parents=True, exist_ok=True)
+        note.write_text(_release_note(target), encoding="utf-8")
         changed.append(note.relative_to(root).as_posix())
 
-    stale: list[str] = []
-    for path in _tracked_files(root):
-        relative = path.relative_to(root)
-        if relative.parts[:2] == ("docs", "releases"):
-            continue
-        try:
-            data = path.read_bytes()
-        except OSError:
-            continue
-        if b"\0" not in data and current.encode() in data:
-            stale.append(relative.as_posix())
-    if current != target and stale:
-        raise RuntimeError("stale release references remain: " + ", ".join(stale))
-
-    return sorted(set(changed))
+    return sorted(changed)
 
 
 def main() -> int:

--- a/server.json
+++ b/server.json
@@ -3,6 +3,7 @@
   "name": "io.github.juyterman1000/entroly",
   "title": "Entroly",
   "description": "Local context OS for AI coding agents with token optimization, receipts, exact recovery, memory, and verification.",
+  "websiteUrl": "https://github.com/juyterman1000/entroly",
   "repository": {
     "url": "https://github.com/juyterman1000/entroly",
     "source": "github"
@@ -11,19 +12,35 @@
   "packages": [
     {
       "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
       "identifier": "entroly",
       "version": "1.0.51",
+      "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
     },
     {
       "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "entroly-mcp",
       "version": "1.0.51",
+      "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
     }
   ]
 }

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_VERSION = "1.0.51"
+CANONICAL_MCP_NAME = "io.github.juyterman1000/entroly"
+CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
 
 
 def _read_json(path: str) -> dict:
@@ -35,6 +37,9 @@ def _read_project_metadata(path: str) -> dict[str, object]:
             continue
         if current_section == "project" and line.startswith("version"):
             metadata["version"] = line.split("=", 1)[1].strip().strip('"')
+            continue
+        if current_section == "project" and line.startswith("readme"):
+            metadata["readme"] = line.split("=", 1)[1].strip().strip('"')
             continue
         if current_section == "project" and line.startswith("dependencies"):
             current_list_key = "dependencies"
@@ -78,6 +83,38 @@ def test_mcp_registry_manifest_points_at_release_package() -> None:
     assert packages
     assert packages[0]["identifier"] == "entroly"
     assert packages[0]["version"] == RELEASE_VERSION
+
+
+def test_mcp_registry_identity_is_canonical_and_non_squattable() -> None:
+    manifest = _read_json("server.json")
+    npm_manifest = _read_json("entroly/npm/package.json")
+
+    assert manifest["name"] == CANONICAL_MCP_NAME
+    assert manifest["websiteUrl"] == CANONICAL_REPOSITORY
+    assert manifest["repository"] == {
+        "url": CANONICAL_REPOSITORY,
+        "source": "github",
+    }
+    assert npm_manifest["mcpName"] == CANONICAL_MCP_NAME
+    assert _read_project_metadata("pyproject.toml")["readme"] == "PYPI_README.md"
+    assert f"mcp-name: {CANONICAL_MCP_NAME}" in (
+        ROOT / "PYPI_README.md"
+    ).read_text(encoding="utf-8")
+
+    expected = {
+        ("pypi", "entroly", "uvx", ("serve",)),
+        ("npm", "entroly-mcp", "npx", ("serve",)),
+    }
+    actual = {
+        (
+            package["registryType"],
+            package["identifier"],
+            package["runtimeHint"],
+            tuple(argument["value"] for argument in package["packageArguments"]),
+        )
+        for package in manifest["packages"]
+    }
+    assert actual == expected
 
 
 def test_native_engine_is_optional_for_first_time_install() -> None:

--- a/tests/test_release_sync_safety.py
+++ b/tests/test_release_sync_safety.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_sync_module():
+    path = ROOT / "scripts" / "sync_release_version.py"
+    spec = importlib.util.spec_from_file_location("entroly_sync_release_version", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_release_surface_allowlist_excludes_workflows() -> None:
+    module = _load_sync_module()
+
+    assert module.RELEASE_SURFACES
+    assert all(
+        not surface.startswith(".github/workflows/")
+        for surface in module.RELEASE_SURFACES
+    )
+
+
+def test_synchronizer_never_rewrites_workflow_definitions(tmp_path: Path) -> None:
+    module = _load_sync_module()
+    module.RELEASE_SURFACES = ("pyproject.toml", "server.json")
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "entroly"\nversion = "1.0.51"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "server.json").write_text(
+        '{"name":"io.github.juyterman1000/entroly","version":"1.0.51"}\n',
+        encoding="utf-8",
+    )
+    workflow = tmp_path / ".github" / "workflows" / "release.yml"
+    workflow.parent.mkdir(parents=True)
+    original = "name: release\n# example current package 1.0.51\n"
+    workflow.write_text(original, encoding="utf-8")
+
+    changed = module.synchronize(tmp_path, "1.0.52")
+
+    assert set(changed) == {
+        "docs/releases/v1.0.52.md",
+        "pyproject.toml",
+        "server.json",
+    }
+    assert workflow.read_text(encoding="utf-8") == original
+    assert 'version = "1.0.52"' in (
+        tmp_path / "pyproject.toml"
+    ).read_text(encoding="utf-8")
+    assert '"version":"1.0.52"' in (
+        tmp_path / "server.json"
+    ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Security hardening

Locks Entroly's official MCP identity to `io.github.juyterman1000/entroly` and prevents a cloned repository from publishing under that canonical namespace.

### Controls
- GitHub OIDC publishing only from `juyterman1000/entroly`
- exact repository owner, repository URL, release actor, release commit, and main-branch ancestry checks
- production GitHub environment boundary for registry publication
- pinned MCP Registry publisher version instead of downloading `latest`
- exact PyPI/npm package allowlist and startup arguments
- post-publication verification of registry repository and package identities
- dedicated PyPI README with the official `mcp-name` ownership marker
- CODEOWNERS protection for release and identity surfaces
- release-contract tests that fail on namespace, repository, runtime, package, or startup-command drift

### Copilot/client compatibility
- PyPI package advertises `uvx` plus `serve`
- npm package advertises `npx` plus `serve`
- official manifest remains installable by GitHub Copilot/VS Code and other MCP clients

The official MCP Registry validates `io.github.<owner>` namespace ownership through GitHub authentication/OIDC. A fork can run the same source, but its OIDC identity is the fork owner and cannot publish as `io.github.juyterman1000/entroly`.