### PR TITLE
Restore verifiable public trust for Entroly 1.0.58

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/.github/workflows/public-trust.yml
+++ b/.github/workflows/public-trust.yml
@@ -1,0 +1,42 @@
+name: Public Trust Contracts
+
+on:
+  pull_request:
+    paths:
+      - README.md
+      - PYPI_README.md
+      - server.json
+      - benchmarks/results/context_commit_conformance.json
+      - benchmarks/results/halueval_qa_faithful.json
+      - docs/discord.html
+      - docs/public-evidence.md
+      - scripts/verify_public_trust.py
+      - .github/workflows/public-trust.yml
+  schedule:
+    - cron: "23 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  offline-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify public claims against committed evidence
+        run: python scripts/verify_public_trust.py
+
+  online-destinations:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check canonical public destinations
+        run: python scripts/verify_public_trust.py --online --require-published-version --retries 3 --timeout 20

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -121,8 +121,8 @@ jobs:
           canonical_repo = 'https://github.com/juyterman1000/entroly'
           canonical_name = 'io.github.juyterman1000/entroly'
           expected_packages = {
-              ('pypi', 'entroly'): ('uvx', ['serve']),
-              ('npm', 'entroly-mcp'): ('npx', ['serve']),
+              ('pypi', 'entroly'): ('uvx', []),
+              ('npm', 'entroly-mcp'): ('npx', []),
           }
 
           with (root / 'pyproject.toml').open('rb') as fh:

--- a/.mcpb-build/manifest.json
+++ b/.mcpb-build/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "entroly",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Open-source context control plane for AI coding agents. Compresses prompts 70-95%, stabilizes KV-cache prefixes, routes tasks to cheaper models, and verifies answers locally with WITNESS.",
   "author": {
     "name": "juyterman1000",

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -24,18 +24,25 @@ entroly simulate
 
 ## MCP server
 
-Start the stdio MCP server directly:
+For an MCP client, register the installed `entroly` command with no arguments.
+When an MCP client launches it with a stdio pipe, Entroly starts the installed
+Python server directly:
 
 ```bash
-entroly serve
+entroly
 ```
 
-Or use a package runner:
+Or register a package runner, also with no `serve` argument:
 
 ```bash
-uvx --from entroly entroly serve
-npx -y entroly-mcp serve
+uvx --from entroly entroly
+npx -y entroly-mcp
 ```
+
+`entroly serve` is a different deployment path: it uses the Entroly Docker
+image by default. For the installed Python runtime in an interactive shell, use
+`ENTROLY_NO_DOCKER=1 entroly serve` on macOS/Linux or set
+`ENTROLY_NO_DOCKER=1` in the client environment.
 
 Entroly works with GitHub Copilot in VS Code, Claude Code, Cursor, Windsurf,
 Cline, Continue, Zed, and other MCP-compatible clients.
@@ -50,19 +57,20 @@ Create `.vscode/mcp.json`:
     "entroly": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["--from", "entroly", "entroly", "serve"]
+      "args": ["--from", "entroly", "entroly"]
     }
   }
 }
 ```
 
-Or install through the MCP gallery after the official registry listing becomes
-available by searching for **Entroly**.
+External MCP galleries can lag a release. Direct stdio registration above is
+the canonical setup; confirm a gallery entry's package version and validation
+status before relying on it.
 
 ### Claude Code
 
 ```bash
-claude mcp add entroly -- uvx --from entroly entroly serve
+claude mcp add entroly -- uvx --from entroly entroly
 ```
 
 ### Generic MCP configuration
@@ -72,7 +80,7 @@ claude mcp add entroly -- uvx --from entroly entroly serve
   "mcpServers": {
     "entroly": {
       "command": "uvx",
-      "args": ["--from", "entroly", "entroly", "serve"]
+      "args": ["--from", "entroly", "entroly"]
     }
   }
 }
@@ -86,7 +94,7 @@ claude mcp add entroly -- uvx --from entroly entroly serve
 - **Exact recovery** of compressed fragments through stable handles
 - **Local verification** through WITNESS and receipt checks
 - **Context Check** coverage evidence for changed files and CI risk gates
-- **Rust and WASM engines** with a pure-Python fallback
+- **Pure-Python base runtime**, optional Rust acceleration, and a separate npm/WASM runtime
 - **Local-first operation** with no outbound analytics by default
 
 ## Links
@@ -94,7 +102,9 @@ claude mcp add entroly -- uvx --from entroly entroly serve
 - Repository: https://github.com/juyterman1000/entroly
 - Documentation: https://juyterman1000.github.io/entroly/
 - PyPI: https://pypi.org/project/entroly/
+- npm runtime: https://www.npmjs.com/package/entroly
 - npm MCP bridge: https://www.npmjs.com/package/entroly-mcp
+- Public evidence policy: https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md
 
 ## MCP Registry identity
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,4 @@
 <p align="center">
-  <a href="docs/i18n/README.zh-CN.md">中文</a> •
-  <a href="docs/i18n/README.ja.md">日本語</a> •
-  <a href="docs/i18n/README.ko.md">한국어</a> •
-  <a href="docs/i18n/README.pt-BR.md">Português</a> •
-  <a href="docs/i18n/README.es.md">Español</a> •
-  <a href="docs/i18n/README.de.md">Deutsch</a> •
-  <a href="docs/i18n/README.fr.md">Français</a> •
-  <a href="docs/i18n/README.ru.md">Русский</a> •
-  <a href="docs/i18n/README.hi.md">हिन्दी</a> •
-  <a href="docs/i18n/README.tr.md">Türkçe</a>
-</p>
-
-<p align="center">
   <img src="docs/assets/entroly_wordmark.svg" width="820" alt="Entroly">
 </p>
 
@@ -19,44 +6,48 @@
 Entroly creates replayable <b>Context Commits</b>: content-addressed proof of the evidence selected, omitted, and kept recoverable for each model request.</p>
 
 <p align="center">
-  <sub>Drop-in for <b>Cursor, Claude Code, Codex, Aider + 34 more</b> and custom providers — 60s, no code changes.</sub>
+  <sub>Integrates with Cursor, Claude Code, Codex, Aider, OpenClaw, MCP clients, and custom provider applications. Choose the supported setup path for your client.</sub>
 </p>
 
 <p align="center">
-  <sub>Auditable context control plane · every answer gets a receipt: what was used, what was omitted, why, and the risks that remain · local-first · Rust + WASM · reversible · savings measured on real workloads</sub>
+  <sub>Auditable context control plane · receipt-producing selection paths record what was used, what was omitted, and residual risks · local-first · Python with optional Rust acceleration · Node/WASM runtime</sub>
 </p>
 
+<!-- Distribution and licensing: registry badges report live package metadata. -->
 <p align="center">
-  <img src="https://img.shields.io/pypi/v/entroly?color=blue&label=PyPI" alt="PyPI">
-  <a href="https://lobehub.com/mcp/juyterman1000-entroly"><img src="https://lobehub.com/badge/mcp/juyterman1000-entroly" alt="Entroly on LobeHub"></a>
-  <img src="https://img.shields.io/npm/v/entroly-wasm?color=red&label=npm" alt="npm">
-  <a href="https://github.com/juyterman1000/entroly/stargazers"><img src="https://img.shields.io/github/stars/juyterman1000/entroly?style=social" alt="GitHub stars"></a>
-  <a href="https://juyterman1000.github.io/entroly/docs/discord.html"><img src="https://img.shields.io/badge/Discord-Join_Community-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
-  <img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="License">
-  <img src="https://img.shields.io/badge/Token_Savings-workload_dependent-brightgreen" alt="Token savings">
-  <img src="https://img.shields.io/badge/Hallucination-HaluEval--QA_0.844_AUROC_·_%240-blueviolet" alt="Hallucination guard">
-  <img src="https://img.shields.io/badge/Engine-Rust_+_WASM-orange?logo=rust" alt="Rust + WASM">
-  <img src="https://img.shields.io/badge/Context_Commits-128%2F128_replayed_+_768%2F768_tamper_detected-0A7B83" alt="Context Commit conformance">
+  <a href="https://pypi.org/project/entroly/"><img src="https://img.shields.io/pypi/v/entroly?color=blue&label=PyPI" alt="Entroly on PyPI"></a>
+  <a href="https://www.npmjs.com/package/entroly"><img src="https://img.shields.io/npm/v/entroly?color=red&label=npm" alt="Entroly on npm"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache-2.0 license"></a>
 </p>
+
+<!-- Reproducible evidence: every badge links to the exact committed artifact. -->
+<p align="center">
+  <a href="benchmarks/results/context_commit_conformance.json"><img src="https://img.shields.io/badge/Context_Commits-128%2F128_replayed_+_768%2F768_tamper_detected-0A7B83" alt="Context Commit conformance evidence"></a>
+  <a href="benchmarks/results/halueval_qa_faithful.json"><img src="https://img.shields.io/badge/WITNESS-HaluEval--QA_0.7976_AUROC-blueviolet" alt="WITNESS HaluEval-QA evidence"></a>
+  <a href="docs/product-surface.md"><img src="https://img.shields.io/badge/Runtimes-Python_%7C_optional_Rust_%7C_WASM-orange?logo=rust" alt="Python, optional Rust, and WASM runtimes"></a>
+  <a href="#proof"><img src="https://img.shields.io/badge/Token_savings-measure_your_workload-brightgreen" alt="Measure token savings on your workload"></a>
+</p>
+
+<!-- Community signals are not product or benchmark verification. -->
+<p align="center">
+  <a href="https://github.com/juyterman1000/entroly"><img src="https://img.shields.io/github/stars/juyterman1000/entroly?style=social" alt="Entroly repository and GitHub stars"></a>
+  <a href="https://juyterman1000.github.io/entroly/docs/discord.html"><img src="https://img.shields.io/badge/Discord-Join_Community-5865F2?logo=discord&logoColor=white" alt="Entroly Discord community"></a>
+</p>
+
+<p align="center"><sub>Registry badges show distribution metadata. Evidence badges link to committed results with scope and caveats. Community and marketplace status are not treated as technical proof.</sub></p>
 
 <p align="center">
   <code>pip install -U entroly && cd /your/repo && entroly verify-claims && entroly simulate</code>
 </p>
 
 <p align="center">
-  <a href="#get-started-60-seconds"><b>Get started</b></a> ·
+  <a href="#get-started"><b>Get started</b></a> ·
   <a href="#proof"><b>Proof</b></a> ·
   <a href="#works-with-your-stack"><b>Integrations</b></a> ·
   <a href="#whats-inside"><b>What's inside</b></a> ·
   <a href="docs/DETAILS.md"><b>Architecture</b></a> ·
   <a href="docs/for-teams.md"><b>For teams</b></a> ·
   <a href="docs/limitations.md"><b>Limitations</b></a>
-</p>
-
-<p align="center">
-  <a href="https://huggingface.co/spaces/entroly/entroly-context-compression"><img src="https://img.shields.io/badge/▶_Try_it_live-no_install-FF4B4B?logo=huggingface&logoColor=white" alt="Live demo"></a>
-  &nbsp;
-  <a href="https://juyterman1000.github.io/entroly/docs/dashboard.html"><img src="https://img.shields.io/badge/See_the_dashboard-live-2EA44F" alt="Dashboard"></a>
 </p>
 
 <p align="center">
@@ -76,10 +67,10 @@ Most compression tools shrink whatever text the agent already chose. Entroly sta
 
 - **Receipts** - every selection run can explain selected chunks, omitted nearby evidence, dependency links, fingerprints, token ratio, and residual risks.
 - **Select** - ranks your repo or document set, then sends the answer-relevant context under a token budget.
-- **Verify** - WITNESS checks the model's answer against the evidence it was given and flags unsupported claims. $0, ~3 ms, no extra API call.
+- **Verify** - WITNESS can check an answer against supplied evidence locally, without an additional model call. See the scoped benchmark under [Proof](#proof).
 - **Route** - sends easy, repeated tasks to a cheaper model and keeps the flagship for hard ones (opt-in, fail-closed).
 - **Cache-align** - keeps the injected prefix byte-stable so provider prefix caches can keep hitting where terms and API shape allow it.
-- **Learn** - improves which files it picks for *your* workflow from local feedback. No embeddings API, no training job.
+- **Learn** - adapts local ranking signals from recorded outcomes. No embeddings API or training job is required for that path.
 
 Use it however you work: **wrap** your agent, run it as a **proxy**, plug it in as an **MCP server**, or import the **library**.
 
@@ -114,7 +105,11 @@ Entroly ships as a full local runtime, not one proxy command:
 | **Self-improvement** | PRISM/RAVS feedback, autotune, skill crystallization, promotion gates, evolution logging, and budget-gated skill synthesis |
 | **Observability** | Dashboard, daemon supervisor, control plane, health reports, value tracker, release-surface checks, and local JSON proof reports |
 
-Under the hood, the Python control plane is backed by a Rust/WASM engine with BM25, entropy scoring, SimHash dedup, dependency graphs, knapsack/IOS selection, EGSC caching, PRISM learning, SAST, QCCR, EICV, witness checks, CogOps, cache economics, and memory primitives.
+Under the hood, the Python control plane has a pure-Python path and can use the
+optional Rust extension for supported operations. The separate Node runtime
+uses WASM. The implementation includes BM25, entropy scoring, SimHash dedup,
+dependency graphs, budgeted selection, caching, verification, and memory
+primitives; installed capabilities depend on the selected package and extras.
 
 See the full code-derived map in [docs/product-surface.md](docs/product-surface.md).
 
@@ -132,11 +127,11 @@ your agent  ──►  Entroly (local)  ──►  LLM provider
                  └─ verify the reply      (WITNESS hallucination guard)
 ```
 
-Critical files go in full. Supporting files become signatures. Everything else becomes a reference you can expand on demand — so the model gets a **broader** view of your codebase in a **smaller** prompt. Nothing is lost: every compressed fragment is fully retrievable.
+Critical files go in full. Supporting files can become signatures. Other material can become a reference that can be expanded on demand. Exact recovery is available only while the corresponding receipt and recovery store are retained; deleting that state deletes Entroly's recovery path.
 
 ---
 
-## Get started (60 seconds)
+## Get started
 
 The best first run is local and proof-driven. It should work before you connect
 an API key, proxy, paid model, or enterprise setup.
@@ -158,7 +153,7 @@ entroly simulate           # local no-LLM savings estimate on your current repo
 |---|---|---|
 | Claude Code subscription | `entroly attach create --client claude --project . --ttl 4h --install` | Installs scoped, expiring MCP access without placing a bearer token in process arguments |
 | Codex or OpenClaw | `entroly attach create --client codex --project . --ttl 4h --install` | Binds Entroly to this project with revocable least-privilege access; replace `codex` with `openclaw` as needed |
