### PR TITLE
Make post-release publication race-free and reviewable

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -405,7 +405,23 @@ jobs:
           python-version: '3.12'
 
       - name: Install the capability-probed Python bridge
-        run: python -m pip install --no-cache-dir --index-url https://pypi.org/simple "entroly==${RELEASE_VERSION}"
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 20); do
+            if python -m pip install --no-cache-dir \
+              --index-url https://pypi.org/simple \
+              "entroly==${RELEASE_VERSION}"
+            then
+              exit 0
+            fi
+            echo "PyPI ${RELEASE_VERSION} is not visible to this runner yet (attempt ${attempt}/20)."
+            if [[ "$attempt" -lt 20 ]]; then
+              sleep 15
+            fi
+          done
+          echo "Unable to install Entroly ${RELEASE_VERSION} after waiting for PyPI propagation." >&2
+          exit 1
 
       - name: Update and validate OpenClaw plugin
         working-directory: integrations/openclaw

--- a/.github/workflows/sync-homebrew-formula.yml
+++ b/.github/workflows/sync-homebrew-formula.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: sync-homebrew-main
@@ -211,18 +212,42 @@ jobs:
           python -m pytest tests/test_release_surface.py -q
           git diff --check
 
-      - name: Commit synchronized formula
+      - name: Open synchronized formula pull request
         if: steps.release.outputs.sha256 != ''
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
           if git diff --quiet -- packaging/homebrew/entroly.rb tests/test_release_surface.py; then
-            echo "Homebrew formula already matches Entroly ${{ steps.release.outputs.version }}."
+            echo "Homebrew formula already matches Entroly ${VERSION}."
             exit 0
           fi
           git config user.name "juyterman1000"
           git config user.email "208309368+juyterman1000@users.noreply.github.com"
           git add packaging/homebrew/entroly.rb tests/test_release_surface.py
-          git commit -m "Update Homebrew formula for ${{ steps.release.outputs.version }}"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git commit -m "Update Homebrew formula for ${VERSION}"
+
+          BRANCH="agent/homebrew-${VERSION}"
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+            git push --force-with-lease="refs/heads/${BRANCH}" \
+              origin "HEAD:refs/heads/${BRANCH}"
+          else
+            git push origin "HEAD:refs/heads/${BRANCH}"
+          fi
+
+          PR_URL="$(gh pr list --base main --head "${BRANCH}" --state open \
+            --json url --jq '.[0].url // empty')"
+          BODY="Synchronizes the Homebrew formula to the exact PyPI ${VERSION} sdist and verified SHA-256 after the coordinated release completed."
+          if [[ -n "${PR_URL}" ]]; then
+            gh pr edit "${PR_URL}" \
+              --title "Update Homebrew formula for ${VERSION}" \
+              --body "${BODY}"
+            echo "Updated ${PR_URL}"
+          else
+            gh pr create --base main --head "${BRANCH}" \
+              --title "Update Homebrew formula for ${VERSION}" \
+              --body "${BODY}"
+          fi

