### PR TITLE
Update Homebrew formula for 1.0.57

### DIFF
--- a/packaging/homebrew/entroly.rb
+++ b/packaging/homebrew/entroly.rb
@@ -21,8 +21,8 @@ class Entroly < Formula
 
   desc "Token-saving proxy and context compression engine for AI coding agents"
   homepage "https://github.com/juyterman1000/entroly"
-  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-1.0.54.tar.gz"
-  sha256 "db87e6f9e1b5a311a177cc1083c6e9ea5ace6c98d2178828f7c9f91f427a08fd"
+  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-1.0.57.tar.gz"
+  sha256 "fef09c6b5e2616a09333a911f48fdef70b94747e22c56d9cc44a41832271c9b4"
   license "Apache-2.0"
   head "https://github.com/juyterman1000/entroly.git", branch: "main"
 

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_VERSION = "1.0.57"
-HOMEBREW_FORMULA_VERSION = "1.0.54"
-HOMEBREW_FORMULA_SHA256 = "db87e6f9e1b5a311a177cc1083c6e9ea5ace6c98d2178828f7c9f91f427a08fd"
+HOMEBREW_FORMULA_VERSION = "1.0.57"
+HOMEBREW_FORMULA_SHA256 = "fef09c6b5e2616a09333a911f48fdef70b94747e22c56d9cc44a41832271c9b4"
 CANONICAL_MCP_NAME = "io.github.juyterman1000/entroly"
 CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
 


### PR DESCRIPTION
## What changed
- update the Homebrew formula from Entroly 1.0.54 to 1.0.57
- pin the independently verified PyPI sdist SHA-256
- synchronize the release-surface assertions

## Root cause
The post-release Homebrew workflow generated this correct update, but its direct push to protected `main` was rejected because seven required checks must run on a pull request.

## Validation
- downloaded the published 1.0.57 sdist and independently verified SHA-256 `fef09c6b5e2616a09333a911f48fdef70b94747e22c56d9cc44a41832271c9b4`
- `python -m pytest tests/test_release_surface.py -q` (12 passed)
- `git diff --check`