-| Cursor, VS Code, Windsurf, or another MCP client | `entroly init` or `entroly serve` | Local MCP tools for context, receipts, recovery, and feedback |
+| Cursor, VS Code, Windsurf, or another MCP client | `entroly init`, or register `entroly` as a stdio command with no arguments | Local MCP tools without requiring Docker |
 | Pay-as-you-go API keys or a custom app | `entroly proxy` | Transparent Anthropic/OpenAI-compatible optimization path |
 | Python app | `from entroly import compress, compress_messages, optimize` | Direct SDK control |
 | Node/npm workflow | `npm install -g entroly` | WASM runtime without a Python-first setup |
@@ -205,7 +200,9 @@ entroly perf            # local no-LLM savings + optimizer latency
 entroly verify-claims   # runs the packaged self-test, writes a JSON report
 ```
 
-> Local-first: your code is indexed and selected on-device, never sent anywhere for analysis. Apache-2.0. No outbound analytics by default.
+> Local-first: Entroly performs indexing and selection on-device. The selected
+> prompt is sent only through the model integration you configure. Entroly does
+> not send outbound analytics by default. Apache-2.0.
 
 ### First-run success contract
 
@@ -256,7 +253,10 @@ operator identity matters. [Contract and threat model](docs/context-commits.md).
 
 ## Context Receipts
 
-Entroly gives every AI answer a context receipt: what was used, what was omitted, why, and what risks remain. This is built for hard multi-document work such as contracts, policies, addenda, code reviews, and audit evidence where "top-k chunks" is not enough.
+Receipt-producing selection workflows record what was used, what was omitted,
+why, and what risks remain. This is useful for hard multi-document work such as
+contracts, policies, addenda, code reviews, and audit evidence where a bare
+top-k result is not enough.
 
 ```bash
 entroly ingest ./docs
@@ -308,15 +308,10 @@ and unsupported claims.
 [Read the preregistered protocol](docs/benchmarks/context-efficiency-frontier.md).
 No headline result is claimed until the paired confidence bounds pass.
 
-Every number below is reproducible and backed by a committed JSON artifact you can audit — not a screenshot.
-
-**Token savings** (this repo, `entroly verify-claims`, local, no API):
-
-| Budget | Token reduction |
-|---|---|
-| 8K  | **99.1%** |
-| 32K | **96.7%** |
-| average across workloads | **87.0%** |
+The tables below link each reported number to its committed result. Treat them
+as evidence for those specific datasets, budgets, models, and commits—not as a
+guarantee for another repository. `entroly simulate` uses a local token
+estimate; use provider-observed usage for a billing or production claim.
 
 **Accuracy retention** — does compression hurt answers? Measured with `gpt-4o-mini`; intervals are Wilson 95% CIs. Each row links its raw result file.
 
@@ -330,15 +325,21 @@ Every number below is reproducible and backed by a committed JSON artifact you c
 
 <sub>*pass-through: context already fit the budget, so Entroly left it unchanged. Reproduce: `python benchmarks/run_readme_benchmarks.py` (needs `OPENAI_API_KEY`). Full table + MMLU/TruthfulQA in [DETAILS](docs/DETAILS.md).</sub>
 
