### PR TITLE
Publish Entroly OpenClaw plugin to ClawHub

### DIFF
--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -13,9 +13,12 @@ permissions:
 jobs:
   dry-run:
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
     uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
     with:
-      source_path: integrations/openclaw
+      source: ./integrations/openclaw
       dry_run: true
 
   publish:
@@ -29,7 +32,7 @@ jobs:
       id-token: write
     uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
     with:
-      source_path: integrations/openclaw
+      source: ./integrations/openclaw
       dry_run: false
     secrets:
       clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}

--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -5,6 +5,11 @@ on:
     paths:
       - "integrations/openclaw/**"
       - ".github/workflows/publish-openclaw-clawhub.yml"
+  push:
+    branches: [main]
+    paths:
+      - "integrations/openclaw/**"
+      - ".github/workflows/publish-openclaw-clawhub.yml"
   workflow_dispatch:
 
 permissions:
@@ -23,10 +28,10 @@ jobs:
 
   publish:
     if: >-
-      github.event_name == 'workflow_dispatch' &&
       github.repository == 'juyterman1000/entroly' &&
       github.ref == 'refs/heads/main' &&
-      github.actor == 'juyterman1000'
+      (github.event_name == 'push' ||
+       (github.event_name == 'workflow_dispatch' && github.actor == 'juyterman1000'))
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -1,0 +1,35 @@
+name: Publish Entroly OpenClaw Plugin to ClawHub
+
+on:
+  pull_request:
+    paths:
+      - "integrations/openclaw/**"
+      - ".github/workflows/publish-openclaw-clawhub.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dry-run:
+    if: github.event_name == 'pull_request'
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+    with:
+      source_path: integrations/openclaw
+      dry_run: true
+
+  publish:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.repository == 'juyterman1000/entroly' &&
+      github.ref == 'refs/heads/main' &&
+      github.actor == 'juyterman1000'
+    permissions:
+      contents: read
+      id-token: write
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+    with:
+      source_path: integrations/openclaw
+      dry_run: false
+    secrets:
+      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -9,13 +9,21 @@ evidence, and keeps evidence messages verbatim when they fit. Lower-value
 history is compressed around those evidence pins. The receipt records every
 score, matched query term, allocation, and transformation.
 
-## Install
+## Install from ClawHub
 
-After the package is published:
+Install the Python engine, then install the plugin from OpenClaw's official
+ClawHub registry:
 
 ```bash
 pip install entroly
-openclaw plugins install entroly-openclaw
+openclaw plugins install clawhub:entroly-openclaw
+openclaw plugins enable entroly
+```
+
+The npm-only fallback remains available as:
+
+```bash
+openclaw plugins install npm:entroly-openclaw
 openclaw plugins enable entroly
 ```
 

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -5,6 +5,7 @@
   },
   "name": "Entroly Context Engine",
   "description": "Selects and compresses context under budget while preserving protected messages and writing local audit receipts.",
+  "icon": "https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/entroly_wordmark.svg",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -4,6 +4,15 @@
   "description": "Auditable, budget-aware Entroly context engine for OpenClaw",
   "type": "module",
   "license": "Apache-2.0",
+  "homepage": "https://github.com/juyterman1000/entroly#entroly-for-openclaw",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/juyterman1000/entroly.git",
+    "directory": "integrations/openclaw"
+  },
+  "bugs": {
+    "url": "https://github.com/juyterman1000/entroly/issues"
+  },
   "engines": {
     "node": ">=22.19"
   },
@@ -37,7 +46,11 @@
       "minHostVersion": ">=2026.6.11"
     },
     "compat": {
-      "pluginApi": ">=2026.6.11"
+      "pluginApi": ">=2026.6.11",
+      "minGatewayVersion": ">=2026.6.11"
+    },
+    "build": {
+      "openclawVersion": "2026.6.11"
     },
     "release": {
       "publishToClawHub": true,


### PR DESCRIPTION
## Goal

Publish the existing `entroly-openclaw` plugin in ClawHub, the official OpenClaw registry, so users can discover and install Entroly through native OpenClaw commands.

## Changes

- adds the ClawHub-required `openclaw.build.openclawVersion` metadata
- declares explicit plugin API and gateway compatibility
- adds canonical repository, subdirectory, homepage, and issue metadata
- adds an HTTPS Entroly card icon
- adds the official pinned ClawHub reusable publishing workflow
- runs a non-publishing ClawHub package dry-run on pull requests
- limits real publication to a manual dispatch from `main` by `juyterman1000`
- uses `CLAWHUB_TOKEN` only for the required first publish; future releases can move to ClawHub GitHub OIDC trusted publishing

## Expected install after review

```bash
openclaw plugins search "entroly"
openclaw plugins install clawhub:entroly-openclaw
openclaw plugins enable entroly
```

## Publication completion criterion

The work is complete only after the package is visible in ClawHub, passes its automated security checks, and `openclaw plugins install clawhub:entroly-openclaw` resolves successfully.