### PR TITLE
Fix cross-process recovery durability with verified holdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,25 @@ Context Efficiency Frontier above is the required gate for a real-model claim.</
   <a href="benchmarks/results/compression_gauntlet.md"><img src="docs/assets/compression_gauntlet.svg" width="900" alt="Entroly and Headroom same-input compression gauntlet with evidence-retention caveat"></a>
 </p>
 
+**Cross-process recovery holdout:** the preregistered six-writer test first
+exposed a serious Entroly failure (only 8/32 development payloads survived),
+which is preserved in the evidence. After the durability repair, Entroly 1.0.59
+source and published Headroom 0.31.0 both wrote and recovered **66/66** holdout
+payloads byte-exactly after restart with zero wrong payloads. This closes the
+integrity gap; it does not establish recovery superiority.
+
+On this Windows/Python 3.10 run, Headroom had lower store-call latency
+(0.797 ms versus 22.606 ms p50). Entroly had lower retrieval latency (0.042 ms
+versus 0.279 ms p50) and a smaller live state footprint (95,438 versus
+1,581,416 bytes). Headroom used SQLite WAL with `synchronous=NORMAL`; Entroly
+fsynced its state file on each commit, so this is not a matched power-loss
+durability comparison. These are scoped workload measurements, not universal
+claims.
+
+[Frozen protocol and full result table](docs/benchmarks/competitive-evidence-matrix.md)
+| [holdout artifact](benchmarks/results/recovery_resilience_holdout.json) |
+[original failing artifact](benchmarks/results/recovery_resilience_development_before.json).
+
 **PRISM-R neural research preview:** a generic MiniLM encoder did **not** beat
 BM25 as a primary paragraph scorer (97.7% versus 99.0% held-out evidence
 recall), so Entroly rejects that neural-primary claim. A disagreement guard

--- a/benchmarks/competitive_evidence_protocol.json
+++ b/benchmarks/competitive_evidence_protocol.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "entroly.competitive-evidence-protocol.v1",
+  "frozen_at": "2026-07-14T11:30:00Z",
+  "comparison": {
+    "entroly": "1.0.59 merged source",
+    "headroom": "headroom-ai 0.31.0 / tag v0.31.0 / commit 55efb1c77d5b67f7ad0620372c6256c8b0547591"
+  },
+  "claim_policy": {
+    "aggregate_score_allowed": false,
+    "failures_remain_in_sample": true,
+    "negative_results_are_published": true,
+    "per_dimension_claims_only": true,
+    "universal_superiority_claim_allowed": false
+  },
+  "dimensions": [
+    {
+      "id": "active_context_quality",
+      "status": "implemented",
+      "evidence": "benchmarks/results/compression_frontier.json"
+    },
+    {
+      "id": "recovery_resilience",
+      "status": "implemented",
+      "evidence": "benchmarks/recovery_resilience.py"
+    },
+    {
+      "id": "end_to_end_model_recovery",
+      "status": "planned"
+    },
+    {
+      "id": "compression_latency",
+      "status": "planned"
+    },
+    {
+      "id": "provider_protocol_conformance",
+      "status": "planned"
+    },
+    {
+      "id": "interruption_recovery",
+      "status": "planned"
+    },
+    {
+      "id": "security_and_secret_handling",
+      "status": "planned"
+    },
+    {
+      "id": "packaging_and_first_run",
+      "status": "planned"
+    },
+    {
+      "id": "operator_ux_and_diagnostics",
+      "status": "planned"
+    },
+    {
+      "id": "provider_observed_cost",
+      "status": "planned"
+    }
+  ],
+  "suites": {
+    "recovery_resilience": {
+      "development": {
+        "workers": 4,
+        "entries_per_worker": 8,
+        "seed": 20260714
+      },
+      "holdout": {
+        "workers": 6,
+        "entries_per_worker": 11,
+        "seed": 20260715
+      },
+      "gates": {
+        "worker_exit_success_rate": 1.0,
+        "write_success_rate": 1.0,
+        "restart_recovery_rate": 1.0,
+        "exact_byte_recovery_rate": 1.0,
+        "incorrect_payloads": 0
+      },
+      "latency_policy": "Report per-system p50 and p95 store/retrieve latency descriptively; correctness gates cannot be traded for speed.",
+      "development_policy": "Development results may guide implementation and remain visible but cannot support a public leadership claim.",
+      "holdout_policy": "Run once after implementation. A scoped public claim requires the complete holdout matrix and a passing verifier."
+    }
+  }
+}