--- a/.github/workflows/verify-clawhub-listing.yml
+++ b/.github/workflows/verify-clawhub-listing.yml
@@ -1,12 +1,9 @@
 name: Verify Entroly ClawHub Listing
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "integrations/openclaw/**"
-      - ".github/workflows/publish-openclaw-clawhub.yml"
-      - ".github/workflows/verify-clawhub-listing.yml"
+  workflow_run:
+    workflows: ["Build and Push Entroly Docker Image"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -19,10 +16,27 @@ concurrency:
 
 jobs:
   verify:
+    if: >-
+      github.repository == 'juyterman1000/entroly' &&
+      (
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_repository.full_name == 'juyterman1000/entroly' &&
+          github.event.workflow_run.actor.login == 'juyterman1000'
+        ) ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      SOURCE_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout exact release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          persist-credentials: false
 
       - name: Verify exact public package, search result, and artifact
         id: verify
@@ -40,6 +54,8 @@ jobs:
           import urllib.request
 
           package_name = "entroly-openclaw"
+          package_owner = "juyterman1000"
+          public_url = f"https://clawhub.ai/{package_owner}/plugins/{package_name}"
           expected_version = json.loads(
               pathlib.Path("integrations/openclaw/package.json").read_text(encoding="utf-8")
           )["version"]
@@ -101,7 +117,7 @@ jobs:
                       "scan_status": package.get("scanStatus"),
                       "verification_tier": (package.get("verification") or {}).get("tier"),
                       "artifact_sha256": artifact.get("sha256"),
-                      "public_url": f"https://clawhub.ai/plugins/{package_name}",
+                      "public_url": public_url,
                   }
                   pathlib.Path("clawhub-verification.json").write_text(
                       json.dumps(result, indent=2, sort_keys=True) + "\n",
@@ -111,7 +127,7 @@ jobs:
                   with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
                       output.write("state=success\n")
                       output.write(f"description=ClawHub {package_name} {expected_version} is public\n")
-                      output.write(f"target_url=https://clawhub.ai/plugins/{package_name}\n")
+                      output.write(f"target_url={public_url}\n")
                   raise SystemExit(0)
               except (urllib.error.HTTPError, urllib.error.URLError, ValueError, RuntimeError) as exc:
                   last_error = str(exc)
@@ -119,10 +135,13 @@ jobs:
                   if attempt < 40:
                       time.sleep(15)
 
+          safe_error = " ".join(last_error.split())
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write("state=failure\n")
-              output.write("description=Entroly is not publicly verifiable in ClawHub yet\n")
-              output.write("target_url=https://clawhub.ai/plugins/entroly-openclaw\n")
+              output.write(
+                  f"description=ClawHub {expected_version} unavailable: {safe_error}\n"
+              )
+              output.write(f"target_url={public_url}\n")
           pathlib.Path("clawhub-verification-error.txt").write_text(
               last_error + "\n", encoding="utf-8"
           )
@@ -131,15 +150,19 @@ jobs:
       - name: Record public verification status
         if: always()
         uses: actions/github-script@v8
+        env:
+          CLAWHUB_STATE: ${{ steps.verify.outputs.state }}
+          CLAWHUB_DESCRIPTION: ${{ steps.verify.outputs.description }}
+          CLAWHUB_TARGET_URL: ${{ steps.verify.outputs.target_url }}
         with:
           script: |
-            const state = '${{ steps.verify.outputs.state }}' || 'failure';
-            const description = '${{ steps.verify.outputs.description }}' || 'ClawHub verification did not complete';
-            const targetUrl = '${{ steps.verify.outputs.target_url }}' || 'https://clawhub.ai/plugins/entroly-openclaw';
+            const state = process.env.CLAWHUB_STATE || 'failure';
+            const description = process.env.CLAWHUB_DESCRIPTION || 'ClawHub verification did not complete';
+            const targetUrl = process.env.CLAWHUB_TARGET_URL || 'https://clawhub.ai/juyterman1000/plugins/entroly-openclaw';
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.sha,
+              sha: process.env.SOURCE_SHA,
               state,
               context: 'ClawHub Public Listing',
               description: description.slice(0, 140),

--- a/packaging/homebrew/entroly.rb
+++ b/packaging/homebrew/entroly.rb
@@ -21,8 +21,8 @@ class Entroly < Formula
 
   desc "Token-saving proxy and context compression engine for AI coding agents"
   homepage "https://github.com/juyterman1000/entroly"
-  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-1.0.57.tar.gz"
-  sha256 "fef09c6b5e2616a09333a911f48fdef70b94747e22c56d9cc44a41832271c9b4"
+  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-1.0.58.tar.gz"
+  sha256 "f2d561e7316cf12c07ffffadeff0b8f26368538564d776eee86b4b76a896959e"
   license "Apache-2.0"
   head "https://github.com/juyterman1000/entroly.git", branch: "main"
 

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -183,6 +183,11 @@ def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> 
     assert "probe-npm-openclaw:" in text
     assert "needs: [release-metadata, probe-npm-openclaw]" in text
     assert '"openclaw@2026.6.11" "entroly-openclaw@${RELEASE_VERSION}"' in text
+    openclaw_publisher = text.split("  publish-npm-openclaw:", 1)[1].split(
+        "  probe-npm-openclaw:", 1
+    )[0]
+    assert "for attempt in $(seq 1 20)" in openclaw_publisher
+    assert "waiting for PyPI propagation" in openclaw_publisher
 
 
 def test_homebrew_sync_is_single_pinned_release_workflow() -> None:

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -257,3 +257,24 @@ def test_mcp_registry_follows_every_anchored_parent_release() -> None:
     assert 'if [[ "$TAG_SHA" != "$SOURCE_SHA" ]]' in text
     assert 'echo "should_publish=false" >> "$GITHUB_OUTPUT"' in text
     assert "if: steps.release_guard.outputs.should_publish == 'true'" in text
+
+
+def test_clawhub_verifier_follows_coordinated_release() -> None:
+    text = (ROOT / ".github/workflows/verify-clawhub-listing.yml").read_text(
+        encoding="utf-8"
+    )
+    triggers = text.split("permissions:", 1)[0]
+
+    assert 'workflows: ["Build and Push Entroly Docker Image"]' in triggers
+    assert "workflow_run:" in triggers
+    assert "\n  push:" not in triggers
+    assert "github.event.workflow_run.conclusion == 'success'" in text
+    assert "github.event.workflow_run.head_sha || github.sha" in text
+    assert "ref: ${{ env.SOURCE_SHA }}" in text
+    assert "sha: process.env.SOURCE_SHA" in text
+    assert "const description = process.env.CLAWHUB_DESCRIPTION" in text
+    assert "const description = '${{ steps.verify.outputs.description }}'" not in text
+    assert (
+        "https://clawhub.ai/juyterman1000/plugins/entroly-openclaw" in text
+    )
+    assert "ClawHub {expected_version} unavailable: {safe_error}" in text

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_VERSION = "1.0.58"
-HOMEBREW_FORMULA_VERSION = "1.0.57"
-HOMEBREW_FORMULA_SHA256 = "fef09c6b5e2616a09333a911f48fdef70b94747e22c56d9cc44a41832271c9b4"
+HOMEBREW_FORMULA_VERSION = "1.0.58"
+HOMEBREW_FORMULA_SHA256 = "f2d561e7316cf12c07ffffadeff0b8f26368538564d776eee86b4b76a896959e"
 CANONICAL_MCP_NAME = "io.github.juyterman1000/entroly"
 CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
 
@@ -202,6 +202,10 @@ def test_homebrew_sync_is_single_pinned_release_workflow() -> None:
     assert "group: sync-homebrew-main" in text
     assert "if target_tuple < current_tuple:" in text
     assert "refusing to downgrade Homebrew" in text
+    assert "pull-requests: write" in text
+    assert 'BRANCH="agent/homebrew-${VERSION}"' in text
+    assert "gh pr create --base main" in text
+    assert "git push origin HEAD:main" not in text
 
 
 def test_release_artifacts_have_one_quality_gated_publisher() -> None:


### PR DESCRIPTION
## Incidents exposed by 1.0.58

1. ClawHub verification started on the release commit's `main` push, before coordinated publication.
2. The OpenClaw npm publisher hit a stale PyPI CDN edge immediately after a different runner's successful live probe.
3. Homebrew synchronization tried to push its generated commit directly to protected `main`, which GitHub correctly rejected.

These were release-orchestration defects, not product-package defects.

## Fix

- Run ClawHub verification after successful coordinated-release completion.
- Bind checkout and commit status to the exact parent release SHA.
- Use the owner-qualified ClawHub URL and actionable version-specific failures.
- Remove unsafe external-output interpolation into JavaScript source.
- Retry the consuming OpenClaw job during PyPI CDN propagation.
- Change Homebrew synchronization to open/update a deterministic reviewable PR instead of bypassing branch protection.
- Pin the repository Homebrew formula to the verified 1.0.58 sdist and SHA-256.
- Add regression assertions for all three contracts.

## Validation

- `python -m pytest tests/test_release_surface.py tests/test_public_trust.py -q`: 14 passed
- `python -m ruff check tests/test_release_surface.py`: passed
- Pre-push Ruff, Clippy, and 531 Rust library tests: passed
- Exact Homebrew sdist re-downloaded; SHA-256 verified as `f2d561e7316cf12c07ffffadeff0b8f26368538564d776eee86b4b76a896959e`
- `git diff --check`: passed
- Coordinated 1.0.58 release attempt 2: successful
- Live PyPI, npm OpenClaw, and authenticated ClawHub publication: successful