### PR TITLE
Release v1.0.54: fix ClawHub install metadata

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: openclaw/clawhub
-          ref: 873b7e9a3403dbaa2c66ef15b655803562bd63c0
+          ref: v0.23.1
           path: clawhub-source
 
       - name: Install ClawHub validator dependencies
@@ -61,7 +61,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@873b7e9a3403dbaa2c66ef15b655803562bd63c0
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.1
     with:
       source: ./integrations/openclaw
       dry_run: true
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@873b7e9a3403dbaa2c66ef15b655803562bd63c0
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.1
     with:
       source: ./integrations/openclaw
       dry_run: false

--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -15,6 +15,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: clawhub-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CLAWHUB_CLI_VERSION: 0.23.1
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -23,48 +30,38 @@ jobs:
       - name: Checkout Entroly
         uses: actions/checkout@v6
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
-          bun-version: 1.3.10
+          node-version: "22"
 
-      - name: Checkout pinned ClawHub validator
-        uses: actions/checkout@v6
-        with:
-          repository: openclaw/clawhub
-          ref: v0.23.1
-          path: clawhub-source
-
-      - name: Install ClawHub validator dependencies
-        working-directory: clawhub-source
-        run: bun install --frozen-lockfile
+      - name: Install pinned ClawHub CLI
+        run: npm install --global "clawhub@${CLAWHUB_CLI_VERSION}"
 
       - name: Validate OpenClaw package metadata and artifact
         shell: bash
         run: |
           set -euo pipefail
-          bun "$GITHUB_WORKSPACE/clawhub-source/packages/clawhub/src/cli.ts" \
-            package validate "$GITHUB_WORKSPACE/integrations/openclaw" \
+          clawhub package validate "$GITHUB_WORKSPACE/integrations/openclaw" \
             --json | tee "$RUNNER_TEMP/clawhub-package-validate.json"
+
+      - name: Dry-run package publication
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          clawhub package publish "$GITHUB_WORKSPACE/integrations/openclaw" \
+            --dry-run --json | tee "$RUNNER_TEMP/clawhub-package-publish-dry-run.json"
 
       - name: Upload ClawHub validation evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: clawhub-package-validation
-          path: ${{ runner.temp }}/clawhub-package-validate.json
+          path: |
+            ${{ runner.temp }}/clawhub-package-validate.json
+            ${{ runner.temp }}/clawhub-package-publish-dry-run.json
           if-no-files-found: ignore
-
-  dry-run:
-    needs: validate
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.1
-    with:
-      source: ./integrations/openclaw
-      dry_run: true
 
   publish:
     needs: validate
@@ -73,12 +70,45 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' ||
        (github.event_name == 'workflow_dispatch' && github.actor == 'juyterman1000'))
-    permissions:
-      contents: read
-      id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.1
-    with:
-      source: ./integrations/openclaw
-      dry_run: false
-    secrets:
-      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Entroly
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install pinned ClawHub CLI
+        run: npm install --global "clawhub@${CLAWHUB_CLI_VERSION}"
+
+      - name: Authenticate to ClawHub
+        shell: bash
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$CLAWHUB_TOKEN"
+          echo "CLAWHUB_CONFIG_PATH=$RUNNER_TEMP/clawhub-config.json" >> "$GITHUB_ENV"
+          CLAWHUB_CONFIG_PATH="$RUNNER_TEMP/clawhub-config.json" \
+            clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+
+      - name: Publish Entroly OpenClaw plugin
+        shell: bash
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          clawhub package publish "$GITHUB_WORKSPACE/integrations/openclaw" \
+            --manual-override-reason "GitHub Actions release from juyterman1000/entroly" \
+            --json | tee "$RUNNER_TEMP/clawhub-package-publish.json"
+
+      - name: Upload ClawHub publication evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clawhub-package-publish
+          path: ${{ runner.temp }}/clawhub-package-publish.json
+          if-no-files-found: ignore

--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: openclaw/clawhub
-          ref: v0.12.0
+          ref: 873b7e9a3403dbaa2c66ef15b655803562bd63c0
           path: clawhub-source
 
       - name: Install ClawHub validator dependencies
@@ -61,7 +61,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@873b7e9a3403dbaa2c66ef15b655803562bd63c0
     with:
       source: ./integrations/openclaw
       dry_run: true
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@873b7e9a3403dbaa2c66ef15b655803562bd63c0
     with:
       source: ./integrations/openclaw
       dry_run: false