--- a/benchmarks/recovery_resilience.py
+++ b/benchmarks/recovery_resilience.py
@@ -1,0 +1,695 @@
+"""Preregistered cross-process recovery-store resilience benchmark.
+
+This suite evaluates the local source-of-truth behind reversible compression.
+It does not score token savings or model quality. Independent worker processes
+write unique omitted payloads, exit, and a fresh process attempts exact recovery.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+
+SCHEMA_VERSION = "entroly.recovery-resilience.v1"
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL_PATH = ROOT / "benchmarks" / "competitive_evidence_protocol.json"
+SECRET_MARKERS = ("API_KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "AUTH")
+
+
+def _sha256(value: str | bytes) -> str:
+    payload = value.encode("utf-8") if isinstance(value, str) else value
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _canonical_sha256(value: Any) -> str:
+    return _sha256(
+        json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    )
+
+
+def _canonical_source_sha256(paths: Sequence[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        source = path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+        digest.update(source)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _distribution_record_sha256(package: str) -> str | None:
+    try:
+        record = importlib.metadata.distribution(package).read_text("RECORD")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    return _sha256(record) if record else None
+
+
+def _protocol() -> dict[str, Any]:
+    return json.loads(PROTOCOL_PATH.read_text(encoding="utf-8"))
+
+
+def _phase_config(protocol: dict[str, Any], phase: str) -> dict[str, int]:
+    raw = protocol["suites"]["recovery_resilience"][phase]
+    return {
+        "workers": int(raw["workers"]),
+        "entries_per_worker": int(raw["entries_per_worker"]),
+        "seed": int(raw["seed"]),
+    }
+
+
+def _percentile(values: Sequence[float], probability: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = probability * (len(ordered) - 1)
+    lower = int(math.floor(position))
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _latency_summary(values: Sequence[float]) -> dict[str, Any]:
+    samples = [round(float(value), 6) for value in values]
+    return {
+        "samples_ms": samples,
+        "p50_ms": round(statistics.median(samples), 6) if samples else 0.0,
+        "p95_ms": round(_percentile(samples, 0.95), 6),
+    }
+
+
+def _payload(seed: int, worker_id: int, entry_index: int) -> str:
+    identity = f"{seed}:{worker_id}:{entry_index}"
+    nonce = _sha256(identity)[:24]
+    return (
+        f"recovery-entry worker={worker_id} index={entry_index} nonce={nonce}\n"
+        f"exact-payload-{nonce}-" + (f"segment-{worker_id}-{entry_index} " * 24).strip()
+    )
+
+
+def _store_paths(system: str, state_dir: Path) -> list[Path]:
+    if system == "entroly":
+        return [state_dir / "recovery.json"]
+    if system == "headroom":
+        return [state_dir / "ccr.db"]
+    raise ValueError(f"unsupported system: {system}")
+
+
+def _open_store(system: str, state_dir: Path) -> tuple[Any, dict[str, Any]]:
+    if system == "entroly":
+        from entroly.compression_retrieval_store import CompressionRetrievalStore
+
+        path = state_dir / "recovery.json"
+        return CompressionRetrievalStore(path), {
+            "backend": "entroly atomic JSON recovery store",
+            "path": path.name,
+        }
+    if system == "headroom":
+        from headroom.cache.backends.sqlite import SQLiteBackend
+        from headroom.cache.compression_store import CompressionStore
+
+        path = state_dir / "ccr.db"
+        return CompressionStore(backend=SQLiteBackend(path)), {
+            "backend": "headroom SQLite CCR store",
+            "path": path.name,
+        }
+    raise ValueError(f"unsupported system: {system}")
+
+
+def _store_payload(system: str, store: Any, payload: str) -> dict[str, str]:
+    compressed = "[omitted; recover by emitted reference]"
+    if system == "entroly":
+        stored = store.put(
+            original_text=payload,
+            compressed_text=compressed,
+            receipt={
+                "original_tokens": max(1, len(payload.encode("utf-8")) // 4),
+                "compressed_tokens": max(1, len(compressed) // 4),
+                "omitted_spans": [
+                    {"start_line": 1, "end_line": 2, "reason": "benchmark"}
+                ],
+            },
+            metadata={"suite": SCHEMA_VERSION},
+        )
+        if len(stored.spans) != 1:
+            raise RuntimeError("Entroly did not persist exactly one omitted span")
+        return {
+            "receipt_id": stored.receipt_id,
+            "span_id": stored.spans[0].span_id,
+        }
+    if system == "headroom":
+        hash_key = store.store(
+            original=payload,
+            compressed=compressed,
+            original_tokens=max(1, len(payload.encode("utf-8")) // 4),
+            compressed_tokens=max(1, len(compressed) // 4),
+            original_item_count=1,
+            compressed_item_count=0,
+            tool_name="recovery_resilience",
+            compression_strategy="preregistered_exact_recovery",
+        )
+        return {"hash": str(hash_key)}
+    raise ValueError(f"unsupported system: {system}")
+
+
+def _retrieve_payload(system: str, store: Any, reference: dict[str, str]) -> str | None:
+    if system == "entroly":
+        span = store.get_span(reference["receipt_id"], reference["span_id"])
+        return None if span is None else str(span.content)
+    if system == "headroom":
+        entry = store.retrieve(reference["hash"])
+        return None if entry is None else str(entry.original_content)
+    raise ValueError(f"unsupported system: {system}")
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _worker(args: argparse.Namespace) -> int:
+    state_dir = args.state_dir.resolve()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    output = args.output.resolve()
+    result: dict[str, Any] = {
+        "worker_id": args.worker_id,
+        "entries": [],
+        "errors": [],
+    }
+    try:
+        store, _metadata = _open_store(args.system, state_dir)
+        (state_dir / f"ready-{args.worker_id}").write_text("ready\n", encoding="utf-8")
+        deadline = time.monotonic() + args.timeout
+        start_flag = state_dir / "start.flag"
+        while not start_flag.exists():
+            if time.monotonic() >= deadline:
+                raise TimeoutError("timed out waiting for coordinated start")
+            time.sleep(0.005)
+        for entry_index in range(args.entries):
+            payload = _payload(args.seed, args.worker_id, entry_index)
+            started = time.perf_counter()
+            reference = _store_payload(args.system, store, payload)
+            latency_ms = (time.perf_counter() - started) * 1_000
+            result["entries"].append(
+                {
+                    "worker_id": args.worker_id,
+                    "entry_index": entry_index,
+                    "payload_sha256": _sha256(payload),
+                    "reference": reference,
+                    "store_latency_ms": round(latency_ms, 6),
+                }
+            )
+    except Exception as error:  # benchmark errors remain in the matrix
+        result["errors"].append(
+            {"type": type(error).__name__, "message": str(error)[:1000]}
+        )
+    _write_json(output, result)
+    return 0 if not result["errors"] else 1
+
+
+def _subprocess_env() -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not any(marker in key.upper() for marker in SECRET_MARKERS)
+    }
+    env["PYTHONHASHSEED"] = "0"
+    env["PYTHONNOUSERSITE"] = "1"
+    env["PYTHONPATH"] = str(ROOT)
+    return env
+
+
+def _adapter(args: argparse.Namespace) -> int:
+    state_dir = args.state_dir.resolve()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    if any(state_dir.iterdir()):
+        raise ValueError("adapter state directory must be empty")
+
+    workers: list[tuple[int, subprocess.Popen[str], Path]] = []
+    env = _subprocess_env()
+    for worker_id in range(args.workers):
+        output = state_dir / f"worker-{worker_id}.json"
+        command = [
+            sys.executable,
+            "-m",
+            "benchmarks.recovery_resilience",
+            "worker",
+            "--system",
+            args.system,
+            "--state-dir",
+            str(state_dir),
+            "--worker-id",
+            str(worker_id),
+            "--entries",
+            str(args.entries),
+            "--seed",
+            str(args.seed),
+            "--timeout",
+            str(args.timeout),
+            "--output",
+            str(output),
+        ]
+        process = subprocess.Popen(
+            command,
+            cwd=ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        workers.append((worker_id, process, output))
+
+    ready_deadline = time.monotonic() + args.timeout
+    while len(list(state_dir.glob("ready-*"))) < args.workers:
+        if time.monotonic() >= ready_deadline:
+            break
+        if any(process.poll() is not None for _, process, _ in workers):
+            break
+        time.sleep(0.01)
+    (state_dir / "start.flag").write_text("start\n", encoding="utf-8")
+
+    worker_runs: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
+    for worker_id, process, output in workers:
+        try:
+            stdout, stderr = process.communicate(timeout=args.timeout)
+            exit_code: int | None = process.returncode
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+            exit_code = None
+        parsed: dict[str, Any] = {
+            "worker_id": worker_id,
+            "entries": [],
+            "errors": [
+                {"type": "MissingWorkerResult", "message": "worker output missing"}
+            ],
+        }
+        if output.exists():
+            try:
+                parsed = json.loads(output.read_text(encoding="utf-8"))
+            except Exception as error:
+                parsed["errors"] = [
+                    {"type": type(error).__name__, "message": str(error)[:1000]}
+                ]
+        worker_runs.append(
+            {
+                "worker_id": worker_id,
+                "exit_code": exit_code,
+                "errors": list(parsed.get("errors", [])),
+                "stdout_sha256": _sha256(stdout),
+                "stderr_sha256": _sha256(stderr),
+                "stderr_tail": stderr[-1000:],
+            }
+        )
+        rows.extend(dict(row) for row in parsed.get("entries", []))
+
+    recovery_open_error: dict[str, str] | None = None
+    try:
+        recovery_store, store_metadata = _open_store(args.system, state_dir)
+    except Exception as error:
+        recovery_store = None
+        store_metadata = {"backend": "failed to reopen", "path": "unknown"}
+        recovery_open_error = {
+            "type": type(error).__name__,
+            "message": str(error)[:1000],
+        }
+
+    for row in rows:
+        recovered: str | None = None
+        retrieval_error: dict[str, str] | None = None
+        started = time.perf_counter()
+        if recovery_store is not None:
+            try:
+                recovered = _retrieve_payload(
+                    args.system, recovery_store, dict(row["reference"])
+                )
+            except Exception as error:
+                retrieval_error = {
+                    "type": type(error).__name__,
+                    "message": str(error)[:1000],
+                }
+        retrieval_ms = (time.perf_counter() - started) * 1_000
+        recovered_sha = _sha256(recovered) if recovered is not None else None
+        row.update(
+            {
+                "system": args.system,
+                "recovered_sha256": recovered_sha,
+                "exact": recovered_sha == row["payload_sha256"],
+                "retrieve_latency_ms": round(retrieval_ms, 6),
+                "retrieval_error": retrieval_error,
+            }
+        )
+
+    state_files: list[dict[str, Any]] = []
+    for base in _store_paths(args.system, state_dir):
+        for path in sorted(base.parent.glob(base.name + "*")):
+            if path.is_file():
+                state_files.append(
+                    {"name": path.name, "bytes": path.stat().st_size}
+                )
+
+    if args.system == "entroly":
+        from entroly import __version__
+
+        participant = {
+            "package": "entroly",
+            "version": __version__,
+            "release_status": "merged source checkout",
+            "runtime": {
+                "python": platform.python_version(),
+                "platform": platform.platform(),
+                "implementation_sha256": _canonical_source_sha256(
+                    (
+                        Path(__file__).resolve(),
+                        ROOT / "entroly" / "compression_retrieval_store.py",
+                    )
+                ),
+            },
+        }
+    else:
+        participant = {
+            "package": "headroom-ai",
+            "version": importlib.metadata.version("headroom-ai"),
+            "release_status": "published PyPI release",
+            "runtime": {
+                "python": platform.python_version(),
+                "platform": platform.platform(),
+                "distribution_record_sha256": _distribution_record_sha256(
+                    "headroom-ai"
+                ),
+            },
+        }
+
+    result = {
+        "system": args.system,
+        "participant": participant,
+        "configuration": {
+            "workers": args.workers,
+            "entries_per_worker": args.entries,
+            "seed": args.seed,
+            **store_metadata,
+        },
+        "worker_runs": worker_runs,
+        "recovery_open_error": recovery_open_error,
+        "rows": sorted(rows, key=lambda row: (row["worker_id"], row["entry_index"])),
+        "state_files": state_files,
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+def _aggregate(adapter: dict[str, Any]) -> dict[str, Any]:
+    config = adapter["configuration"]
+    expected = int(config["workers"]) * int(config["entries_per_worker"])
+    rows = adapter["rows"]
+    worker_runs = adapter["worker_runs"]
+    worker_successes = sum(
+        run.get("exit_code") == 0 and not run.get("errors") for run in worker_runs
+    )
+    recovered = sum(row.get("recovered_sha256") is not None for row in rows)
+    exact = sum(bool(row.get("exact")) for row in rows)
+    incorrect = sum(
+        row.get("recovered_sha256") is not None and not bool(row.get("exact"))
+        for row in rows
+    )
+    worker_errors = sum(len(run.get("errors", [])) for run in worker_runs)
+    retrieval_errors = sum(row.get("retrieval_error") is not None for row in rows)
+    store_latencies = [float(row["store_latency_ms"]) for row in rows]
+    retrieve_latencies = [float(row["retrieve_latency_ms"]) for row in rows]
+    gates = {
+        "worker_exit_success_rate": round(
+            worker_successes / int(config["workers"]), 6
+        ),
+        "write_success_rate": round(len(rows) / expected, 6),
+        "restart_recovery_rate": round(recovered / expected, 6),
+        "exact_byte_recovery_rate": round(exact / expected, 6),
+        "incorrect_payloads": incorrect,
+    }
+    passed = (
+        gates["worker_exit_success_rate"] == 1.0
+        and gates["write_success_rate"] == 1.0
+        and gates["restart_recovery_rate"] == 1.0
+        and gates["exact_byte_recovery_rate"] == 1.0
+        and incorrect == 0
+        and worker_errors == 0
+        and retrieval_errors == 0
+        and adapter.get("recovery_open_error") is None
+    )
+    return {
+        "expected_entries": expected,
+        "written_entries": len(rows),
+        "recovered_entries": recovered,
+        "exact_entries": exact,
+        "incorrect_payloads": incorrect,
+        "worker_errors": worker_errors,
+        "retrieval_errors": retrieval_errors,
+        "store_latency": _latency_summary(store_latencies),
+        "retrieve_latency": _latency_summary(retrieve_latencies),
+        "state_bytes": sum(int(item["bytes"]) for item in adapter["state_files"]),
+        "gates": gates,
+        "passed": passed,
+    }
+
+
+def analyze(
+    *,
+    protocol: dict[str, Any],
+    phase: str,
+    adapters: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    expected_config = _phase_config(protocol, phase)
+    systems = sorted(str(adapter["system"]) for adapter in adapters)
+    if systems != ["entroly", "headroom"]:
+        raise ValueError("recovery comparison requires Entroly and Headroom")
+    by_system = {str(adapter["system"]): adapter for adapter in adapters}
+    expected_versions = {
+        "entroly": str(protocol["comparison"]["entroly"]).split()[0],
+        "headroom": str(protocol["comparison"]["headroom"]).split()[1],
+    }
+    for system, adapter in by_system.items():
+        observed_version = str(adapter["participant"]["version"])
+        if observed_version != expected_versions[system]:
+            raise ValueError(
+                f"{system} participant version {observed_version!r} does not match "
+                f"frozen version {expected_versions[system]!r}"
+            )
+        observed = {
+            "workers": int(adapter["configuration"]["workers"]),
+            "entries_per_worker": int(
+                adapter["configuration"]["entries_per_worker"]
+            ),
+            "seed": int(adapter["configuration"]["seed"]),
+        }
+        if observed != expected_config:
+            raise ValueError(f"{system} adapter configuration drifted from protocol")
+
+    aggregates = {system: _aggregate(by_system[system]) for system in systems}
+    if phase == "development":
+        label = "Development evidence only; no public leadership claim"
+    elif aggregates["entroly"]["passed"] and aggregates["headroom"]["passed"]:
+        label = "Both systems satisfy the frozen recovery-integrity gate"
+    elif aggregates["entroly"]["passed"]:
+        label = "Entroly alone satisfies the frozen recovery-integrity gate"
+    else:
+        label = "Entroly recovery leadership is not established"
+
+    report: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "phase": phase,
+        "protocol": protocol,
+        "protocol_sha256": _canonical_sha256(protocol),
+        "participants": {
+            system: by_system[system]["participant"] for system in systems
+        },
+        "adapters": by_system,
+        "aggregates": aggregates,
+        "claim_gate": {
+            "label": label,
+            "public_leadership_claim_allowed": phase == "holdout"
+            and aggregates["entroly"]["passed"]
+            and not aggregates["headroom"]["passed"],
+            "universal_superiority_claim_allowed": False,
+        },
+    }
+    report["payload_sha256"] = _canonical_sha256(report)
+    return report
+
+
+def verify_report(report: dict[str, Any]) -> None:
+    if report.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+    stored_hash = report.get("payload_sha256")
+    unhashed = {key: value for key, value in report.items() if key != "payload_sha256"}
+    if stored_hash != _canonical_sha256(unhashed):
+        raise ValueError("payload_sha256 mismatch")
+    protocol = report["protocol"]
+    if report.get("protocol_sha256") != _canonical_sha256(protocol):
+        raise ValueError("protocol_sha256 mismatch")
+    if protocol != _protocol():
+        raise ValueError("artifact protocol does not match frozen protocol file")
+    phase = str(report["phase"])
+    adapters = [report["adapters"][system] for system in ("entroly", "headroom")]
+    recomputed = analyze(protocol=protocol, phase=phase, adapters=adapters)
+    for field in ("participants", "aggregates", "claim_gate"):
+        if report[field] != recomputed[field]:
+            raise ValueError(f"{field} mismatch")
+
+
+def _invoke_adapter(
+    python: str,
+    system: str,
+    config: dict[str, int],
+    *,
+    timeout: float,
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix=f"entroly-{system}-recovery-") as temp:
+        command = [
+            str(Path(python).resolve()),
+            "-m",
+            "benchmarks.recovery_resilience",
+            "adapter",
+            "--system",
+            system,
+            "--state-dir",
+            temp,
+            "--workers",
+            str(config["workers"]),
+            "--entries",
+            str(config["entries_per_worker"]),
+            "--seed",
+            str(config["seed"]),
+            "--timeout",
+            str(timeout),
+        ]
+        completed = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=_subprocess_env(),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout * (config["workers"] + 2),
+            check=False,
+        )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"{system} adapter failed with {completed.returncode}: "
+            f"{completed.stderr[-2000:]}"
+        )
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            f"{system} adapter returned invalid JSON: {completed.stdout[-1000:]}"
+        ) from error
+    result["adapter_stderr_sha256"] = _sha256(completed.stderr)
+    result["adapter_stderr_tail"] = completed.stderr[-1000:]
+    return result
+
+
+def _run(args: argparse.Namespace) -> int:
+    protocol = _protocol()
+    config = _phase_config(protocol, args.phase)
+    adapters = [
+        _invoke_adapter(sys.executable, "entroly", config, timeout=args.timeout),
+        _invoke_adapter(
+            args.headroom_python, "headroom", config, timeout=args.timeout
+        ),
+    ]
+    report = analyze(protocol=protocol, phase=args.phase, adapters=adapters)
+    verify_report(report)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    _write_json(args.output, report)
+    print(
+        json.dumps(
+            {
+                "output": str(args.output),
+                "phase": args.phase,
+                "aggregates": report["aggregates"],
+                "claim_gate": report["claim_gate"],
+                "payload_sha256": report["payload_sha256"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _verify(args: argparse.Namespace) -> int:
+    report = json.loads(args.input.read_text(encoding="utf-8"))
+    verify_report(report)
+    print(
+        f"verified phase={report['phase']} payload_sha256={report['payload_sha256']}"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run = subparsers.add_parser("run")
+    run.add_argument("--phase", choices=("development", "holdout"), required=True)
+    run.add_argument("--headroom-python", required=True)
+    run.add_argument("--timeout", type=float, default=60.0)
+    run.add_argument("--output", type=Path, required=True)
+    run.set_defaults(func=_run)
+
+    adapter = subparsers.add_parser("adapter", help=argparse.SUPPRESS)
+    adapter.add_argument("--system", choices=("entroly", "headroom"), required=True)
+    adapter.add_argument("--state-dir", type=Path, required=True)
+    adapter.add_argument("--workers", type=int, required=True)
+    adapter.add_argument("--entries", type=int, required=True)
+    adapter.add_argument("--seed", type=int, required=True)
+    adapter.add_argument("--timeout", type=float, required=True)
+    adapter.set_defaults(func=_adapter)
+
+    worker = subparsers.add_parser("worker", help=argparse.SUPPRESS)
+    worker.add_argument("--system", choices=("entroly", "headroom"), required=True)
+    worker.add_argument("--state-dir", type=Path, required=True)
+    worker.add_argument("--worker-id", type=int, required=True)
+    worker.add_argument("--entries", type=int, required=True)
+    worker.add_argument("--seed", type=int, required=True)
+    worker.add_argument("--timeout", type=float, required=True)
+    worker.add_argument("--output", type=Path, required=True)
+    worker.set_defaults(func=_worker)
+
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("input", type=Path)
+    verify.set_defaults(func=_verify)
+
+    args = parser.parse_args()
+    for field in ("workers", "entries"):
+        if hasattr(args, field) and int(getattr(args, field)) < 1:
+            parser.error(f"--{field} must be positive")
+    if hasattr(args, "timeout") and float(args.timeout) <= 0:
+        parser.error("--timeout must be positive")
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/results/recovery_resilience_development_after.json
+++ b/benchmarks/results/recovery_resilience_development_after.json
@@ -1,0 +1,1379 @@
+{
+  "adapters": {
+    "entroly": {
+      "adapter_stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "adapter_stderr_tail": "",
+      "configuration": {
+        "backend": "entroly atomic JSON recovery store",
+        "entries_per_worker": 8,
+        "path": "recovery.json",
+        "seed": 20260714,
+        "workers": 4
+      },
+      "participant": {
+        "package": "entroly",
+        "release_status": "merged source checkout",
+        "runtime": {
+          "implementation_sha256": "3508e479c7d9fa846c8171d0eebbbd7d979410d9c09b4fef95727f821e4ecb6a",
+          "platform": "Windows-10-10.0.26200-SP0",
+          "python": "3.10.0"
+        },
+        "version": "1.0.59"
+      },
+      "recovery_open_error": null,
+      "rows": [
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "recovered_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "reference": {
+            "receipt_id": "79cecf8a4ce94a7a",
+            "span_id": "c2cd4db42d1a1844"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0851,
+          "store_latency_ms": 5.7222,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "recovered_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "reference": {
+            "receipt_id": "4b9db6becc9b5e9d",
+            "span_id": "9cadf6b96df64bd5"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.044,
+          "store_latency_ms": 11.8639,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "recovered_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "reference": {
+            "receipt_id": "347faab3b858cccf",
+            "span_id": "783a88589d787cb6"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0402,
+          "store_latency_ms": 15.8382,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "recovered_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "reference": {
+            "receipt_id": "1644396539422bdf",
+            "span_id": "c58e60c7245877d2"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.04,
+          "store_latency_ms": 15.6855,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "recovered_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "reference": {
+            "receipt_id": "e27779e564c3cb00",
+            "span_id": "e4c236fbe24479f8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0376,
+          "store_latency_ms": 16.2584,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "recovered_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "reference": {
+            "receipt_id": "58acb7c9f157be2c",
+            "span_id": "f44b897b51f8474c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0368,
+          "store_latency_ms": 16.551,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "recovered_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "reference": {
+            "receipt_id": "ac433c2d7519e512",
+            "span_id": "824d6bf4d75a4369"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0372,
+          "store_latency_ms": 15.3594,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "recovered_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "reference": {
+            "receipt_id": "571f905988c428e3",
+            "span_id": "22298e082b86066a"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.037,
+          "store_latency_ms": 15.8629,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "recovered_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "reference": {
+            "receipt_id": "decaf319ee2927de",
+            "span_id": "21f55649391028fa"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0368,
+          "store_latency_ms": 3106.382,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "recovered_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "reference": {
+            "receipt_id": "dbf80c26904889b0",
+            "span_id": "4d3f442c86c35224"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0334,
+          "store_latency_ms": 59.2335,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "recovered_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "reference": {
+            "receipt_id": "5f9c33d8e85d0ce3",
+            "span_id": "7e50120584f4a179"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.033,
+          "store_latency_ms": 28.5138,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "recovered_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "reference": {
+            "receipt_id": "e07bfe1856505184",
+            "span_id": "5b7fb008f936aa25"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.037,
+          "store_latency_ms": 55.5724,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "recovered_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "reference": {
+            "receipt_id": "68977c86a63da439",
+            "span_id": "54e0bb32f6ccac9c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0351,
+          "store_latency_ms": 48.3341,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "recovered_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "reference": {
+            "receipt_id": "7db78e5d9db94135",
+            "span_id": "f786bf232f5633f5"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0711,
+          "store_latency_ms": 59.511,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "recovered_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "reference": {
+            "receipt_id": "94bbc36e1869be35",
+            "span_id": "c67b6d76a2b869a4"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0466,
+          "store_latency_ms": 64.5351,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "recovered_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "reference": {
+            "receipt_id": "9e247dedce310a1f",
+            "span_id": "5680d871d5582a2e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0369,
+          "store_latency_ms": 44.2247,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "recovered_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "reference": {
+            "receipt_id": "69001d8ca5f32ff0",
+            "span_id": "106b4549d0549b81"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0388,
+          "store_latency_ms": 1028.1128,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "recovered_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "reference": {
+            "receipt_id": "502ee3d27ed55fa8",
+            "span_id": "d74e25619f9d3e12"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0371,
+          "store_latency_ms": 13.2715,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "recovered_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "reference": {
+            "receipt_id": "0cab750258373e1b",
+            "span_id": "b5ad86d7c97f67e3"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0357,
+          "store_latency_ms": 10.2793,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "recovered_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "reference": {
+            "receipt_id": "ce71a7221cd696fe",
+            "span_id": "912d6877a7ea2744"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0338,
+          "store_latency_ms": 11.8587,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "recovered_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "reference": {
+            "receipt_id": "a81d7d4db464800f",
+            "span_id": "ffc61438c10f301d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0336,
+          "store_latency_ms": 12.6033,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "recovered_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "reference": {
+            "receipt_id": "92dacbe4cea35fa4",
+            "span_id": "e0d9f57d3bd332b4"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0352,
+          "store_latency_ms": 10.3011,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "recovered_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "reference": {
+            "receipt_id": "3600f8a73421ff19",
+            "span_id": "5e91c1cb40ba5997"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0367,
+          "store_latency_ms": 9.7149,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "recovered_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "reference": {
+            "receipt_id": "9c50bb63ea870b02",
+            "span_id": "0de3c60cf3e4eb20"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0363,
+          "store_latency_ms": 10.5375,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "recovered_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "reference": {
+            "receipt_id": "c972706b7426bea5",
+            "span_id": "f5366c31b0f940c7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0368,
+          "store_latency_ms": 2068.2651,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "recovered_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "reference": {
+            "receipt_id": "b7ae88fefbedd5b3",
+            "span_id": "393b9df95af1a758"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0358,
+          "store_latency_ms": 34.086,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "recovered_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "reference": {
+            "receipt_id": "59b06c5f19f2a283",
+            "span_id": "d118cdbe4e4af770"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0328,
+          "store_latency_ms": 38.4443,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "recovered_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "reference": {
+            "receipt_id": "3b7f0765f090a283",
+            "span_id": "dd81ef4f41dce6e1"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0331,
+          "store_latency_ms": 43.3716,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "recovered_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "reference": {
+            "receipt_id": "a84e8d7fdbace83f",
+            "span_id": "d11641b659358947"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0372,
+          "store_latency_ms": 38.2537,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "recovered_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "reference": {
+            "receipt_id": "8884f065e7a24bb1",
+            "span_id": "5cf49dc535972684"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0333,
+          "store_latency_ms": 43.0066,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "recovered_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "reference": {
+            "receipt_id": "e5165b37b227d7d2",
+            "span_id": "4d1b0cdb2f987876"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0328,
+          "store_latency_ms": 67.0473,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "recovered_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "reference": {
+            "receipt_id": "a60c6531f2280e93",
+            "span_id": "68d21f07ac67d8a5"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.033,
+          "store_latency_ms": 57.013,
+          "system": "entroly",
+          "worker_id": 3
+        }
+      ],
+      "state_files": [
+        {
+          "bytes": 46219,
+          "name": "recovery.json"
+        },
+        {
+          "bytes": 1,
+          "name": "recovery.json.lock"
+        }
+      ],
+      "system": "entroly",
+      "worker_runs": [
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 0
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 1
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 2
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 3
+        }
+      ]
+    },
+    "headroom": {
+      "adapter_stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "adapter_stderr_tail": "",
+      "configuration": {
+        "backend": "headroom SQLite CCR store",
+        "entries_per_worker": 8,
+        "path": "ccr.db",
+        "seed": 20260714,
+        "workers": 4
+      },
+      "participant": {
+        "package": "headroom-ai",
+        "release_status": "published PyPI release",
+        "runtime": {
+          "distribution_record_sha256": "4220e07c6ed4e116badc3c86e8d8e29922a529f73e798b86e759203834b6e349",
+          "platform": "Windows-10-10.0.26200-SP0",
+          "python": "3.10.0"
+        },
+        "version": "0.31.0"
+      },
+      "recovery_open_error": null,
+      "rows": [
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "recovered_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "reference": {
+            "hash": "13abb549a3303b712118554e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 18.508,
+          "store_latency_ms": 21.44,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "recovered_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "reference": {
+            "hash": "4b571090c5ea50e9bdba52bb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.8562,
+          "store_latency_ms": 0.4777,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "recovered_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "reference": {
+            "hash": "cb7cc9f0f9cf035e2af1a4df"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.6854,
+          "store_latency_ms": 0.5385,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "recovered_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "reference": {
+            "hash": "55693c07b7ed589bd23cf68e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.7352,
+          "store_latency_ms": 0.3006,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "recovered_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "reference": {
+            "hash": "9315292f86bfc71d03410eca"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.7491,
+          "store_latency_ms": 0.3033,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "recovered_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "reference": {
+            "hash": "9c0ee641b2845516a7fd334d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.6078,
+          "store_latency_ms": 0.3559,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "recovered_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "reference": {
+            "hash": "9117413f2db5797a166fc6fe"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.533,
+          "store_latency_ms": 0.4339,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "recovered_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "reference": {
+            "hash": "df38a5b297b940e374386bd7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4959,
+          "store_latency_ms": 0.451,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "recovered_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "reference": {
+            "hash": "2b12b57de155d64f3de528d9"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5458,
+          "store_latency_ms": 19.6664,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "recovered_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "reference": {
+            "hash": "9c13b8b051661e5e33e39785"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5588,
+          "store_latency_ms": 0.4104,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "recovered_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "reference": {
+            "hash": "06f1e30ae24d8d59a90236e9"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3899,
+          "store_latency_ms": 0.3369,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "recovered_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "reference": {
+            "hash": "0890d1500b494d94ffe59346"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2497,
+          "store_latency_ms": 0.357,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "recovered_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "reference": {
+            "hash": "1ab8412cc1c0c4e45f152bec"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3143,
+          "store_latency_ms": 0.3638,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "recovered_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "reference": {
+            "hash": "38bfd0ab659672174aa1657f"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2301,
+          "store_latency_ms": 0.3529,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "recovered_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "reference": {
+            "hash": "79997c2a906e0cc17827c546"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2171,
+          "store_latency_ms": 24.3305,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "recovered_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "reference": {
+            "hash": "a5c1517791afef53d8985cbb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2597,
+          "store_latency_ms": 1.2705,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "recovered_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "reference": {
+            "hash": "ebad1056605d1c6932489c76"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2974,
+          "store_latency_ms": 14.7559,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "recovered_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "reference": {
+            "hash": "1c3e3249c25b4e96c72739d7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2483,
+          "store_latency_ms": 0.2004,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "recovered_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "reference": {
+            "hash": "5407b6bfc80cdf15968497f0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5652,
+          "store_latency_ms": 0.1467,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "recovered_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "reference": {
+            "hash": "e7ca96cb6a4d6e7cb83bdc0b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3916,
+          "store_latency_ms": 0.1655,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "recovered_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "reference": {
+            "hash": "362f5c66c611dfe55f2e8b08"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.625,
+          "store_latency_ms": 0.4166,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "recovered_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "reference": {
+            "hash": "457882522b2189a1134194df"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.6994,
+          "store_latency_ms": 0.3027,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "recovered_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "reference": {
+            "hash": "0f06f0617ed42e8831a9b555"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2435,
+          "store_latency_ms": 0.221,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "recovered_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "reference": {
+            "hash": "892df86f6a0208b74b5acaa8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2214,
+          "store_latency_ms": 0.1963,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "recovered_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "reference": {
+            "hash": "4499945012c866f2251bc499"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3427,
+          "store_latency_ms": 30.5798,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "recovered_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "reference": {
+            "hash": "557298eedf84774d4a9cf585"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2202,
+          "store_latency_ms": 0.4937,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "recovered_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "reference": {
+            "hash": "676358cfda7e74ddbaa4c85c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.209,
+          "store_latency_ms": 0.4107,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "recovered_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "reference": {
+            "hash": "e34cec1ec039737cd5980942"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2437,
+          "store_latency_ms": 0.4334,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "recovered_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "reference": {
+            "hash": "8ffd136a94aab8df710d118b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2336,
+          "store_latency_ms": 0.5238,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "recovered_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "reference": {
+            "hash": "6b4d3a2a539f98903378b1b8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2312,
+          "store_latency_ms": 0.4409,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "recovered_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "reference": {
+            "hash": "cd2d92428e73b4b9e946cb65"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3775,
+          "store_latency_ms": 0.5002,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "recovered_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "reference": {
+            "hash": "a4e85847efb2aaf1b2719454"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2973,
+          "store_latency_ms": 0.4267,
+          "system": "headroom",
+          "worker_id": 3
+        }
+      ],
+      "state_files": [
+        {
+          "bytes": 49152,
+          "name": "ccr.db"
+        },
+        {
+          "bytes": 32768,
+          "name": "ccr.db-shm"
+        },
+        {
+          "bytes": 696312,
+          "name": "ccr.db-wal"
+        }
+      ],
+      "system": "headroom",
+      "worker_runs": [
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 0
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 1
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 2
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 3
+        }
+      ]
+    }
+  },
+  "aggregates": {
+    "entroly": {
+      "exact_entries": 32,
+      "expected_entries": 32,
+      "gates": {
+        "exact_byte_recovery_rate": 1.0,
+        "incorrect_payloads": 0,
+        "restart_recovery_rate": 1.0,
+        "worker_exit_success_rate": 1.0,
+        "write_success_rate": 1.0
+      },
+      "incorrect_payloads": 0,
+      "passed": true,
+      "recovered_entries": 32,
+      "retrieval_errors": 0,
+      "retrieve_latency": {
+        "p50_ms": 0.0368,
+        "p95_ms": 0.057625,
+        "samples_ms": [
+          0.0851,
+          0.044,
+          0.0402,
+          0.04,
+          0.0376,
+          0.0368,
+          0.0372,
+          0.037,
+          0.0368,
+          0.0334,
+          0.033,
+          0.037,
+          0.0351,
+          0.0711,
+          0.0466,
+          0.0369,
+          0.0388,
+          0.0371,
+          0.0357,
+          0.0338,
+          0.0336,
+          0.0352,
+          0.0367,
+          0.0363,
+          0.0368,
+          0.0358,
+          0.0328,
+          0.0331,
+          0.0372,
+          0.0333,
+          0.0328,
+          0.033
+        ]
+      },
+      "state_bytes": 46220,
+      "store_latency": {
+        "p50_ms": 31.2999,
+        "p95_ms": 1496.181335,
+        "samples_ms": [
+          5.7222,
+          11.8639,
+          15.8382,
+          15.6855,
+          16.2584,
+          16.551,
+          15.3594,
+          15.8629,
+          3106.382,
+          59.2335,
+          28.5138,
+          55.5724,
+          48.3341,
+          59.511,
+          64.5351,
+          44.2247,
+          1028.1128,
+          13.2715,
+          10.2793,
+          11.8587,
+          12.6033,
+          10.3011,
+          9.7149,
+          10.5375,
+          2068.2651,
+          34.086,
+          38.4443,
+          43.3716,
+          38.2537,
+          43.0066,
+          67.0473,
+          57.013
+        ]
+      },
+      "worker_errors": 0,
+      "written_entries": 32
+    },
+    "headroom": {
+      "exact_entries": 32,
+      "expected_entries": 32,
+      "gates": {
+        "exact_byte_recovery_rate": 1.0,
+        "incorrect_payloads": 0,
+        "restart_recovery_rate": 1.0,
+        "worker_exit_success_rate": 1.0,
+        "write_success_rate": 1.0
+      },
+      "incorrect_payloads": 0,
+      "passed": true,
+      "recovered_entries": 32,
+      "retrieval_errors": 0,
+      "retrieve_latency": {
+        "p50_ms": 0.3601,
+        "p95_ms": 0.797295,
+        "samples_ms": [
+          18.508,
+          0.8562,
+          0.6854,
+          0.7352,
+          0.7491,
+          0.6078,
+          0.533,
+          0.4959,
+          0.5458,
+          0.5588,
+          0.3899,
+          0.2497,
+          0.3143,
+          0.2301,
+          0.2171,
+          0.2597,
+          0.2974,
+          0.2483,
+          0.5652,
+          0.3916,
+          0.625,
+          0.6994,
+          0.2435,
+          0.2214,
+          0.3427,
+          0.2202,
+          0.209,
+          0.2437,
+          0.2336,
+          0.2312,
+          0.3775,
+          0.2973
+        ]
+      },
+      "state_bytes": 778232,
+      "store_latency": {
+        "p50_ms": 0.42165,
+        "p95_ms": 22.740725,
+        "samples_ms": [
+          21.44,
+          0.4777,
+          0.5385,
+          0.3006,
+          0.3033,
+          0.3559,
+          0.4339,
+          0.451,
+          19.6664,
+          0.4104,
+          0.3369,
+          0.357,
+          0.3638,
+          0.3529,
+          24.3305,
+          1.2705,
+          14.7559,
+          0.2004,
+          0.1467,
+          0.1655,
+          0.4166,
+          0.3027,
+          0.221,
+          0.1963,
+          30.5798,
+          0.4937,
+          0.4107,
+          0.4334,
+          0.5238,
+          0.4409,
+          0.5002,
+          0.4267
+        ]
+      },
+      "worker_errors": 0,
+      "written_entries": 32
+    }
+  },
+  "claim_gate": {
+    "label": "Development evidence only; no public leadership claim",
+    "public_leadership_claim_allowed": false,
+    "universal_superiority_claim_allowed": false
+  },
+  "generated_at": "2026-07-14T11:37:31.926472+00:00",
+  "participants": {
+    "entroly": {
+      "package": "entroly",
+      "release_status": "merged source checkout",
+      "runtime": {
+        "implementation_sha256": "3508e479c7d9fa846c8171d0eebbbd7d979410d9c09b4fef95727f821e4ecb6a",
+        "platform": "Windows-10-10.0.26200-SP0",
+        "python": "3.10.0"
+      },
+      "version": "1.0.59"
+    },
+    "headroom": {
+      "package": "headroom-ai",
+      "release_status": "published PyPI release",
+      "runtime": {
+        "distribution_record_sha256": "4220e07c6ed4e116badc3c86e8d8e29922a529f73e798b86e759203834b6e349",
+        "platform": "Windows-10-10.0.26200-SP0",
+        "python": "3.10.0"
+      },
+      "version": "0.31.0"
+    }
+  },
+  "payload_sha256": "ffa5a977f6dd83f6f93c66244b582e96885178c8add8656d1e0eb80e53c6f514",
+  "phase": "development",
+  "protocol": {
+    "claim_policy": {
+      "aggregate_score_allowed": false,
+      "failures_remain_in_sample": true,
+      "negative_results_are_published": true,
+      "per_dimension_claims_only": true,
+      "universal_superiority_claim_allowed": false
+    },
+    "comparison": {
+      "entroly": "1.0.59 merged source",
+      "headroom": "headroom-ai 0.31.0 / tag v0.31.0 / commit 55efb1c77d5b67f7ad0620372c6256c8b0547591"
+    },
+    "dimensions": [
+      {
+        "evidence": "benchmarks/results/compression_frontier.json",
+        "id": "active_context_quality",
+        "status": "implemented"
+      },
+      {
+        "evidence": "benchmarks/recovery_resilience.py",
+        "id": "recovery_resilience",
+        "status": "implemented"
+      },
+      {
+        "id": "end_to_end_model_recovery",
+        "status": "planned"
+      },
+      {
+        "id": "compression_latency",
+        "status": "planned"
+      },
+      {
+        "id": "provider_protocol_conformance",
+        "status": "planned"
+      },
+      {
+        "id": "interruption_recovery",
+        "status": "planned"
+      },
+      {
+        "id": "security_and_secret_handling",
+        "status": "planned"
+      },
+      {
+        "id": "packaging_and_first_run",
+        "status": "planned"
+      },
+      {
+        "id": "operator_ux_and_diagnostics",
+        "status": "planned"
+      },
+      {
+        "id": "provider_observed_cost",
+        "status": "planned"
+      }
+    ],
+    "frozen_at": "2026-07-14T11:30:00Z",
+    "schema_version": "entroly.competitive-evidence-protocol.v1",
+    "suites": {
+      "recovery_resilience": {
+        "development": {
+          "entries_per_worker": 8,
+          "seed": 20260714,
+          "workers": 4
+        },
+        "development_policy": "Development results may guide implementation and remain visible but cannot support a public leadership claim.",
+        "gates": {
+          "exact_byte_recovery_rate": 1.0,
+          "incorrect_payloads": 0,
+          "restart_recovery_rate": 1.0,
+          "worker_exit_success_rate": 1.0,
+          "write_success_rate": 1.0
+        },
+        "holdout": {
+          "entries_per_worker": 11,
+          "seed": 20260715,
+          "workers": 6
+        },
+        "holdout_policy": "Run once after implementation. A scoped public claim requires the complete holdout matrix and a passing verifier.",
+        "latency_policy": "Report per-system p50 and p95 store/retrieve latency descriptively; correctness gates cannot be traded for speed."
+      }
+    }
+  },
+  "protocol_sha256": "67149234fcff176f63e4663676d77a9bced0f55e83ee8258d7017c9bc65accb0",
+  "schema_version": "entroly.recovery-resilience.v1"
+}

--- a/benchmarks/results/recovery_resilience_development_before.json
+++ b/benchmarks/results/recovery_resilience_development_before.json
@@ -1,0 +1,1016 @@
+{
+  "adapters": {
+    "entroly": {
+      "adapter_stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "adapter_stderr_tail": "",
+      "configuration": {
+        "backend": "entroly atomic JSON recovery store",
+        "entries_per_worker": 8,
+        "path": "recovery.json",
+        "seed": 20260714,
+        "workers": 4
+      },
+      "participant": {
+        "package": "entroly",
+        "release_status": "merged source checkout",
+        "runtime": {
+          "implementation_sha256": "94fc4de3dded3056c8194d5965511f3047a103552478f13e882bfc32d7af73ba",
+          "platform": "Windows-10-10.0.26200-SP0",
+          "python": "3.10.0"
+        },
+        "version": "1.0.59"
+      },
+      "recovery_open_error": null,
+      "rows": [
+        {
+          "entry_index": 0,
+          "exact": false,
+          "payload_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "recovered_sha256": null,
+          "reference": {
+            "receipt_id": "79cecf8a4ce94a7a",
+            "span_id": "c2cd4db42d1a1844"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0084,
+          "store_latency_ms": 2.6106,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 0,
+          "exact": false,
+          "payload_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "recovered_sha256": null,
+          "reference": {
+            "receipt_id": "decaf319ee2927de",
+            "span_id": "21f55649391028fa"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0021,
+          "store_latency_ms": 1.8058,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "recovered_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "reference": {
+            "receipt_id": "69001d8ca5f32ff0",
+            "span_id": "106b4549d0549b81"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.005,
+          "store_latency_ms": 2.8309,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "recovered_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "reference": {
+            "receipt_id": "502ee3d27ed55fa8",
+            "span_id": "d74e25619f9d3e12"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0018,
+          "store_latency_ms": 1.6293,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "recovered_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "reference": {
+            "receipt_id": "0cab750258373e1b",
+            "span_id": "b5ad86d7c97f67e3"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0017,
+          "store_latency_ms": 1.8555,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "recovered_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "reference": {
+            "receipt_id": "ce71a7221cd696fe",
+            "span_id": "912d6877a7ea2744"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0015,
+          "store_latency_ms": 1.2584,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "recovered_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "reference": {
+            "receipt_id": "a81d7d4db464800f",
+            "span_id": "ffc61438c10f301d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0014,
+          "store_latency_ms": 1.3548,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "recovered_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "reference": {
+            "receipt_id": "92dacbe4cea35fa4",
+            "span_id": "e0d9f57d3bd332b4"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0018,
+          "store_latency_ms": 1.2173,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "recovered_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "reference": {
+            "receipt_id": "3600f8a73421ff19",
+            "span_id": "5e91c1cb40ba5997"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0013,
+          "store_latency_ms": 2.3009,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "recovered_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "reference": {
+            "receipt_id": "9c50bb63ea870b02",
+            "span_id": "0de3c60cf3e4eb20"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0014,
+          "store_latency_ms": 2.8191,
+          "system": "entroly",
+          "worker_id": 2
+        }
+      ],
+      "state_files": [
+        {
+          "bytes": 11870,
+          "name": "recovery.json"
+        }
+      ],
+      "system": "entroly",
+      "worker_runs": [
+        {
+          "errors": [
+            {
+              "message": "[Errno 13] Permission denied: 'C:\\\\Users\\\\abhis\\\\AppData\\\\Local\\\\Temp\\\\entroly-entroly-recovery-7t31nez2\\\\recovery.json.tmp'",
+              "type": "PermissionError"
+            }
+          ],
+          "exit_code": 1,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 0
+        },
+        {
+          "errors": [
+            {
+              "message": "[WinError 5] Access is denied: 'C:\\\\Users\\\\abhis\\\\AppData\\\\Local\\\\Temp\\\\entroly-entroly-recovery-7t31nez2\\\\recovery.json.tmp' -> 'C:\\\\Users\\\\abhis\\\\AppData\\\\Local\\\\Temp\\\\entroly-entroly-recovery-7t31nez2\\\\recovery.json'",
+              "type": "PermissionError"
+            }
+          ],
+          "exit_code": 1,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 1
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 2
+        },
+        {
+          "errors": [
+            {
+              "message": "[WinError 32] The process cannot access the file because it is being used by another process: 'C:\\\\Users\\\\abhis\\\\AppData\\\\Local\\\\Temp\\\\entroly-entroly-recovery-7t31nez2\\\\recovery.json.tmp' -> 'C:\\\\Users\\\\abhis\\\\AppData\\\\Local\\\\Temp\\\\entroly-entroly-recovery-7t31nez2\\\\recovery.json'",
+              "type": "PermissionError"
+            }
+          ],
+          "exit_code": 1,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 3
+        }
+      ]
+    },
+    "headroom": {
+      "adapter_stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "adapter_stderr_tail": "",
+      "configuration": {
+        "backend": "headroom SQLite CCR store",
+        "entries_per_worker": 8,
+        "path": "ccr.db",
+        "seed": 20260714,
+        "workers": 4
+      },
+      "participant": {
+        "package": "headroom-ai",
+        "release_status": "published PyPI release",
+        "runtime": {
+          "distribution_record_sha256": "4220e07c6ed4e116badc3c86e8d8e29922a529f73e798b86e759203834b6e349",
+          "platform": "Windows-10-10.0.26200-SP0",
+          "python": "3.10.0"
+        },
+        "version": "0.31.0"
+      },
+      "recovery_open_error": null,
+      "rows": [
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "recovered_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "reference": {
+            "hash": "13abb549a3303b712118554e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 15.3765,
+          "store_latency_ms": 11.5364,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "recovered_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "reference": {
+            "hash": "4b571090c5ea50e9bdba52bb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3958,
+          "store_latency_ms": 0.1393,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "recovered_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "reference": {
+            "hash": "cb7cc9f0f9cf035e2af1a4df"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3106,
+          "store_latency_ms": 0.1208,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "recovered_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "reference": {
+            "hash": "55693c07b7ed589bd23cf68e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2233,
+          "store_latency_ms": 0.1887,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "recovered_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "reference": {
+            "hash": "9315292f86bfc71d03410eca"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2248,
+          "store_latency_ms": 0.256,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "recovered_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "reference": {
+            "hash": "9c0ee641b2845516a7fd334d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4297,
+          "store_latency_ms": 0.3225,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "recovered_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "reference": {
+            "hash": "9117413f2db5797a166fc6fe"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3964,
+          "store_latency_ms": 0.2936,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "recovered_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "reference": {
+            "hash": "df38a5b297b940e374386bd7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3774,
+          "store_latency_ms": 0.6471,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "recovered_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "reference": {
+            "hash": "2b12b57de155d64f3de528d9"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4097,
+          "store_latency_ms": 16.5308,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "recovered_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "reference": {
+            "hash": "9c13b8b051661e5e33e39785"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3146,
+          "store_latency_ms": 0.4585,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "recovered_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "reference": {
+            "hash": "06f1e30ae24d8d59a90236e9"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5206,
+          "store_latency_ms": 0.5663,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "recovered_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "reference": {
+            "hash": "0890d1500b494d94ffe59346"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3759,
+          "store_latency_ms": 0.7553,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "recovered_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "reference": {
+            "hash": "1ab8412cc1c0c4e45f152bec"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3435,
+          "store_latency_ms": 0.6762,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "recovered_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "reference": {
+            "hash": "38bfd0ab659672174aa1657f"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.315,
+          "store_latency_ms": 0.6844,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "recovered_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "reference": {
+            "hash": "79997c2a906e0cc17827c546"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3326,
+          "store_latency_ms": 0.5775,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "recovered_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "reference": {
+            "hash": "a5c1517791afef53d8985cbb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.343,
+          "store_latency_ms": 0.6095,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "recovered_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "reference": {
+            "hash": "ebad1056605d1c6932489c76"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4226,
+          "store_latency_ms": 31.806,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "recovered_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "reference": {
+            "hash": "1c3e3249c25b4e96c72739d7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3049,
+          "store_latency_ms": 1.3823,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "recovered_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "reference": {
+            "hash": "5407b6bfc80cdf15968497f0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3327,
+          "store_latency_ms": 0.5645,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "recovered_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "reference": {
+            "hash": "e7ca96cb6a4d6e7cb83bdc0b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4255,
+          "store_latency_ms": 0.4633,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "recovered_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "reference": {
+            "hash": "362f5c66c611dfe55f2e8b08"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3983,
+          "store_latency_ms": 0.4235,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "recovered_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "reference": {
+            "hash": "457882522b2189a1134194df"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3202,
+          "store_latency_ms": 0.4145,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "recovered_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "reference": {
+            "hash": "0f06f0617ed42e8831a9b555"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4734,
+          "store_latency_ms": 0.5228,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "recovered_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "reference": {
+            "hash": "892df86f6a0208b74b5acaa8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.311,
+          "store_latency_ms": 0.5032,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "recovered_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "reference": {
+            "hash": "4499945012c866f2251bc499"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3854,
+          "store_latency_ms": 14.3263,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "recovered_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "reference": {
+            "hash": "557298eedf84774d4a9cf585"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3152,
+          "store_latency_ms": 0.4485,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "recovered_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "reference": {
+            "hash": "676358cfda7e74ddbaa4c85c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3875,
+          "store_latency_ms": 0.4065,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "recovered_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "reference": {
+            "hash": "e34cec1ec039737cd5980942"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3746,
+          "store_latency_ms": 0.3863,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "recovered_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "reference": {
+            "hash": "8ffd136a94aab8df710d118b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5432,
+          "store_latency_ms": 0.7729,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "recovered_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "reference": {
+            "hash": "6b4d3a2a539f98903378b1b8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.6214,
+          "store_latency_ms": 0.405,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "recovered_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "reference": {
+            "hash": "cd2d92428e73b4b9e946cb65"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3625,
+          "store_latency_ms": 0.3877,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "recovered_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "reference": {
+            "hash": "a4e85847efb2aaf1b2719454"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3328,
+          "store_latency_ms": 0.3963,
+          "system": "headroom",
+          "worker_id": 3
+        }
+      ],
+      "state_files": [
+        {
+          "bytes": 49152,
+          "name": "ccr.db"
+        },
+        {
+          "bytes": 32768,
+          "name": "ccr.db-shm"
+        },
+        {
+          "bytes": 749872,
+          "name": "ccr.db-wal"
+        }
+      ],
+      "system": "headroom",
+      "worker_runs": [
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 0
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 1
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 2
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 3
+        }
+      ]
+    }
+  },
+  "aggregates": {
+    "entroly": {
+      "exact_entries": 8,
+      "expected_entries": 32,
+      "gates": {
+        "exact_byte_recovery_rate": 0.25,
+        "incorrect_payloads": 0,
+        "restart_recovery_rate": 0.25,
+        "worker_exit_success_rate": 0.25,
+        "write_success_rate": 0.3125
+      },
+      "incorrect_payloads": 0,
+      "passed": false,
+      "recovered_entries": 8,
+      "retrieval_errors": 0,
+      "retrieve_latency": {
+        "p50_ms": 0.00175,
+        "p95_ms": 0.00687,
+        "samples_ms": [
+          0.0084,
+          0.0021,
+          0.005,
+          0.0018,
+          0.0017,
+          0.0015,
+          0.0014,
+          0.0018,
+          0.0013,
+          0.0014
+        ]
+      },
+      "state_bytes": 11870,
+      "store_latency": {
+        "p50_ms": 1.83065,
+        "p95_ms": 2.82559,
+        "samples_ms": [
+          2.6106,
+          1.8058,
+          2.8309,
+          1.6293,
+          1.8555,
+          1.2584,
+          1.3548,
+          1.2173,
+          2.3009,
+          2.8191
+        ]
+      },
+      "worker_errors": 3,
+      "written_entries": 10
+    },
+    "headroom": {
+      "exact_entries": 32,
+      "expected_entries": 32,
+      "gates": {
+        "exact_byte_recovery_rate": 1.0,
+        "incorrect_payloads": 0,
+        "restart_recovery_rate": 1.0,
+        "worker_exit_success_rate": 1.0,
+        "write_success_rate": 1.0
+      },
+      "incorrect_payloads": 0,
+      "passed": true,
+      "recovered_entries": 32,
+      "retrieval_errors": 0,
+      "retrieve_latency": {
+        "p50_ms": 0.37525,
+        "p95_ms": 0.57839,
+        "samples_ms": [
+          15.3765,
+          0.3958,
+          0.3106,
+          0.2233,
+          0.2248,
+          0.4297,
+          0.3964,
+          0.3774,
+          0.4097,
+          0.3146,
+          0.5206,
+          0.3759,
+          0.3435,
+          0.315,
+          0.3326,
+          0.343,
+          0.4226,
+          0.3049,
+          0.3327,
+          0.4255,
+          0.3983,
+          0.3202,
+          0.4734,
+          0.311,
+          0.3854,
+          0.3152,
+          0.3875,
+          0.3746,
+          0.5432,
+          0.6214,
+          0.3625,
+          0.3328
+        ]
+      },
+      "state_bytes": 831792,
+      "store_latency": {
+        "p50_ms": 0.48325,
+        "p95_ms": 15.318325,
+        "samples_ms": [
+          11.5364,
+          0.1393,
+          0.1208,
+          0.1887,
+          0.256,
+          0.3225,
+          0.2936,
+          0.6471,
+          16.5308,
+          0.4585,
+          0.5663,
+          0.7553,
+          0.6762,
+          0.6844,
+          0.5775,
+          0.6095,
+          31.806,
+          1.3823,
+          0.5645,
+          0.4633,
+          0.4235,
+          0.4145,
+          0.5228,
+          0.5032,
+          14.3263,
+          0.4485,
+          0.4065,
+          0.3863,
+          0.7729,
+          0.405,
+          0.3877,
+          0.3963
+        ]
+      },
+      "worker_errors": 0,
+      "written_entries": 32
+    }
+  },
+  "claim_gate": {
+    "label": "Development evidence only; no public leadership claim",
+    "public_leadership_claim_allowed": false,
+    "universal_superiority_claim_allowed": false
+  },
+  "generated_at": "2026-07-14T11:33:39.339744+00:00",
+  "participants": {
+    "entroly": {
+      "package": "entroly",
+      "release_status": "merged source checkout",
+      "runtime": {
+        "implementation_sha256": "94fc4de3dded3056c8194d5965511f3047a103552478f13e882bfc32d7af73ba",
+        "platform": "Windows-10-10.0.26200-SP0",
+        "python": "3.10.0"
+      },
+      "version": "1.0.59"
+    },
+    "headroom": {
+      "package": "headroom-ai",
+      "release_status": "published PyPI release",
+      "runtime": {
+        "distribution_record_sha256": "4220e07c6ed4e116badc3c86e8d8e29922a529f73e798b86e759203834b6e349",
+        "platform": "Windows-10-10.0.26200-SP0",
+        "python": "3.10.0"
+      },
+      "version": "0.31.0"
+    }
+  },
+  "payload_sha256": "f32a15abf42f07ba1b324a3131d6577cba9aa417e8949c03b3b8b9d19d30be7c",
+  "phase": "development",
+  "protocol": {
+    "claim_policy": {
+      "aggregate_score_allowed": false,
+      "failures_remain_in_sample": true,
+      "negative_results_are_published": true,
+      "per_dimension_claims_only": true,
+      "universal_superiority_claim_allowed": false
+    },
+    "comparison": {
+      "entroly": "1.0.59 merged source",
+      "headroom": "headroom-ai 0.31.0 / tag v0.31.0 / commit 55efb1c77d5b67f7ad0620372c6256c8b0547591"
+    },
+    "dimensions": [
+      {
+        "evidence": "benchmarks/results/compression_frontier.json",
+        "id": "active_context_quality",
+        "status": "implemented"
+      },
+      {
+        "evidence": "benchmarks/recovery_resilience.py",
+        "id": "recovery_resilience",
+        "status": "implemented"
+      },
+      {
+        "id": "end_to_end_model_recovery",
+        "status": "planned"
+      },
+      {
+        "id": "compression_latency",
+        "status": "planned"
+      },
+      {
+        "id": "provider_protocol_conformance",
+        "status": "planned"
+      },
+      {
+        "id": "interruption_recovery",
+        "status": "planned"
+      },
+      {
+        "id": "security_and_secret_handling",
+        "status": "planned"
+      },
+      {
+        "id": "packaging_and_first_run",
+        "status": "planned"
+      },
+      {
+        "id": "operator_ux_and_diagnostics",
+        "status": "planned"
+      },
+      {
+        "id": "provider_observed_cost",
+        "status": "planned"
+      }
+    ],
+    "frozen_at": "2026-07-14T11:30:00Z",
+    "schema_version": "entroly.competitive-evidence-protocol.v1",
+    "suites": {
+      "recovery_resilience": {
+        "development": {
+          "entries_per_worker": 8,
+          "seed": 20260714,
+          "workers": 4
+        },
+        "development_policy": "Development results may guide implementation and remain visible but cannot support a public leadership claim.",
+        "gates": {
+          "exact_byte_recovery_rate": 1.0,
+          "incorrect_payloads": 0,
+          "restart_recovery_rate": 1.0,
+          "worker_exit_success_rate": 1.0,
+          "write_success_rate": 1.0
+        },
+        "holdout": {
+          "entries_per_worker": 11,
+          "seed": 20260715,
+          "workers": 6
+        },
+        "holdout_policy": "Run once after implementation. A scoped public claim requires the complete holdout matrix and a passing verifier.",
+        "latency_policy": "Report per-system p50 and p95 store/retrieve latency descriptively; correctness gates cannot be traded for speed."
+      }
+    }
+  },
+  "protocol_sha256": "67149234fcff176f63e4663676d77a9bced0f55e83ee8258d7017c9bc65accb0",
+  "schema_version": "entroly.recovery-resilience.v1"
+}

--- a/benchmarks/results/recovery_resilience_development_optimized.json
+++ b/benchmarks/results/recovery_resilience_development_optimized.json
@@ -1,0 +1,1379 @@
+{
+  "adapters": {
+    "entroly": {
+      "adapter_stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "adapter_stderr_tail": "",
+      "configuration": {
+        "backend": "entroly atomic JSON recovery store",
+        "entries_per_worker": 8,
+        "path": "recovery.json",
+        "seed": 20260714,
+        "workers": 4
+      },
+      "participant": {
+        "package": "entroly",
+        "release_status": "merged source checkout",
+        "runtime": {
+          "implementation_sha256": "d78afa677500b5f11d0198e6333e7a85698649b9c175fda47b972cbf8cd518d9",
+          "platform": "Windows-10-10.0.26200-SP0",
+          "python": "3.10.0"
+        },
+        "version": "1.0.59"
+      },
+      "recovery_open_error": null,
+      "rows": [
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "recovered_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "reference": {
+            "receipt_id": "79cecf8a4ce94a7a",
+            "span_id": "c2cd4db42d1a1844"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0803,
+          "store_latency_ms": 566.9621,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "recovered_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "reference": {
+            "receipt_id": "4b9db6becc9b5e9d",
+            "span_id": "9cadf6b96df64bd5"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0398,
+          "store_latency_ms": 23.2939,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "recovered_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "reference": {
+            "receipt_id": "347faab3b858cccf",
+            "span_id": "783a88589d787cb6"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0356,
+          "store_latency_ms": 23.5308,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "recovered_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "reference": {
+            "receipt_id": "1644396539422bdf",
+            "span_id": "c58e60c7245877d2"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0382,
+          "store_latency_ms": 17.5994,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "recovered_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "reference": {
+            "receipt_id": "e27779e564c3cb00",
+            "span_id": "e4c236fbe24479f8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0346,
+          "store_latency_ms": 19.7874,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "recovered_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "reference": {
+            "receipt_id": "58acb7c9f157be2c",
+            "span_id": "f44b897b51f8474c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0337,
+          "store_latency_ms": 16.501,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "recovered_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "reference": {
+            "receipt_id": "ac433c2d7519e512",
+            "span_id": "824d6bf4d75a4369"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0338,
+          "store_latency_ms": 22.4371,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "recovered_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "reference": {
+            "receipt_id": "571f905988c428e3",
+            "span_id": "22298e082b86066a"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0329,
+          "store_latency_ms": 26.8491,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "recovered_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "reference": {
+            "receipt_id": "decaf319ee2927de",
+            "span_id": "21f55649391028fa"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0338,
+          "store_latency_ms": 4.7822,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "recovered_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "reference": {
+            "receipt_id": "dbf80c26904889b0",
+            "span_id": "4d3f442c86c35224"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0341,
+          "store_latency_ms": 17.5038,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "recovered_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "reference": {
+            "receipt_id": "5f9c33d8e85d0ce3",
+            "span_id": "7e50120584f4a179"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0346,
+          "store_latency_ms": 16.2602,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "recovered_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "reference": {
+            "receipt_id": "e07bfe1856505184",
+            "span_id": "5b7fb008f936aa25"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0354,
+          "store_latency_ms": 13.3938,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "recovered_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "reference": {
+            "receipt_id": "68977c86a63da439",
+            "span_id": "54e0bb32f6ccac9c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0337,
+          "store_latency_ms": 19.3901,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "recovered_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "reference": {
+            "receipt_id": "7db78e5d9db94135",
+            "span_id": "f786bf232f5633f5"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0335,
+          "store_latency_ms": 18.8184,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "recovered_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "reference": {
+            "receipt_id": "94bbc36e1869be35",
+            "span_id": "c67b6d76a2b869a4"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.033,
+          "store_latency_ms": 16.9535,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "recovered_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "reference": {
+            "receipt_id": "9e247dedce310a1f",
+            "span_id": "5680d871d5582a2e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.033,
+          "store_latency_ms": 18.7468,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "recovered_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "reference": {
+            "receipt_id": "69001d8ca5f32ff0",
+            "span_id": "106b4549d0549b81"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0324,
+          "store_latency_ms": 160.4793,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "recovered_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "reference": {
+            "receipt_id": "502ee3d27ed55fa8",
+            "span_id": "d74e25619f9d3e12"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0333,
+          "store_latency_ms": 19.6368,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "recovered_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "reference": {
+            "receipt_id": "0cab750258373e1b",
+            "span_id": "b5ad86d7c97f67e3"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0332,
+          "store_latency_ms": 17.5951,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "recovered_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "reference": {
+            "receipt_id": "ce71a7221cd696fe",
+            "span_id": "912d6877a7ea2744"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0325,
+          "store_latency_ms": 18.2437,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "recovered_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "reference": {
+            "receipt_id": "a81d7d4db464800f",
+            "span_id": "ffc61438c10f301d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0326,
+          "store_latency_ms": 17.1479,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "recovered_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "reference": {
+            "receipt_id": "92dacbe4cea35fa4",
+            "span_id": "e0d9f57d3bd332b4"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0325,
+          "store_latency_ms": 16.7011,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "recovered_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "reference": {
+            "receipt_id": "3600f8a73421ff19",
+            "span_id": "5e91c1cb40ba5997"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0329,
+          "store_latency_ms": 17.8701,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "recovered_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "reference": {
+            "receipt_id": "9c50bb63ea870b02",
+            "span_id": "0de3c60cf3e4eb20"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0325,
+          "store_latency_ms": 21.2885,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "recovered_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "reference": {
+            "receipt_id": "c972706b7426bea5",
+            "span_id": "f5366c31b0f940c7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0326,
+          "store_latency_ms": 371.1721,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "recovered_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "reference": {
+            "receipt_id": "b7ae88fefbedd5b3",
+            "span_id": "393b9df95af1a758"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0323,
+          "store_latency_ms": 15.8174,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "recovered_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "reference": {
+            "receipt_id": "59b06c5f19f2a283",
+            "span_id": "d118cdbe4e4af770"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0321,
+          "store_latency_ms": 20.5036,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "recovered_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "reference": {
+            "receipt_id": "3b7f0765f090a283",
+            "span_id": "dd81ef4f41dce6e1"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0327,
+          "store_latency_ms": 17.2843,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "recovered_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "reference": {
+            "receipt_id": "a84e8d7fdbace83f",
+            "span_id": "d11641b659358947"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0582,
+          "store_latency_ms": 24.934,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "recovered_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "reference": {
+            "receipt_id": "8884f065e7a24bb1",
+            "span_id": "5cf49dc535972684"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0332,
+          "store_latency_ms": 24.744,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "recovered_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "reference": {
+            "receipt_id": "e5165b37b227d7d2",
+            "span_id": "4d1b0cdb2f987876"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0389,
+          "store_latency_ms": 24.6243,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "recovered_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "reference": {
+            "receipt_id": "a60c6531f2280e93",
+            "span_id": "68d21f07ac67d8a5"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0326,
+          "store_latency_ms": 23.5615,
+          "system": "entroly",
+          "worker_id": 3
+        }
+      ],
+      "state_files": [
+        {
+          "bytes": 46219,
+          "name": "recovery.json"
+        },
+        {
+          "bytes": 1,
+          "name": "recovery.json.lock"
+        }
+      ],
+      "system": "entroly",
+      "worker_runs": [
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 0
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 1
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 2
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 3
+        }
+      ]
+    },
+    "headroom": {
+      "adapter_stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "adapter_stderr_tail": "",
+      "configuration": {
+        "backend": "headroom SQLite CCR store",
+        "entries_per_worker": 8,
+        "path": "ccr.db",
+        "seed": 20260714,
+        "workers": 4
+      },
+      "participant": {
+        "package": "headroom-ai",
+        "release_status": "published PyPI release",
+        "runtime": {
+          "distribution_record_sha256": "4220e07c6ed4e116badc3c86e8d8e29922a529f73e798b86e759203834b6e349",
+          "platform": "Windows-10-10.0.26200-SP0",
+          "python": "3.10.0"
+        },
+        "version": "0.31.0"
+      },
+      "recovery_open_error": null,
+      "rows": [
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "recovered_sha256": "13abb549a3303b712118554e3cd70349d588da954fe01151042f7c2372235390",
+          "reference": {
+            "hash": "13abb549a3303b712118554e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 26.5251,
+          "store_latency_ms": 15.3609,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "recovered_sha256": "4b571090c5ea50e9bdba52bb13fff7cd7fd9a981858118c1bc497a0e9a954a5b",
+          "reference": {
+            "hash": "4b571090c5ea50e9bdba52bb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5043,
+          "store_latency_ms": 0.2817,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "recovered_sha256": "cb7cc9f0f9cf035e2af1a4df91e26f0aed8198680d38ce5df886af5d048c4a59",
+          "reference": {
+            "hash": "cb7cc9f0f9cf035e2af1a4df"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.597,
+          "store_latency_ms": 0.2753,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "recovered_sha256": "55693c07b7ed589bd23cf68e13667e9b4b952ce170b80e797867847eeb18d9ef",
+          "reference": {
+            "hash": "55693c07b7ed589bd23cf68e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5145,
+          "store_latency_ms": 0.1954,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "recovered_sha256": "9315292f86bfc71d03410eca5990abb989aa8cce3268a3f8dfbd6ad5ccb55dc8",
+          "reference": {
+            "hash": "9315292f86bfc71d03410eca"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5437,
+          "store_latency_ms": 0.1845,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "recovered_sha256": "9c0ee641b2845516a7fd334d55acd8f70210f73bdcf8f99a6e200955bda63804",
+          "reference": {
+            "hash": "9c0ee641b2845516a7fd334d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4042,
+          "store_latency_ms": 0.1704,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "recovered_sha256": "9117413f2db5797a166fc6fecaf369832adfd7463b95d91470b2977fc4469f8e",
+          "reference": {
+            "hash": "9117413f2db5797a166fc6fe"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3368,
+          "store_latency_ms": 0.1656,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "recovered_sha256": "df38a5b297b940e374386bd750f9d695c89e337311a6cfad1618c695926e10e4",
+          "reference": {
+            "hash": "df38a5b297b940e374386bd7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3594,
+          "store_latency_ms": 0.2217,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "recovered_sha256": "2b12b57de155d64f3de528d919f52c1757fe12290faf4ed743135a91e7ac1500",
+          "reference": {
+            "hash": "2b12b57de155d64f3de528d9"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4086,
+          "store_latency_ms": 17.2191,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "recovered_sha256": "9c13b8b051661e5e33e3978565acc0a75c5ec4352deae18d4a5bb3177f3630a8",
+          "reference": {
+            "hash": "9c13b8b051661e5e33e39785"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3723,
+          "store_latency_ms": 0.3444,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "recovered_sha256": "06f1e30ae24d8d59a90236e96fa3cde9f4430c18c9254af1b133a4232a12215b",
+          "reference": {
+            "hash": "06f1e30ae24d8d59a90236e9"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3712,
+          "store_latency_ms": 0.3346,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "recovered_sha256": "0890d1500b494d94ffe5934651961108ee78e8156d0d061f4ad522fc5c85ad1c",
+          "reference": {
+            "hash": "0890d1500b494d94ffe59346"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3901,
+          "store_latency_ms": 13.799,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "recovered_sha256": "1ab8412cc1c0c4e45f152bec6049a3e560f188353bd140aed7c14d70262f7126",
+          "reference": {
+            "hash": "1ab8412cc1c0c4e45f152bec"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3288,
+          "store_latency_ms": 0.7151,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "recovered_sha256": "38bfd0ab659672174aa1657fd0316de651e0c478881617e62eaa0d812f489077",
+          "reference": {
+            "hash": "38bfd0ab659672174aa1657f"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.226,
+          "store_latency_ms": 0.6112,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "recovered_sha256": "79997c2a906e0cc17827c5466f9cd923dfd8053119ed47ab8cb31a2ba3923ab1",
+          "reference": {
+            "hash": "79997c2a906e0cc17827c546"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2414,
+          "store_latency_ms": 0.6831,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "recovered_sha256": "a5c1517791afef53d8985cbb08b6ac3f10813c797a53e4121fc269c60cdda841",
+          "reference": {
+            "hash": "a5c1517791afef53d8985cbb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2091,
+          "store_latency_ms": 0.5753,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "recovered_sha256": "ebad1056605d1c6932489c76e790e4a2509df8ed0a7c8b66f878af9422b2965e",
+          "reference": {
+            "hash": "ebad1056605d1c6932489c76"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2729,
+          "store_latency_ms": 47.7441,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "recovered_sha256": "1c3e3249c25b4e96c72739d79d45d32dc395f88365e480e5443cad74433862d0",
+          "reference": {
+            "hash": "1c3e3249c25b4e96c72739d7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2149,
+          "store_latency_ms": 0.96,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "recovered_sha256": "5407b6bfc80cdf15968497f03c73e84fa27696784437aeb0d151540c24622cfc",
+          "reference": {
+            "hash": "5407b6bfc80cdf15968497f0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.257,
+          "store_latency_ms": 0.5935,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "recovered_sha256": "e7ca96cb6a4d6e7cb83bdc0b31de6a313f62865f0e3937927619c82d5dd90dbb",
+          "reference": {
+            "hash": "e7ca96cb6a4d6e7cb83bdc0b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2079,
+          "store_latency_ms": 0.6393,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "recovered_sha256": "362f5c66c611dfe55f2e8b0891060f90a4be8f97106507a0bb5c39c428fa5930",
+          "reference": {
+            "hash": "362f5c66c611dfe55f2e8b08"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2391,
+          "store_latency_ms": 0.9753,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "recovered_sha256": "457882522b2189a1134194df063fc0f7af6a58f7d13650abc3bd1dd7c72ec5de",
+          "reference": {
+            "hash": "457882522b2189a1134194df"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3331,
+          "store_latency_ms": 0.4855,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "recovered_sha256": "0f06f0617ed42e8831a9b555925421a9ca21447f5a006bf335b312bc4236c17d",
+          "reference": {
+            "hash": "0f06f0617ed42e8831a9b555"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2354,
+          "store_latency_ms": 0.52,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "recovered_sha256": "892df86f6a0208b74b5acaa89ba197c58e6f4b34cd925af84ef0525a3f93fa8a",
+          "reference": {
+            "hash": "892df86f6a0208b74b5acaa8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2024,
+          "store_latency_ms": 0.4642,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "recovered_sha256": "4499945012c866f2251bc49908a672e82ffe548d2f4704e4222c42055a0b28f6",
+          "reference": {
+            "hash": "4499945012c866f2251bc499"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3079,
+          "store_latency_ms": 17.6068,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "recovered_sha256": "557298eedf84774d4a9cf5853e7257bb0f97c2fe2cf0b9eca37286d75ee9102c",
+          "reference": {
+            "hash": "557298eedf84774d4a9cf585"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2754,
+          "store_latency_ms": 0.6358,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "recovered_sha256": "676358cfda7e74ddbaa4c85c15d49360d584a166e7e453e941f3f051206149ce",
+          "reference": {
+            "hash": "676358cfda7e74ddbaa4c85c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2362,
+          "store_latency_ms": 0.6288,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "recovered_sha256": "e34cec1ec039737cd59809421cc248e5d47dd47f5576f509625fcfb348d0bfa3",
+          "reference": {
+            "hash": "e34cec1ec039737cd5980942"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2032,
+          "store_latency_ms": 0.5181,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "recovered_sha256": "8ffd136a94aab8df710d118b7f65c00e2789ee80b7bed1bb10765f8f98fa13a2",
+          "reference": {
+            "hash": "8ffd136a94aab8df710d118b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2202,
+          "store_latency_ms": 0.2753,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "recovered_sha256": "6b4d3a2a539f98903378b1b816d8cd78f44ebad42a51cd799302a6bc6616fe12",
+          "reference": {
+            "hash": "6b4d3a2a539f98903378b1b8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2607,
+          "store_latency_ms": 0.3634,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "recovered_sha256": "cd2d92428e73b4b9e946cb65e5beaba07e8a86c4ca3d10214ce1e3b6200d5b08",
+          "reference": {
+            "hash": "cd2d92428e73b4b9e946cb65"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2135,
+          "store_latency_ms": 0.3781,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "recovered_sha256": "a4e85847efb2aaf1b2719454c0d423fab0eb098133654df77aac9861e246b5a8",
+          "reference": {
+            "hash": "a4e85847efb2aaf1b2719454"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2072,
+          "store_latency_ms": 0.3479,
+          "system": "headroom",
+          "worker_id": 3
+        }
+      ],
+      "state_files": [
+        {
+          "bytes": 49152,
+          "name": "ccr.db"
+        },
+        {
+          "bytes": 32768,
+          "name": "ccr.db-shm"
+        },
+        {
+          "bytes": 762232,
+          "name": "ccr.db-wal"
+        }
+      ],
+      "system": "headroom",
+      "worker_runs": [
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 0
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 1
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 2
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 3
+        }
+      ]
+    }
+  },
+  "aggregates": {
+    "entroly": {
+      "exact_entries": 32,
+      "expected_entries": 32,
+      "gates": {
+        "exact_byte_recovery_rate": 1.0,
+        "incorrect_payloads": 0,
+        "restart_recovery_rate": 1.0,
+        "worker_exit_success_rate": 1.0,
+        "write_success_rate": 1.0
+      },
+      "incorrect_payloads": 0,
+      "passed": true,
+      "recovered_entries": 32,
+      "retrieval_errors": 0,
+      "retrieve_latency": {
+        "p50_ms": 0.03325,
+        "p95_ms": 0.04808,
+        "samples_ms": [
+          0.0803,
+          0.0398,
+          0.0356,
+          0.0382,
+          0.0346,
+          0.0337,
+          0.0338,
+          0.0329,
+          0.0338,
+          0.0341,
+          0.0346,
+          0.0354,
+          0.0337,
+          0.0335,
+          0.033,
+          0.033,
+          0.0324,
+          0.0333,
+          0.0332,
+          0.0325,
+          0.0326,
+          0.0325,
+          0.0329,
+          0.0325,
+          0.0326,
+          0.0323,
+          0.0321,
+          0.0327,
+          0.0582,
+          0.0332,
+          0.0389,
+          0.0326
+        ]
+      },
+      "state_bytes": 46220,
+      "store_latency": {
+        "p50_ms": 19.10425,
+        "p95_ms": 255.29106,
+        "samples_ms": [
+          566.9621,
+          23.2939,
+          23.5308,
+          17.5994,
+          19.7874,
+          16.501,
+          22.4371,
+          26.8491,
+          4.7822,
+          17.5038,
+          16.2602,
+          13.3938,
+          19.3901,
+          18.8184,
+          16.9535,
+          18.7468,
+          160.4793,
+          19.6368,
+          17.5951,
+          18.2437,
+          17.1479,
+          16.7011,
+          17.8701,
+          21.2885,
+          371.1721,
+          15.8174,
+          20.5036,
+          17.2843,
+          24.934,
+          24.744,
+          24.6243,
+          23.5615
+        ]
+      },
+      "worker_errors": 0,
+      "written_entries": 32
+    },
+    "headroom": {
+      "exact_entries": 32,
+      "expected_entries": 32,
+      "gates": {
+        "exact_byte_recovery_rate": 1.0,
+        "incorrect_payloads": 0,
+        "restart_recovery_rate": 1.0,
+        "worker_exit_success_rate": 1.0,
+        "write_success_rate": 1.0
+      },
+      "incorrect_payloads": 0,
+      "passed": true,
+      "recovered_entries": 32,
+      "retrieval_errors": 0,
+      "retrieve_latency": {
+        "p50_ms": 0.27415,
+        "p95_ms": 0.567685,
+        "samples_ms": [
+          26.5251,
+          0.5043,
+          0.597,
+          0.5145,
+          0.5437,
+          0.4042,
+          0.3368,
+          0.3594,
+          0.4086,
+          0.3723,
+          0.3712,
+          0.3901,
+          0.3288,
+          0.226,
+          0.2414,
+          0.2091,
+          0.2729,
+          0.2149,
+          0.257,
+          0.2079,
+          0.2391,
+          0.3331,
+          0.2354,
+          0.2024,
+          0.3079,
+          0.2754,
+          0.2362,
+          0.2032,
+          0.2202,
+          0.2607,
+          0.2135,
+          0.2072
+        ]
+      },
+      "state_bytes": 844152,
+      "store_latency": {
+        "p50_ms": 0.51905,
+        "p95_ms": 17.393565,
+        "samples_ms": [
+          15.3609,
+          0.2817,
+          0.2753,
+          0.1954,
+          0.1845,
+          0.1704,
+          0.1656,
+          0.2217,
+          17.2191,
+          0.3444,
+          0.3346,
+          13.799,
+          0.7151,
+          0.6112,
+          0.6831,
+          0.5753,
+          47.7441,
+          0.96,
+          0.5935,
+          0.6393,
+          0.9753,
+          0.4855,
+          0.52,
+          0.4642,
+          17.6068,
+          0.6358,
+          0.6288,
+          0.5181,
+          0.2753,
+          0.3634,
+          0.3781,
+          0.3479
+        ]
+      },
+      "worker_errors": 0,
+      "written_entries": 32
+    }
+  },
+  "claim_gate": {
+    "label": "Development evidence only; no public leadership claim",
+    "public_leadership_claim_allowed": false,
+    "universal_superiority_claim_allowed": false
+  },
+  "generated_at": "2026-07-14T11:38:10.084169+00:00",
+  "participants": {
+    "entroly": {
+      "package": "entroly",
+      "release_status": "merged source checkout",
+      "runtime": {
+        "implementation_sha256": "d78afa677500b5f11d0198e6333e7a85698649b9c175fda47b972cbf8cd518d9",
+        "platform": "Windows-10-10.0.26200-SP0",
+        "python": "3.10.0"
+      },
+      "version": "1.0.59"
+    },
+    "headroom": {
+      "package": "headroom-ai",
+      "release_status": "published PyPI release",
+      "runtime": {
+        "distribution_record_sha256": "4220e07c6ed4e116badc3c86e8d8e29922a529f73e798b86e759203834b6e349",
+        "platform": "Windows-10-10.0.26200-SP0",
+        "python": "3.10.0"
+      },
+      "version": "0.31.0"
+    }
+  },
+  "payload_sha256": "650d92f9803d932e23c7b33da71a8b459e67e4dd10b5371e35af880d4d31d3d9",
+  "phase": "development",
+  "protocol": {
+    "claim_policy": {
+      "aggregate_score_allowed": false,
+      "failures_remain_in_sample": true,
+      "negative_results_are_published": true,
+      "per_dimension_claims_only": true,
+      "universal_superiority_claim_allowed": false
+    },
+    "comparison": {
+      "entroly": "1.0.59 merged source",
+      "headroom": "headroom-ai 0.31.0 / tag v0.31.0 / commit 55efb1c77d5b67f7ad0620372c6256c8b0547591"
+    },
+    "dimensions": [
+      {
+        "evidence": "benchmarks/results/compression_frontier.json",
+        "id": "active_context_quality",
+        "status": "implemented"
+      },
+      {
+        "evidence": "benchmarks/recovery_resilience.py",
+        "id": "recovery_resilience",
+        "status": "implemented"
+      },
+      {
+        "id": "end_to_end_model_recovery",
+        "status": "planned"
+      },
+      {
+        "id": "compression_latency",
+        "status": "planned"
+      },
+      {
+        "id": "provider_protocol_conformance",
+        "status": "planned"
+      },
+      {
+        "id": "interruption_recovery",
+        "status": "planned"
+      },
+      {
+        "id": "security_and_secret_handling",
+        "status": "planned"
+      },
+      {
+        "id": "packaging_and_first_run",
+        "status": "planned"
+      },
+      {
+        "id": "operator_ux_and_diagnostics",
+        "status": "planned"
+      },
+      {
+        "id": "provider_observed_cost",
+        "status": "planned"
+      }
+    ],
+    "frozen_at": "2026-07-14T11:30:00Z",
+    "schema_version": "entroly.competitive-evidence-protocol.v1",
+    "suites": {
+      "recovery_resilience": {
+        "development": {
+          "entries_per_worker": 8,
+          "seed": 20260714,
+          "workers": 4
+        },
+        "development_policy": "Development results may guide implementation and remain visible but cannot support a public leadership claim.",
+        "gates": {
+          "exact_byte_recovery_rate": 1.0,
+          "incorrect_payloads": 0,
+          "restart_recovery_rate": 1.0,
+          "worker_exit_success_rate": 1.0,
+          "write_success_rate": 1.0
+        },
+        "holdout": {
+          "entries_per_worker": 11,
+          "seed": 20260715,
+          "workers": 6
+        },
+        "holdout_policy": "Run once after implementation. A scoped public claim requires the complete holdout matrix and a passing verifier.",
+        "latency_policy": "Report per-system p50 and p95 store/retrieve latency descriptively; correctness gates cannot be traded for speed."
+      }
+    }
+  },
+  "protocol_sha256": "67149234fcff176f63e4663676d77a9bced0f55e83ee8258d7017c9bc65accb0",
+  "schema_version": "entroly.recovery-resilience.v1"
+}

--- a/benchmarks/results/recovery_resilience_holdout.json
+++ b/benchmarks/results/recovery_resilience_holdout.json
@@ -1,0 +1,2533 @@
+{
+  "adapters": {
+    "entroly": {
+      "adapter_stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "adapter_stderr_tail": "",
+      "configuration": {
+        "backend": "entroly atomic JSON recovery store",
+        "entries_per_worker": 11,
+        "path": "recovery.json",
+        "seed": 20260715,
+        "workers": 6
+      },
+      "participant": {
+        "package": "entroly",
+        "release_status": "merged source checkout",
+        "runtime": {
+          "implementation_sha256": "58f4b6a482d16d7d2d3ea03738ff3332194b960d41fdad67ec014b7146ebce9a",
+          "platform": "Windows-10-10.0.26200-SP0",
+          "python": "3.10.0"
+        },
+        "version": "1.0.59"
+      },
+      "recovery_open_error": null,
+      "rows": [
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "f9ff7a78a2085204b8c7afa81df821b5dde3d4bce5ea87fa63358482a5f71334",
+          "recovered_sha256": "f9ff7a78a2085204b8c7afa81df821b5dde3d4bce5ea87fa63358482a5f71334",
+          "reference": {
+            "receipt_id": "0fc214dffe64cfed",
+            "span_id": "f556e6f3054144c0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0833,
+          "store_latency_ms": 756.8916,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "0b89de4c5e5dc021ca5c883439b448f21757d146ca7ffa1d95536657333c906f",
+          "recovered_sha256": "0b89de4c5e5dc021ca5c883439b448f21757d146ca7ffa1d95536657333c906f",
+          "reference": {
+            "receipt_id": "0a2521b0e93e67c5",
+            "span_id": "b184c5f448a36a09"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0416,
+          "store_latency_ms": 31.9457,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "cea8c60f52f39577c4ccb6bd572cd5b47a775767ed752c2951294c1dcc7fbd9b",
+          "recovered_sha256": "cea8c60f52f39577c4ccb6bd572cd5b47a775767ed752c2951294c1dcc7fbd9b",
+          "reference": {
+            "receipt_id": "ba624b71b26617e7",
+            "span_id": "41e925396a178f27"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0395,
+          "store_latency_ms": 26.3195,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "6aee39af461f496cc0c288cd52bf1fcdf90a94bf4662e80cb37ed1c44204b935",
+          "recovered_sha256": "6aee39af461f496cc0c288cd52bf1fcdf90a94bf4662e80cb37ed1c44204b935",
+          "reference": {
+            "receipt_id": "9589827d1e4db7aa",
+            "span_id": "e166af379c1b6220"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0397,
+          "store_latency_ms": 21.3376,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "c1eebc2e40338703567819f1e9b2bf315c7370c021f94bf1d5b01cd0691164d6",
+          "recovered_sha256": "c1eebc2e40338703567819f1e9b2bf315c7370c021f94bf1d5b01cd0691164d6",
+          "reference": {
+            "receipt_id": "e80898d4ff753d92",
+            "span_id": "244460a71706c211"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0368,
+          "store_latency_ms": 21.4892,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "7eec2efdc65b5937c316ef13a6cc811f600a2d14ca1ba5fd5ae88337edf48a2a",
+          "recovered_sha256": "7eec2efdc65b5937c316ef13a6cc811f600a2d14ca1ba5fd5ae88337edf48a2a",
+          "reference": {
+            "receipt_id": "5fea5904494f25f2",
+            "span_id": "98d5ea13ee6b804c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.035,
+          "store_latency_ms": 20.1795,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "52cede1dd2972590be53ac1462a1621852ab2234ccc3f420c0f6c2ef34bdb006",
+          "recovered_sha256": "52cede1dd2972590be53ac1462a1621852ab2234ccc3f420c0f6c2ef34bdb006",
+          "reference": {
+            "receipt_id": "677c1d7e7dcce441",
+            "span_id": "56ce207829a54f11"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0382,
+          "store_latency_ms": 24.4327,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "6ab0d229e82155ce7d0b4a60e0c63dc88654acc7cf754f4d2649e8e1c499ea0b",
+          "recovered_sha256": "6ab0d229e82155ce7d0b4a60e0c63dc88654acc7cf754f4d2649e8e1c499ea0b",
+          "reference": {
+            "receipt_id": "3ccfa70592fde57b",
+            "span_id": "551713c42734503e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0388,
+          "store_latency_ms": 24.0698,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "d1eca89553a2d526b91e0624d0d2a96b66f2bfb2c3773e002485337d20a03b4d",
+          "recovered_sha256": "d1eca89553a2d526b91e0624d0d2a96b66f2bfb2c3773e002485337d20a03b4d",
+          "reference": {
+            "receipt_id": "88fc877c63a868c1",
+            "span_id": "4be9c1ad534bcb87"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0373,
+          "store_latency_ms": 27.3759,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "e02d70f8fd42fa4c1765a38c0a7068ba2faf8173d42b9236abca9213c120a59e",
+          "recovered_sha256": "e02d70f8fd42fa4c1765a38c0a7068ba2faf8173d42b9236abca9213c120a59e",
+          "reference": {
+            "receipt_id": "66cdf10967166995",
+            "span_id": "7b6f18a2b5655641"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0346,
+          "store_latency_ms": 21.0612,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "7d6a091849b035e231de0399bb51b0a1e5d4b781e1b1c8a1e1c28162324bdf06",
+          "recovered_sha256": "7d6a091849b035e231de0399bb51b0a1e5d4b781e1b1c8a1e1c28162324bdf06",
+          "reference": {
+            "receipt_id": "51e073fcfb736ca4",
+            "span_id": "64da747021d7ab19"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0354,
+          "store_latency_ms": 23.9919,
+          "system": "entroly",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "6dd22baf643af574254c3a44391752b24f6bd9b8ac841817028f9aa7374a6dae",
+          "recovered_sha256": "6dd22baf643af574254c3a44391752b24f6bd9b8ac841817028f9aa7374a6dae",
+          "reference": {
+            "receipt_id": "8e05d98ee9b0fe50",
+            "span_id": "aa0e849f7680c7d1"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0364,
+          "store_latency_ms": 4.5176,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "49ab776afef82aea8029be24620783cfaad17242a237186b81218526ce159afc",
+          "recovered_sha256": "49ab776afef82aea8029be24620783cfaad17242a237186b81218526ce159afc",
+          "reference": {
+            "receipt_id": "4618df9098637548",
+            "span_id": "a9b70bc79470366a"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0376,
+          "store_latency_ms": 19.4612,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "3d233284fce5aa1600c08cd11a88d398d31af9dda151bb2eb7f75dcfaa8ef352",
+          "recovered_sha256": "3d233284fce5aa1600c08cd11a88d398d31af9dda151bb2eb7f75dcfaa8ef352",
+          "reference": {
+            "receipt_id": "5971074e816ece1c",
+            "span_id": "cc0729e439c8268e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.037,
+          "store_latency_ms": 14.0302,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "812ad3f54bb7da6d140477b7065f9c4e5fcd6f016c8e11e8edcf2408c37f892d",
+          "recovered_sha256": "812ad3f54bb7da6d140477b7065f9c4e5fcd6f016c8e11e8edcf2408c37f892d",
+          "reference": {
+            "receipt_id": "daeb9d84d4c8afa4",
+            "span_id": "f206db0bd641e42c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0369,
+          "store_latency_ms": 16.1699,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "5bb97c06fc775a0bfced3ebb93659504bcb0ad35ba4385ac56bcb75c01bced82",
+          "recovered_sha256": "5bb97c06fc775a0bfced3ebb93659504bcb0ad35ba4385ac56bcb75c01bced82",
+          "reference": {
+            "receipt_id": "93a6075c6730d8cf",
+            "span_id": "b8ead26920d156da"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0369,
+          "store_latency_ms": 19.0585,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "1109034410b03262109e4e52d58a4d374faaa80121c265d5c46b73358c067186",
+          "recovered_sha256": "1109034410b03262109e4e52d58a4d374faaa80121c265d5c46b73358c067186",
+          "reference": {
+            "receipt_id": "ce8f4ecf4815704a",
+            "span_id": "433361a723760240"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0373,
+          "store_latency_ms": 18.0473,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "9cd4229b8574550f97f720ec89e314f836606c5110cbd779c2066eda4dc4c800",
+          "recovered_sha256": "9cd4229b8574550f97f720ec89e314f836606c5110cbd779c2066eda4dc4c800",
+          "reference": {
+            "receipt_id": "53f440be9cbf43f9",
+            "span_id": "4c556960f8b6104e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0367,
+          "store_latency_ms": 17.0886,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "2012c3138a72f5056f2b372b9620d8a11e3923eef01eddb5a98379d3641a79db",
+          "recovered_sha256": "2012c3138a72f5056f2b372b9620d8a11e3923eef01eddb5a98379d3641a79db",
+          "reference": {
+            "receipt_id": "14c9af0d5115eb81",
+            "span_id": "d0ebee4798e6a7b3"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.048,
+          "store_latency_ms": 21.7615,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "6c3636e28b5f31a534053dc11ee33c90061aa725cbf0727de7905be7241ca974",
+          "recovered_sha256": "6c3636e28b5f31a534053dc11ee33c90061aa725cbf0727de7905be7241ca974",
+          "reference": {
+            "receipt_id": "6b8306135944e206",
+            "span_id": "6de597a812ee84ef"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0406,
+          "store_latency_ms": 22.7551,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "6ba83b2283d149d2fa3c6899a15f7d3df6adc8bb625d9290a40ab1f63af1fa1a",
+          "recovered_sha256": "6ba83b2283d149d2fa3c6899a15f7d3df6adc8bb625d9290a40ab1f63af1fa1a",
+          "reference": {
+            "receipt_id": "15ca1d081eac2fbf",
+            "span_id": "aa946d8228ab72f9"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0384,
+          "store_latency_ms": 22.0404,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "4351e2ba67f65b59b4c553b77e844ba18d77256a258532223269f0423a3f1145",
+          "recovered_sha256": "4351e2ba67f65b59b4c553b77e844ba18d77256a258532223269f0423a3f1145",
+          "reference": {
+            "receipt_id": "446c4b3b87b6f45d",
+            "span_id": "31a346cdda366fd1"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0381,
+          "store_latency_ms": 437.0441,
+          "system": "entroly",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "1eb8f2d35e8e99bb2463f2805990c26412c0f6f76e7c39326ba3550ba92d7408",
+          "recovered_sha256": "1eb8f2d35e8e99bb2463f2805990c26412c0f6f76e7c39326ba3550ba92d7408",
+          "reference": {
+            "receipt_id": "1edb5a56ed833e72",
+            "span_id": "2d25f27409a86260"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0376,
+          "store_latency_ms": 1065.8275,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "915c9287dac70cdb61869ac8f50c34db23bf215476dbc6fe7cdc328362312449",
+          "recovered_sha256": "915c9287dac70cdb61869ac8f50c34db23bf215476dbc6fe7cdc328362312449",
+          "reference": {
+            "receipt_id": "8786c1f1442e943b",
+            "span_id": "81dfb64e2c2b4b55"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.038,
+          "store_latency_ms": 25.1657,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "ed584064f6ec00791d18cc627478bd0b4e449f3d848b202fdd33b210190ede23",
+          "recovered_sha256": "ed584064f6ec00791d18cc627478bd0b4e449f3d848b202fdd33b210190ede23",
+          "reference": {
+            "receipt_id": "7c550fa0faaf4006",
+            "span_id": "64a42105bdfae76c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0377,
+          "store_latency_ms": 22.2448,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "d6d32a1abc2d4e8da2c134efbd8a6d5a2d40eeb86a7e2f9e2751c5e5c1dd151e",
+          "recovered_sha256": "d6d32a1abc2d4e8da2c134efbd8a6d5a2d40eeb86a7e2f9e2751c5e5c1dd151e",
+          "reference": {
+            "receipt_id": "ea8108c02b9194bf",
+            "span_id": "53b59a7a683cee6b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0376,
+          "store_latency_ms": 21.9547,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "fe802675bfec17a747df18644257a8f7157edb42a8c23a92295d35d670ffa43f",
+          "recovered_sha256": "fe802675bfec17a747df18644257a8f7157edb42a8c23a92295d35d670ffa43f",
+          "reference": {
+            "receipt_id": "63eb3b814b1a4930",
+            "span_id": "5f12cc5ca435a3bb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0383,
+          "store_latency_ms": 22.3451,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "44118ec1f48445db6b36e6a01fb3e0bb6bb922e4bf72fce3fc7dcae6c36fc2b6",
+          "recovered_sha256": "44118ec1f48445db6b36e6a01fb3e0bb6bb922e4bf72fce3fc7dcae6c36fc2b6",
+          "reference": {
+            "receipt_id": "cae20a97cabf4030",
+            "span_id": "396951d8fc3e7850"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0387,
+          "store_latency_ms": 21.262,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "eb6a7057aa20abbc83345f9341715ee773949ba5535d0dcb9ec1ddca5cce0a10",
+          "recovered_sha256": "eb6a7057aa20abbc83345f9341715ee773949ba5535d0dcb9ec1ddca5cce0a10",
+          "reference": {
+            "receipt_id": "872a547af80b8407",
+            "span_id": "78fd9586b4cc7471"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0366,
+          "store_latency_ms": 24.3037,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "9763a027cdf2bee0b8d89f2fe53c101e76806b9788c3bc99aa5aeeda51af3e5f",
+          "recovered_sha256": "9763a027cdf2bee0b8d89f2fe53c101e76806b9788c3bc99aa5aeeda51af3e5f",
+          "reference": {
+            "receipt_id": "fe6b2ca56353d044",
+            "span_id": "66e20c1a127e26fb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0374,
+          "store_latency_ms": 22.4973,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "1fafabb5285a25e295d00cd4db90840b6b940682b4f05a82dd02752ffd6e32f9",
+          "recovered_sha256": "1fafabb5285a25e295d00cd4db90840b6b940682b4f05a82dd02752ffd6e32f9",
+          "reference": {
+            "receipt_id": "cf731cdde141a5ce",
+            "span_id": "10a177ec05f33d35"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0362,
+          "store_latency_ms": 19.2318,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "5da8ea83104be09fa3d8c7f5d04e27771e7b7ee31ad3b341ed6a680eec9fb9e7",
+          "recovered_sha256": "5da8ea83104be09fa3d8c7f5d04e27771e7b7ee31ad3b341ed6a680eec9fb9e7",
+          "reference": {
+            "receipt_id": "f11ba8344e4affa6",
+            "span_id": "192caa5933f1b0fd"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0368,
+          "store_latency_ms": 21.8887,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "dcfb17dcf55cd166bf07d011935633a9826410f09224a4032a4bad8d90019f91",
+          "recovered_sha256": "dcfb17dcf55cd166bf07d011935633a9826410f09224a4032a4bad8d90019f91",
+          "reference": {
+            "receipt_id": "7e9e63db5ded0c83",
+            "span_id": "14cf308b2c1b4c33"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0362,
+          "store_latency_ms": 21.278,
+          "system": "entroly",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "649f1864bda447ee5f216c9b40e007dd4710c09d97034aad9e213ed6023969fc",
+          "recovered_sha256": "649f1864bda447ee5f216c9b40e007dd4710c09d97034aad9e213ed6023969fc",
+          "reference": {
+            "receipt_id": "5b009237bad94811",
+            "span_id": "5fd9a64443e04597"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0372,
+          "store_latency_ms": 1324.2337,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "f45e9314c7be1d7dca5b8b357ee8a7cb3961db77892b1a224e5dce5fe09c8cf5",
+          "recovered_sha256": "f45e9314c7be1d7dca5b8b357ee8a7cb3961db77892b1a224e5dce5fe09c8cf5",
+          "reference": {
+            "receipt_id": "6cf1841fd56c7171",
+            "span_id": "4a5edc43f63b0984"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0381,
+          "store_latency_ms": 23.9585,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "82724755c205d2bd890fe37fdcee33cee16d73bd05427db84f50f1b45750fdc7",
+          "recovered_sha256": "82724755c205d2bd890fe37fdcee33cee16d73bd05427db84f50f1b45750fdc7",
+          "reference": {
+            "receipt_id": "e71ad213b922607d",
+            "span_id": "cb4bb141d8ea1360"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0419,
+          "store_latency_ms": 23.8088,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "fd717279c0bf48022b7fef8df6bfc31cc39fa09a6a5325618522be84cd3592c9",
+          "recovered_sha256": "fd717279c0bf48022b7fef8df6bfc31cc39fa09a6a5325618522be84cd3592c9",
+          "reference": {
+            "receipt_id": "d9041f357194202d",
+            "span_id": "53433c7e14462bcc"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0451,
+          "store_latency_ms": 24.644,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "ca5a7ccb8951b374bcded22d2462f0d8061a24579768aef1af695793993f09d8",
+          "recovered_sha256": "ca5a7ccb8951b374bcded22d2462f0d8061a24579768aef1af695793993f09d8",
+          "reference": {
+            "receipt_id": "e226f5344f2d7c2b",
+            "span_id": "17ba8284c53d63f0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.043,
+          "store_latency_ms": 24.8717,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "36a74060869739d726b6bf71cf81e2f469405b27c00ca621edfeaa1a046d814f",
+          "recovered_sha256": "36a74060869739d726b6bf71cf81e2f469405b27c00ca621edfeaa1a046d814f",
+          "reference": {
+            "receipt_id": "665f3113063c5228",
+            "span_id": "b7bd080afc6d2b78"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0429,
+          "store_latency_ms": 25.7179,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "30073a63d8115932ea118005cf64e25b9243e07cbabe32ba7884b2bf7ba9eba3",
+          "recovered_sha256": "30073a63d8115932ea118005cf64e25b9243e07cbabe32ba7884b2bf7ba9eba3",
+          "reference": {
+            "receipt_id": "eb40317b7f2c81de",
+            "span_id": "7b5094b7e4a7ddf3"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0452,
+          "store_latency_ms": 25.6628,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "3bac9daeb19fbcbd3f24d8e1fbea012e8dceae9d9ab68d63e30bf920e1226cb9",
+          "recovered_sha256": "3bac9daeb19fbcbd3f24d8e1fbea012e8dceae9d9ab68d63e30bf920e1226cb9",
+          "reference": {
+            "receipt_id": "70aaa157ba85b0e9",
+            "span_id": "42753f00520e58d8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0459,
+          "store_latency_ms": 24.8412,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "cc62448bf45e140ea58f2b289de64c79618220b5edcaf44c706a874e389d0d9c",
+          "recovered_sha256": "cc62448bf45e140ea58f2b289de64c79618220b5edcaf44c706a874e389d0d9c",
+          "reference": {
+            "receipt_id": "f980c017a679dc07",
+            "span_id": "64db1ad4e0d87cbd"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.044,
+          "store_latency_ms": 20.275,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "f485c8115a9563b93d49b04ee4dcbb89faca55d63150284e0b68e7add364b29f",
+          "recovered_sha256": "f485c8115a9563b93d49b04ee4dcbb89faca55d63150284e0b68e7add364b29f",
+          "reference": {
+            "receipt_id": "caabaa278ca5f8b8",
+            "span_id": "859847df20f6e50e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0434,
+          "store_latency_ms": 19.2084,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "990d3f40c2fa09392b31532ef80c29b2f330135c8b700d2a151e4aa940a777b7",
+          "recovered_sha256": "990d3f40c2fa09392b31532ef80c29b2f330135c8b700d2a151e4aa940a777b7",
+          "reference": {
+            "receipt_id": "dd788354ad818b5f",
+            "span_id": "558fdcb5abeb16cb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0439,
+          "store_latency_ms": 23.6255,
+          "system": "entroly",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "50da1b53ae77b4506a41b3be0b290555dd3eb78d4dd5e949cc955b90f420b3b8",
+          "recovered_sha256": "50da1b53ae77b4506a41b3be0b290555dd3eb78d4dd5e949cc955b90f420b3b8",
+          "reference": {
+            "receipt_id": "da91c36084b02bf0",
+            "span_id": "a300e4108e58c566"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0463,
+          "store_latency_ms": 432.7307,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "313d593e213ecd518a502506c489581f181ec63e9f2b0006fedc0e02d7cbfb76",
+          "recovered_sha256": "313d593e213ecd518a502506c489581f181ec63e9f2b0006fedc0e02d7cbfb76",
+          "reference": {
+            "receipt_id": "6f0bbdbef0de74e0",
+            "span_id": "4989d9b13dc10f31"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0437,
+          "store_latency_ms": 23.3956,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "1c119c0804651a78e6d28f4474fb969dbb95b3c28133f84209974eadb8f03f9b",
+          "recovered_sha256": "1c119c0804651a78e6d28f4474fb969dbb95b3c28133f84209974eadb8f03f9b",
+          "reference": {
+            "receipt_id": "3eda9ec387ed0bcc",
+            "span_id": "78de684c3ffa0e16"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0435,
+          "store_latency_ms": 24.46,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "b3d118325757af105ffd3cfbc80b0e5158026dea50830cd22ce9e8aca29c8e96",
+          "recovered_sha256": "b3d118325757af105ffd3cfbc80b0e5158026dea50830cd22ce9e8aca29c8e96",
+          "reference": {
+            "receipt_id": "4fb0fb8748f7819c",
+            "span_id": "aca1c47b86bcae8c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.044,
+          "store_latency_ms": 18.1146,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "63097a6266b50689be57eeaba232d59820fb8e0622c535b881d1240c5174c149",
+          "recovered_sha256": "63097a6266b50689be57eeaba232d59820fb8e0622c535b881d1240c5174c149",
+          "reference": {
+            "receipt_id": "057ac79b44a48166",
+            "span_id": "058aa47f2b2cdd6e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0435,
+          "store_latency_ms": 19.9577,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "3cf31d46173f6c50bd8b9e72fc007bd9284686af7cb918937e2dd36213058a83",
+          "recovered_sha256": "3cf31d46173f6c50bd8b9e72fc007bd9284686af7cb918937e2dd36213058a83",
+          "reference": {
+            "receipt_id": "ce6d1a64b7a2e1fa",
+            "span_id": "6f3d1dc93c787a49"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0471,
+          "store_latency_ms": 21.388,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "43c09b9b0a840e2c97c9d5446c742e3cd5ac010dbd8b04f24bde9e2609c27861",
+          "recovered_sha256": "43c09b9b0a840e2c97c9d5446c742e3cd5ac010dbd8b04f24bde9e2609c27861",
+          "reference": {
+            "receipt_id": "b60c7b137595afdb",
+            "span_id": "1648aca8c3f07c92"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0453,
+          "store_latency_ms": 23.3045,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "7f1830c3666e0b60a53eb89dcbded8e4a56f2dcc8baaeab2e33344d10623ab47",
+          "recovered_sha256": "7f1830c3666e0b60a53eb89dcbded8e4a56f2dcc8baaeab2e33344d10623ab47",
+          "reference": {
+            "receipt_id": "e8289f682d6449b0",
+            "span_id": "bc5f789970f2a886"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0452,
+          "store_latency_ms": 23.3479,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "824876e986d392975b9f3a478889f4083ba98d2a9127015f662cf68bb1276ed7",
+          "recovered_sha256": "824876e986d392975b9f3a478889f4083ba98d2a9127015f662cf68bb1276ed7",
+          "reference": {
+            "receipt_id": "b0243cba844cd424",
+            "span_id": "5bcb182dcc1cf6ac"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0458,
+          "store_latency_ms": 60.0732,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "7eb45b754125b3cc042932b004945246eb1eefa4fe6c9b603cc20382c7df99dd",
+          "recovered_sha256": "7eb45b754125b3cc042932b004945246eb1eefa4fe6c9b603cc20382c7df99dd",
+          "reference": {
+            "receipt_id": "910a98e324b7c271",
+            "span_id": "176aa1697d4a7fd4"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0442,
+          "store_latency_ms": 24.7266,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "0ebf6fcb1c75c374617225f492f571cac613f0f43614732a262bbedf1f39783a",
+          "recovered_sha256": "0ebf6fcb1c75c374617225f492f571cac613f0f43614732a262bbedf1f39783a",
+          "reference": {
+            "receipt_id": "eac83b9b7e222790",
+            "span_id": "2bbbdb8a5868df4f"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0448,
+          "store_latency_ms": 19.1226,
+          "system": "entroly",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "46df3622bd65b9fabaaeb30004e1b9a72774e9c03f5fb2e0a15e5a13c39f3788",
+          "recovered_sha256": "46df3622bd65b9fabaaeb30004e1b9a72774e9c03f5fb2e0a15e5a13c39f3788",
+          "reference": {
+            "receipt_id": "4f2392b0b7387cae",
+            "span_id": "f52d4770dad2b7cf"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0487,
+          "store_latency_ms": 193.6142,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "97b0a53ed55665f4860b2e7084333baf5561038a9de789f7258c1c01911d8dbd",
+          "recovered_sha256": "97b0a53ed55665f4860b2e7084333baf5561038a9de789f7258c1c01911d8dbd",
+          "reference": {
+            "receipt_id": "63c8f723b20f23ba",
+            "span_id": "fb54752cf9a76834"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0471,
+          "store_latency_ms": 19.2241,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "2b1596d11595a3675fb99130a6747b6cddb495b838fb5a257a87a712838cd036",
+          "recovered_sha256": "2b1596d11595a3675fb99130a6747b6cddb495b838fb5a257a87a712838cd036",
+          "reference": {
+            "receipt_id": "7c1b9c66bfa35ce1",
+            "span_id": "c088299c728ceaca"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.046,
+          "store_latency_ms": 18.468,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "70c85fde887d060ac890810ae59418ce6fed0404fd070b12b7912c59fbc2832a",
+          "recovered_sha256": "70c85fde887d060ac890810ae59418ce6fed0404fd070b12b7912c59fbc2832a",
+          "reference": {
+            "receipt_id": "fd442c5419783c67",
+            "span_id": "8ed047dc211a312c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0458,
+          "store_latency_ms": 22.7144,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "0693c38ce6aac8468427aa62bbe1435a602404d0f7a553188ee0a1d15e6a1647",
+          "recovered_sha256": "0693c38ce6aac8468427aa62bbe1435a602404d0f7a553188ee0a1d15e6a1647",
+          "reference": {
+            "receipt_id": "ab5a135bd2310ddd",
+            "span_id": "fb4fc1494b55aa86"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0453,
+          "store_latency_ms": 23.7177,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "1f0c4e3298e6405a8111426a7fa0054ad48b72827293f3415d53f7f06b6c82f0",
+          "recovered_sha256": "1f0c4e3298e6405a8111426a7fa0054ad48b72827293f3415d53f7f06b6c82f0",
+          "reference": {
+            "receipt_id": "42594cb31c90b38f",
+            "span_id": "ae51e7d409429988"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0458,
+          "store_latency_ms": 23.2052,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "cbde09c4f9f5c0b21a22cefb60987465cc458ba4c9fad4b324d3eb14cafa84d0",
+          "recovered_sha256": "cbde09c4f9f5c0b21a22cefb60987465cc458ba4c9fad4b324d3eb14cafa84d0",
+          "reference": {
+            "receipt_id": "a377efdc2e69280d",
+            "span_id": "4ad0000ab3f02ef0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0475,
+          "store_latency_ms": 16.4987,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "31b2c7464260e70cdfe9abae53ef363481893fdb6ca12bcf4b389b404b1d4101",
+          "recovered_sha256": "31b2c7464260e70cdfe9abae53ef363481893fdb6ca12bcf4b389b404b1d4101",
+          "reference": {
+            "receipt_id": "6cec58f6e9bac7b0",
+            "span_id": "fdaa9c5292142b70"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0587,
+          "store_latency_ms": 21.3107,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "794a67d58f4612f5a12cb1f2089fa91e463504ae5bd5b499199a7c44de606f33",
+          "recovered_sha256": "794a67d58f4612f5a12cb1f2089fa91e463504ae5bd5b499199a7c44de606f33",
+          "reference": {
+            "receipt_id": "529fa0a6e50fe59e",
+            "span_id": "cfe3829496ca7cb0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0498,
+          "store_latency_ms": 23.1047,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "c7078eeb3fbcaa40ff75740c5125495d774fccf8c1f99ffc1b7001908e88604f",
+          "recovered_sha256": "c7078eeb3fbcaa40ff75740c5125495d774fccf8c1f99ffc1b7001908e88604f",
+          "reference": {
+            "receipt_id": "39b09e71c0ef072c",
+            "span_id": "e790e8901cd2d51b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0466,
+          "store_latency_ms": 21.9651,
+          "system": "entroly",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "790f5a38052471c29b32b31275bf71c88aad9e50c353dcc2d7d7c4d311e7deaf",
+          "recovered_sha256": "790f5a38052471c29b32b31275bf71c88aad9e50c353dcc2d7d7c4d311e7deaf",
+          "reference": {
+            "receipt_id": "8871af9dcc45c910",
+            "span_id": "f02fcfdd688879ff"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.0498,
+          "store_latency_ms": 21.5501,
+          "system": "entroly",
+          "worker_id": 5
+        }
+      ],
+      "state_files": [
+        {
+          "bytes": 95437,
+          "name": "recovery.json"
+        },
+        {
+          "bytes": 1,
+          "name": "recovery.json.lock"
+        }
+      ],
+      "system": "entroly",
+      "worker_runs": [
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 0
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 1
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 2
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 3
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 4
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 5
+        }
+      ]
+    },
+    "headroom": {
+      "adapter_stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "adapter_stderr_tail": "",
+      "configuration": {
+        "backend": "headroom SQLite CCR store",
+        "entries_per_worker": 11,
+        "path": "ccr.db",
+        "seed": 20260715,
+        "workers": 6
+      },
+      "participant": {
+        "package": "headroom-ai",
+        "release_status": "published PyPI release",
+        "runtime": {
+          "distribution_record_sha256": "4220e07c6ed4e116badc3c86e8d8e29922a529f73e798b86e759203834b6e349",
+          "platform": "Windows-10-10.0.26200-SP0",
+          "python": "3.10.0"
+        },
+        "version": "0.31.0"
+      },
+      "recovery_open_error": null,
+      "rows": [
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "f9ff7a78a2085204b8c7afa81df821b5dde3d4bce5ea87fa63358482a5f71334",
+          "recovered_sha256": "f9ff7a78a2085204b8c7afa81df821b5dde3d4bce5ea87fa63358482a5f71334",
+          "reference": {
+            "hash": "f9ff7a78a2085204b8c7afa8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 19.3121,
+          "store_latency_ms": 25.6792,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "0b89de4c5e5dc021ca5c883439b448f21757d146ca7ffa1d95536657333c906f",
+          "recovered_sha256": "0b89de4c5e5dc021ca5c883439b448f21757d146ca7ffa1d95536657333c906f",
+          "reference": {
+            "hash": "0b89de4c5e5dc021ca5c8834"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5125,
+          "store_latency_ms": 0.645,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "cea8c60f52f39577c4ccb6bd572cd5b47a775767ed752c2951294c1dcc7fbd9b",
+          "recovered_sha256": "cea8c60f52f39577c4ccb6bd572cd5b47a775767ed752c2951294c1dcc7fbd9b",
+          "reference": {
+            "hash": "cea8c60f52f39577c4ccb6bd"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3593,
+          "store_latency_ms": 0.6693,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "6aee39af461f496cc0c288cd52bf1fcdf90a94bf4662e80cb37ed1c44204b935",
+          "recovered_sha256": "6aee39af461f496cc0c288cd52bf1fcdf90a94bf4662e80cb37ed1c44204b935",
+          "reference": {
+            "hash": "6aee39af461f496cc0c288cd"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2581,
+          "store_latency_ms": 0.5764,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "c1eebc2e40338703567819f1e9b2bf315c7370c021f94bf1d5b01cd0691164d6",
+          "recovered_sha256": "c1eebc2e40338703567819f1e9b2bf315c7370c021f94bf1d5b01cd0691164d6",
+          "reference": {
+            "hash": "c1eebc2e40338703567819f1"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2546,
+          "store_latency_ms": 0.5106,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "7eec2efdc65b5937c316ef13a6cc811f600a2d14ca1ba5fd5ae88337edf48a2a",
+          "recovered_sha256": "7eec2efdc65b5937c316ef13a6cc811f600a2d14ca1ba5fd5ae88337edf48a2a",
+          "reference": {
+            "hash": "7eec2efdc65b5937c316ef13"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2585,
+          "store_latency_ms": 0.528,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "52cede1dd2972590be53ac1462a1621852ab2234ccc3f420c0f6c2ef34bdb006",
+          "recovered_sha256": "52cede1dd2972590be53ac1462a1621852ab2234ccc3f420c0f6c2ef34bdb006",
+          "reference": {
+            "hash": "52cede1dd2972590be53ac14"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2458,
+          "store_latency_ms": 0.579,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "6ab0d229e82155ce7d0b4a60e0c63dc88654acc7cf754f4d2649e8e1c499ea0b",
+          "recovered_sha256": "6ab0d229e82155ce7d0b4a60e0c63dc88654acc7cf754f4d2649e8e1c499ea0b",
+          "reference": {
+            "hash": "6ab0d229e82155ce7d0b4a60"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2285,
+          "store_latency_ms": 1.0023,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "d1eca89553a2d526b91e0624d0d2a96b66f2bfb2c3773e002485337d20a03b4d",
+          "recovered_sha256": "d1eca89553a2d526b91e0624d0d2a96b66f2bfb2c3773e002485337d20a03b4d",
+          "reference": {
+            "hash": "d1eca89553a2d526b91e0624"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3163,
+          "store_latency_ms": 0.8269,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "e02d70f8fd42fa4c1765a38c0a7068ba2faf8173d42b9236abca9213c120a59e",
+          "recovered_sha256": "e02d70f8fd42fa4c1765a38c0a7068ba2faf8173d42b9236abca9213c120a59e",
+          "reference": {
+            "hash": "e02d70f8fd42fa4c1765a38c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.219,
+          "store_latency_ms": 1.7679,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "7d6a091849b035e231de0399bb51b0a1e5d4b781e1b1c8a1e1c28162324bdf06",
+          "recovered_sha256": "7d6a091849b035e231de0399bb51b0a1e5d4b781e1b1c8a1e1c28162324bdf06",
+          "reference": {
+            "hash": "7d6a091849b035e231de0399"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2352,
+          "store_latency_ms": 13.2187,
+          "system": "headroom",
+          "worker_id": 0
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "6dd22baf643af574254c3a44391752b24f6bd9b8ac841817028f9aa7374a6dae",
+          "recovered_sha256": "6dd22baf643af574254c3a44391752b24f6bd9b8ac841817028f9aa7374a6dae",
+          "reference": {
+            "hash": "6dd22baf643af574254c3a44"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2915,
+          "store_latency_ms": 30.3605,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "49ab776afef82aea8029be24620783cfaad17242a237186b81218526ce159afc",
+          "recovered_sha256": "49ab776afef82aea8029be24620783cfaad17242a237186b81218526ce159afc",
+          "reference": {
+            "hash": "49ab776afef82aea8029be24"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.214,
+          "store_latency_ms": 1.7854,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "3d233284fce5aa1600c08cd11a88d398d31af9dda151bb2eb7f75dcfaa8ef352",
+          "recovered_sha256": "3d233284fce5aa1600c08cd11a88d398d31af9dda151bb2eb7f75dcfaa8ef352",
+          "reference": {
+            "hash": "3d233284fce5aa1600c08cd1"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2893,
+          "store_latency_ms": 1.6507,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "812ad3f54bb7da6d140477b7065f9c4e5fcd6f016c8e11e8edcf2408c37f892d",
+          "recovered_sha256": "812ad3f54bb7da6d140477b7065f9c4e5fcd6f016c8e11e8edcf2408c37f892d",
+          "reference": {
+            "hash": "812ad3f54bb7da6d140477b7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5145,
+          "store_latency_ms": 1.144,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "5bb97c06fc775a0bfced3ebb93659504bcb0ad35ba4385ac56bcb75c01bced82",
+          "recovered_sha256": "5bb97c06fc775a0bfced3ebb93659504bcb0ad35ba4385ac56bcb75c01bced82",
+          "reference": {
+            "hash": "5bb97c06fc775a0bfced3ebb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3473,
+          "store_latency_ms": 0.9019,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "1109034410b03262109e4e52d58a4d374faaa80121c265d5c46b73358c067186",
+          "recovered_sha256": "1109034410b03262109e4e52d58a4d374faaa80121c265d5c46b73358c067186",
+          "reference": {
+            "hash": "1109034410b03262109e4e52"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3682,
+          "store_latency_ms": 1.199,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "9cd4229b8574550f97f720ec89e314f836606c5110cbd779c2066eda4dc4c800",
+          "recovered_sha256": "9cd4229b8574550f97f720ec89e314f836606c5110cbd779c2066eda4dc4c800",
+          "reference": {
+            "hash": "9cd4229b8574550f97f720ec"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4252,
+          "store_latency_ms": 25.0259,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "2012c3138a72f5056f2b372b9620d8a11e3923eef01eddb5a98379d3641a79db",
+          "recovered_sha256": "2012c3138a72f5056f2b372b9620d8a11e3923eef01eddb5a98379d3641a79db",
+          "reference": {
+            "hash": "2012c3138a72f5056f2b372b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3877,
+          "store_latency_ms": 1.2982,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "6c3636e28b5f31a534053dc11ee33c90061aa725cbf0727de7905be7241ca974",
+          "recovered_sha256": "6c3636e28b5f31a534053dc11ee33c90061aa725cbf0727de7905be7241ca974",
+          "reference": {
+            "hash": "6c3636e28b5f31a534053dc1"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4405,
+          "store_latency_ms": 1.0896,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "6ba83b2283d149d2fa3c6899a15f7d3df6adc8bb625d9290a40ab1f63af1fa1a",
+          "recovered_sha256": "6ba83b2283d149d2fa3c6899a15f7d3df6adc8bb625d9290a40ab1f63af1fa1a",
+          "reference": {
+            "hash": "6ba83b2283d149d2fa3c6899"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.398,
+          "store_latency_ms": 1.2994,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "4351e2ba67f65b59b4c553b77e844ba18d77256a258532223269f0423a3f1145",
+          "recovered_sha256": "4351e2ba67f65b59b4c553b77e844ba18d77256a258532223269f0423a3f1145",
+          "reference": {
+            "hash": "4351e2ba67f65b59b4c553b7"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3921,
+          "store_latency_ms": 0.8586,
+          "system": "headroom",
+          "worker_id": 1
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "1eb8f2d35e8e99bb2463f2805990c26412c0f6f76e7c39326ba3550ba92d7408",
+          "recovered_sha256": "1eb8f2d35e8e99bb2463f2805990c26412c0f6f76e7c39326ba3550ba92d7408",
+          "reference": {
+            "hash": "1eb8f2d35e8e99bb2463f280"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3492,
+          "store_latency_ms": 46.0684,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "915c9287dac70cdb61869ac8f50c34db23bf215476dbc6fe7cdc328362312449",
+          "recovered_sha256": "915c9287dac70cdb61869ac8f50c34db23bf215476dbc6fe7cdc328362312449",
+          "reference": {
+            "hash": "915c9287dac70cdb61869ac8"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4273,
+          "store_latency_ms": 2.3966,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "ed584064f6ec00791d18cc627478bd0b4e449f3d848b202fdd33b210190ede23",
+          "recovered_sha256": "ed584064f6ec00791d18cc627478bd0b4e449f3d848b202fdd33b210190ede23",
+          "reference": {
+            "hash": "ed584064f6ec00791d18cc62"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3341,
+          "store_latency_ms": 1.4924,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "d6d32a1abc2d4e8da2c134efbd8a6d5a2d40eeb86a7e2f9e2751c5e5c1dd151e",
+          "recovered_sha256": "d6d32a1abc2d4e8da2c134efbd8a6d5a2d40eeb86a7e2f9e2751c5e5c1dd151e",
+          "reference": {
+            "hash": "d6d32a1abc2d4e8da2c134ef"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3083,
+          "store_latency_ms": 1.1108,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "fe802675bfec17a747df18644257a8f7157edb42a8c23a92295d35d670ffa43f",
+          "recovered_sha256": "fe802675bfec17a747df18644257a8f7157edb42a8c23a92295d35d670ffa43f",
+          "reference": {
+            "hash": "fe802675bfec17a747df1864"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.516,
+          "store_latency_ms": 0.7949,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "44118ec1f48445db6b36e6a01fb3e0bb6bb922e4bf72fce3fc7dcae6c36fc2b6",
+          "recovered_sha256": "44118ec1f48445db6b36e6a01fb3e0bb6bb922e4bf72fce3fc7dcae6c36fc2b6",
+          "reference": {
+            "hash": "44118ec1f48445db6b36e6a0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3275,
+          "store_latency_ms": 0.7736,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "eb6a7057aa20abbc83345f9341715ee773949ba5535d0dcb9ec1ddca5cce0a10",
+          "recovered_sha256": "eb6a7057aa20abbc83345f9341715ee773949ba5535d0dcb9ec1ddca5cce0a10",
+          "reference": {
+            "hash": "eb6a7057aa20abbc83345f93"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3409,
+          "store_latency_ms": 0.7995,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "9763a027cdf2bee0b8d89f2fe53c101e76806b9788c3bc99aa5aeeda51af3e5f",
+          "recovered_sha256": "9763a027cdf2bee0b8d89f2fe53c101e76806b9788c3bc99aa5aeeda51af3e5f",
+          "reference": {
+            "hash": "9763a027cdf2bee0b8d89f2f"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2275,
+          "store_latency_ms": 0.8559,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "1fafabb5285a25e295d00cd4db90840b6b940682b4f05a82dd02752ffd6e32f9",
+          "recovered_sha256": "1fafabb5285a25e295d00cd4db90840b6b940682b4f05a82dd02752ffd6e32f9",
+          "reference": {
+            "hash": "1fafabb5285a25e295d00cd4"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2987,
+          "store_latency_ms": 0.7906,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "5da8ea83104be09fa3d8c7f5d04e27771e7b7ee31ad3b341ed6a680eec9fb9e7",
+          "recovered_sha256": "5da8ea83104be09fa3d8c7f5d04e27771e7b7ee31ad3b341ed6a680eec9fb9e7",
+          "reference": {
+            "hash": "5da8ea83104be09fa3d8c7f5"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2242,
+          "store_latency_ms": 0.8084,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "dcfb17dcf55cd166bf07d011935633a9826410f09224a4032a4bad8d90019f91",
+          "recovered_sha256": "dcfb17dcf55cd166bf07d011935633a9826410f09224a4032a4bad8d90019f91",
+          "reference": {
+            "hash": "dcfb17dcf55cd166bf07d011"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2361,
+          "store_latency_ms": 0.8575,
+          "system": "headroom",
+          "worker_id": 2
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "649f1864bda447ee5f216c9b40e007dd4710c09d97034aad9e213ed6023969fc",
+          "recovered_sha256": "649f1864bda447ee5f216c9b40e007dd4710c09d97034aad9e213ed6023969fc",
+          "reference": {
+            "hash": "649f1864bda447ee5f216c9b"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4106,
+          "store_latency_ms": 18.2436,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "f45e9314c7be1d7dca5b8b357ee8a7cb3961db77892b1a224e5dce5fe09c8cf5",
+          "recovered_sha256": "f45e9314c7be1d7dca5b8b357ee8a7cb3961db77892b1a224e5dce5fe09c8cf5",
+          "reference": {
+            "hash": "f45e9314c7be1d7dca5b8b35"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.7098,
+          "store_latency_ms": 0.51,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "82724755c205d2bd890fe37fdcee33cee16d73bd05427db84f50f1b45750fdc7",
+          "recovered_sha256": "82724755c205d2bd890fe37fdcee33cee16d73bd05427db84f50f1b45750fdc7",
+          "reference": {
+            "hash": "82724755c205d2bd890fe37f"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.5126,
+          "store_latency_ms": 0.4028,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "fd717279c0bf48022b7fef8df6bfc31cc39fa09a6a5325618522be84cd3592c9",
+          "recovered_sha256": "fd717279c0bf48022b7fef8df6bfc31cc39fa09a6a5325618522be84cd3592c9",
+          "reference": {
+            "hash": "fd717279c0bf48022b7fef8d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.4711,
+          "store_latency_ms": 0.3913,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "ca5a7ccb8951b374bcded22d2462f0d8061a24579768aef1af695793993f09d8",
+          "recovered_sha256": "ca5a7ccb8951b374bcded22d2462f0d8061a24579768aef1af695793993f09d8",
+          "reference": {
+            "hash": "ca5a7ccb8951b374bcded22d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.278,
+          "store_latency_ms": 0.4237,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "36a74060869739d726b6bf71cf81e2f469405b27c00ca621edfeaa1a046d814f",
+          "recovered_sha256": "36a74060869739d726b6bf71cf81e2f469405b27c00ca621edfeaa1a046d814f",
+          "reference": {
+            "hash": "36a74060869739d726b6bf71"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2352,
+          "store_latency_ms": 0.519,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "30073a63d8115932ea118005cf64e25b9243e07cbabe32ba7884b2bf7ba9eba3",
+          "recovered_sha256": "30073a63d8115932ea118005cf64e25b9243e07cbabe32ba7884b2bf7ba9eba3",
+          "reference": {
+            "hash": "30073a63d8115932ea118005"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2798,
+          "store_latency_ms": 0.6617,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "3bac9daeb19fbcbd3f24d8e1fbea012e8dceae9d9ab68d63e30bf920e1226cb9",
+          "recovered_sha256": "3bac9daeb19fbcbd3f24d8e1fbea012e8dceae9d9ab68d63e30bf920e1226cb9",
+          "reference": {
+            "hash": "3bac9daeb19fbcbd3f24d8e1"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2274,
+          "store_latency_ms": 0.5081,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "cc62448bf45e140ea58f2b289de64c79618220b5edcaf44c706a874e389d0d9c",
+          "recovered_sha256": "cc62448bf45e140ea58f2b289de64c79618220b5edcaf44c706a874e389d0d9c",
+          "reference": {
+            "hash": "cc62448bf45e140ea58f2b28"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2689,
+          "store_latency_ms": 0.4999,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "f485c8115a9563b93d49b04ee4dcbb89faca55d63150284e0b68e7add364b29f",
+          "recovered_sha256": "f485c8115a9563b93d49b04ee4dcbb89faca55d63150284e0b68e7add364b29f",
+          "reference": {
+            "hash": "f485c8115a9563b93d49b04e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.272,
+          "store_latency_ms": 0.6667,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "990d3f40c2fa09392b31532ef80c29b2f330135c8b700d2a151e4aa940a777b7",
+          "recovered_sha256": "990d3f40c2fa09392b31532ef80c29b2f330135c8b700d2a151e4aa940a777b7",
+          "reference": {
+            "hash": "990d3f40c2fa09392b31532e"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2364,
+          "store_latency_ms": 0.7153,
+          "system": "headroom",
+          "worker_id": 3
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "50da1b53ae77b4506a41b3be0b290555dd3eb78d4dd5e949cc955b90f420b3b8",
+          "recovered_sha256": "50da1b53ae77b4506a41b3be0b290555dd3eb78d4dd5e949cc955b90f420b3b8",
+          "reference": {
+            "hash": "50da1b53ae77b4506a41b3be"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2374,
+          "store_latency_ms": 14.9785,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "313d593e213ecd518a502506c489581f181ec63e9f2b0006fedc0e02d7cbfb76",
+          "recovered_sha256": "313d593e213ecd518a502506c489581f181ec63e9f2b0006fedc0e02d7cbfb76",
+          "reference": {
+            "hash": "313d593e213ecd518a502506"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2948,
+          "store_latency_ms": 0.1853,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "1c119c0804651a78e6d28f4474fb969dbb95b3c28133f84209974eadb8f03f9b",
+          "recovered_sha256": "1c119c0804651a78e6d28f4474fb969dbb95b3c28133f84209974eadb8f03f9b",
+          "reference": {
+            "hash": "1c119c0804651a78e6d28f44"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2448,
+          "store_latency_ms": 0.1572,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "b3d118325757af105ffd3cfbc80b0e5158026dea50830cd22ce9e8aca29c8e96",
+          "recovered_sha256": "b3d118325757af105ffd3cfbc80b0e5158026dea50830cd22ce9e8aca29c8e96",
+          "reference": {
+            "hash": "b3d118325757af105ffd3cfb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2165,
+          "store_latency_ms": 0.1665,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "63097a6266b50689be57eeaba232d59820fb8e0622c535b881d1240c5174c149",
+          "recovered_sha256": "63097a6266b50689be57eeaba232d59820fb8e0622c535b881d1240c5174c149",
+          "reference": {
+            "hash": "63097a6266b50689be57eeab"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2117,
+          "store_latency_ms": 0.2634,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "3cf31d46173f6c50bd8b9e72fc007bd9284686af7cb918937e2dd36213058a83",
+          "recovered_sha256": "3cf31d46173f6c50bd8b9e72fc007bd9284686af7cb918937e2dd36213058a83",
+          "reference": {
+            "hash": "3cf31d46173f6c50bd8b9e72"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.366,
+          "store_latency_ms": 0.3492,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "43c09b9b0a840e2c97c9d5446c742e3cd5ac010dbd8b04f24bde9e2609c27861",
+          "recovered_sha256": "43c09b9b0a840e2c97c9d5446c742e3cd5ac010dbd8b04f24bde9e2609c27861",
+          "reference": {
+            "hash": "43c09b9b0a840e2c97c9d544"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2277,
+          "store_latency_ms": 0.1889,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "7f1830c3666e0b60a53eb89dcbded8e4a56f2dcc8baaeab2e33344d10623ab47",
+          "recovered_sha256": "7f1830c3666e0b60a53eb89dcbded8e4a56f2dcc8baaeab2e33344d10623ab47",
+          "reference": {
+            "hash": "7f1830c3666e0b60a53eb89d"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2447,
+          "store_latency_ms": 0.1775,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "824876e986d392975b9f3a478889f4083ba98d2a9127015f662cf68bb1276ed7",
+          "recovered_sha256": "824876e986d392975b9f3a478889f4083ba98d2a9127015f662cf68bb1276ed7",
+          "reference": {
+            "hash": "824876e986d392975b9f3a47"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2651,
+          "store_latency_ms": 0.2016,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "7eb45b754125b3cc042932b004945246eb1eefa4fe6c9b603cc20382c7df99dd",
+          "recovered_sha256": "7eb45b754125b3cc042932b004945246eb1eefa4fe6c9b603cc20382c7df99dd",
+          "reference": {
+            "hash": "7eb45b754125b3cc042932b0"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2133,
+          "store_latency_ms": 0.1975,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "0ebf6fcb1c75c374617225f492f571cac613f0f43614732a262bbedf1f39783a",
+          "recovered_sha256": "0ebf6fcb1c75c374617225f492f571cac613f0f43614732a262bbedf1f39783a",
+          "reference": {
+            "hash": "0ebf6fcb1c75c374617225f4"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.281,
+          "store_latency_ms": 0.2115,
+          "system": "headroom",
+          "worker_id": 4
+        },
+        {
+          "entry_index": 0,
+          "exact": true,
+          "payload_sha256": "46df3622bd65b9fabaaeb30004e1b9a72774e9c03f5fb2e0a15e5a13c39f3788",
+          "recovered_sha256": "46df3622bd65b9fabaaeb30004e1b9a72774e9c03f5fb2e0a15e5a13c39f3788",
+          "reference": {
+            "hash": "46df3622bd65b9fabaaeb300"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2079,
+          "store_latency_ms": 22.9351,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 1,
+          "exact": true,
+          "payload_sha256": "97b0a53ed55665f4860b2e7084333baf5561038a9de789f7258c1c01911d8dbd",
+          "recovered_sha256": "97b0a53ed55665f4860b2e7084333baf5561038a9de789f7258c1c01911d8dbd",
+          "reference": {
+            "hash": "97b0a53ed55665f4860b2e70"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3276,
+          "store_latency_ms": 0.4348,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 2,
+          "exact": true,
+          "payload_sha256": "2b1596d11595a3675fb99130a6747b6cddb495b838fb5a257a87a712838cd036",
+          "recovered_sha256": "2b1596d11595a3675fb99130a6747b6cddb495b838fb5a257a87a712838cd036",
+          "reference": {
+            "hash": "2b1596d11595a3675fb99130"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2129,
+          "store_latency_ms": 9.5434,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 3,
+          "exact": true,
+          "payload_sha256": "70c85fde887d060ac890810ae59418ce6fed0404fd070b12b7912c59fbc2832a",
+          "recovered_sha256": "70c85fde887d060ac890810ae59418ce6fed0404fd070b12b7912c59fbc2832a",
+          "reference": {
+            "hash": "70c85fde887d060ac890810a"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2357,
+          "store_latency_ms": 1.131,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 4,
+          "exact": true,
+          "payload_sha256": "0693c38ce6aac8468427aa62bbe1435a602404d0f7a553188ee0a1d15e6a1647",
+          "recovered_sha256": "0693c38ce6aac8468427aa62bbe1435a602404d0f7a553188ee0a1d15e6a1647",
+          "reference": {
+            "hash": "0693c38ce6aac8468427aa62"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3288,
+          "store_latency_ms": 1.1304,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 5,
+          "exact": true,
+          "payload_sha256": "1f0c4e3298e6405a8111426a7fa0054ad48b72827293f3415d53f7f06b6c82f0",
+          "recovered_sha256": "1f0c4e3298e6405a8111426a7fa0054ad48b72827293f3415d53f7f06b6c82f0",
+          "reference": {
+            "hash": "1f0c4e3298e6405a8111426a"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2267,
+          "store_latency_ms": 1.4742,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 6,
+          "exact": true,
+          "payload_sha256": "cbde09c4f9f5c0b21a22cefb60987465cc458ba4c9fad4b324d3eb14cafa84d0",
+          "recovered_sha256": "cbde09c4f9f5c0b21a22cefb60987465cc458ba4c9fad4b324d3eb14cafa84d0",
+          "reference": {
+            "hash": "cbde09c4f9f5c0b21a22cefb"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.1952,
+          "store_latency_ms": 1.4922,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 7,
+          "exact": true,
+          "payload_sha256": "31b2c7464260e70cdfe9abae53ef363481893fdb6ca12bcf4b389b404b1d4101",
+          "recovered_sha256": "31b2c7464260e70cdfe9abae53ef363481893fdb6ca12bcf4b389b404b1d4101",
+          "reference": {
+            "hash": "31b2c7464260e70cdfe9abae"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2281,
+          "store_latency_ms": 0.8924,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 8,
+          "exact": true,
+          "payload_sha256": "794a67d58f4612f5a12cb1f2089fa91e463504ae5bd5b499199a7c44de606f33",
+          "recovered_sha256": "794a67d58f4612f5a12cb1f2089fa91e463504ae5bd5b499199a7c44de606f33",
+          "reference": {
+            "hash": "794a67d58f4612f5a12cb1f2"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2078,
+          "store_latency_ms": 0.6736,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 9,
+          "exact": true,
+          "payload_sha256": "c7078eeb3fbcaa40ff75740c5125495d774fccf8c1f99ffc1b7001908e88604f",
+          "recovered_sha256": "c7078eeb3fbcaa40ff75740c5125495d774fccf8c1f99ffc1b7001908e88604f",
+          "reference": {
+            "hash": "c7078eeb3fbcaa40ff75740c"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.3007,
+          "store_latency_ms": 0.7073,
+          "system": "headroom",
+          "worker_id": 5
+        },
+        {
+          "entry_index": 10,
+          "exact": true,
+          "payload_sha256": "790f5a38052471c29b32b31275bf71c88aad9e50c353dcc2d7d7c4d311e7deaf",
+          "recovered_sha256": "790f5a38052471c29b32b31275bf71c88aad9e50c353dcc2d7d7c4d311e7deaf",
+          "reference": {
+            "hash": "790f5a38052471c29b32b312"
+          },
+          "retrieval_error": null,
+          "retrieve_latency_ms": 0.2791,
+          "store_latency_ms": 0.6589,
+          "system": "headroom",
+          "worker_id": 5
+        }
+      ],
+      "state_files": [
+        {
+          "bytes": 86016,
+          "name": "ccr.db"
+        },
+        {
+          "bytes": 32768,
+          "name": "ccr.db-shm"
+        },
+        {
+          "bytes": 1462632,
+          "name": "ccr.db-wal"
+        }
+      ],
+      "system": "headroom",
+      "worker_runs": [
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 0
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 1
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 2
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 3
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 4
+        },
+        {
+          "errors": [],
+          "exit_code": 0,
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "stderr_tail": "",
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "worker_id": 5
+        }
+      ]
+    }
+  },
+  "aggregates": {
+    "entroly": {
+      "exact_entries": 66,
+      "expected_entries": 66,
+      "gates": {
+        "exact_byte_recovery_rate": 1.0,
+        "incorrect_payloads": 0,
+        "restart_recovery_rate": 1.0,
+        "worker_exit_success_rate": 1.0,
+        "write_success_rate": 1.0
+      },
+      "incorrect_payloads": 0,
+      "passed": true,
+      "recovered_entries": 66,
+      "retrieval_errors": 0,
+      "retrieve_latency": {
+        "p50_ms": 0.04175,
+        "p95_ms": 0.049525,
+        "samples_ms": [
+          0.0833,
+          0.0416,
+          0.0395,
+          0.0397,
+          0.0368,
+          0.035,
+          0.0382,
+          0.0388,
+          0.0373,
+          0.0346,
+          0.0354,
+          0.0364,
+          0.0376,
+          0.037,
+          0.0369,
+          0.0369,
+          0.0373,
+          0.0367,
+          0.048,
+          0.0406,
+          0.0384,
+          0.0381,
+          0.0376,
+          0.038,
+          0.0377,
+          0.0376,
+          0.0383,
+          0.0387,
+          0.0366,
+          0.0374,
+          0.0362,
+          0.0368,
+          0.0362,
+          0.0372,
+          0.0381,
+          0.0419,
+          0.0451,
+          0.043,
+          0.0429,
+          0.0452,
+          0.0459,
+          0.044,
+          0.0434,
+          0.0439,
+          0.0463,
+          0.0437,
+          0.0435,
+          0.044,
+          0.0435,
+          0.0471,
+          0.0453,
+          0.0452,
+          0.0458,
+          0.0442,
+          0.0448,
+          0.0487,
+          0.0471,
+          0.046,
+          0.0458,
+          0.0453,
+          0.0458,
+          0.0475,
+          0.0587,
+          0.0498,
+          0.0466,
+          0.0498
+        ]
+      },
+      "state_bytes": 95438,
+      "store_latency": {
+        "p50_ms": 22.60585,
+        "p95_ms": 435.96575,
+        "samples_ms": [
+          756.8916,
+          31.9457,
+          26.3195,
+          21.3376,
+          21.4892,
+          20.1795,
+          24.4327,
+          24.0698,
+          27.3759,
+          21.0612,
+          23.9919,
+          4.5176,
+          19.4612,
+          14.0302,
+          16.1699,
+          19.0585,
+          18.0473,
+          17.0886,
+          21.7615,
+          22.7551,
+          22.0404,
+          437.0441,
+          1065.8275,
+          25.1657,
+          22.2448,
+          21.9547,
+          22.3451,
+          21.262,
+          24.3037,
+          22.4973,
+          19.2318,
+          21.8887,
+          21.278,
+          1324.2337,
+          23.9585,
+          23.8088,
+          24.644,
+          24.8717,
+          25.7179,
+          25.6628,
+          24.8412,
+          20.275,
+          19.2084,
+          23.6255,
+          432.7307,
+          23.3956,
+          24.46,
+          18.1146,
+          19.9577,
+          21.388,
+          23.3045,
+          23.3479,
+          60.0732,
+          24.7266,
+          19.1226,
+          193.6142,
+          19.2241,
+          18.468,
+          22.7144,
+          23.7177,
+          23.2052,
+          16.4987,
+          21.3107,
+          23.1047,
+          21.9651,
+          21.5501
+        ]
+      },
+      "worker_errors": 0,
+      "written_entries": 66
+    },
+    "headroom": {
+      "exact_entries": 66,
+      "expected_entries": 66,
+      "gates": {
+        "exact_byte_recovery_rate": 1.0,
+        "incorrect_payloads": 0,
+        "restart_recovery_rate": 1.0,
+        "worker_exit_success_rate": 1.0,
+        "write_success_rate": 1.0
+      },
+      "incorrect_payloads": 0,
+      "passed": true,
+      "recovered_entries": 66,
+      "retrieval_errors": 0,
+      "retrieve_latency": {
+        "p50_ms": 0.27945,
+        "p95_ms": 0.514025,
+        "samples_ms": [
+          19.3121,
+          0.5125,
+          0.3593,
+          0.2581,
+          0.2546,
+          0.2585,
+          0.2458,
+          0.2285,
+          0.3163,
+          0.219,
+          0.2352,
+          0.2915,
+          0.214,
+          0.2893,
+          0.5145,
+          0.3473,
+          0.3682,
+          0.4252,
+          0.3877,
+          0.4405,
+          0.398,
+          0.3921,
+          0.3492,
+          0.4273,
+          0.3341,
+          0.3083,
+          0.516,
+          0.3275,
+          0.3409,
+          0.2275,
+          0.2987,
+          0.2242,
+          0.2361,
+          0.4106,
+          0.7098,
+          0.5126,
+          0.4711,
+          0.278,
+          0.2352,
+          0.2798,
+          0.2274,
+          0.2689,
+          0.272,
+          0.2364,
+          0.2374,
+          0.2948,
+          0.2448,
+          0.2165,
+          0.2117,
+          0.366,
+          0.2277,
+          0.2447,
+          0.2651,
+          0.2133,
+          0.281,
+          0.2079,
+          0.3276,
+          0.2129,
+          0.2357,
+          0.3288,
+          0.2267,
+          0.1952,
+          0.2281,
+          0.2078,
+          0.3007,
+          0.2791
+        ]
+      },
+      "state_bytes": 1581416,
+      "store_latency": {
+        "p50_ms": 0.7972,
+        "p95_ms": 24.5032,
+        "samples_ms": [
+          25.6792,
+          0.645,
+          0.6693,
+          0.5764,
+          0.5106,
+          0.528,
+          0.579,
+          1.0023,
+          0.8269,
+          1.7679,
+          13.2187,
+          30.3605,
+          1.7854,
+          1.6507,
+          1.144,
+          0.9019,
+          1.199,
+          25.0259,
+          1.2982,
+          1.0896,
+          1.2994,
+          0.8586,
+          46.0684,
+          2.3966,
+          1.4924,
+          1.1108,
+          0.7949,
+          0.7736,
+          0.7995,
+          0.8559,
+          0.7906,
+          0.8084,
+          0.8575,
+          18.2436,
+          0.51,
+          0.4028,
+          0.3913,
+          0.4237,
+          0.519,
+          0.6617,
+          0.5081,
+          0.4999,
+          0.6667,
+          0.7153,
+          14.9785,
+          0.1853,
+          0.1572,
+          0.1665,
+          0.2634,
+          0.3492,
+          0.1889,
+          0.1775,
+          0.2016,
+          0.1975,
+          0.2115,
+          22.9351,
+          0.4348,
+          9.5434,
+          1.131,
+          1.1304,
+          1.4742,
+          1.4922,
+          0.8924,
+          0.6736,
+          0.7073,
+          0.6589
+        ]
+      },
+      "worker_errors": 0,
+      "written_entries": 66
+    }
+  },
+  "claim_gate": {
+    "label": "Both systems satisfy the frozen recovery-integrity gate",
+    "public_leadership_claim_allowed": false,
+    "universal_superiority_claim_allowed": false
+  },
+  "generated_at": "2026-07-14T11:41:05.169041+00:00",
+  "participants": {
+    "entroly": {
+      "package": "entroly",
+      "release_status": "merged source checkout",
+      "runtime": {
+        "implementation_sha256": "58f4b6a482d16d7d2d3ea03738ff3332194b960d41fdad67ec014b7146ebce9a",
+        "platform": "Windows-10-10.0.26200-SP0",
+        "python": "3.10.0"
+      },
+      "version": "1.0.59"
+    },
+    "headroom": {
+      "package": "headroom-ai",
+      "release_status": "published PyPI release",
+      "runtime": {
+        "distribution_record_sha256": "4220e07c6ed4e116badc3c86e8d8e29922a529f73e798b86e759203834b6e349",
+        "platform": "Windows-10-10.0.26200-SP0",
+        "python": "3.10.0"
+      },
+      "version": "0.31.0"
+    }
+  },
+  "payload_sha256": "59bef188abc6eccbba47164fd63f4db9c6b5100696f8c733615109bc371e7f43",
+  "phase": "holdout",
+  "protocol": {
+    "claim_policy": {
+      "aggregate_score_allowed": false,
+      "failures_remain_in_sample": true,
+      "negative_results_are_published": true,
+      "per_dimension_claims_only": true,
+      "universal_superiority_claim_allowed": false
+    },
+    "comparison": {
+      "entroly": "1.0.59 merged source",
+      "headroom": "headroom-ai 0.31.0 / tag v0.31.0 / commit 55efb1c77d5b67f7ad0620372c6256c8b0547591"
+    },
+    "dimensions": [
+      {
+        "evidence": "benchmarks/results/compression_frontier.json",
+        "id": "active_context_quality",
+        "status": "implemented"
+      },
+      {
+        "evidence": "benchmarks/recovery_resilience.py",
+        "id": "recovery_resilience",
+        "status": "implemented"
+      },
+      {
+        "id": "end_to_end_model_recovery",
+        "status": "planned"
+      },
+      {
+        "id": "compression_latency",
+        "status": "planned"
+      },
+      {
+        "id": "provider_protocol_conformance",
+        "status": "planned"
+      },
+      {
+        "id": "interruption_recovery",
+        "status": "planned"
+      },
+      {
+        "id": "security_and_secret_handling",
+        "status": "planned"
+      },
+      {
+        "id": "packaging_and_first_run",
+        "status": "planned"
+      },
+      {
+        "id": "operator_ux_and_diagnostics",
+        "status": "planned"
+      },
+      {
+        "id": "provider_observed_cost",
+        "status": "planned"
+      }
+    ],
+    "frozen_at": "2026-07-14T11:30:00Z",
+    "schema_version": "entroly.competitive-evidence-protocol.v1",
+    "suites": {
+      "recovery_resilience": {
+        "development": {
+          "entries_per_worker": 8,
+          "seed": 20260714,
+          "workers": 4
+        },
+        "development_policy": "Development results may guide implementation and remain visible but cannot support a public leadership claim.",
+        "gates": {
+          "exact_byte_recovery_rate": 1.0,
+          "incorrect_payloads": 0,
+          "restart_recovery_rate": 1.0,
+          "worker_exit_success_rate": 1.0,
+          "write_success_rate": 1.0
+        },
+        "holdout": {
+          "entries_per_worker": 11,
+          "seed": 20260715,
+          "workers": 6
+        },
+        "holdout_policy": "Run once after implementation. A scoped public claim requires the complete holdout matrix and a passing verifier.",
+        "latency_policy": "Report per-system p50 and p95 store/retrieve latency descriptively; correctness gates cannot be traded for speed."
+      }
+    }
+  },
+  "protocol_sha256": "67149234fcff176f63e4663676d77a9bced0f55e83ee8258d7017c9bc65accb0",
+  "schema_version": "entroly.recovery-resilience.v1"
+}

--- a/docs/benchmarks/competitive-evidence-matrix.md
+++ b/docs/benchmarks/competitive-evidence-matrix.md
@@ -1,0 +1,116 @@
+# Competitive evidence matrix
+
+This protocol measures Entroly against the current released Headroom package
+without collapsing unlike properties into a promotional score. Quality,
+recovery, latency, provider behavior, reliability, security, packaging, cost,
+and operator experience are reported separately. A win in one dimension cannot
+hide a loss in another.
+
+The machine-readable source of truth is
+[`benchmarks/competitive_evidence_protocol.json`](../../benchmarks/competitive_evidence_protocol.json).
+Thresholds and holdout parameters are frozen before results are inspected.
+
+## Claim rules
+
+- Preserve every failed, timed-out, missing, and incorrect row.
+- Publish development losses as engineering evidence, not as product wins.
+- Never replace achieved measurements with requested targets.
+- Never claim universal superiority; claims name the system versions, workload,
+  boundary, metric, and caveat.
+- Correctness and data integrity cannot be traded for compression or latency.
+- Provider cost claims require provider-observed usage and immutable pricing or
+  invoice provenance.
+
+## Evaluation dimensions
+
+| Dimension | Required evidence | Current state |
+|---|---|---|
+| Active-context quality | matched caps, exact outputs, paired statistics | implemented |
+| Recovery resilience | restart replay, concurrent writers, exact bytes | implemented |
+| End-to-end model recovery | model-triggered retrieval and final answer | planned |
+| Compression latency | warm/cold p50 and p95 by content type | planned |
+| Provider conformance | Anthropic, OpenAI Chat/Responses, Gemini shapes | planned |
+| Interruption recovery | crash, retry, replay, idempotency | planned |
+| Security | secret logs, marker injection, path and tenant isolation | planned |
+| Packaging and first run | clean install, doctor, wrap, rollback | planned |
+| Operator UX | actionable errors, dashboard truth, recovery steps | planned |
+| Provider-observed cost | paired usage and pricing provenance | planned |
+
+## Recovery-resilience suite
+
+The first suite stresses the local source-of-truth store behind reversible
+compression. Independent processes write unique omitted evidence concurrently,
+exit, and a fresh process attempts to recover every payload by its emitted
+reference.
+
+The development matrix uses four writers with eight entries each. It is allowed
+to reveal defects and guide implementation. The frozen holdout uses six writers
+with eleven entries each and is run only after the repair.
+
+A participant passes only when:
+
+1. every worker exits successfully;
+2. every intended write returns a reference;
+3. a new process recovers every reference after the writers exit;
+4. every recovered payload matches its expected SHA-256; and
+5. no wrong payload is ever returned.
+
+Store and retrieval latency are descriptive. A faster system that loses or
+misroutes one payload fails.
+
+```powershell
+python -m benchmarks.recovery_resilience run `
+  --phase development `
+  --headroom-python C:\path\to\headroom-0.31.0\Scripts\python.exe `
+  --output benchmarks/results/recovery_resilience_development.json
+
+python -m benchmarks.recovery_resilience verify `
+  benchmarks/results/recovery_resilience_holdout.json
+```
+
+The JSON artifact includes the frozen protocol hash, package and implementation
+identities, complete entry matrix, worker errors and exit codes, exact recovered
+hashes, latency samples, state-file sizes, aggregate gates, and a canonical
+payload hash.
+
+## Recorded recovery results
+
+The development run found a real Entroly data-loss bug. With four pre-opened
+writers, only 8 of 32 intended entries survived restart byte-exactly; Headroom
+recovered 32 of 32. Three Entroly workers failed. This unfavorable result is
+retained in
+[`recovery_resilience_development_before.json`](../../benchmarks/results/recovery_resilience_development_before.json).
+
+Entroly then added cross-process read/merge/write serialization, unique durable
+temporary files, file and directory synchronization, stale-reader refresh, and
+process-level regression tests. The frozen holdout was not changed.
+
+On the six-writer, 66-entry Windows/Python 3.10 holdout, Entroly 1.0.59 source
+and the published Headroom 0.31.0 wheel both wrote and recovered 66 of 66
+payloads byte-exactly after restart, with zero incorrect payloads and no worker
+or retrieval errors. Therefore the verifier explicitly disallows a
+recovery-integrity leadership claim.
+
+| Holdout metric | Entroly 1.0.59 source | Headroom 0.31.0 |
+|---|---:|---:|
+| Successful writes | 66 / 66 | 66 / 66 |
+| Byte-exact restart recovery | 66 / 66 | 66 / 66 |
+| Incorrect payloads | 0 | 0 |
+| Store-call p50 / p95 | 22.606 / 435.966 ms | **0.797 / 24.503 ms** |
+| Retrieval p50 / p95 | **0.042 / 0.050 ms** | 0.279 / 0.514 ms |
+| Live state files | **95,438 bytes** | 1,581,416 bytes |
+
+These latency and size observations describe this workload and platform; they
+are not standalone product-superiority claims. Headroom was substantially
+faster for writes. Entroly was faster for retrieval and used less live state.
+Headroom used SQLite WAL with `synchronous=NORMAL`; Entroly fsynced its state
+file on every commit and its parent directory where supported. The suite did
+not simulate machine power loss, so the store-call latency is not a matched
+power-loss-durability comparison.
+The complete samples, environment identities, hashes, and errors are in the
+[`holdout artifact`](../../benchmarks/results/recovery_resilience_holdout.json).
+The post-repair development iterations remain available as
+[`first repair`](../../benchmarks/results/recovery_resilience_development_after.json)
+and
+[`Windows lock optimization`](../../benchmarks/results/recovery_resilience_development_optimized.json)
+evidence.

--- a/entroly/compression_retrieval_store.py
+++ b/entroly/compression_retrieval_store.py
@@ -14,13 +14,16 @@ agent. Explicit retrieval IDs make those debits idempotent across retries.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
+import os
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterator
 
 if TYPE_CHECKING:
     from .optimization_ledger import OptimizationLedger
@@ -140,7 +143,7 @@ class StoredCompression:
 
 
 class CompressionRetrievalStore:
-    """Thread-safe local store with retrieval-adjusted savings accounting."""
+    """Process-safe local store with retrieval-adjusted savings accounting."""
 
     def __init__(
         self,
@@ -152,6 +155,7 @@ class CompressionRetrievalStore:
         self.optimization_ledger = optimization_ledger
         self._items: dict[str, StoredCompression] = {}
         self._lock = threading.RLock()
+        self._disk_signature: tuple[int, int, int] | None = None
         if self.path is not None and self.path.exists():
             self._load()
         if self.optimization_ledger is not None:
@@ -166,6 +170,69 @@ class CompressionRetrievalStore:
                             token_count,
                             retrieval_id=retrieval_id,
                         )
+
+    @property
+    def _lock_path(self) -> Path | None:
+        if self.path is None:
+            return None
+        return self.path.with_name(self.path.name + ".lock")
+
+    @staticmethod
+    def _signature(stat: os.stat_result) -> tuple[int, int, int]:
+        return (int(stat.st_mtime_ns), int(stat.st_size), int(stat.st_ino))
+
+    @contextmanager
+    def _interprocess_lock(self) -> Iterator[None]:
+        """Serialize disk mutations across independent Entroly processes."""
+        lock_path = self._lock_path
+        if lock_path is None:
+            yield
+            return
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as handle:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            if os.name == "nt":
+                import msvcrt
+
+                deadline = time.monotonic() + 30.0
+                delay = 0.001
+                while True:
+                    try:
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                        break
+                    except OSError as error:
+                        if error.errno not in {errno.EACCES, errno.EAGAIN}:
+                            raise
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                f"timed out acquiring recovery-store lock {lock_path}"
+                            ) from error
+                        time.sleep(delay)
+                        delay = min(0.05, delay * 1.5)
+                try:
+                    yield
+                finally:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _refresh_if_changed(self, *, force: bool = False) -> None:
+        if self.path is None or not self.path.exists():
+            return
+        current = self._signature(self.path.stat())
+        if force or current != self._disk_signature:
+            self._load()
 
     def put(
         self,
@@ -211,15 +278,17 @@ class CompressionRetrievalStore:
             metadata={"savings_confidence": "measured", **dict(metadata or {})},
         )
         with self._lock:
-            previous = self._items.get(receipt_id)
-            if previous is not None:
-                return previous
-            self._items[receipt_id] = stored
-            try:
-                self._persist()
-            except Exception:
-                self._items.pop(receipt_id, None)
-                raise
+            with self._interprocess_lock():
+                self._refresh_if_changed(force=True)
+                previous = self._items.get(receipt_id)
+                if previous is not None:
+                    return previous
+                self._items[receipt_id] = stored
+                try:
+                    self._persist()
+                except Exception:
+                    self._items.pop(receipt_id, None)
+                    raise
         self._record_compression(stored)
         return stored
 
@@ -366,20 +435,23 @@ class CompressionRetrievalStore:
             },
         )
         with self._lock:
-            previous = self._items.get(receipt_id)
-            if previous is not None:
-                return previous
-            self._items[receipt_id] = stored
-            try:
-                self._persist()
-            except Exception:
-                self._items.pop(receipt_id, None)
-                raise
+            with self._interprocess_lock():
+                self._refresh_if_changed(force=True)
+                previous = self._items.get(receipt_id)
+                if previous is not None:
+                    return previous
+                self._items[receipt_id] = stored
+                try:
+                    self._persist()
+                except Exception:
+                    self._items.pop(receipt_id, None)
+                    raise
         self._record_compression(stored)
         return stored
 
     def get_receipt(self, receipt_id: str) -> StoredCompression | None:
         with self._lock:
+            self._refresh_if_changed()
             return self._items.get(receipt_id)
 
     def get_span(
@@ -390,6 +462,7 @@ class CompressionRetrievalStore:
         record_retrieval: bool = False,
     ) -> StoredSpan | None:
         with self._lock:
+            self._refresh_if_changed()
             item = self._items.get(receipt_id)
             if item is None:
                 return None
@@ -407,43 +480,50 @@ class CompressionRetrievalStore:
     ) -> StoredSpan | None:
         """Return a span and debit its tokens from measured gross savings."""
         with self._lock:
-            span = self.get_span(receipt_id, span_id, record_retrieval=False)
-            item = self._items.get(receipt_id)
-            if span is None or item is None:
-                return None
-            token_count = _estimate_tokens(span.content)
-            now_ns = time.time_ns()
-            effective_id = retrieval_id or (
-                f"{receipt_id}:{span_id}:{span.retrieval_count + 1}"
-            )
-            if effective_id in span.retrieval_ids:
-                return span
-            previous_span_state = (
-                span.retrieval_count,
-                span.retrieved_tokens,
-                span.last_retrieved_ns,
-                list(span.retrieval_ids),
-            )
-            previous_item_state = (item.retrieval_count, item.last_retrieved_ns)
-            if not span.record_retrieval(
-                tokens=token_count,
-                retrieved_ns=now_ns,
-                retrieval_id=effective_id,
-            ):
-                return span
-            item.retrieval_count += 1
-            item.last_retrieved_ns = now_ns
-            try:
-                self._persist()
-            except Exception:
-                (
+            with self._interprocess_lock():
+                self._refresh_if_changed(force=True)
+                item = self._items.get(receipt_id)
+                if item is None:
+                    return None
+                span = next(
+                    (entry for entry in item.spans if entry.span_id == span_id),
+                    None,
+                )
+                if span is None:
+                    return None
+                token_count = _estimate_tokens(span.content)
+                now_ns = time.time_ns()
+                effective_id = retrieval_id or (
+                    f"{receipt_id}:{span_id}:{span.retrieval_count + 1}"
+                )
+                if effective_id in span.retrieval_ids:
+                    return span
+                previous_span_state = (
                     span.retrieval_count,
                     span.retrieved_tokens,
                     span.last_retrieved_ns,
-                    span.retrieval_ids,
-                ) = previous_span_state
-                item.retrieval_count, item.last_retrieved_ns = previous_item_state
-                raise
+                    list(span.retrieval_ids),
+                )
+                previous_item_state = (item.retrieval_count, item.last_retrieved_ns)
+                if not span.record_retrieval(
+                    tokens=token_count,
+                    retrieved_ns=now_ns,
+                    retrieval_id=effective_id,
+                ):
+                    return span
+                item.retrieval_count += 1
+                item.last_retrieved_ns = now_ns
+                try:
+                    self._persist()
+                except Exception:
+                    (
+                        span.retrieval_count,
+                        span.retrieved_tokens,
+                        span.last_retrieved_ns,
+                        span.retrieval_ids,
+                    ) = previous_span_state
+                    item.retrieval_count, item.last_retrieved_ns = previous_item_state
+                    raise
         self._record_retrieval(
             receipt_id,
             span_id,
@@ -451,6 +531,7 @@ class CompressionRetrievalStore:
             retrieval_id=effective_id,
         )
         return span
+
     def search(
         self,
         query: str,
@@ -461,6 +542,7 @@ class CompressionRetrievalStore:
     ) -> list[StoredSpan]:
         terms = {part.lower() for part in query.split() if len(part) >= 3}
         with self._lock:
+            self._refresh_if_changed()
             scored: list[tuple[int, StoredSpan]] = []
             for item in self._items.values():
                 for span in item.spans:
@@ -485,11 +567,15 @@ class CompressionRetrievalStore:
         return recorded
 
     def realized_savings(self, receipt_id: str) -> dict[str, object] | None:
-        item = self._items.get(receipt_id)
-        return item.savings_record() if item is not None else None
+        with self._lock:
+            self._refresh_if_changed()
+            item = self._items.get(receipt_id)
+            return item.savings_record() if item is not None else None
 
     def realized_savings_summary(self) -> dict[str, object]:
-        records = [item.savings_record() for item in self._items.values()]
+        with self._lock:
+            self._refresh_if_changed()
+            records = [item.savings_record() for item in self._items.values()]
         total = {
             "receipts": len(records),
             "gross_saved_tokens": 0,
@@ -526,6 +612,7 @@ class CompressionRetrievalStore:
 
     def list_receipts(self) -> list[dict[str, object]]:
         with self._lock:
+            self._refresh_if_changed()
             return [
                 {
                     "receipt_id": item.receipt_id,
@@ -550,6 +637,7 @@ class CompressionRetrievalStore:
 
     def savings_summary(self) -> dict[str, int | str]:
         with self._lock:
+            self._refresh_if_changed()
             gross = sum(item.gross_tokens_saved for item in self._items.values())
             retrieved = sum(item.retrieved_tokens for item in self._items.values())
         return {
@@ -601,7 +689,9 @@ class CompressionRetrievalStore:
 
     def _load(self) -> None:
         assert self.path is not None
-        raw = json.loads(self.path.read_text(encoding="utf-8"))
+        with self.path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+            signature = self._signature(os.fstat(handle.fileno()))
         schema_version = int(raw.get("schema_version", 1))
         if schema_version not in {1, 2, 3}:
             raise ValueError(
@@ -666,6 +756,7 @@ class CompressionRetrievalStore:
                 raise ValueError(f"duplicate recovery receipt {stored.receipt_id}")
             loaded[stored.receipt_id] = stored
         self._items = loaded
+        self._disk_signature = signature
 
     def _persist(self) -> None:
         if self.path is None:
@@ -677,13 +768,32 @@ class CompressionRetrievalStore:
                 item.as_dict(include_internal=True) for item in self._items.values()
             ],
         }
-        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        tmp = self.path.with_name(
+            f".{self.path.name}.{os.getpid()}.{threading.get_ident()}."
+            f"{time.time_ns()}.tmp"
+        )
         try:
-            tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-            tmp.replace(self.path)
+            with tmp.open("x", encoding="utf-8", newline="\n") as handle:
+                handle.write(serialized)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, self.path)
+            self._disk_signature = self._signature(self.path.stat())
+            self._sync_parent_directory()
         except Exception:
             tmp.unlink(missing_ok=True)
             raise
+
+    def _sync_parent_directory(self) -> None:
+        """Durably record the atomic rename where the platform permits it."""
+        if self.path is None or os.name == "nt":
+            return
+        descriptor = os.open(self.path.parent, os.O_RDONLY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
 
 
 def _estimate_tokens(text: str) -> int:

--- a/tests/test_compression_retrieval_store.py
+++ b/tests/test_compression_retrieval_store.py
@@ -1,9 +1,95 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+import time
+
 import pytest
 
 from entroly.compression_proxy import compress_proxy_payload, compress_proxy_payload_from_env
 from entroly.compression_retrieval_store import CompressionRetrievalStore
+
+
+_CONCURRENT_WRITER = r"""
+import json
+import sys
+import time
+from pathlib import Path
+
+from entroly.compression_retrieval_store import CompressionRetrievalStore
+
+store_path = Path(sys.argv[1])
+coordination_dir = Path(sys.argv[2])
+worker_id = int(sys.argv[3])
+entries = int(sys.argv[4])
+store = CompressionRetrievalStore(store_path)
+(coordination_dir / f"ready-{worker_id}").write_text("ready", encoding="utf-8")
+start = coordination_dir / "start"
+deadline = time.monotonic() + 30
+while not start.exists():
+    if time.monotonic() >= deadline:
+        raise TimeoutError("test writer timed out waiting for start")
+    time.sleep(0.005)
+
+references = []
+for entry_index in range(entries):
+    payload = (
+        f"worker={worker_id} entry={entry_index}\n"
+        + (f"exact concurrent payload {worker_id}:{entry_index} " * 20).strip()
+    )
+    stored = store.put(
+        original_text=payload,
+        compressed_text="[omitted]",
+        receipt={
+            "original_tokens": len(payload) // 4,
+            "compressed_tokens": 3,
+            "omitted_spans": [{"start_line": 1, "end_line": 2}],
+        },
+    )
+    references.append(
+        {
+            "receipt_id": stored.receipt_id,
+            "span_id": stored.spans[0].span_id,
+            "payload": payload,
+        }
+    )
+(coordination_dir / f"result-{worker_id}.json").write_text(
+    json.dumps(references), encoding="utf-8"
+)
+"""
+
+
+_CONCURRENT_RETRIEVER = r"""
+import sys
+import time
+from pathlib import Path
+
+from entroly.compression_retrieval_store import CompressionRetrievalStore
+
+store_path = Path(sys.argv[1])
+coordination_dir = Path(sys.argv[2])
+worker_id = int(sys.argv[3])
+receipt_id = sys.argv[4]
+span_id = sys.argv[5]
+store = CompressionRetrievalStore(store_path)
+(coordination_dir / f"retrieval-ready-{worker_id}").write_text(
+    "ready", encoding="utf-8"
+)
+start = coordination_dir / "retrieval-start"
+deadline = time.monotonic() + 30
+while not start.exists():
+    if time.monotonic() >= deadline:
+        raise TimeoutError("test retriever timed out waiting for start")
+    time.sleep(0.005)
+span = store.retrieve_span(
+    receipt_id,
+    span_id,
+    retrieval_id=f"concurrent-retrieval-{worker_id}",
+)
+if span is None:
+    raise RuntimeError("stored span disappeared")
+"""
 
 
 def test_retrieval_store_saves_and_fetches_omitted_spans(tmp_path) -> None:
@@ -38,6 +124,132 @@ def test_retrieval_store_saves_and_fetches_omitted_spans(tmp_path) -> None:
     restored_span = restored.get_span(receipt_id, span_id)
     assert restored_span is not None
     assert restored_span.content == span.content
+
+
+def test_long_lived_reader_observes_another_store_commit(tmp_path) -> None:
+    path = tmp_path / "shared.json"
+    reader = CompressionRetrievalStore(path)
+    writer = CompressionRetrievalStore(path)
+    original = "line one\nline two"
+
+    stored = writer.put(
+        original_text=original,
+        compressed_text="[omitted]",
+        receipt={
+            "original_tokens": 4,
+            "compressed_tokens": 2,
+            "omitted_spans": [{"start_line": 1, "end_line": 2}],
+        },
+    )
+
+    observed = reader.get_span(stored.receipt_id, stored.spans[0].span_id)
+    assert observed is not None
+    assert observed.content == original
+
+
+def test_independent_concurrent_writers_preserve_every_payload(tmp_path) -> None:
+    store_path = tmp_path / "shared.json"
+    workers = 4
+    entries = 5
+    processes: list[subprocess.Popen[str]] = []
+    for worker_id in range(workers):
+        processes.append(
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    _CONCURRENT_WRITER,
+                    str(store_path),
+                    str(tmp_path),
+                    str(worker_id),
+                    str(entries),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
+
+    for _attempt in range(600):
+        if len(list(tmp_path.glob("ready-*"))) == workers:
+            break
+        if any(process.poll() is not None for process in processes):
+            break
+        time.sleep(0.01)
+    assert len(list(tmp_path.glob("ready-*"))) == workers
+    (tmp_path / "start").write_text("start", encoding="utf-8")
+
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=30)
+        assert process.returncode == 0, f"stdout={stdout}\nstderr={stderr}"
+
+    restored = CompressionRetrievalStore(store_path)
+    references = []
+    for worker_id in range(workers):
+        references.extend(
+            json.loads(
+                (tmp_path / f"result-{worker_id}.json").read_text(encoding="utf-8")
+            )
+        )
+    assert len(restored.list_receipts()) == workers * entries
+    for reference in references:
+        span = restored.get_span(reference["receipt_id"], reference["span_id"])
+        assert span is not None
+        assert span.content == reference["payload"]
+
+
+def test_independent_retrievers_preserve_every_accounting_debit(tmp_path) -> None:
+    store_path = tmp_path / "shared.json"
+    original = "first line\nsecond line"
+    stored = CompressionRetrievalStore(store_path).put(
+        original_text=original,
+        compressed_text="[omitted]",
+        receipt={
+            "original_tokens": 6,
+            "compressed_tokens": 2,
+            "omitted_spans": [{"start_line": 1, "end_line": 2}],
+        },
+    )
+    workers = 4
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                _CONCURRENT_RETRIEVER,
+                str(store_path),
+                str(tmp_path),
+                str(worker_id),
+                stored.receipt_id,
+                stored.spans[0].span_id,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for worker_id in range(workers)
+    ]
+    for _attempt in range(600):
+        if len(list(tmp_path.glob("retrieval-ready-*"))) == workers:
+            break
+        if any(process.poll() is not None for process in processes):
+            break
+        time.sleep(0.01)
+    assert len(list(tmp_path.glob("retrieval-ready-*"))) == workers
+    (tmp_path / "retrieval-start").write_text("start", encoding="utf-8")
+
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=30)
+        assert process.returncode == 0, f"stdout={stdout}\nstderr={stderr}"
+
+    restored = CompressionRetrievalStore(store_path)
+    span = restored.get_span(stored.receipt_id, stored.spans[0].span_id)
+    receipt = restored.get_receipt(stored.receipt_id)
+    assert span is not None
+    assert receipt is not None
+    assert span.retrieval_count == workers
+    assert len(span.retrieval_ids) == workers
+    assert receipt.retrieval_count == workers
 
 
 def test_retrieval_store_searches_omitted_spans() -> None:

--- a/tests/test_recovery_resilience.py
+++ b/tests/test_recovery_resilience.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks import recovery_resilience as resilience
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _adapter(
+    system: str,
+    *,
+    workers: int,
+    entries_per_worker: int,
+    seed: int,
+    missing: int = 0,
+) -> dict[str, object]:
+    expected = workers * entries_per_worker
+    rows = [
+        {
+            "worker_id": index // entries_per_worker,
+            "entry_index": index % entries_per_worker,
+            "payload_sha256": f"payload-{index}",
+            "recovered_sha256": f"payload-{index}",
+            "exact": True,
+            "store_latency_ms": 1.0,
+            "retrieve_latency_ms": 0.5,
+            "retrieval_error": None,
+        }
+        for index in range(expected - missing)
+    ]
+    return {
+        "system": system,
+        "participant": {
+            "package": system,
+            "version": "1.0.59" if system == "entroly" else "0.31.0",
+        },
+        "configuration": {
+            "workers": workers,
+            "entries_per_worker": entries_per_worker,
+            "seed": seed,
+        },
+        "worker_runs": [
+            {"worker_id": index, "exit_code": 0, "errors": []}
+            for index in range(workers)
+        ],
+        "recovery_open_error": None,
+        "rows": rows,
+        "state_files": [{"name": "state", "bytes": 100}],
+    }
+
+
+def test_protocol_freezes_broad_evidence_program_and_forbids_aggregate_claim() -> None:
+    protocol = resilience._protocol()
+    dimension_ids = {item["id"] for item in protocol["dimensions"]}
+
+    assert protocol["claim_policy"]["aggregate_score_allowed"] is False
+    assert protocol["claim_policy"]["failures_remain_in_sample"] is True
+    assert protocol["claim_policy"]["negative_results_are_published"] is True
+    assert {
+        "active_context_quality",
+        "recovery_resilience",
+        "end_to_end_model_recovery",
+        "compression_latency",
+        "provider_protocol_conformance",
+        "interruption_recovery",
+        "security_and_secret_handling",
+        "packaging_and_first_run",
+        "operator_ux_and_diagnostics",
+        "provider_observed_cost",
+    } <= dimension_ids
+
+
+def test_verified_development_report_never_allows_public_claim() -> None:
+    protocol = resilience._protocol()
+    config = resilience._phase_config(protocol, "development")
+    adapters = [
+        _adapter("entroly", **config),
+        _adapter("headroom", **config),
+    ]
+
+    report = resilience.analyze(
+        protocol=protocol,
+        phase="development",
+        adapters=adapters,
+    )
+
+    resilience.verify_report(report)
+    assert report["claim_gate"]["public_leadership_claim_allowed"] is False
+    assert report["aggregates"]["entroly"]["passed"] is True
+    assert report["aggregates"]["headroom"]["passed"] is True
+
+
+def test_holdout_claim_requires_entroly_pass_and_headroom_failure() -> None:
+    protocol = resilience._protocol()
+    config = resilience._phase_config(protocol, "holdout")
+    report = resilience.analyze(
+        protocol=protocol,
+        phase="holdout",
+        adapters=[
+            _adapter("entroly", **config),
+            _adapter("headroom", **config, missing=1),
+        ],
+    )
+
+    assert report["claim_gate"]["public_leadership_claim_allowed"] is True
+    assert report["claim_gate"]["universal_superiority_claim_allowed"] is False
+
+
+def test_verifier_rejects_payload_tampering() -> None:
+    protocol = resilience._protocol()
+    config = resilience._phase_config(protocol, "development")
+    report = resilience.analyze(
+        protocol=protocol,
+        phase="development",
+        adapters=[
+            _adapter("entroly", **config),
+            _adapter("headroom", **config),
+        ],
+    )
+    tampered = copy.deepcopy(report)
+    tampered["aggregates"]["entroly"]["exact_entries"] -= 1
+
+    with pytest.raises(ValueError, match="payload_sha256 mismatch"):
+        resilience.verify_report(tampered)
+
+
+def test_committed_holdout_is_current_verified_and_scoped_in_readme() -> None:
+    report = json.loads(
+        (ROOT / "benchmarks/results/recovery_resilience_holdout.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    resilience.verify_report(report)
+    current_implementation = resilience._canonical_source_sha256(
+        (
+            Path(resilience.__file__).resolve(),
+            ROOT / "entroly/compression_retrieval_store.py",
+        )
+    )
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert (
+        report["participants"]["entroly"]["runtime"]["implementation_sha256"]
+        == current_implementation
+    )
+    assert report["aggregates"]["entroly"]["exact_entries"] == 66
+    assert report["aggregates"]["headroom"]["exact_entries"] == 66
+    assert report["claim_gate"]["public_leadership_claim_allowed"] is False
+    assert "it does not establish recovery superiority" in readme
+    assert "original failing artifact" in readme


### PR DESCRIPTION
## Summary

- prevent independent Entroly processes from clobbering recovery receipts or retrieval accounting by serializing read/merge/write commits
- refresh stale readers, use unique fsynced temporary files, atomically replace the store, and fsync the parent directory where supported
- add a frozen, version-pinned Entroly-vs-Headroom recovery-resilience runner with complete raw artifacts and tamper verification
- publish the mixed result without an aggregate score or universal claim

## Evidence

The development run exposed the bug rather than hiding it: Entroly recovered 8/32 intended payloads after restart while published Headroom 0.31.0 recovered 32/32. Three Entroly workers failed.

After the repair, the untouched six-writer holdout recorded:

| Metric | Entroly 1.0.59 source | Headroom 0.31.0 |
|---|---:|---:|
| Byte-exact restart recovery | 66/66 | 66/66 |
| Incorrect payloads | 0 | 0 |
| Store-call p50 | 22.606 ms | 0.797 ms |
| Retrieval p50 | 0.042 ms | 0.279 ms |
| Live state | 95,438 bytes | 1,581,416 bytes |

Both systems pass the integrity gate, so the verifier explicitly forbids a recovery-integrity leadership claim. Headroom remains substantially faster for store calls in this Windows/Python 3.10 workload. Headroom used SQLite WAL with `synchronous=NORMAL`; Entroly fsynced its state file on every commit and its parent directory where supported. The suite did not simulate machine power loss, so this is not a matched power-loss-durability comparison.

## Validation

- `python -m pytest -q` — 1,901 passed, 48 skipped, 1 xfailed
- focused recovery consumers — 61 passed
- benchmark/store contract — 14 passed
- `python -m ruff check ...` — passed
- pre-push Rust gate — clippy passed; 531 library tests passed
- holdout payload SHA-256: `59bef188abc6eccbba47164fd63f4db9c6b5100696f8c733615109bc371e7f43`

## Compatibility and risk

The on-disk JSON schema remains version 3. A persistent one-byte `.lock` sidecar is added for process coordination. Lock acquisition is bounded to 30 seconds on Windows and reports an actionable timeout instead of silently dropping data.