-**Hallucination guard** — [HaluEval-QA](https://github.com/RUCAIBox/HaluEval), standard protocol, GPT-judge baseline on identical data:
+**Hallucination detection** — committed [HaluEval-QA](https://github.com/RUCAIBox/HaluEval)
+balanced, both-answers-scored run:
 
-| System | Accuracy | AUROC | Cost / latency |
-|---|---|---|---|
-| **WITNESS + STAVE** (default) | **85.8%** | **0.844** | **$0, ~3 ms/decision** |
-| gpt-4o-mini (grounded judge) | 86.3% | — | LLM call |
-| gpt-3.5-turbo (HaluEval paper) | 62.6% | — | LLM call |
+| Result | Decisions | Accuracy | AUROC | Scope |
+|---|---:|---:|---:|---|
+| WITNESS full benchmark | 20,000 | 84.92% on the 16,000-decision held-out split | **0.7976** | Local, deterministic verifier |
+| WITNESS on the shared GPT sample | 1,200 | 86.58% | 0.8132 | Same sampled decisions used for the GPT rows |
+| gpt-4o-mini on the shared sample | 1,200 | 86.25% | not reported | API judge comparison only |
 
-<sub>$0, zero-network verifier that statistically ties a strong LLM judge. Reproduce: `python benchmarks/halueval_qa_faithful.py`. [Proof JSON](benchmarks/results/stave_benchmark.json).</sub>
+Reproduce: `python benchmarks/halueval_qa_faithful.py`.
+[Protocol and raw result](benchmarks/results/halueval_qa_faithful.json). The
+shared-sample accuracies overlap within their reported uncertainty; this result
+does not establish superiority, general hallucination prevention, or production
+answer quality. The separate [STAVE exploratory result](benchmarks/results/stave_benchmark.json)
+is not used for the headline because it follows a different evaluation setup.
 
 ---
 
@@ -348,7 +349,12 @@ Every number below is reproducible and backed by a committed JSON artifact you c
 
 OpenClaw remains the conversation and agent runtime. Attach Entroly as its context control plane with `entroly attach create --client openclaw --project . --ttl 4h --install`.
 
-The OpenClaw context-engine plugin is provider-independent: one Entroly assembly path boosts OpenAI, Anthropic, Gemini, Nemotron, OpenRouter, Ollama, and custom routes because OpenClaw owns provider routing/authentication and supplies the resolved prompt budget. Entroly preserves opaque provider blocks and delegates `/compact` and overflow recovery back to OpenClaw.
+The OpenClaw context-engine plugin keeps context assembly separate from provider
+routing. The same assembly path can be used with OpenAI, Anthropic, Gemini,
+Nemotron, OpenRouter, Ollama, and custom routes because OpenClaw owns routing
+and authentication and supplies the resolved prompt budget. Entroly preserves
+opaque provider blocks and delegates `/compact` and overflow recovery back to
+OpenClaw.
 
 The beta OpenClaw context engine scores older messages against the current
 request. Matching evidence is pinned verbatim when it fits a bounded reserve;
@@ -429,40 +435,49 @@ before publishing a savings claim.
 
 ## What's inside
 
-Most people install Entroly for input-token compression. It actually ships **19 local cost-saving mechanisms** across input, inference, output, verification, and learning — each one readable in the source with a committed benchmark where applicable.
+Entroly exposes **19 local control mechanisms** across input, inference, output,
+verification, and learning. The table describes their role and source location;
+it does not assign an unmeasured savings percentage to each mechanism.
 
 <details>
-<summary><b>The 19 levers (and the file that implements each)</b></summary>
+<summary><b>The 19 mechanisms (and the file that implements each)</b></summary>
 
-| # | Lever | Win | Source |
+| # | Mechanism | Role | Source |
 |---|---|---|---|
-| 1 | Context compression (knapsack + 9 compressors + dep-graph) | 39–99% input tokens | `proxy_transform.py`, `qccr.py` |
-| 2 | WITNESS + STAVE hallucination gateway | AUROC 0.844, $0 | `witness.py`, `verifiers/stave.py` |
-| 3 | Cache Aligner | up to 90% off cached calls | `cache_aligner.py` |
-| 4 | Escalation cascade (conformally calibrated) | avoids most flagship calls | `escalation.py` |
-| 5 | Conformal cascade | proven cost/coverage tradeoff | `conformal_cascade.py` |
+| 1 | Context compression (knapsack + compressors + dep-graph) | Select and transform context under an explicit budget | `proxy_transform.py`, `qccr.py` |
+| 2 | WITNESS + STAVE verification gateway | Produce local grounding-risk signals; benchmark protocols remain separate | `witness.py`, `verifiers/stave.py` |
+| 3 | Cache Aligner | Preserve eligible prompt-prefix bytes for provider cache reuse | `cache_aligner.py` |
+| 4 | Escalation cascade (conformally calibrated) | Gate opt-in escalation under configured confidence policy | `escalation.py` |
+| 5 | Conformal cascade | Calibrate a cost/coverage operating point | `conformal_cascade.py` |
 | 6 | RAVS Bayesian router | routes easy tasks to cheaper models | `ravs/router.py` |
-| 7 | Fast-path crystallized skills | 100% LLM cost saved on cache hits | `fast_path.py` |
+| 7 | Fast-path crystallized skills | Reuse an accepted cached result when its key and policy match | `fast_path.py` |
 | 8 | Adaptive compression budget | right-sizes budget per query | `adaptive_budget.py` |
 | 9 | Entropic conversation pruning | flattens history-growth cost | `proxy_transform.py` |
-| 10 | Shell-output compression | 60–95% on tool output | `proxy_transform.py`, `shell_codec.py` |
+| 10 | Shell-output compression | Reduce tool output under an explicit policy and budget | `proxy_transform.py`, `shell_codec.py` |
 | 11 | Response distillation | fewer output tokens billed | `proxy_transform.py` |
-| 12 | Local DeBERTa NLI (opt-in) | $0 offline NLI | `witness.py` |
-| 13 | EICV suppressor | stops bad info propagating | `eicv_suppressor.py` |
-| 14 | PRISM 5D adaptive weights | quality improves with use | `online_learner.py`, `prism.rs` |
-| 15 | Federation (opt-in) | amortized cold-start | `federation.py` |
+| 12 | Local DeBERTa NLI (opt-in) | Run supported NLI checks without an API call | `witness.py` |
+| 13 | EICV suppressor | Suppress content that crosses the configured risk threshold | `eicv_suppressor.py` |
+| 14 | PRISM 5D adaptive weights | Adapt weights from recorded outcomes | `online_learner.py`, `prism.rs` |
+| 15 | Federation (opt-in) | Share explicitly enabled weight contributions | `federation.py` |
 | 16 | Entropic Shell Codec | universal tool-output fallback | `shell_codec.py` |
-| 17 | Semantic Resolution Protocol | 40–70% fewer tokens on file reads | `semantic_resolution.py` |
-| 18 | Adversarial Context Firewall | blocks prompt-injection / poisoning | `context_firewall.py` |
-| 19 | Witness-Verified Handoff | filters hallucinations between agents | `verified_handoff.py` |
+| 17 | Semantic Resolution Protocol | resolution-aware file reads | `semantic_resolution.py` |
+| 18 | Adversarial Context Firewall | Detect and apply policy to prompt-injection patterns | `context_firewall.py` |
+| 19 | Witness-Verified Handoff | Check handoff claims against supplied evidence | `verified_handoff.py` |
 
-Most levers are **multiplicative**: input compression × cache alignment × cheaper-model routing × output distillation can leave well under 1% of the original input-token spend on the bill. Per-lever contribution shows up in the dashboard's Cost Intelligence panel. Full math and proofs in [docs/DETAILS.md](docs/DETAILS.md).
+Some levers can compound: input selection, cache alignment, opt-in model routing,
+and output distillation affect different parts of a request. The dashboard
+reports each contribution separately. Do not multiply estimated percentages
+into a billing claim; validate the complete path with provider-observed usage.
+Implementation details are in [docs/DETAILS.md](docs/DETAILS.md).
 </details>
 
 <details>
 <summary><b>Engine & install options</b></summary>
 
-Python is the reference runtime; the Rust core (via PyO3) does the heavy compute at 50–100× Python speed, and the same engine ships to Node via WASM.
+Python is the reference runtime. The optional Rust core accelerates supported
+compute-heavy paths through PyO3, and a separate Node runtime ships through
+WASM. The base Python install does not imply that the Rust extension is active;
+`entroly verify-claims` reports the engine mode it actually exercised.
 
 ```bash
 pip install entroly            # core: MCP server + Python engine
@@ -491,7 +506,7 @@ entroly witness --context-file evidence.txt --output-file answer.txt --mode stri
 entroly proxy --witness strict --witness-profile rag    # suppress unsupported claims inline
 ```
 
-Profiles tune false-positive behavior per workload (`rag`, `qa`, `code` fail closed; `chat`, `summary` warn). Every non-streaming response gets a proof certificate; the dashboard shows flagged claims, evidence snippets, and suppression counts. Optional offline DeBERTa NLI (`ENTROLY_LOCAL_NLI=1`) raises accuracy further at $0.
+Profiles tune false-positive behavior per workload (`rag`, `qa`, `code` fail closed; `chat`, `summary` warn). When WITNESS is enabled on a supported non-streaming proxy path, Entroly emits a certificate and the dashboard can show flagged claims, evidence snippets, and suppression counts. Optional offline DeBERTa NLI is enabled with `ENTROLY_LOCAL_NLI=1`; evaluate it on your workload before making an accuracy claim.
 
 ---
 
@@ -541,15 +556,14 @@ This is the important distinction: Entroly does not just remember context. It ca
 
 ## Compared to
 
-| | **Entroly** | Compression tools | Top-K / RAG | Raw truncation |
-|---|---|---|---|---|
-| Approach | Rank → select → compress | Compress whatever's given | Embedding retrieval | Cut off |
-| Token savings | **70–95%** (large repos) | 50–70% | 30–50% | 0% |
-| Quality loss | **None measured** | 2–5% | Variable | High |
-| Needs embeddings API | **No** | Varies | Yes | No |
-| Reversible | **Yes** | Varies | Yes | No |
-| Learns over time | **Yes (PRISM)** | No | No | No |
-| Verifies the answer | **Yes (WITNESS)** | No | No | No |
+| Question | Entroly's documented behavior |
+|---|---|
+| What happens before compression? | Query-aware ranking and budgeted selection |
+| How are omissions handled? | Receipts and recovery handles when recoverable state is retained |
+| How are savings reported? | Local estimates for exploration; provider-observed usage for production claims |
+| Is answer quality guaranteed? | No. Use the linked task benchmarks and validate the target workload |
+| Is an embeddings API required? | No for the default local selection path |
+| Is answer verification automatic everywhere? | No. WITNESS must be enabled on a supported integration path |
 
 > Compressing a *bad* selection is still a bad selection. Entroly ranks first, then compresses — so the model gets structure, not just fewer tokens.
 
@@ -568,7 +582,8 @@ This is the important distinction: Entroly does not just remember context. It ca
 | `entroly wrap <agent>` | Wrap a specific coding agent (38 supported) |
 | `entroly attach create/list/revoke` | Grant, inspect, or revoke scoped and expiring MCP access for Claude Code, Codex, or OpenClaw |
 | `entroly proxy` | Start the HTTP proxy on `localhost:9377` |
-| `entroly serve` | Start the MCP server |
+| `entroly` as an MCP stdio command | Start the installed Python MCP server when launched by an MCP client |
+| `entroly serve` | Start through the Docker image by default; set `ENTROLY_NO_DOCKER=1` for the installed Python runtime |
 | `entroly daemon` | Supervise proxy + dashboard + MCP + file watcher |
 | `entroly dashboard` | Open the live metrics dashboard |
 | `entroly demo` | Before/after token + cost estimate on your repo |
@@ -593,8 +608,21 @@ This is the important distinction: Entroly does not just remember context. It ca
 - **[First-run trust guide](docs/first-run-trust.md)** — exactly what a new user should run before wiring a paid model.
 - **[For teams](docs/for-teams.md)** — ROI, security, deployment one-pager.
 - **[Limitations](docs/limitations.md)** — where Entroly helps, where it passes through, and what it does not guarantee.
+- **[Public evidence policy](docs/public-evidence.md)** — claim tiers, benchmark scope, package links, and marketplace status.
 - **[Cookbook](cookbook/README.md)** — copy-paste recipes for common workflows.
 - **[Discord Community](https://juyterman1000.github.io/entroly/docs/discord.html)** · **[Discussions](https://github.com/juyterman1000/entroly/discussions)** · **[Issues](https://github.com/juyterman1000/entroly/issues)**
+
+### Marketplace status
+
+Marketplace pages are discovery surfaces, not release verification. The public
+[LobeHub listing](https://lobehub.com/mcp/juyterman1000-entroly?activeTab=score)
+was still showing stale version and capability metadata in the latest recorded
+audit. Use the live page for current external status and the
+[LobeHub score audit](docs/lobehub-score-audit.md) for the dated baseline. Until
+the listing matches the published package and passes external validation,
+install from PyPI or npm using the instructions above.
+
+<a href="https://lobehub.com/mcp/juyterman1000-entroly"><img src="https://lobehub.com/badge/mcp/juyterman1000-entroly" alt="Current external Entroly status on LobeHub"></a>
 
 <p align="center"><sub>Apache-2.0 · local-first · no outbound analytics by default</sub></p>
 <p align="center"><code>pip install entroly && entroly go</code></p>

--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -118,7 +118,7 @@ pip install entroly && entroly demo    # see savings on YOUR codebase
 
 ---
 
-## 30-Second Install
+## Install options
 
 **Python:**
 ```bash
@@ -143,9 +143,13 @@ entroly optimize 8000 "fix the auth bug"
 entroly demo
 ```
 
-Both npm packages run the full Rust engine natively in Node.js — **no Python required**.
+Both npm commands use the Node/WASM runtime and do not require Python. They are
+not evidence that the optional PyO3 extension is installed in a Python setup.
 
-**That's it.** `entroly go` (Python) or `entroly serve` / `npx entroly-wasm serve` (Node.js) auto-detects your IDE, starts the engine, and begins optimizing. Point your AI tool to `http://localhost:9377/v1`.
+For Python MCP clients, `entroly init` generates supported client configuration,
+or the client can launch `entroly` with no arguments over stdio. The Node/WASM
+commands above start their MCP server. `http://localhost:9377/v1` belongs to the
+separate Python `entroly proxy` path; an MCP server is not an HTTP proxy.
 
 ### Or step by step
 

--- a/docs/best-context-compression-tools.html
+++ b/docs/best-context-compression-tools.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Best Open-Source Context Compression Tools for LLMs (2026) — Entroly</title>

--- a/docs/claude-code-setup.html
+++ b/docs/claude-code-setup.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Claude Code + Entroly — Local MCP Context, Receipts, and Verification</title>

--- a/docs/cursor-context-guide.html
+++ b/docs/cursor-context-guide.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>How to Give Cursor Your Full Codebase — Fix Context Window Limits | Entroly</title>

--- a/docs/cursor-token-usage-fix.html
+++ b/docs/cursor-token-usage-fix.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Cursor Token Usage Too High? Fix It in 30 Seconds (Free Tool)</title>

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Live Dashboard — Real-Time LLM Token Savings & API Cost Reduction | Entroly</title>

--- a/docs/discord.html
+++ b/docs/discord.html
@@ -6,7 +6,7 @@
   <title>Join the Entroly Community · Discord</title>
   <meta name="description" content="Join the Entroly Discord — chat about AI context management, token savings, hallucination prevention, and share your setups.">
   <meta property="og:title" content="Entroly Community · Discord">
-  <meta property="og:description" content="Join developers cutting AI token bills by 70–95% with Entroly. Ask questions, share setups, and follow the roadmap.">
+  <meta property="og:description" content="Ask Entroly setup questions, share measured results, and follow the open-source roadmap.">
   <meta property="og:image" content="https://juyterman1000.github.io/entroly/docs/assets/og-discord.png">
   <!-- Auto-redirect after 2s -->
   <meta http-equiv="refresh" content="2; url=https://discord.gg/G833X5c7R6">
@@ -264,24 +264,23 @@
 
     <h1>Join the Entroly Community</h1>
     <p class="subtitle">
-      Ask questions, share setups, and follow the roadmap alongside developers cutting
-      their AI token bills by 70–95%.
+      Ask questions, share setups and measured results, and follow the open-source roadmap.
     </p>
 
     <div class="stats">
       <div class="stat">
-        <div class="stat-value">70–95%</div>
-        <div class="stat-label">Token savings</div>
+        <div class="stat-value">Local</div>
+        <div class="stat-label">Context control</div>
       </div>
       <div class="divider"></div>
       <div class="stat">
-        <div class="stat-value">$0</div>
-        <div class="stat-label">Hallucination guard</div>
+        <div class="stat-value">Receipts</div>
+        <div class="stat-label">Inspectable evidence</div>
       </div>
       <div class="divider"></div>
       <div class="stat">
-        <div class="stat-value">3 ms</div>
-        <div class="stat-label">Local verification</div>
+        <div class="stat-value">Open</div>
+        <div class="stat-label">Apache-2.0</div>
       </div>
     </div>
 
@@ -310,7 +309,7 @@
       </div>
       <div class="channel">
         <div class="channel-name">show-and-tell</div>
-        <div class="channel-desc">Share your savings & setups</div>
+        <div class="channel-desc">Share measured results & setups</div>
       </div>
       <div class="channel">
         <div class="channel-name">general</div>

--- a/docs/first-run-trust.md
+++ b/docs/first-run-trust.md
@@ -55,7 +55,7 @@ The simulation is not a quality benchmark and does not claim provider-bill parit
 | User type | Recommended path | Why |
 |---|---|---|
 | Claude Code subscription user | `claude mcp add entroly -- entroly` | Keeps Claude Code as the client and adds Entroly tools without proxy billing assumptions |
-| Cursor, VS Code, Windsurf, or MCP-native IDE user | `entroly init` or `entroly serve` | Adds local context, recovery, receipts, and feedback tools through MCP |
+| Cursor, VS Code, Windsurf, or MCP-native IDE user | `entroly init`, or register `entroly` with no arguments | Adds the installed Python MCP runtime without a Docker requirement |
 | Pay-as-you-go API user | `entroly proxy` | Transparent optimization for Anthropic/OpenAI-compatible clients |
 | Python SDK user | `from entroly import compress, compress_messages, optimize` | Direct library control |
 | Node/npm user | `npm install -g entroly` | WASM runtime path without Python-first setup |

--- a/docs/hallucination-guard.html
+++ b/docs/hallucination-guard.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>LLM Hallucination Guard — $0 Local Hallucination Detection | Entroly WITNESS</title>

--- a/docs/how-to-reduce-claude-api-costs.html
+++ b/docs/how-to-reduce-claude-api-costs.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>How to Reduce Claude API Costs by 90% — Prompt Compression Guide (2026)</title>

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.zh-CN.md">🇨🇳 中文</a> •

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -1,3 +1,5 @@
+> **Archived translation:** This file is not aligned with the current evidence-backed README and may contain outdated or unsupported claims. Use the [canonical README](../../README.md) and [public evidence policy](../public-evidence.md).
+
 <p align="center">
   <a href="../../README.md">🇬🇧 English</a> •
   <a href="README.ja.md">🇯🇵 日本語</a> •

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
       "url": "https://github.com/juyterman1000/entroly"
     },
     "featureList": [
-      "Prompt Compression (70-95% token savings)",
+      "Budgeted context selection with workload-specific measurement",
       "KV-Cache Aligner (prefix cache discounts)",
       "WITNESS Hallucination Guard (local output audit)",
       "ModelContextProtocol (MCP) Server support",
@@ -957,14 +957,14 @@
     </div>
 
     <div style="margin-top: 12px; font-size: 13px; color: var(--muted); max-width: 620px;">
-      Then the <b style="color:var(--accent)">Cache Aligner</b> holds your prefix stable so provider caches actually hit —
-      <b style="color:var(--text)">90% off</b> cached reads on Anthropic, <b style="color:var(--text)">50% off</b> on OpenAI (provider-set rates).
+      The <b style="color:var(--accent)">Cache Aligner</b> keeps eligible prompt prefixes byte-stable. Whether a request
+      receives a cache hit or discount is determined by the provider; verify it from provider-reported usage.
     </div>
 
     <div class="preview" role="button" tabindex="0" aria-label="Play Entroly demo video"
          onclick="openDemo()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openDemo();}">
       <img src="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/demo.svg"
-        alt="Entroly Demo — 70-95% token savings"
+        alt="Entroly context-selection and receipt demo"
         loading="eager" decoding="async">
       <div class="play-overlay">
         <div class="play-btn" aria-hidden="true">
@@ -989,6 +989,9 @@
       <a href="https://pypi.org/project/entroly/" aria-label="View Entroly on PyPI">
         <img src="https://img.shields.io/pypi/v/entroly?style=for-the-badge&logo=pypi&logoColor=white&color=4ade80&labelColor=0e0e15" alt="PyPI version">
       </a>
+      <a href="https://www.npmjs.com/package/entroly" aria-label="View Entroly on npm">
+        <img src="https://img.shields.io/npm/v/entroly?style=for-the-badge&logo=npm&logoColor=white&color=ef4444&labelColor=0e0e15" alt="npm version">
+      </a>
       <a href="https://github.com/juyterman1000/entroly/blob/main/LICENSE" aria-label="View license">
         <img src="https://img.shields.io/badge/license-Apache--2.0-818cf8?style=for-the-badge&labelColor=0e0e15" alt="License: Apache-2.0">
       </a>
@@ -1001,7 +1004,7 @@
       <button class="lightbox-close" onclick="closeDemo()" aria-label="Close demo">×</button>
       <img id="demoVideoFull"
         src="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/demo.svg"
-        alt="Entroly Demo — 70-95% token savings"
+        alt="Entroly context-selection and receipt demo"
         style="width:100%;height:100%;object-fit:contain;display:block;background:#050508;">
     </div>
   </div>
@@ -1022,49 +1025,53 @@
 
   <div class="stats-grid">
     <div class="stat-card">
-      <div class="val"><span style="opacity:0.4;font-size:0.6em;font-weight:400">70-</span>95%</div>
-      <div class="label">Token Reduction</div>
+      <div class="val">128/128</div>
+      <div class="label">Context Replays</div>
     </div>
     <div class="stat-card">
-      <div class="val">100%</div>
-      <div class="label">Code Visibility</div>
+      <div class="val">768/768</div>
+      <div class="label">Tamper Trials Detected</div>
     </div>
     <div class="stat-card">
-      <div class="val">&lt;8ms</div>
-      <div class="label">Engine Latency</div>
+      <div class="val">20,000</div>
+      <div class="label">Faithful HaluEval Decisions</div>
     </div>
     <div class="stat-card">
-      <div class="val">436</div>
-      <div class="label">Tests Passing</div>
+      <div class="val">3 paths</div>
+      <div class="label">Python · Optional Rust · WASM</div>
     </div>
   </div>
+
+  <p class="video-caption">
+    Integrity counts: <a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/context_commit_conformance.json">Context Commit conformance JSON</a>.
+    WITNESS count: <a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/halueval_qa_faithful.json">faithful HaluEval-QA JSON</a>.
+    These results are protocol-scoped, not production guarantees.
+  </p>
 
   <section id="why">
     <div class="section-header">
       <span class="tag">The Problem</span>
-      <h2>RAG isn't enough for coding.</h2>
+      <h2>Selection needs an audit trail.</h2>
     </div>
 
     <div class="comp-grid">
       <div class="comp-card bad" data-reveal>
-        <h3>Standard Context</h3>
-        <div class="row"><span class="lbl">Files visible</span><span class="val">5-10 files</span></div>
-        <div class="row"><span class="lbl">Visibility</span><span class="val">~5%</span></div>
-        <div class="row"><span class="lbl">Tokens used</span><span class="val">186,420 (Raw)</span></div>
-        <div class="row"><span class="lbl">Cost / 1K Req</span><span class="val">$560.00</span></div>
-        <div class="row" style="border:0"><span class="lbl">Quality</span><span class="val">Hallucination risk</span>
+        <h3>Uncontrolled Context</h3>
+        <div class="row"><span class="lbl">Budget</span><span class="val">Implicit or absent</span></div>
+        <div class="row"><span class="lbl">Omissions</span><span class="val">Often unexplained</span></div>
+        <div class="row"><span class="lbl">Recovery</span><span class="val">Integration-dependent</span></div>
+        <div class="row"><span class="lbl">Measurement</span><span class="val">Provider usage required</span></div>
+        <div class="row" style="border:0"><span class="lbl">Trust question</span><span class="val">What evidence was used?</span>
         </div>
       </div>
 
       <div class="comp-card good" data-reveal>
-        <h3>With Entroly</h3>
-        <div class="row"><span class="lbl">Files visible</span><span class="val">ALL 847 files</span></div>
-        <div class="row"><span class="lbl">Visibility</span><span class="val">100%</span></div>
-        <div class="row"><span class="lbl">Tokens used</span><span class="val"><span
-              style="opacity:0.5;font-weight:400">9,300 -</span> 55,000</span></div>
-        <div class="row"><span class="lbl">Cost / 1K Req</span><span class="val"><span
-              style="opacity:0.5;font-weight:400">$28 -</span> $168</span></div>
-        <div class="row" style="border:0"><span class="lbl">Quality</span><span class="val">Dependency Aware</span>
+        <h3>Entroly-Controlled Context</h3>
+        <div class="row"><span class="lbl">Budget</span><span class="val">Explicit</span></div>
+        <div class="row"><span class="lbl">Omissions</span><span class="val">Recorded in receipts</span></div>
+        <div class="row"><span class="lbl">Recovery</span><span class="val">Available while recovery state is retained</span></div>
+        <div class="row"><span class="lbl">Measurement</span><span class="val">Local estimate + provider pilot</span></div>
+        <div class="row" style="border:0"><span class="lbl">Trust answer</span><span class="val">Inspect and replay the receipt</span>
         </div>
       </div>
     </div>
@@ -1092,13 +1099,14 @@
       <div class="feat-card" data-reveal>
         <div class="icon">🧠</div>
         <h3>PRISM Optimizer</h3>
-        <p>Reinforcement Learning adjusts context weights based on AI response quality. Gets smarter every time you
-          code.</p>
+        <p>Recorded outcomes can adjust local context weights. Candidate changes remain subject to promotion and
+          rollback policy; adaptation is not an accuracy guarantee.</p>
       </div>
       <div class="feat-card" data-reveal>
         <div class="icon">🔒</div>
         <h3>Built-in Security</h3>
-        <p>55 SAST rules catch hardcoded secrets and SQL injection before they reach the AI. Security by design.</p>
+        <p>Local SAST and prompt-injection checks can flag configured patterns before context is selected. Review
+          findings; these checks are not a substitute for a security audit.</p>
       </div>
       <div class="feat-card" data-reveal>
         <div class="icon">📊</div>
@@ -1116,13 +1124,13 @@
 
   <section id="levers" class="levers">
     <div class="section-header">
-      <span class="tag">Why it compounds</span>
-      <h2>19 cost-saving levers. One install.</h2>
+      <span class="tag">Inspectable controls</span>
+      <h2>19 mechanisms. Source-linked.</h2>
       <p>
         Most context tools optimize a <b style="color:var(--text)">single</b> lever — input compression.
         Entroly ships <b style="color:var(--text)">19 distinct mechanisms</b> across input, inference, output,
-        verification, and learning. Most are <b style="color:var(--text)">multiplicative</b>, not additive — and
-        every one reads from a real source file you can open and audit.
+        verification, and learning. Their effects must be measured separately and end to end; each source file can
+        be opened and audited.
       </p>
     </div>
 
@@ -1132,16 +1140,16 @@
         <h3>Cache Aligner</h3>
         <p>Compressors re-rank context on every call, which busts the provider's KV cache. The aligner hashes the
           injected context and holds the prefix stable so cache hits actually land.</p>
-        <div class="metric">90% / 50%</div>
-        <div class="src">Anthropic cached-read · OpenAI · entroly/cache_aligner.py</div>
+        <div class="metric">Byte-stable prefix</div>
+        <div class="src">Confirm hits from provider usage · entroly/cache_aligner.py</div>
       </div>
       <div class="lever-hi" data-reveal>
-        <div class="kicker">$0 hallucination guard</div>
-        <h3>WITNESS + STAVE</h3>
-        <p>Deterministic faithfulness verifier — no second LLM, no API call. Statistically ties a modern LLM judge on
-          HaluEval-QA at zero marginal cost.</p>
-        <div class="metric">AUROC 0.84</div>
-        <div class="src">~3 ms/decision · entroly/witness.py · stave.py</div>
+        <div class="kicker">Local grounding-risk signal</div>
+        <h3>WITNESS</h3>
+        <p>Deterministic verifier with no second model call. The committed faithful HaluEval-QA run reports scope,
+          sample size, held-out accuracy, and uncertainty; it does not establish general hallucination prevention.</p>
+        <div class="metric">AUROC 0.7976</div>
+        <div class="src">20,000 decisions · <a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/halueval_qa_faithful.json">raw result</a></div>
       </div>
       <div class="lever-hi" data-reveal>
         <div class="kicker">Pay for the model you need</div>
@@ -1155,12 +1163,12 @@
 
     <div class="lever-grid">
       <div class="lever" data-reveal><div class="num">01</div><h4>Context compression</h4><p>Knapsack DP + 9 specialized compressors + a dep-graph pick the most information-dense fragments that fit your budget.</p><span class="src">proxy_transform.py</span></div>
-      <div class="lever" data-reveal><div class="num">02</div><h4>WITNESS + STAVE</h4><p>Deterministic $0 faithfulness verifier — no second LLM, no API call.</p><span class="src">witness.py · stave.py</span></div>
-      <div class="lever" data-reveal><div class="num">03</div><h4>Cache Aligner</h4><p>Holds the prefix stable so Anthropic's 90% / OpenAI's 50% cached-read discount actually lands.</p><span class="src">cache_aligner.py</span></div>
+      <div class="lever" data-reveal><div class="num">02</div><h4>WITNESS + STAVE</h4><p>Local grounding-risk signals with separately documented evaluation protocols.</p><span class="src">witness.py · stave.py</span></div>
+      <div class="lever" data-reveal><div class="num">03</div><h4>Cache Aligner</h4><p>Holds eligible prefix bytes stable; provider-reported usage determines whether a cache hit occurred.</p><span class="src">cache_aligner.py</span></div>
       <div class="lever" data-reveal><div class="num">04</div><h4>Escalation cascade</h4><p>Cheap model first; escalate only when verifier risk demands it. Bounded regret via split-conformal coverage.</p><span class="src">escalation.py</span></div>
       <div class="lever" data-reveal><div class="num">05</div><h4>Conformal cascade</h4><p>Two-verifier cascade with a measured Pareto frontier vs. either verifier alone.</p><span class="src">conformal_cascade.py</span></div>
       <div class="lever" data-reveal><div class="num">06</div><h4>RAVS Bayesian router</h4><p>Per-task model routing — cheap when capable, strong when needed. Fail-closed.</p><span class="src">ravs/router.py</span></div>
-      <div class="lever" data-reveal><div class="num">07</div><h4>Fast-path skills</h4><p>Queries that match a proven crystallized skill short-circuit the whole pipeline — 100% LLM cost saved.</p><span class="src">fast_path.py</span></div>
+      <div class="lever" data-reveal><div class="num">07</div><h4>Fast-path skills</h4><p>Queries that match an accepted cache key can reuse the recorded result under the configured policy.</p><span class="src">fast_path.py</span></div>
       <div class="lever" data-reveal><div class="num">08</div><h4>Adaptive Compression Budget</h4><p>Learns the right token budget per query so easy questions don't overspend.</p><span class="src">adaptive_budget.py</span></div>
       <div class="lever" data-reveal><div class="num">09</div><h4>Entropic Conversation Pruning</h4><p>Compresses chat history each turn so long conversations don't bloat the input.</p><span class="src">proxy_transform.py</span></div>
       <div class="lever" data-reveal><div class="num">10</div><h4>Shell-output compression</h4><p>Targeted fast paths for git, builds, logs, JSON, and test output — 60–95% smaller.</p><span class="src">proxy_transform.py</span></div>
@@ -1247,11 +1255,11 @@
             <td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/squad_accuracy.json">squad_accuracy.json</a></td>
           </tr>
           <tr>
-            <td>WITNESS+STAVE hallucination (HaluEval-QA)</td>
-            <td class="num">AUROC 0.84</td>
-            <td class="num">~3 ms · $0/call</td>
-            <td class="num">2,000</td>
-            <td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/stave_benchmark.json">stave_benchmark.json</a></td>
+            <td>WITNESS grounding-risk benchmark (HaluEval-QA)</td>
+            <td class="num">AUROC 0.7976</td>
+            <td class="num">84.92% held-out accuracy</td>
+            <td class="num">20,000 decisions</td>
+            <td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/halueval_qa_faithful.json">halueval_qa_faithful.json</a></td>
           </tr>
         </tbody>
       </table>
@@ -1270,8 +1278,8 @@
   </section>
 
   <div class="cta-banner" data-reveal>
-    <h2>Stop paying for boilerplate.</h2>
-    <p>Free your AI from context blindness today.</p>
+    <h2>Measure it before you trust it.</h2>
+    <p>Run the local package, recovery, and workload-estimate checks first.</p>
     <a href="https://github.com/juyterman1000/entroly" class="btn btn-primary"
       style="padding: 12px 32px; font-size: 16px;">View on GitHub</a>
     <div style="margin-top: 24px; font-family: 'JetBrains Mono', monospace; font-size: 14px; color: var(--green);">
@@ -1282,15 +1290,11 @@
   <footer>
     <p>Entroly — Apache-2.0 Licensed · Context Intelligence, Not Compression</p>
     <p style="margin-top: 16px;">
-      <a href="/entroly/docs/reduce-llm-api-costs.html">Reduce LLM API Costs</a>
-      <a href="/entroly/docs/prompt-compression.html">Prompt Compression</a>
-      <a href="/entroly/docs/hallucination-guard.html">Hallucination Guard</a>
-      <a href="/entroly/docs/token-optimization.html">Token Optimization</a>
-      <a href="/entroly/docs/context-engineering.html">Context Engineering</a>
-      <a href="/entroly/docs/cursor-context-guide.html">Cursor Guide</a>
-      <a href="/entroly/docs/claude-code-setup.html">Claude Code Guide</a>
+      <a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Public Evidence</a>
+      <a href="https://github.com/juyterman1000/entroly/blob/main/docs/first-run-trust.md">First-Run Trust</a>
+      <a href="https://github.com/juyterman1000/entroly/blob/main/docs/limitations.md">Limitations</a>
+      <a href="https://github.com/juyterman1000/entroly/blob/main/docs/product-surface.md">Product Surface</a>
       <a href="/entroly/docs/mcp-server-guide.html">MCP Server</a>
-      <a href="/entroly/docs/dashboard.html">Live Dashboard</a>
     </p>
     <p style="margin-top: 12px;">
       <a href="https://github.com/juyterman1000/entroly">GitHub</a>

--- a/docs/marketing/registry_submissions.md
+++ b/docs/marketing/registry_submissions.md
@@ -1,76 +1,66 @@
-# Developer Directories & MCP Registry Submissions
+# Marketplace and directory submission copy
 
-To increase search engine authority (backlinks) and user adoption, submit Entroly to high-traffic registries and directories. This document lists targets, URLs, submission steps, and copy-paste templates.
+Use these templates only after checking the published package and the target
+listing. A marketplace is a discovery surface, not evidence that Entroly was
+installed, validated, or benchmarked successfully.
 
----
+## Canonical facts to verify before submission
 
-## 1. MCP Server Registries
+- Repository: `https://github.com/juyterman1000/entroly`
+- License: Apache-2.0
+- Python package: `https://pypi.org/project/entroly/`
+- Node/WASM package: `https://www.npmjs.com/package/entroly`
+- npm bridge to an installed Python runtime: `https://www.npmjs.com/package/entroly-mcp`
+- MCP identity: `io.github.juyterman1000/entroly`
+- Python MCP command: `entroly` with no arguments
+- Package-runner command: `uvx --from entroly entroly` with no `serve` argument
+- npm bridge command: `npx -y entroly-mcp` with no `serve` argument
 
-Since Entroly operates as an MCP server (`entroly serve`), it qualifies for inclusion in directories cataloging MCP integrations.
+Confirm that the versions on PyPI, npm, `server.json`, and the release tag agree
+before copying any version into an external form.
 
-### A. Glama MCP Registry
-- **URL:** [glama.ai/mcp/servers](https://glama.ai/mcp/servers)
-- **Action:** Click "Submit Server" / login with GitHub.
-- **Form Values:**
-  - **Name:** `Entroly`
-  - **Category:** `Developer Tools` / `Context Engineering`
-  - **GitHub URL:** `https://github.com/juyterman1000/entroly`
-  - **MCP Command:** `npx -y @juyterman1000/entroly-mcp` or `pip install entroly && entroly serve`
-  - **Short Description:** `Local context engineering & prompt compression proxy for AI coding agents. Reduces input tokens by 70–95% while preserving KV cache alignment and validating answers locally.`
-  - **Details:** `An open-source (Apache-2.0) local gateway and MCP server that optimizes prompt context for Cursor, Cline, and Claude Code. Features a prompt prefix Cache Aligner, Content-Compressed Retrieval (CCR) handles, and WITNESS—a local Natural Language Inference (NLI) verifier that checks model output against source files.`
+## Short description
 
-### B. Awesome MCP Servers (GitHub List)
-- **URL:** [github.com/punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)
-- **Action:** Fork the repository and open a Pull Request.
-- **Section:** `Developer Tools` or `Utilities`
-- **Markdown Line to Insert:**
-  ```markdown
-  * [Entroly](https://github.com/juyterman1000/entroly) - A local context-engineering and prompt compression gateway that stabilizes prompt prefixes for KV caching discounts, generates exact-recovery CCR handles, and audits model responses locally.
-  ```
+> Local context control for AI agents with budgeted selection, recoverable
+> omissions, Context Receipts, and optional answer verification.
 
----
+## Long description
 
-## 2. Open-Source Comparison & Alternative Directories
+> Entroly is an Apache-2.0 local context-control plane for AI agents. It can
+> select context under a token budget, record selected and omitted evidence,
+> retain recovery handles, and expose those capabilities through Python, MCP,
+> proxy, and Node/WASM integrations. The base Python package includes a
+> pure-Python path; Rust acceleration is optional. Token reduction and answer
+> quality depend on the workload, model, budget, and integration. Reproducible
+> results and caveats are linked from the repository's public evidence policy.
 
-### A. AlternativeTo
-- **URL:** [alternativeto.net/software/entroly/](https://alternativeto.net)
-- **Action:** Log in and select "Add an application".
-- **Form Values:**
-  - **Title:** `Entroly`
-  - **Official Website:** `https://juyterman1000.github.io/entroly/`
-  - **GitHub Repository:** `https://github.com/juyterman1000/entroly`
-  - **License:** `Open Source (Apache-2.0)`
-  - **Platform:** `Mac`, `Windows`, `Linux`
-  - **Short Tagline:** `Local context compression & verification gateway for AI coding agents.`
-  - **Alternatives to:** List categories such as `context engineering`, `prompt compression`, `MCP server`, and `local AI developer tools`.
-  - **Description:** 
-    ```text
-    Entroly is an open-source, local-first context engineering gateway for developer AI workflows. It sits as a local proxy or MCP server between your coding client (such as Cursor, Claude Code, Cline, or Aider) and your LLM provider.
+## Submission rules
 
-    Key Features:
-    - Token Savings: Slashes input tokens by 70-95% on large codebases.
-    - Cache Aligner: Stabilizes prompt prefixes to secure Anthropic's 90% and OpenAI's 50% caching discounts.
-    - Recoverable Retrieval: Uses CCR handles to let models query full-resolution code fragments if needed.
-    - Zero Hallucinations: Includes a local, deterministic NLI verifier (WITNESS) that checks model claims against repository evidence at $0 cost.
-    ```
+1. Do not publish a universal token-savings or bill-reduction percentage.
+2. Do not describe WITNESS as preventing or eliminating hallucinations.
+3. Do not claim that cache alignment guarantees a provider cache hit or discount.
+4. Do not call the base PyPI install Rust-backed without runtime verification.
+5. Do not claim a marketplace score, ownership state, or validation result from
+   repository-local tests.
+6. Link measured claims to the exact result file, not the results directory.
+7. Recheck every third-party listing after publication and record its visible
+   version, capability counts, ownership state, and validation state.
 
-### B. LibHunt (Python Comparisons)
-- **URL:** [py.libhunt.com](https://py.libhunt.com)
-- **Action:** LibHunt automatically indexes repositories, but you can suggest comparisons or claim the project page once indexed.
-- **Suggested Comparison Title:** `Entroly context engineering for AI coding agents`.
+## LobeHub-specific status
 
----
+The ownership badge must remain in the primary README for LobeHub's external
+claim workflow, but it belongs in the contextualized marketplace section rather
+than the top evidence row. The dated
+[LobeHub score audit](../lobehub-score-audit.md) is repository evidence only.
+Use the
+[live score page](https://lobehub.com/mcp/juyterman1000-entroly?activeTab=score)
+for current external status, and do not report an improvement until that page
+shows the published version and successful external validation.
 
-## 3. General AI Developer Platforms
+## Other directory targets
 
-### A. There's An AI For That (TAAFT)
-- **URL:** [theresanaiforthat.com](https://theresanaiforthat.com)
-- **Action:** Submit tool via their standard submission form.
-- **Title:** `Entroly`
-- **Category:** `Developer Tools`, `LLM cost optimization`
-- **Pricing:** `Free & Open Source`
-
-### B. Toolify.ai
-- **URL:** [toolify.ai](https://www.toolify.ai)
-- **Action:** Click "Submit Tool".
-- **Short Info:** `A local context-engineering tool that slashes AI coding costs by stabilizing prompt caching and compressing repository assets.`
+For Glama, awesome lists, AlternativeTo, LibHunt, and similar directories, use
+the canonical facts and descriptions above. Treat each form as untrusted until
+the resulting public page is reviewed. If a directory rewrites the package
+name, command, license, version, or benchmark language, request correction or
+remove the listing from release messaging.

--- a/docs/marketing/tutorial_devto.md
+++ b/docs/marketing/tutorial_devto.md
@@ -1,112 +1,88 @@
-# How to Slash Your Claude Code & Cursor API Bills by 90% with a Local Context Proxy
+# Auditable context control for AI coding agents with Entroly
 
-If you use autonomous AI coding agents (like **Claude Code**, **Aider**, or **Roo-Cline**) or advanced IDEs like **Cursor**, you have likely experienced that sinking feeling when checking your API billing console. 
+> Maintainer draft. Re-run every command and review the linked evidence before
+> publishing. Do not add a universal savings or accuracy claim.
 
-Large repositories easily average **150,000+ tokens per request**. At Claude 3.5 Sonnet pricing, that translates to roughly **$0.45 per single message**. Run a feedback loop of 10-15 steps, and you've spent $7 on a single feature.
+Long coding sessions accumulate logs, duplicate files, and stale conversation
+history. Sending everything can be expensive; deleting context blindly can
+remove the evidence the model needs. Entroly provides a local middle path:
+budgeted selection, recoverable omissions, and receipts describing what was
+selected and left out.
 
-Here is the exact technical breakdown of why this happens, and how to configure a local context proxy to cut your API costs by 70% to 95% without sacrificing code quality or switching to weaker models.
+## Install and verify locally
 
----
-
-## The Hidden Culprit: Prefix Cache Busting
-
-Most developers focus on **input compression** (slashing whitespace, removing comments, or dropping files). While helpful, this ignores the single largest discount leverage: **Prompt Caching**.
-
-Anthropic provides a **90% discount** for cached prompt prefixes ($0.30 per million tokens instead of $3.00). OpenAI offers a **50% discount**. 
-
-Prompt caching works by reusing the key-value (KV) cache of the prefix bytes *if* the prefix remains identical byte-for-byte between requests.
-
-### The Re-Ranking Trap
-Every time your agentic coding loop runs:
-1. It updates the terminal history.
-2. It fetches git status or runs lint tools.
-3. It re-ranks and re-orders context files to find the most relevant snippets.
-
-Because the re-ranking changes the exact order of the files in the prompt, **the byte-by-byte prefix changes slightly on every single message**. Your cache hits drop to 0%, and you pay full price for the entire 150K codebase context over and over.
-
----
-
-## The Solution: Entroly Local Gateway
-
-[Entroly](https://github.com/juyterman1000/entroly) is an open-source, fully offline local context engine that acts as a middleware between your coding tool and your LLM provider.
-
-```
-┌─────────────────┐       ┌───────────────────────────┐       ┌──────────────┐
-│  AI Coding Tool │ ────> │   Entroly Proxy (Local)   │ ────> │ LLM Provider │
-│  (Cursor/Claude)│       │                           │       │ (Anthropic)  │
-└─────────────────┘       └───────────────────────────┘       └──────────────┘
-                                │
-                                ├─ Cache Aligner (Prefix stability)
-                                ├─ Knapsack Optimizer (Evidence-locked selection)
-                                └─ WITNESS Verification ($0 hallucination guard)
-```
-
-Instead of simply pruning text, Entroly manages context through three distinct layers:
-1. **Cache Aligner:** Anchors your context files at the front of the prompt and mathematically stabilizes their prefix bytes. Even if history changes, the large codebase remains cached, capturing the 90% discount.
-2. **Evidence-Locked Selection:** Emits content-compressed retrieval (CCR) handles. If the model needs details from a compressed snippet, it queries a local lookup rather than requesting the entire raw file.
-3. **WITNESS Verification:** A $0 local NLI verifier that checks if the model's response is grounded in local evidence *before* streaming, blocking hallucinations without running a second API check.
-
----
-
-## 🛠️ Step-by-Step Setup Guide
-
-### 1. Install Entroly
-Entroly runs entirely locally with no outbound telemetry or cloud dependencies:
 ```bash
-pip install entroly
-```
-
-### 2. Run a Local Smoke Test
-Before routing live API traffic, run a bounded simulation on your current repository:
-```bash
-cd /path/to/your/project
+pip install -U entroly
 entroly verify-claims
+entroly simulate
 ```
-This generates a `.entroly_verification.json` report showing you exactly how much context can be optimized based on your directory structures.
 
-### 3. Spin Up the Local Proxy
-Start the proxy to intercept API traffic:
+`verify-claims` is a bounded package and recovery smoke test. `simulate` is a
+local token estimate for the current repository. Neither command proves a bill
+reduction or downstream answer quality.
+
+## Connect an MCP client
+
+For supported IDEs, let Entroly generate the configuration:
+
 ```bash
-entroly proxy --port 9377
+entroly init
 ```
-This automatically stands up a live dashboard at `http://localhost:9378` to track your real-time cache hits, original-vs-compressed token sizes, and cumulative cost savings.
 
-### 4. Configure Your Tools
+For a generic MCP client, register the installed command with no arguments:
 
-#### For Claude Code / Aider
-Redirect the base URL of your API requests to your local Entroly gateway:
+```json
+{
+  "mcpServers": {
+    "entroly": {
+      "command": "entroly",
+      "args": []
+    }
+  }
+}
+```
+
+Under an MCP client's stdio pipe, the bare command starts the installed Python
+server. `entroly serve` is Docker-first unless `ENTROLY_NO_DOCKER=1` is set.
+
+Claude Code users can register the same command directly:
+
 ```bash
-# For Anthropic Sonnet / Opus
-export ANTHROPIC_BASE_URL="http://localhost:9377/v1"
-
-# For OpenAI models
-export OPENAI_BASE_URL="http://localhost:9377/v1"
+claude mcp add entroly -- entroly
 ```
 
-#### For Cursor (MCP Mode)
-Entroly can also run as a Model Context Protocol (MCP) server:
-1. Run `entroly serve` in your terminal.
-2. Open Cursor Settings -> **Features** -> **MCP**.
-3. Click **+ Add New MCP Server**:
-   - **Name:** `entroly`
-   - **Type:** `command`
-   - **Command:** `entroly serve`
+## Use proxy mode only when it fits
 
----
+If you control a provider API key and the client supports a custom endpoint:
 
-## 📊 Expected Cost Savings
+```bash
+entroly proxy
+```
 
-| Repo Size | Average Input Tokens | Cache Hit Rate | Bill Reduction |
-|---|---|---|---|
-| Medium (100–300 files) | 120,000 | ~85% | **~75% lower** |
-| Large (500+ files) | 280,000 | ~92% | **~90% lower** |
+Then configure only the provider base URL supported by that client. Entroly
+performs local selection, but the resulting prompt still goes to the model
+provider configured by the user. Cache alignment can preserve eligible prefix
+bytes; only provider-reported usage can establish that a cache hit occurred.
 
-*Note: For very small repositories (under 30 files) or simple single-file lookups, context compression is less effective. Entroly is designed for complex, multi-file codebases and autonomous loop tasks.*
+## Measure before making a claim
 
----
+Record:
 
-## 🔗 Links & Resources
+- the raw request and Entroly request under the same task;
+- provider-observed input, cached, and output tokens;
+- model and provider;
+- context budget and Entroly version;
+- task success and answer-critical evidence recall; and
+- retries, recovery calls, and omitted evidence.
 
-- **GitHub Repository:** [juyterman1000/entroly](https://github.com/juyterman1000/entroly)
-- **Detailed Guides:** [juyterman1000.github.io/entroly](https://juyterman1000.github.io/entroly)
-- **License:** Apache-2.0
+The repository includes a preregistered
+[Context Efficiency Frontier](../benchmarks/context-efficiency-frontier.md)
+protocol for paired evaluation. Public benchmark numbers and their caveats live
+in the [public evidence policy](../public-evidence.md).
+
+## What to say accurately
+
+Entroly is an Apache-2.0, local context-control plane with Python, optional Rust
+acceleration, MCP and proxy integrations, and a separate Node/WASM runtime. It
+can reduce selected context on some workloads, but the amount and any effect on
+answer quality depend on the corpus, query, budget, model, and integration.

--- a/docs/marketing/tutorial_reddit.md
+++ b/docs/marketing/tutorial_reddit.md
@@ -1,135 +1,62 @@
-# Community Reddit Marketing Templates
+# Community post templates
 
-Use these templates to share Entroly on relevant subreddits. Focus on providing raw value, explaining the mechanics, and letting users verify their savings locally before making any external network requests.
+> Maintainer drafts. Follow each community's self-promotion rules, disclose your
+> relationship to Entroly, and answer questions with links to exact evidence.
+> Do not post a universal savings, cache-hit, latency, or accuracy claim.
 
----
+## Technical project post
 
-## 1. Subreddit: r/ClaudeAI / r/ClaudeCode
-
-**Title:** Guide: Why your Claude Code / Cline loops are costing you a fortune (and how prompt cache alignment fixes it)
-
-**Body:**
-```markdown
-If you’ve been running autonomous coding agents like Claude Code, Cline, or Roo-Cline heavily, you’ve probably seen some staggering numbers on your Anthropic API bill. 
-
-For a medium-sized codebase, prompts easily hit **120k–180k tokens** on every message loop. At Sonnet 3.5 rates, that's ~$0.45 per run. A single debugging loop of 10–15 steps can run you $6.00.
-
-### The Problem: Re-Ranking busts Anthropic's 90% Cache Discount
-Anthropic offers a massive 90% discount on cached prompt prefixes. So why isn't it saving you money? 
-
-Every time your coding agent loops:
-1. It updates the chat history with tool results or shell outputs.
-2. It re-ranks and re-orders context files to try and fit them under the token limit.
-
-This re-ranking changes the exact sequence of bytes in the prompt prefix. Because caching requires a **100% exact byte-by-byte match**, the prefix cache is invalidated (busted) on every single turn. You end up paying full price for the entire context over and over.
-
-### The Solution: Prompt Cache Alignment
-I built **Entroly**—a local context control proxy—to address this exact issue. It sits between your coding tool and the API.
-
-Instead of re-ordering files blindly, Entroly’s **Cache Aligner** keeps the context files anchored at the beginning of the prompt and stabilizes their prefix structure. By isolating dynamic chat history to the end, the large codebase remains permanently cached at the provider level, securing the 90% discount.
-
-It also features:
-- **Knapsack Selection:** Solves optimal file packing under a strict token budget.
-- **WITNESS:** A local $0 Natural Language Inference (NLI) verifier that checks model output against local files before showing it to you (preventing hallucinated imports/APIs).
-
-### Setup in 30 Seconds:
-It runs entirely locally with no phone-home telemetry:
-
-1. Install it:
-   ```bash
-   pip install entroly
-   ```
-2. Run a local simulation on your repo with no API keys:
-   ```bash
-   entroly verify-claims
-   ```
-3. Start the proxy:
-   ```bash
-   entroly proxy --port 9377
-   ```
-4. Point Claude Code / Aider to it:
-   ```bash
-   export ANTHROPIC_BASE_URL="http://localhost:9377/v1"
-   ```
-
-It opens a dashboard at `http://localhost:9378` showing your real-time cache hits and billing savings.
-
-It’s open source (Apache-2.0). If you are running long agent loops on large codebases, check it out and see if it helps keep your API bills reasonable!
-
-👉 **GitHub:** https://github.com/juyterman1000/entroly
-👉 **Documentation & Guides:** https://juyterman1000.github.io/entroly/
-```
-
----
-
-## 2. Subreddit: r/LocalLLaMA
-
-**Title:** Entroly - Open source local context-engineering gateway (Rust/Python, Apache-2.0)
+**Title:** Entroly: open-source context receipts and recoverable selection for AI agents
 
 **Body:**
-```markdown
-Hi LocalLLaMA community,
 
-If you are using local models (like Ollama, Llama.cpp, or vLLM) for coding agents or complex RAG tasks, you know that keeping context windows optimized is crucial for both speed (prompt processing latency) and reasoning accuracy.
+> I maintain Entroly, an Apache-2.0 local context-control plane for AI agents.
+> It selects evidence under a budget, records selected and omitted context, and
+> can keep omitted source recoverable through receipts and handles.
+>
+> The base Python install has a pure-Python path; Rust acceleration is optional,
+> and the Node package uses a separate WASM runtime. MCP clients register the
+> bare `entroly` command with no arguments.
+>
+> I am deliberately not posting a universal token-savings percentage. The repo
+> links each prominent benchmark number to its exact result and caveats, and it
+> includes a paired protocol for measuring provider-observed usage and task
+> quality. I would value feedback on the receipt format, recovery model, and
+> reproducibility rather than stars alone.
 
-I developed **Entroly**, a local context-control plane designed specifically to solve this.
+Links:
 
-Unlike generic summarizers that just delete lines or drop structural elements of the code, Entroly handles context allocation as a resource-constrained knapsack optimization problem:
+- Repository: `https://github.com/juyterman1000/entroly`
+- Public evidence policy: `https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md`
+- Limitations: `https://github.com/juyterman1000/entroly/blob/main/docs/limitations.md`
 
-1. **Entropy Density Ranking:** Evaluates code blocks based on information density (using Shannon entropy + BM25 + SimHash deduplication).
-2. **Knapsack Pack:** Fits the most relevant code fragments exactly within the local model's token limits.
-3. **Reversibility (CCR):** Emits Content-Compressed Retrieval handles. If the local LLM needs raw details from a compressed file snippet, it queries a local backend to retrieve full-resolution detail rather than flooding the context window up-front.
-4. **WITNESS Guard:** Includes a local, deterministic $0 Natural Language Inference (NLI) verifier that runs locally to check if model outputs are grounded in your source files.
+## Setup-focused response
 
-It compiles down to a PyO3-based Rust core (`entroly-core`) for sub-10ms performance, wrapped in a developer-friendly Python/CLI toolkit.
-
-It runs 100% locally with no telemetry by default.
-
-### Test it locally:
 ```bash
-pip install entroly
-cd /your/repo
+pip install -U entroly
 entroly verify-claims
-```
-This runs a local smoke test simulation on your project directory and outputs `.entroly_verification.json` containing token-packing and index efficiency statistics.
-
-Would love to get feedback on how it behaves on large repositories and if it speeds up your local code generation pipelines.
-
-👉 **GitHub:** https://github.com/juyterman1000/entroly
-👉 **Specs:** https://juyterman1000.github.io/entroly/docs/context-engineering.html
+entroly simulate
 ```
 
----
+For an MCP client:
 
-## 3. Subreddit: r/selfhosted
-
-**Title:** Show selfhosted: Entroly — Self-hosted context compression & verification proxy for AI developer workflows (Apache-2.0)
-
-**Body:**
-```markdown
-Hey r/selfhosted,
-
-I wanted to share **Entroly**, a project I've been working on to self-host context control and verification for AI coding tools. 
-
-If you self-host LLM APIs or use third-party endpoints with IDE tools like Cursor or Continue, prompt volume and hallucination rates are the biggest pain points. Entroly sits as a local gateway on your machine to optimize and audit these connections.
-
-### What it does:
-- **Reduces token usage by 70–95%** on large directories using local knapsack optimization.
-- **Preserves KV prompt caches** by stabilizing the prompt prefix byte-structure (ensures you actually capture Anthropic's 90% or OpenAI's 50% cache discounts).
-- **WITNESS verification:** Audits AI responses locally against your files to block hallucinated methods/configs before they render.
-- **Offline first:** Zero outbound telemetry or cloud dependencies.
-
-### Quick Start:
-```bash
-pip install entroly
-entroly proxy --port 9377
+```json
+{
+  "mcpServers": {
+    "entroly": { "command": "entroly", "args": [] }
+  }
+}
 ```
-Then configure your self-hosted tools (like Open WebUI, Cline, or Continue) to use the proxy base URL: `http://localhost:9377/v1`.
 
-You can view real-time optimization logs, exact cache hit ratios, and estimated dollar savings via a local dashboard at `http://localhost:9378`.
+Explain that `verify-claims` is a bounded local smoke test and `simulate` is an
+estimate. Ask the user to share the generated JSON and exact client/version if
+setup fails. Do not tell them a passing smoke test proves production savings.
 
-Check out the repo if you want to optimize your self-hosted AI developer setup!
+## Maintainer response rules
 
-👉 **GitHub:** https://github.com/juyterman1000/entroly
-👉 **Documentation:** https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html
-```
+1. State that you maintain or contribute to Entroly.
+2. Link the exact result file for any number.
+3. Distinguish pure-Python, optional Rust, and Node/WASM paths.
+4. Distinguish MCP from the HTTP proxy.
+5. Say when a result is estimated rather than provider-observed.
+6. Treat bug reports as trust failures and provide a reproducible recovery path.

--- a/docs/mcp-server-guide.html
+++ b/docs/mcp-server-guide.html
@@ -105,10 +105,14 @@ entroly init</pre>
 <p>Auto-detects your IDE and generates the appropriate MCP configuration.</p>
 
 <h3>Any MCP-Compatible Tool</h3>
-<pre>pip install -U entroly
-entroly serve --transport stdio</pre>
-<p>Or with SSE transport for remote connections:</p>
-<pre>entroly serve --transport sse --port 9378</pre>
+<pre>{
+  "mcpServers": {
+    "entroly": { "command": "entroly", "args": [] }
+  }
+}</pre>
+<p>Install with <code>pip install -U entroly</code>, then register the bare
+<code>entroly</code> command. An MCP client's stdio pipe starts the installed
+Python server without requiring Docker.</p>
 
 <h3>Node/WASM, No Python</h3>
 <pre>npm install -g entroly
@@ -137,7 +141,7 @@ entroly serve</pre>
 
 <ol>
   <li>The AI tool calls <code>optimize_context</code> with the user's query and token budget</li>
-  <li>Entroly's Rust engine scores and selects the optimal code fragments in &lt;10ms</li>
+  <li>The installed engine scores and selects context under the requested budget; the base package can use its pure-Python path and the optional native extra enables supported Rust paths</li>
   <li>The selected context is delivered at variable resolution — full text, signatures, or references</li>
   <li>The AI tool receives broader useful context under a smaller token budget; exact savings depend on the repo, query, and budget</li>
   <li>After the AI responds, <code>record_outcome</code> feeds the learning loop</li>
@@ -146,22 +150,23 @@ entroly serve</pre>
 <h2>Configuration</h2>
 
 <h3>Transport Options</h3>
-<pre># stdio (default — for local IDE connections)
-entroly serve --transport stdio
+<pre># stdio (default): register this command in the MCP client
+entroly
 
-# SSE (for remote / multi-client setups)
-entroly serve --transport sse --port 9378</pre>
+# installed Python runtime in a POSIX shell
+ENTROLY_NO_DOCKER=1 entroly serve
 
-<h3>Quality Presets</h3>
-<pre>entroly serve --quality balanced    # recommended
-entroly serve --quality max         # best context, slightly more latency
-entroly serve --quality speed       # fastest, lighter optimization</pre>
+# SSE through the installed Python runtime
+ENTROLY_NO_DOCKER=1 ENTROLY_MCP_TRANSPORT=sse ENTROLY_MCP_PORT=9379 entroly serve</pre>
+<p><code>entroly serve</code> is Docker-first unless <code>ENTROLY_NO_DOCKER=1</code>
+is set. The CLI does not accept <code>--transport</code>, <code>--port</code>, or
+<code>--quality</code> on the <code>serve</code> command.</p>
 
 <h3>Environment Variables</h3>
 <table>
   <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
   <tr><td><code>ENTROLY_MCP_TRANSPORT</code></td><td>stdio</td><td>Transport mode</td></tr>
-  <tr><td><code>ENTROLY_QUALITY</code></td><td>0.5</td><td>Quality dial (0.0-1.0)</td></tr>
+  <tr><td><code>ENTROLY_MCP_PORT</code></td><td>9379</td><td>SSE port when MCP transport is <code>sse</code></td></tr>
   <tr><td><code>ENTROLY_MAX_FILES</code></td><td>5000</td><td>Max files to index</td></tr>
 </table>
 
@@ -169,7 +174,7 @@ entroly serve --quality speed       # fastest, lighter optimization</pre>
 
 <h3>MCP server not connecting</h3>
 <pre>entroly doctor</pre>
-<p>Runs 7 diagnostic checks including MCP connectivity, port availability, and config validation.</p>
+<p>Checks the installed package, configuration, optional Docker availability, local index state, and verifier imports. Read the output for warnings; a passing doctor run is not an end-to-end client or model test.</p>
 
 <h3>Not sure whether to use MCP or proxy?</h3>
 <p>Use MCP for Claude Code subscriptions and MCP-native IDEs. Use proxy mode only when you control a provider API key and want transparent Anthropic/OpenAI-compatible request optimization.</p>
@@ -178,7 +183,10 @@ entroly serve --quality speed       # fastest, lighter optimization</pre>
 <p>Check that <code>.cursor/mcp.json</code> exists and restart Cursor. Entroly needs to be installed globally or in the same environment Cursor can access.</p>
 
 <h3>High latency</h3>
-<p>Switch to a faster quality preset: <code>entroly serve --quality speed</code>. Or install the Rust engine: <code>pip install entroly[native]</code>.</p>
+<p>The first tool call can include indexing work. Confirm the indexed scope and
+engine mode with <code>entroly verify-claims</code>. Install the optional Rust
+engine with <code>pip install 'entroly[native]'</code> where a compatible wheel is
+available, then re-run verification instead of assuming acceleration is active.</p>
 
 <div class="cta-box">
   <h3>Local context OS for AI coding agents.</h3>

--- a/docs/prevent-ai-hallucinations.html
+++ b/docs/prevent-ai-hallucinations.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>How to Prevent AI Hallucinations in Code — Free Open-Source Tool (2026)</title>

--- a/docs/product-surface.md
+++ b/docs/product-surface.md
@@ -61,7 +61,7 @@ entroly wrap cursor
 entroly wrap codex
 entroly wrap aider
 entroly proxy
-entroly serve
+entroly serve  # Docker-first; use ENTROLY_NO_DOCKER=1 for installed Python
 entroly daemon
 ```
 

--- a/docs/prompt-compression.html
+++ b/docs/prompt-compression.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Prompt Compression & Context Compression for LLMs — Entroly</title>
@@ -209,8 +212,8 @@ compressed = compress(log_output, budget=2000)
 context = optimize(fragments, budget=8000, query="fix the login bug")</pre>
 
 <h3>As an MCP Server</h3>
-<pre>entroly serve   # starts MCP server
-# then add to Cursor, Claude Code, VS Code config via: entroly init</pre>
+<pre>entroly init    # generate a supported MCP client configuration
+# or register "entroly" with no arguments as the client's stdio command</pre>
 
 <div class="cta-box">
   <h3>Start Compressing Your Prompts</h3>

--- a/docs/public-evidence.md
+++ b/docs/public-evidence.md
@@ -1,0 +1,131 @@
+# Entroly public evidence policy
+
+Entroly separates availability, implementation, measured results, and external
+marketplace status. These are different kinds of evidence and must not be
+presented as interchangeable trust signals.
+
+## Evidence tiers
+
+| Tier | What it establishes | Required public support |
+|---|---|---|
+| Distribution | A package or license is publicly available | Direct registry or license link and the exact package name |
+| Implementation | A runtime or capability exists in the repository | Source, tests, and accurate optional/default-runtime wording |
+| Reproducible measurement | A result occurred under a specific protocol | Committed result, sample size, configuration, reproduction command, and caveats |
+| Production outcome | A user workload achieved an outcome | Provider-observed usage, workload definition, baseline, and uncertainty |
+| Marketplace status | A third party indexed or validated a release | The live third-party page, checked after publication |
+
+A lower tier cannot be used to imply a higher one. For example, a package badge
+does not prove benchmark quality, a local protocol test does not prove an
+external marketplace validated the server, and a local token estimate does not
+prove a billing reduction.
+
+## Canonical distribution links
+
+- Python package: [PyPI `entroly`](https://pypi.org/project/entroly/)
+- Node/WASM runtime: [npm `entroly`](https://www.npmjs.com/package/entroly)
+- npm bridge to an installed Python runtime: [npm `entroly-mcp`](https://www.npmjs.com/package/entroly-mcp)
+- Standalone WASM package: [npm `entroly-wasm`](https://www.npmjs.com/package/entroly-wasm)
+- License: [Apache-2.0](../LICENSE)
+
+The base PyPI installation includes the Python runtime. Rust acceleration is an
+optional extra (`pip install 'entroly[native]'`). The npm `entroly` package is a
+separate Node/WASM runtime. Documentation must not imply that the base Python
+installation is Rust-backed unless runtime verification reports that mode.
+
+## MCP launch contract
+
+The canonical installed-Python MCP registration is the `entroly` stdio command
+with no positional arguments. Under an MCP client's stdin pipe, it launches the
+installed Python server. The `uvx` and `entroly-mcp` registry entries likewise
+use no `serve` argument.
+
+`entroly serve` is the explicit Docker-first deployment command. It uses the
+published container by default; `ENTROLY_NO_DOCKER=1` selects the installed
+Python runtime. Public setup instructions must state that distinction.
+
+## Prominent reproducible results
+
+### Context Commit integrity
+
+The committed synthetic conformance run reports 128/128 deterministic replays,
+576/576 exact omission recoveries, and 768/768 detected tamper mutations across
+requested Python and Rust modes. It measures artifact integrity and recovery,
+not answer quality or identical cross-engine selection.
+
+- Result: [`context_commit_conformance.json`](../benchmarks/results/context_commit_conformance.json)
+- Reproduce: `python -m benchmarks.context_commit_conformance`
+
+### WITNESS HaluEval-QA run
+
+The committed faithful run scores both answers in the balanced HaluEval-QA
+protocol. WITNESS reports 0.7976 full-dataset AUROC and 84.92% accuracy on the
+16,000-decision held-out split. On the shared 1,200-decision GPT sample, the
+committed accuracies are 86.58% for WITNESS and 86.25% for gpt-4o-mini. The
+reported uncertainty overlaps, so Entroly does not claim superiority or general
+hallucination prevention from this run.
+
+- Result: [`halueval_qa_faithful.json`](../benchmarks/results/halueval_qa_faithful.json)
+- Reproduce: `python benchmarks/halueval_qa_faithful.py`
+- Exploratory STAVE result: [`stave_benchmark.json`](../benchmarks/results/stave_benchmark.json), kept separate because it uses a different evaluation setup
+
+### Token reduction and task quality
+
+Token reduction depends on the corpus, query, budget, tokenizer, integration,
+and recovery behavior. The README's accuracy-retention table links each row to
+its exact committed artifact. Those rows are examples from small benchmark
+runs, not a universal savings range.
+
+Use `entroly simulate` for a no-network local estimate. Use provider-observed
+request usage and the [Context Efficiency Frontier protocol](benchmarks/context-efficiency-frontier.md)
+before publishing a production or billing claim.
+
+## Marketplace status
+
+The LobeHub listing is an external discovery surface. The dated
+[LobeHub score audit](lobehub-score-audit.md) recorded stale version, license,
+capability, ownership, and validation state. Repository readiness and local MCP
+tests do not change that public state. Only the
+[live LobeHub page](https://lobehub.com/mcp/juyterman1000-entroly?activeTab=score)
+can establish the current external result.
+
+The LobeHub ownership badge remains in the README's marketplace section so the
+external claim workflow can detect it. It is deliberately excluded from the
+top distribution and evidence rows until the listing reflects the current
+release and passes external validation.
+
+## Quarantined public surfaces
+
+Trust-sensitive pages are removed from navigation and search indexing when
+their claims cannot be supported. The legacy savings, cost-reduction,
+hallucination, prompt-compression, and projected-dashboard pages currently
+redirect to this policy while their protocols and copy are rebuilt.
+
+The external Hugging Face demo is also excluded from the README's first fold.
+Its public metadata must be updated to remove the unsupported universal savings
+and zero-accuracy-loss language before it can be presented as an Entroly trust
+or demo surface again. An HTTP-successful page is not sufficient evidence that
+its copy or runtime is current.
+
+Legacy translated READMEs are marked as archived and removed from the primary
+language selector because they predate this evidence policy. They must be
+regenerated from the canonical README, including links and caveats, before they
+are promoted again.
+
+## Maintainer rules
+
+Before adding or strengthening a public claim:
+
+1. Link the exact package, source, or result—not a directory or screenshot.
+2. State the workload, model, budget, sample size, baseline, and caveats needed
+   to interpret a measured result.
+3. Keep different benchmark protocols in separate rows.
+4. Describe estimated usage as estimated and provider-reported usage as
+   observed.
+5. Do not claim an external marketplace score from repository-local evidence.
+6. Remove or soften a claim when its evidence cannot be reproduced.
+
+Run `python scripts/verify_public_trust.py` before release. Use `--online` to
+also check canonical public destinations. After publication, add
+`--require-published-version` to require PyPI and npm latest versions to match
+`server.json`. Online checks are retried but remain subject to third-party
+availability.

--- a/docs/reduce-llm-api-costs.html
+++ b/docs/reduce-llm-api-costs.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Reduce LLM API Costs by 70–95% — Cut Claude, OpenAI & Gemini Bills | Entroly</title>

--- a/docs/releases/v1.0.58.md
+++ b/docs/releases/v1.0.58.md
@@ -1,0 +1,39 @@
+# Entroly 1.0.58
+
+This patch release restores consistency between Entroly's public presentation,
+package behavior, and committed evidence.
+
+## Trust and documentation corrections
+
+- separates distribution, reproducible evidence, community signals, and
+  marketplace status in the primary README;
+- links PyPI, npm, Apache-2.0, Context Commit, and WITNESS badges directly to
+  their canonical package or result;
+- replaces the mixed-protocol STAVE headline with the faithful HaluEval-QA
+  result and its explicit sample, held-out split, and caveats;
+- removes unsupported aggregate token-savings, billing, cache-hit, setup-time,
+  and universal answer-quality claims from prominent surfaces;
+- records LobeHub as an external discovery surface whose stale public status
+  cannot be upgraded by repository-local evidence; and
+- quarantines legacy marketing pages, the projected dashboard, external demo
+  promotion, and translations that do not yet meet the current evidence policy.
+
+## MCP installation correction
+
+The canonical installed-Python MCP registration is now consistently documented
+and published as `entroly` with no arguments. The PyPI `uvx` and npm
+`entroly-mcp` registry entries likewise pass no `serve` argument.
+
+`entroly serve` remains the explicit Docker-first deployment command.
+`ENTROLY_NO_DOCKER=1 entroly serve` selects the installed Python runtime.
+
+## Release safeguards
+
+- adds deterministic public-claim and evidence-contract tests;
+- adds a scheduled, retried public-destination health check;
+- treats the intentionally absent optional Rust wheel as a healthy pure-Python
+  base installation in `entroly doctor`, while still failing visibly for an
+  installed but stale or incomplete native engine;
+- validates the MCP manifest against the current registry schema; and
+- keeps the Homebrew formula on the last verified 1.0.57 sdist until PyPI
+  publishes 1.0.58 and the post-release workflow records its real checksum.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,70 +7,10 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/cursor-token-usage-fix.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/prompt-compression.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/hallucination-guard.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
     <loc>https://juyterman1000.github.io/entroly/docs/context-engineering.html</loc>
     <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/claude-code-setup.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/token-optimization.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html</loc>
@@ -79,21 +19,9 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/dashboard.html</loc>
-    <lastmod>2026-07-05</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://juyterman1000.github.io/entroly/docs/discord.html</loc>
     <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://juyterman1000.github.io/entroly/docs/what-is-context-rot.html</loc>
-    <lastmod>2026-07-09</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
 </urlset>

--- a/docs/token-optimization.html
+++ b/docs/token-optimization.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Reduce AI Token Costs by 78% — Token Optimization for AI Coding Tools | Entroly</title>

--- a/docs/what-is-context-rot.html
+++ b/docs/what-is-context-rot.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="robots" content="noindex,nofollow">
+<meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
+<link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>What Is Context Rot? The Hidden Reason Your AI Gets Dumber Over Time (2026)</title>

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "1.0.57"
+version = "1.0.58"
 dependencies = [
  "entroly-qccr",
  "flate2",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.57"
+version = "1.0.58"
 dependencies = [
  "regex",
  "serde",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "1.0.57"
+version = "1.0.58"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=1.0.57"
+python -m pip install --no-cache-dir -U "entroly-core>=1.0.58"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "1.0.57"
+version = "1.0.58"
 description = "Rust core for Entroly: Context Receipts, deterministic ingestion/ranking, dependency audits, and local context optimization"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-qccr/Cargo.lock
+++ b/entroly-qccr/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.57"
+version = "1.0.58"
 dependencies = [
  "regex",
  "regex-lite",

--- a/entroly-qccr/Cargo.toml
+++ b/entroly-qccr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-qccr"
-version = "1.0.57"
+version = "1.0.58"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.57"
+version = "1.0.58"
 dependencies = [
  "regex-lite",
  "serde",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "1.0.57"
+version = "1.0.58"
 dependencies = [
  "entroly-qccr",
  "flate2",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "1.0.57"
+version = "1.0.58"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Pure WebAssembly local context OS for AI agents: context receipts, local optimization, MCP, app SDK helpers, and no Python dependency.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "1.0.57"
+__version__ = "1.0.58"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -51,7 +51,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "1.0.57"
+    __version__ = "1.0.58"
 
 from entroly.config import (
     load_active_tuning_config as _load_active_tuning_config,
@@ -3164,10 +3164,19 @@ def cmd_doctor(args):
         version = f" {native.version}" if native.version else ""
         print(f"  {C.GREEN}+{C.RESET} Rust engine (entroly-core{version}) loaded")
         checks_passed += 1
+    elif not native.available:
+        print(
+            f"  {C.GRAY}-{C.RESET} Optional Rust acceleration not installed "
+            f"{C.GRAY}— pure-Python engine is active{C.RESET}"
+        )
+        print(
+            f"    {C.GRAY}Enable when wanted: python -m pip install "
+            f"\"entroly[native]\"{C.RESET}"
+        )
+        checks_passed += 1
     else:
-        status = "not loaded" if not native.available else "stale or incomplete"
-        print(f"  {C.RED}x{C.RESET} Rust engine (entroly-core) {status} "
-              f"{C.GRAY}— optional; core features still work{C.RESET}")
+        print(f"  {C.RED}x{C.RESET} Installed Rust engine is stale or incomplete "
+              f"{C.GRAY}— pure-Python fallback remains available{C.RESET}")
         if native.version:
             print(f"    {C.GRAY}Loaded version: {native.version}{C.RESET}")
         if native.path:
@@ -3180,7 +3189,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.57\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.58\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -4698,7 +4707,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.57\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.58\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -4741,7 +4750,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.57\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.58\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -69,7 +69,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "1.0.57"
+    version: str = "1.0.58"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -7,7 +7,7 @@ from importlib import metadata
 from types import ModuleType
 
 
-MIN_ENTROLY_CORE_VERSION = "1.0.57"
+MIN_ENTROLY_CORE_VERSION = "1.0.58"
 QCCR_SYMBOLS = (
     "py_qccr_expand_query",
     "py_qccr_rank_files",

--- a/entroly/npm-alias/package.json
+++ b/entroly/npm-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Node/WASM Entroly runtime: local context optimization, MCP server tools, receipts, recovery, and verification without Python.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "dependencies": {
-    "entroly-wasm": "1.0.57"
+    "entroly-wasm": "1.0.58"
   },
   "repository": {
     "type": "git",

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "mcpName": "io.github.juyterman1000/entroly",
   "description": "NPX MCP bridge for Entroly, the local context OS with receipts, recovery, verification, and token optimization for AI coding agents.",
   "main": "index.js",

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.57"
+version = "1.0.58"
 
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, HTTP proxy, and Python SDK."
 readme = "README.md"
@@ -42,14 +42,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.57,<2",
+    "entroly-core>=1.0.58,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.57,<2",
+    "entroly-core>=1.0.58,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -5061,7 +5061,7 @@ def main():
     try:
         from entroly import __version__ as _version
     except Exception:
-        _version = "1.0.57"
+        _version = "1.0.58"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-openclaw",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Provider-independent, auditable context optimization for every OpenClaw model route",
   "type": "module",
   "license": "Apache-2.0",

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -2,13 +2,13 @@
 
 The formula in this directory is the canonical source. To make `brew tap juyterman1000/entroly && brew install entroly` work, the formula must live in a separate repo named `juyterman1000/homebrew-entroly`.
 
-Current release example version: `1.0.57`.
+Current release example version: `1.0.58`.
 
 ## Release checklist
 
 1. Copy `packaging/homebrew/entroly.rb` into `juyterman1000/homebrew-entroly/Formula/entroly.rb`.
-2. Set `VER=1.0.57` when preparing this release.
-3. Download the matching PyPI sdist: `entroly-1.0.57.tar.gz`.
+2. Set `VER=1.0.58` when preparing this release.
+3. Download the matching PyPI sdist: `entroly-1.0.58.tar.gz`.
 4. Recalculate the `sha256` for that tarball before publishing the Homebrew tap update.
 5. Verify locally before pushing with `brew install --build-from-source ./Formula/entroly.rb`, `brew test entroly`, and `brew audit --new --strict entroly`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.57"
+version = "1.0.58"
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, and SDK helpers."
 readme = "PYPI_README.md"
 license = "Apache-2.0"
@@ -42,14 +42,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.57,<2",
+    "entroly-core>=1.0.58,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.57,<2",
+    "entroly-core>=1.0.58,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/scripts/verify_public_trust.py
+++ b/scripts/verify_public_trust.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Verify Entroly's prominent public trust contracts.
+
+The default checks are deterministic and offline. ``--online`` additionally
+checks canonical public destinations with bounded retries; it does not treat a
+marketplace HTTP 200 as marketplace validation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.request
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CANONICAL_LINKS = {
+    "Entroly on PyPI": "https://pypi.org/project/entroly/",
+    "Entroly on npm": "https://www.npmjs.com/package/entroly",
+    "Apache-2.0 license": "LICENSE",
+    "Context Commit conformance evidence": "benchmarks/results/context_commit_conformance.json",
+    "WITNESS HaluEval-QA evidence": "benchmarks/results/halueval_qa_faithful.json",
+    "Python, optional Rust, and WASM runtimes": "docs/product-surface.md",
+    "Measure token savings on your workload": "#proof",
+    "Entroly repository and GitHub stars": "https://github.com/juyterman1000/entroly",
+    "Entroly Discord community": "https://juyterman1000.github.io/entroly/docs/discord.html",
+    "Current external Entroly status on LobeHub": "https://lobehub.com/mcp/juyterman1000-entroly",
+}
+
+ONLINE_DESTINATIONS = {
+    "PyPI": "https://pypi.org/project/entroly/",
+    "npm registry metadata": "https://registry.npmjs.org/entroly/latest",
+    "GitHub": "https://github.com/juyterman1000/entroly",
+    "Discord landing": "https://juyterman1000.github.io/entroly/docs/discord.html",
+    "LobeHub listing": "https://lobehub.com/mcp/juyterman1000-entroly?activeTab=score",
+}
+
+PROMINENT_PUBLIC_FILES = (
+    "README.md",
+    "PYPI_README.md",
+    "docs/index.html",
+    "docs/discord.html",
+    "docs/mcp-server-guide.html",
+    "docs/first-run-trust.md",
+    "docs/public-evidence.md",
+    "docs/marketing/registry_submissions.md",
+    "docs/marketing/tutorial_devto.md",
+    "docs/marketing/tutorial_reddit.md",
+)
+
+RETIRED_MARKETING_PAGES = (
+    "docs/best-context-compression-tools.html",
+    "docs/cursor-token-usage-fix.html",
+    "docs/how-to-reduce-claude-api-costs.html",
+    "docs/reduce-llm-api-costs.html",
+    "docs/prompt-compression.html",
+    "docs/hallucination-guard.html",
+    "docs/prevent-ai-hallucinations.html",
+    "docs/dashboard.html",
+    "docs/token-optimization.html",
+    "docs/what-is-context-rot.html",
+)
+
+RETIRED_SETUP_PAGES = (
+    "docs/cursor-context-guide.html",
+    "docs/claude-code-setup.html",
+)
+
+
+class _BadgeParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._href: str | None = None
+        self.badges: dict[str, str | None] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag == "a":
+            self._href = values.get("href")
+        elif tag == "img":
+            src = values.get("src") or ""
+            if "img.shields.io" in src or "lobehub.com/badge/" in src:
+                self.badges[values.get("alt") or src] = self._href
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a":
+            self._href = None
+
+
+def _read_json(path: str) -> Any:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def collect_offline_failures() -> list[str]:
+    failures: list[str] = []
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    pypi_readme = (ROOT / "PYPI_README.md").read_text(encoding="utf-8")
+
+    parser = _BadgeParser()
+    parser.feed(readme)
+    for alt, expected_href in CANONICAL_LINKS.items():
+        actual = parser.badges.get(alt)
+        if actual != expected_href:
+            failures.append(f"badge {alt!r} links to {actual!r}, expected {expected_href!r}")
+    unlinked = sorted(alt for alt, href in parser.badges.items() if not href)
+    if unlinked:
+        failures.append(f"unlinked public badges: {unlinked}")
+
+    marketplace_heading = readme.find("### Marketplace status")
+    lobehub_badge = readme.find("https://lobehub.com/badge/mcp/juyterman1000-entroly")
+    if marketplace_heading < 0 or lobehub_badge < marketplace_heading:
+        failures.append("LobeHub badge must stay in the contextualized marketplace section")
+
+    banned_readme_claims = {
+        "every answer gets a receipt": "receipt coverage is integration-specific",
+        "Nothing is lost": "recovery depends on retained state",
+        "statistically ties": "benchmark protocols must not be conflated",
+        "70–95%": "universal savings range has no single supporting artifact",
+        "99.1%": "unsupported aggregate token headline",
+        "96.7%": "unsupported aggregate token headline",
+        "87.0%": "unsupported aggregate token headline",
+        "0.844": "STAVE exploratory protocol is not the faithful headline",
+    }
+    for phrase, reason in banned_readme_claims.items():
+        if phrase in readme:
+            failures.append(f"README contains banned claim {phrase!r}: {reason}")
+
+    prominent_text = {
+        path: (ROOT / path).read_text(encoding="utf-8")
+        for path in PROMINENT_PUBLIC_FILES
+    }
+    banned_prominent_claims = {
+        "70–95%": "universal savings range",
+        "70-95%": "universal savings range",
+        "99.1%": "unsupported aggregate token headline",
+        "96.7%": "unsupported aggregate token headline",
+        "87.0%": "unsupported aggregate token headline",
+        "statistically ties": "unsupported cross-protocol comparison",
+        "AUROC 0.84": "exploratory STAVE result used as a headline",
+        "~3 ms": "latency headline without the matching protocol",
+        "Zero Hallucinations": "verification cannot guarantee zero hallucinations",
+        "zero hallucinations": "verification cannot guarantee zero hallucinations",
+        "30-Second Install": "unverified setup-time promise",
+    }
+    for path, text in prominent_text.items():
+        for phrase, reason in banned_prominent_claims.items():
+            if phrase in text:
+                failures.append(f"{path} contains banned public claim {phrase!r}: {reason}")
+
+    mcp_guide = prominent_text["docs/mcp-server-guide.html"]
+    unsupported_serve_flags = (
+        "entroly serve --transport",
+        "entroly serve --quality",
+        "entroly serve --port",
+    )
+    for command in unsupported_serve_flags:
+        if command in mcp_guide:
+            failures.append(f"MCP guide advertises unsupported CLI syntax: {command}")
+
+    sitemap = (ROOT / "docs/sitemap.xml").read_text(encoding="utf-8")
+    redirect = "https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"
+    for path in RETIRED_MARKETING_PAGES:
+        retired = (ROOT / path).read_text(encoding="utf-8")
+        if 'name="robots" content="noindex,nofollow"' not in retired:
+            failures.append(f"retired marketing page is indexable: {path}")
+        if f'http-equiv="refresh" content="0; url={redirect}"' not in retired:
+            failures.append(f"retired marketing page does not redirect to evidence: {path}")
+        if Path(path).name in sitemap:
+            failures.append(f"retired marketing page remains in sitemap: {path}")
+        if f'href="/entroly/{path}"' in prominent_text["docs/index.html"]:
+            failures.append(f"homepage still promotes retired marketing page: {path}")
+
+    setup_redirect = "https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html"
+    for path in RETIRED_SETUP_PAGES:
+        retired = (ROOT / path).read_text(encoding="utf-8")
+        if 'name="robots" content="noindex,nofollow"' not in retired:
+            failures.append(f"retired setup page is indexable: {path}")
+        if f'http-equiv="refresh" content="0; url={setup_redirect}"' not in retired:
+            failures.append(f"retired setup page does not redirect to MCP guide: {path}")
+        if Path(path).name in sitemap:
+            failures.append(f"retired setup page remains in sitemap: {path}")
+        if f'href="/entroly/{path}"' in prominent_text["docs/index.html"]:
+            failures.append(f"homepage still promotes retired setup page: {path}")
+
+    if "docs/i18n/README." in readme:
+        failures.append("primary README still promotes archived translations")
+    translation_warning = "> **Archived translation:**"
+    for path in sorted((ROOT / "docs/i18n").glob("README.*.md")):
+        if not path.read_text(encoding="utf-8").startswith(translation_warning):
+            failures.append(f"stale translation lacks archive warning: {path.relative_to(ROOT)}")
+
+    forbidden_promotions = (
+        "https://huggingface.co/spaces/entroly/entroly-context-compression",
+        "https://juyterman1000.github.io/entroly/docs/dashboard.html",
+    )
+    for url in forbidden_promotions:
+        if url in readme:
+            failures.append(f"primary README promotes quarantined surface: {url}")
+
+    forbidden_pypi_routes = (
+        "uvx --from entroly entroly serve",
+        "npx -y entroly-mcp serve",
+        '"args": ["--from", "entroly", "entroly", "serve"]',
+    )
+    for route in forbidden_pypi_routes:
+        if route in pypi_readme:
+            failures.append(f"PYPI_README.md still advertises Docker-first MCP route: {route}")
+    if "`entroly serve` is a different deployment path" not in pypi_readme:
+        failures.append("PYPI_README.md must explain the Docker-first serve command")
+
+    manifest = _read_json("server.json")
+    for package in manifest.get("packages", []):
+        if package.get("packageArguments"):
+            failures.append(
+                f"server.json {package.get('identifier')} must use argument-free stdio registration"
+            )
+
+    conformance = _read_json("benchmarks/results/context_commit_conformance.json")
+    aggregate = conformance["aggregate"]
+    conformance_expected = {
+        "cases": 128,
+        "deterministic_replay_rate": 1.0,
+        "omitted_chunks_verified": 576,
+        "tamper_trials": 768,
+        "tamper_detection_rate": 1.0,
+    }
+    for key, expected in conformance_expected.items():
+        if aggregate.get(key) != expected:
+            failures.append(f"Context Commit artifact {key}={aggregate.get(key)!r}, expected {expected!r}")
+
+    faithful = _read_json("benchmarks/results/halueval_qa_faithful.json")
+    witness = faithful["witness"]
+    shared = faithful["witness_on_gpt_sample"]
+    gpt4o = next(row for row in faithful["gpt"] if row["model"] == "gpt-4o-mini")
+    expected_values = {
+        "0.7976": witness.get("auroc_full"),
+        "84.92%": 100 * witness["test_accuracy_calibrated"]["accuracy"],
+        "20,000": 2 * witness["n_items"],
+        "16,000": witness["test_accuracy_calibrated"]["n"],
+        "86.58%": 100 * shared["accuracy"],
+        "86.25%": 100 * gpt4o["accuracy"],
+        "1,200": shared["n"],
+    }
+    for rendered, value in expected_values.items():
+        if rendered not in readme:
+            failures.append(f"README is missing faithful benchmark value {rendered} ({value!r})")
+
+    package_names = {
+        _read_json("entroly/npm-alias/package.json")["name"],
+        _read_json("entroly/npm/package.json")["name"],
+        _read_json("entroly-wasm/package.json")["name"],
+    }
+    if package_names != {"entroly", "entroly-mcp", "entroly-wasm"}:
+        failures.append(f"unexpected npm package identity set: {sorted(package_names)}")
+
+    return failures
+
+
+def collect_online_failures(*, retries: int = 3, timeout: float = 15.0) -> list[str]:
+    failures: list[str] = []
+    for name, url in ONLINE_DESTINATIONS.items():
+        error = "unknown failure"
+        for attempt in range(retries):
+            try:
+                request = urllib.request.Request(
+                    url,
+                    headers={"User-Agent": "entroly-public-trust-check/1"},
+                )
+                with urllib.request.urlopen(request, timeout=timeout) as response:
+                    if 200 <= response.status < 400:
+                        error = ""
+                        break
+                    error = f"HTTP {response.status}"
+            except (OSError, urllib.error.URLError) as exc:
+                error = str(exc)
+            if attempt + 1 < retries:
+                time.sleep(1 + attempt)
+        if error:
+            failures.append(f"{name} destination failed after {retries} attempts: {error}")
+    return failures
+
+
+def collect_published_version_failures(*, timeout: float = 15.0) -> list[str]:
+    expected = _read_json("server.json")["version"]
+    sources = {
+        "PyPI": ("https://pypi.org/pypi/entroly/json", lambda data: data["info"]["version"]),
+        "npm": ("https://registry.npmjs.org/entroly/latest", lambda data: data["version"]),
+    }
+    failures: list[str] = []
+    for name, (url, extract) in sources.items():
+        try:
+            request = urllib.request.Request(
+                url,
+                headers={"User-Agent": "entroly-public-trust-check/1"},
+            )
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                published = str(extract(json.load(response)))
+        except (KeyError, OSError, TypeError, urllib.error.URLError, ValueError) as exc:
+            failures.append(f"could not read {name} published version: {exc}")
+            continue
+        if published != expected:
+            failures.append(f"{name} latest is {published}, expected release {expected}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--online", action="store_true")
+    parser.add_argument(
+        "--require-published-version",
+        action="store_true",
+        help="Require PyPI and npm latest versions to match server.json.",
+    )
+    parser.add_argument("--retries", type=int, default=3)
+    parser.add_argument("--timeout", type=float, default=15.0)
+    args = parser.parse_args()
+
+    failures = collect_offline_failures()
+    if args.online:
+        failures.extend(collect_online_failures(retries=args.retries, timeout=args.timeout))
+    if args.require_published_version:
+        failures.extend(collect_published_version_failures(timeout=args.timeout))
+
+    if failures:
+        print("Public trust verification failed:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    scopes = ["offline contracts"]
+    if args.online:
+        scopes.append("online destinations")
+    if args.require_published_version:
+        scopes.append("published version parity")
+    scope = ", ".join(scopes)
+    print(f"Public trust verification passed ({scope}).")
+    print("This check validates declared public contracts; it does not certify every product claim.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_readme.py
+++ b/scripts/verify_readme.py
@@ -22,6 +22,7 @@ check("SDK: compress works", lambda: f"{len(__import__('entroly').compress('hell
 # === CLI: wrap ===
 from entroly.cli import _WRAP_AGENTS  # noqa: E402
 from pathlib import Path  # noqa: E402
+from verify_public_trust import collect_offline_failures  # noqa: E402
 
 README_TEXT = Path("README.md").read_text(encoding="utf-8")
 COOKBOOK_TEXT = Path("cookbook/README.md").read_text(encoding="utf-8")
@@ -101,12 +102,13 @@ check(
 check(
     "README proof-first star CTA",
     lambda: (
-        "img.shields.io/github/stars/juyterman1000/entroly?style=social" in README_TEXT
+        'href="https://github.com/juyterman1000/entroly"' in README_TEXT
+        and "img.shields.io/github/stars/juyterman1000/entroly?style=social" in README_TEXT
         and "Deciding whether to star?" in README_TEXT
         and "entroly verify-claims && entroly simulate" in README_TEXT
         and "open an issue with the verification JSON" in README_TEXT
         and "Token_Savings-tested_70--95%25" not in README_TEXT
-        and "Token_Savings-workload_dependent" in README_TEXT
+        and "Token_savings-measure_your_workload" in README_TEXT
         and "OK"
     ) or (_ for _ in ()).throw(Exception("README must ask for stars through local proof, not broad first-fold claims")),
 )
@@ -120,6 +122,13 @@ check(
         and "https://juyterman1000.github.io/entroly/docs/discord.html" in INSTALL_TEXT
         and "OK"
     ) or (_ for _ in ()).throw(Exception("Public community links must not route to expired Discord invites")),
+)
+check(
+    "prominent public trust contracts",
+    lambda: (
+        not (failures := collect_offline_failures())
+        and "OK"
+    ) or (_ for _ in ()).throw(Exception("; ".join(failures))),
 )
 
 # === Proxy ===
@@ -163,6 +172,7 @@ print(f"  PASSED: {passed}  |  FAILED: {failed}")
 if failed:
     print(f"  README has {failed} unverified claim(s)!")
 else:
-    print("  All README claims verified!")
+    print("  Automated README contracts passed.")
+    print("  This does not certify every product or benchmark claim.")
 print(f"{'='*50}")
 sys.exit(1 if failed else 0)

--- a/server.json
+++ b/server.json
@@ -8,39 +8,27 @@
     "url": "https://github.com/juyterman1000/entroly",
     "source": "github"
   },
-  "version": "1.0.57",
+  "version": "1.0.58",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "entroly",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
-      },
-      "packageArguments": [
-        {
-          "type": "positional",
-          "value": "serve"
-        }
-      ]
+      }
     },
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "entroly-mcp",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
-      },
-      "packageArguments": [
-        {
-          "type": "positional",
-          "value": "serve"
-        }
-      ]
+      }
     }
   ]
 }

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+from entroly import cli
+from entroly.native_status import NativeStatus
+
+
+def test_doctor_treats_absent_optional_native_engine_as_healthy(
+    monkeypatch,
+    capsys,
+) -> None:
+    status = NativeStatus(
+        available=False,
+        module=None,
+        version=None,
+        path=None,
+        missing_symbols=("py_qccr_select",),
+        version_ok=None,
+        error="not installed",
+    )
+    monkeypatch.setattr("entroly.native_status.native_status", lambda _: status)
+
+    cli.cmd_doctor(Namespace(port=9377, privacy=False))
+
+    output = capsys.readouterr().out
+    assert "Optional Rust acceleration not installed" in output
+    assert "pure-Python engine is active" in output
+    assert "8/8 checks passed" in output
+
+
+def test_doctor_flags_an_installed_but_incomplete_native_engine(
+    monkeypatch,
+    capsys,
+) -> None:
+    status = NativeStatus(
+        available=True,
+        module=None,
+        version="1.0.1",
+        path="/tmp/entroly_core.so",
+        missing_symbols=("py_qccr_select",),
+        version_ok=False,
+    )
+    monkeypatch.setattr("entroly.native_status.native_status", lambda _: status)
+
+    cli.cmd_doctor(Namespace(port=9377, privacy=False))
+
+    output = capsys.readouterr().out
+    assert "Installed Rust engine is stale or incomplete" in output
+    assert "Loaded version: 1.0.1" in output
+    assert "7/8 checks passed" in output

--- a/tests/test_mcp_registry_manifest.py
+++ b/tests/test_mcp_registry_manifest.py
@@ -60,9 +60,7 @@ def test_mcp_registry_identity_and_package_contract() -> None:
         assert package["version"] == version
         assert package["runtimeHint"] == expected_runtime[key]
         assert package["transport"] == {"type": "stdio"}
-        assert package["packageArguments"] == [
-            {"type": "positional", "value": "serve"}
-        ]
+        assert package.get("packageArguments", []) == []
 
 
 def test_registry_package_ownership_proofs_are_canonical() -> None:

--- a/tests/test_public_trust.py
+++ b/tests/test_public_trust.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from scripts.verify_public_trust import collect_offline_failures
+
+
+def test_prominent_public_trust_contracts() -> None:
+    assert collect_offline_failures() == []

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-RELEASE_VERSION = "1.0.57"
+RELEASE_VERSION = "1.0.58"
 HOMEBREW_FORMULA_VERSION = "1.0.57"
 HOMEBREW_FORMULA_SHA256 = "fef09c6b5e2616a09333a911f48fdef70b94747e22c56d9cc44a41832271c9b4"
 CANONICAL_MCP_NAME = "io.github.juyterman1000/entroly"
@@ -66,7 +66,7 @@ def _read_project_metadata(path: str) -> dict[str, object]:
     return metadata
 
 
-def test_public_package_versions_are_1_0_57() -> None:
+def test_public_package_versions_are_1_0_58() -> None:
     assert _read_project_metadata("pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_project_metadata("entroly/pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_json("entroly/npm/package.json")["version"] == RELEASE_VERSION
@@ -116,15 +116,15 @@ def test_mcp_registry_identity_is_canonical_and_non_squattable() -> None:
     ).read_text(encoding="utf-8")
 
     expected = {
-        ("pypi", "entroly", "uvx", ("serve",)),
-        ("npm", "entroly-mcp", "npx", ("serve",)),
+        ("pypi", "entroly", "uvx", ()),
+        ("npm", "entroly-mcp", "npx", ()),
     }
     actual = {
         (
             package["registryType"],
             package["identifier"],
             package["runtimeHint"],
-            tuple(argument["value"] for argument in package["packageArguments"]),
+            tuple(argument["value"] for argument in package.get("packageArguments", [])),
         )
         for package in manifest["packages"]
     }


### PR DESCRIPTION
## What changed

- Reorganized README badges and claims by evidentiary strength.
- Replaced unsupported savings and hallucination claims with directly linked benchmark artifacts and explicit limitations.
- Corrected PyPI, npm, uvx, Docker, and MCP marketplace installation contracts.
- Added deterministic public-trust verification for badge destinations, package identities, evidence values, stale claims, and published-version parity.
- Quarantined stale marketing surfaces and removed them from public discovery.
- Made `entroly doctor` distinguish the supported pure-Python runtime from a broken optional native installation.
- Synchronized release version 1.0.58 across Python, Rust, WASM, npm, MCP, OpenClaw, and release metadata.

## Why

Entroly's public presentation had mixed strong experimental evidence with unqualified marketing claims, stale marketplace metadata, and ambiguous installation paths. That weakens user trust even when the underlying product is working. This change makes every prominent claim traceable to a committed artifact and makes unsupported or externally stale surfaces visibly non-authoritative.

## User impact

New users get installation instructions that match the actual runtime. Evaluators can follow each scientific claim to exact evidence and limitations. Maintainers get a scheduled and PR-level regression gate that prevents public claims from silently drifting.

## Validation

- Python suite: 1842 passed, 48 skipped, 1 xfailed
- Rust pre-push suite: 531 passed
- Ruff and Clippy passed
- README verifier: 29 passed, 0 failed
- Offline and live public-trust destination checks passed
- Fresh wheel install and `entroly doctor`: 8/8
- MCP stdio initialization from the built wheel passed
- Wheel and sdist passed `twine check`
- HTML/XML parsing and `git diff --check` passed

## Release contract

The strict published-version check intentionally remains closed until PyPI and npm expose 1.0.58. After merge, the canonical `entroly-v1.0.58` release workflow must publish and independently verify PyPI, npm, GHCR, GitHub Release, and MCP Registry surfaces.