--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -16,7 +16,47 @@ permissions:
   contents: read
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Entroly
+        uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad
+        with:
+          bun-version: 1.3.10
+
+      - name: Checkout pinned ClawHub validator
+        uses: actions/checkout@v6
+        with:
+          repository: openclaw/clawhub
+          ref: v0.12.0
+          path: clawhub-source
+
+      - name: Install ClawHub validator dependencies
+        working-directory: clawhub-source
+        run: bun install --frozen-lockfile
+
+      - name: Validate OpenClaw package metadata and artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun "$GITHUB_WORKSPACE/clawhub-source/packages/clawhub/src/cli.ts" \
+            package validate "$GITHUB_WORKSPACE/integrations/openclaw" \
+            --json | tee "$RUNNER_TEMP/clawhub-package-validate.json"
+
+      - name: Upload ClawHub validation evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clawhub-package-validation
+          path: ${{ runner.temp }}/clawhub-package-validate.json
+          if-no-files-found: ignore
+
   dry-run:
+    needs: validate
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
@@ -27,6 +67,7 @@ jobs:
       dry_run: true
 
   publish:
+    needs: validate
     if: >-
       github.repository == 'juyterman1000/entroly' &&
       github.ref == 'refs/heads/main' &&

--- a/.mcpb-build/manifest.json
+++ b/.mcpb-build/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "entroly",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Open-source context control plane for AI coding agents. Compresses prompts 70-95%, stabilizes KV-cache prefixes, routes tasks to cheaper models, and verifies answers locally with WITNESS.",
   "author": {
     "name": "juyterman1000",

--- a/docs/releases/v1.0.54.md
+++ b/docs/releases/v1.0.54.md
@@ -1,0 +1,8 @@
+# Entroly 1.0.54
+
+Release metadata for Entroly 1.0.54 is synchronized across Python, Rust,
+npm, MCP, OpenClaw, WASM, plugin, Docker, Homebrew, and GitHub release
+surfaces.
+
+See the GitHub release and merged pull requests for the complete feature,
+security, compatibility, and migration notes.

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "1.0.53"
+version = "1.0.54"
 dependencies = [
  "entroly-qccr",
  "flate2",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.53"
+version = "1.0.54"
 dependencies = [
  "regex",
  "serde",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "1.0.53"
+version = "1.0.54"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=1.0.53"
+python -m pip install --no-cache-dir -U "entroly-core>=1.0.54"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "1.0.53"
+version = "1.0.54"
 description = "Rust core for Entroly: Context Receipts, deterministic ingestion/ranking, dependency audits, and local context optimization"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-qccr/Cargo.lock
+++ b/entroly-qccr/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.53"
+version = "1.0.54"
 dependencies = [
  "regex",
  "regex-lite",

--- a/entroly-qccr/Cargo.toml
+++ b/entroly-qccr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-qccr"
-version = "1.0.53"
+version = "1.0.54"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.53"
+version = "1.0.54"
 dependencies = [
  "regex-lite",
  "serde",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "1.0.53"
+version = "1.0.54"
 dependencies = [
  "entroly-qccr",
  "flate2",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "1.0.53"
+version = "1.0.54"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Pure WebAssembly local context OS for AI agents: context receipts, local optimization, MCP, app SDK helpers, and no Python dependency.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "1.0.53"
+__version__ = "1.0.54"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -51,7 +51,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "1.0.53"
+    __version__ = "1.0.54"
 
 from entroly.config import (
     load_active_tuning_config as _load_active_tuning_config,
@@ -3107,7 +3107,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.53\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.54\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -4625,7 +4625,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.53\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.54\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -4668,7 +4668,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.53\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.54\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -69,7 +69,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "1.0.53"
+    version: str = "1.0.54"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -7,7 +7,7 @@ from importlib import metadata
 from types import ModuleType
 
 
-MIN_ENTROLY_CORE_VERSION = "1.0.53"
+MIN_ENTROLY_CORE_VERSION = "1.0.54"
 QCCR_SYMBOLS = (
     "py_qccr_expand_query",
     "py_qccr_rank_files",

--- a/entroly/npm-alias/package.json
+++ b/entroly/npm-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Node/WASM Entroly runtime: local context optimization, MCP server tools, receipts, recovery, and verification without Python.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "dependencies": {
-    "entroly-wasm": "1.0.53"
+    "entroly-wasm": "1.0.54"
   },
   "repository": {
     "type": "git",

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "mcpName": "io.github.juyterman1000/entroly",
   "description": "NPX MCP bridge for Entroly, the local context OS with receipts, recovery, verification, and token optimization for AI coding agents.",
   "main": "index.js",

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.53"
+version = "1.0.54"
 
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, HTTP proxy, and Python SDK."
 readme = "README.md"
@@ -42,14 +42,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.53,<2",
+    "entroly-core>=1.0.54,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.53,<2",
+    "entroly-core>=1.0.54,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -4912,7 +4912,7 @@ def main():
     try:
         from entroly import __version__ as _version
     except Exception:
-        _version = "1.0.53"
+        _version = "1.0.54"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -41,6 +41,7 @@
       "./index.js"
     ],
     "install": {
+      "clawhubSpec": "clawhub:entroly-openclaw",
       "npmSpec": "entroly-openclaw",
       "defaultChoice": "npm",
       "minHostVersion": ">=2026.6.11"

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-openclaw",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Auditable, budget-aware Entroly context engine for OpenClaw",
   "type": "module",
   "license": "Apache-2.0",

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -2,13 +2,13 @@
 
 The formula in this directory is the canonical source. To make `brew tap juyterman1000/entroly && brew install entroly` work, the formula must live in a separate repo named `juyterman1000/homebrew-entroly`.
 
-Current release example version: `1.0.53`.
+Current release example version: `1.0.54`.
 
 ## Release checklist
 
 1. Copy `packaging/homebrew/entroly.rb` into `juyterman1000/homebrew-entroly/Formula/entroly.rb`.
-2. Set `VER=1.0.53` when preparing this release.
-3. Download the matching PyPI sdist: `entroly-1.0.53.tar.gz`.
+2. Set `VER=1.0.54` when preparing this release.
+3. Download the matching PyPI sdist: `entroly-1.0.54.tar.gz`.
 4. Recalculate the `sha256` for that tarball before publishing the Homebrew tap update.
 5. Verify locally before pushing with `brew install --build-from-source ./Formula/entroly.rb`, `brew test entroly`, and `brew audit --new --strict entroly`.
 

--- a/packaging/homebrew/entroly.rb
+++ b/packaging/homebrew/entroly.rb
@@ -21,7 +21,7 @@ class Entroly < Formula
 
   desc "Token-saving proxy and context compression engine for AI coding agents"
   homepage "https://github.com/juyterman1000/entroly"
-  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-1.0.53.tar.gz"
+  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-1.0.54.tar.gz"
   sha256 "94e54692b4e677e9261d2c667a30ecaec3c0f871729c1cc84256854361d9ec1e"
   license "Apache-2.0"
   head "https://github.com/juyterman1000/entroly.git", branch: "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.53"
+version = "1.0.54"
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, and SDK helpers."
 readme = "PYPI_README.md"
 license = "Apache-2.0"
@@ -42,14 +42,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.53,<2",
+    "entroly-core>=1.0.54,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.53,<2",
+    "entroly-core>=1.0.54,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/juyterman1000/entroly",
     "source": "github"
   },
-  "version": "1.0.53",
+  "version": "1.0.54",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "entroly",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -30,7 +30,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "entroly-mcp",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -75,6 +75,18 @@ def test_public_package_versions_are_1_0_54() -> None:
     assert _read_json(".mcpb-build/manifest.json")["version"] == RELEASE_VERSION
 
 
+def test_openclaw_install_metadata_identifies_clawhub_target() -> None:
+    package = _read_json("integrations/openclaw/package.json")
+    openclaw = package["openclaw"]
+    install = openclaw["install"]
+
+    assert openclaw["release"]["publishToClawHub"] is True
+    assert install["clawhubSpec"] == f"clawhub:{package['name']}"
+    assert install["npmSpec"] == package["name"]
+    assert install["defaultChoice"] == "npm"
+    assert install["minHostVersion"] == openclaw["compat"]["pluginApi"]
+
+
 def test_mcp_registry_manifest_points_at_release_package() -> None:
     manifest = _read_json("server.json")
 

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-RELEASE_VERSION = "1.0.53"
+RELEASE_VERSION = "1.0.54"
 CANONICAL_MCP_NAME = "io.github.juyterman1000/entroly"
 CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
 
@@ -64,7 +64,7 @@ def _read_project_metadata(path: str) -> dict[str, object]:
     return metadata
 
 
-def test_public_package_versions_are_1_0_53() -> None:
+def test_public_package_versions_are_1_0_54() -> None:
     assert _read_project_metadata("pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_project_metadata("entroly/pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_json("entroly/npm/package.json")["version"] == RELEASE_VERSION


### PR DESCRIPTION
## Problem

ClawHub reported `package-install-metadata-incomplete` for `entroly-openclaw` v1.0.53 because `openclaw.release.publishToClawHub` was enabled without an `openclaw.install.clawhubSpec` install target.

## Fix

- adds the canonical ClawHub install target: `clawhub:entroly-openclaw`
- preserves the npm install target and npm as the default for the dual-published package
- bumps all approved Entroly release surfaces to v1.0.54
- adds a release-surface regression test tying the ClawHub/npm install targets to the package name
- runs the official pinned `clawhub package validate` command before every ClawHub dry-run or publication
- uploads the validator JSON as CI evidence

## Completion criteria

- official ClawHub validator passes on the packaged plugin
- all Entroly CI gates pass
- v1.0.54 publishes successfully
- ClawHub reports the new release without `package-install-metadata-incomplete`
