### PR TITLE
feat(openclaw): auto-discover trusted context budgets

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/.mcpb-build/manifest.json
+++ b/.mcpb-build/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "entroly",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Open-source context control plane for AI coding agents. Compresses prompts 70-95%, stabilizes KV-cache prefixes, routes tasks to cheaper models, and verifies answers locally with WITNESS.",
   "author": {
     "name": "juyterman1000",

--- a/README.md
+++ b/README.md
@@ -576,9 +576,13 @@ OpenClaw remains the conversation and agent runtime. Attach Entroly as its conte
 The OpenClaw context-engine plugin keeps context assembly separate from provider
 routing. The same assembly path can be used with OpenAI, Anthropic, Gemini,
 Nemotron, OpenRouter, Ollama, and custom routes because OpenClaw owns routing
-and authentication and supplies the resolved prompt budget. Entroly preserves
-opaque provider blocks and delegates `/compact` and overflow recovery back to
-OpenClaw.
+and authentication. Its resolved prompt budget is authoritative; when an older
+or degraded host omits that value, Entroly can derive a conservative input
+ceiling from verified, operator-supplied, or explicitly discovered model
+metadata. Unknown and announced limits fail safely instead of being guessed.
+The receipt binds the discovery trust, registry digest, source, output reserve,
+and safety margin to the assembly decision. Entroly preserves opaque provider
+blocks and delegates `/compact` and overflow recovery back to OpenClaw.
 
 The beta OpenClaw context engine scores older messages against the current
 request. Matching evidence is pinned verbatim when it fits a bounded reserve;

--- a/docs/context-control-plane.md
+++ b/docs/context-control-plane.md
@@ -7,9 +7,12 @@ provider, model, authentication, failover, normalized messages, and prompt
 budget. Entroly transforms only eligible unsigned text before each model call.
 Signed text, thinking blocks, images, tool calls, tool-result identifiers and
 metadata, provider signatures, message metadata, and recent turns remain
-exact. Eligible unsigned text inside an older tool result may be compressed. If
-OpenClaw cannot provide a finite budget and the operator has not configured a
-fallback, Entroly returns the original context with an actionable diagnostic.
+exact. Eligible unsigned text inside an older tool result may be compressed.
+If OpenClaw cannot provide a finite budget, Entroly may derive a conservative
+input ceiling from verified, operator-supplied, or explicitly discovered model
+metadata. Announced and unknown limits are refused. If neither trusted discovery
+nor an operator fallback is available, Entroly returns the original context with
+an actionable diagnostic.
 
 OpenClaw receipts do not persist the plaintext request, matched query terms, or
 reversible per-term digests; they retain only lengths and counts. Append-only

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "1.0.60"
+version = "1.0.61"
 dependencies = [
  "entroly-qccr",
  "flate2",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.60"
+version = "1.0.61"
 dependencies = [
  "regex",
  "serde",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "1.0.60"
+version = "1.0.61"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=1.0.60"
+python -m pip install --no-cache-dir -U "entroly-core>=1.0.61"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/model_registry.json
+++ b/entroly-core/model_registry.json
@@ -208,7 +208,11 @@
     {
       "id": "anthropic/claude-opus-4.6",
       "provider": "anthropic",
-      "aliases": ["claude-opus-4-6", "claude-opus-4.6"],
+      "aliases": [
+        "anthropic/claude-opus-4-6",
+        "claude-opus-4-6",
+        "claude-opus-4.6"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "1.0.60"
+version = "1.0.61"
 description = "Rust core for Entroly: Context Receipts, deterministic ingestion/ranking, dependency audits, and local context optimization"
 readme = "README.md"
 license = "Apache-2.0"

--- a/entroly-qccr/Cargo.lock
+++ b/entroly-qccr/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.60"
+version = "1.0.61"
 dependencies = [
  "regex",
  "regex-lite",

--- a/entroly-qccr/Cargo.toml
+++ b/entroly-qccr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-qccr"
-version = "1.0.60"
+version = "1.0.61"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.60"
+version = "1.0.61"
 dependencies = [
  "regex-lite",
  "serde",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "1.0.60"
+version = "1.0.61"
 dependencies = [
  "entroly-qccr",
  "flate2",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "1.0.60"
+version = "1.0.61"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-wasm",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Pure WebAssembly local context OS for AI agents: context receipts, local optimization, MCP, app SDK helpers, and no Python dependency.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "1.0.60"
+__version__ = "1.0.61"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -51,7 +51,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "1.0.60"
+    __version__ = "1.0.61"
 
 from entroly.config import (
     load_active_tuning_config as _load_active_tuning_config,
@@ -3189,7 +3189,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.60\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.61\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -4707,7 +4707,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.60\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.61\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -4750,7 +4750,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.60\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.61\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -69,7 +69,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "1.0.60"
+    version: str = "1.0.61"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/models/registry.json
+++ b/entroly/models/registry.json
@@ -208,7 +208,11 @@
     {
       "id": "anthropic/claude-opus-4.6",
       "provider": "anthropic",
-      "aliases": ["claude-opus-4-6", "claude-opus-4.6"],
+      "aliases": [
+        "anthropic/claude-opus-4-6",
+        "claude-opus-4-6",
+        "claude-opus-4.6"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -7,7 +7,7 @@ from importlib import metadata
 from types import ModuleType
 
 
-MIN_ENTROLY_CORE_VERSION = "1.0.60"
+MIN_ENTROLY_CORE_VERSION = "1.0.61"
 QCCR_SYMBOLS = (
     "py_qccr_expand_query",
     "py_qccr_rank_files",

--- a/entroly/npm-alias/package.json
+++ b/entroly/npm-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Node/WASM Entroly runtime: local context optimization, MCP server tools, receipts, recovery, and verification without Python.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "dependencies": {
-    "entroly-wasm": "1.0.60"
+    "entroly-wasm": "1.0.61"
   },
   "repository": {
     "type": "git",

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-mcp",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "mcpName": "io.github.juyterman1000/entroly",
   "description": "NPX MCP bridge for Entroly, the local context OS with receipts, recovery, verification, and token optimization for AI coding agents.",
   "main": "index.js",

--- a/entroly/openclaw_bridge.py
+++ b/entroly/openclaw_bridge.py
@@ -29,6 +29,7 @@ PROVIDER_MODE = "openclaw_managed"
 _BUDGET_SOURCES = {
     "openclaw_token_budget",
     "openclaw_runtime_settings",
+    "entroly_model_registry",
     "operator_fallback",
 }
 DEFAULT_RECEIPT_MAX_FILES = 512
@@ -353,6 +354,11 @@ def _runtime_audit_metadata(request: dict[str, Any]) -> dict[str, Any]:
     runtime = raw.get("runtime") if isinstance(raw.get("runtime"), dict) else {}
     model = raw.get("model") if isinstance(raw.get("model"), dict) else {}
     limits = raw.get("limits") if isinstance(raw.get("limits"), dict) else {}
+    discovery = (
+        raw.get("context_discovery")
+        if isinstance(raw.get("context_discovery"), dict)
+        else {}
+    )
     resolved = _bounded_text(model.get("resolved"), 256)
     if resolved is None:
         resolved = _bounded_text(request.get("model"), 256)
@@ -378,6 +384,114 @@ def _runtime_audit_metadata(request: dict[str, Any]) -> dict[str, Any]:
                 limits.get("max_output_tokens")
             ),
         },
+        "context_discovery": {
+            "status": _bounded_text(discovery.get("status"), 32),
+            "trust": _bounded_text(discovery.get("trust"), 32),
+            "model_id": _bounded_text(discovery.get("model_id"), 256),
+            "exact": discovery.get("exact") if isinstance(discovery.get("exact"), bool) else None,
+            "context_window": _positive_int_or_none(discovery.get("context_window")),
+            "output_reserve_tokens": _positive_int_or_none(
+                discovery.get("output_reserve_tokens")
+            ),
+            "safety_tokens": _positive_int_or_none(discovery.get("safety_tokens")),
+            "registry_digest": _bounded_text(discovery.get("registry_digest"), 64),
+            "source": _bounded_text(discovery.get("source"), 512),
+        },
+    }
+
+
+def _resolve_context_budget(request: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a safe prompt budget from trusted, local model metadata.
+
+    This is a fallback for OpenClaw hosts that cannot provide a finite prompt
+    budget. It never accepts announced or generic fallback metadata and never
+    enables remote discovery by itself. Remote discovery remains an explicit
+    Entroly operator opt-in through the model-registry environment controls.
+    """
+    model = _bounded_text(request.get("model"), 256)
+    if model is None:
+        return {
+            "schema_version": BRIDGE_SCHEMA,
+            "ok": True,
+            "status": "unavailable",
+            "warning": "OpenClaw did not identify the active model route.",
+        }
+
+    from .models.registry import RegistryTrust, resolve_model
+
+    resolution = resolve_model(model)
+    capability = resolution.capability
+    accepted_trust = {
+        RegistryTrust.VERIFIED,
+        RegistryTrust.USER,
+        RegistryTrust.DISCOVERED,
+    }
+    if (
+        capability is None
+        or capability.context_window is None
+        or resolution.trust not in accepted_trust
+    ):
+        return {
+            "schema_version": BRIDGE_SCHEMA,
+            "ok": True,
+            "status": "unavailable",
+            "model": model,
+            "trust": resolution.trust.value,
+            "warning": resolution.warning
+            or (
+                f"Model metadata for {model!r} is {resolution.trust.value}; "
+                "Entroly requires verified, user-supplied, or directly discovered limits."
+            ),
+            "registry_digest": resolution.registry_digest,
+        }
+
+    context_window = capability.context_window
+    requested_output = _positive_int_or_none(request.get("requested_output_tokens"))
+    if requested_output is not None:
+        output_reserve = requested_output
+        if capability.max_output_tokens is not None:
+            output_reserve = min(output_reserve, capability.max_output_tokens)
+    elif capability.max_output_tokens is not None:
+        output_reserve = capability.max_output_tokens
+    else:
+        # Unknown output limits must not turn the native context window into an
+        # input budget. Reserve 10% (at least 4K) in addition to the 5% safety
+        # margin used below.
+        output_reserve = max(4096, math.ceil(context_window * 0.10))
+
+    safety_tokens = max(512, math.ceil(context_window * 0.05))
+    token_budget = context_window - output_reserve - safety_tokens
+    if token_budget < 1024:
+        return {
+            "schema_version": BRIDGE_SCHEMA,
+            "ok": True,
+            "status": "unavailable",
+            "model": model,
+            "trust": resolution.trust.value,
+            "warning": "Trusted model limits leave less than 1,024 prompt tokens after reserves.",
+            "registry_digest": resolution.registry_digest,
+        }
+
+    return {
+        "schema_version": BRIDGE_SCHEMA,
+        "ok": True,
+        "status": "resolved",
+        "token_budget": token_budget,
+        "budget_source": "entroly_model_registry",
+        "requested_model": model,
+        "model_id": capability.id,
+        "provider": capability.provider,
+        "trust": resolution.trust.value,
+        "exact": resolution.exact,
+        "context_window": context_window,
+        "max_output_tokens": capability.max_output_tokens,
+        "output_reserve_tokens": output_reserve,
+        "safety_tokens": safety_tokens,
+        "registry_digest": resolution.registry_digest,
+        "base_registry_digest": resolution.base_registry_digest,
+        "source": capability.source,
+        "verified_at": capability.verified_at,
+        "observed_at": capability.observed_at,
     }
 
 
@@ -932,8 +1046,15 @@ def _write_receipt(
         "budget_source": budget_source,
         "budget_authority": (
             "openclaw"
-            if budget_source
-            in {"openclaw_token_budget", "openclaw_runtime_settings"}
+            if budget_source in {"openclaw_token_budget", "openclaw_runtime_settings"}
+            else (
+                "entroly_verified_registry"
+                if runtime_metadata["context_discovery"]["trust"] == "verified"
+                else "operator_registry"
+                if runtime_metadata["context_discovery"]["trust"] == "user"
+                else "local_discovery"
+            )
+            if budget_source == "entroly_model_registry"
             else "operator"
         ),
         "token_budget": request.get("token_budget"),
@@ -1163,6 +1284,12 @@ def assemble(request: dict[str, Any]) -> dict[str, Any]:
             "OpenClaw did not provide a finite prompt budget; Entroly used the "
             "operator-configured fallbackTokenBudget."
         )
+    elif budget_source == "entroly_model_registry":
+        warnings.append(
+            "OpenClaw did not provide a finite prompt budget; Entroly derived a "
+            "conservative input ceiling from trusted model metadata and recorded "
+            "its provenance."
+        )
     evidence: dict[int, dict[str, Any]] = {}
     protected_indexes = {
         index for index, message in enumerate(messages) if _protected_message(message)
@@ -1266,6 +1393,7 @@ def assemble(request: dict[str, Any]) -> dict[str, Any]:
     pinned_indexes = sorted(
         index for index, item in evidence.items() if item.get("evidence_pinned")
     )
+    discovery_metadata = runtime_metadata["context_discovery"]
     return {
         "schema_version": BRIDGE_SCHEMA,
         "ok": True,
@@ -1282,6 +1410,12 @@ def assemble(request: dict[str, Any]) -> dict[str, Any]:
         "provider_mode": PROVIDER_MODE,
         "provider_independent": True,
         "budget_source": budget_source,
+        "context_discovery_status": discovery_metadata["status"],
+        "context_discovery_trust": discovery_metadata["trust"],
+        "context_discovery_model": discovery_metadata["model_id"],
+        "context_window": discovery_metadata["context_window"],
+        "context_output_reserve": discovery_metadata["output_reserve_tokens"],
+        "context_safety_tokens": discovery_metadata["safety_tokens"],
         "model": runtime_metadata["model"]["resolved"],
         "provider_hint": runtime_metadata["model"]["provider"],
         "assembly_strategy": strategy,
@@ -1325,8 +1459,11 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
             "provider_mode": PROVIDER_MODE,
             "provider_independent": True,
             "requires_host_token_budget": True,
+            "supports_context_budget_discovery": True,
             "receipt_commit_protocol": "two_phase",
         }
+    if operation == "resolve_context_budget":
+        return _resolve_context_budget(request)
     if operation == "assemble":
         return assemble(request)
     if operation == "commit_receipt":

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.60"
+version = "1.0.61"
 
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, HTTP proxy, and Python SDK."
 readme = "README.md"
@@ -42,14 +42,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.60,<2",
+    "entroly-core>=1.0.61,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.60,<2",
+    "entroly-core>=1.0.61,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -5061,7 +5061,7 @@ def main():
     try:
         from entroly import __version__ as _version
     except Exception:
-        _version = "1.0.60"
+        _version = "1.0.61"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -68,10 +68,22 @@ local JSONL bridge before inviting users onto the Gateway. The plugin requires
 the Entroly 1.0.57 bridge v2 protocol; doctor reports an actionable upgrade
 instead of accepting an older, incompatible Python installation.
 
-OpenClaw's resolved prompt token budget is authoritative. Entroly never guesses
-a context window from the provider name. For a custom model whose limit
-OpenClaw cannot resolve, configure that model's context window in OpenClaw or
-set an explicit operator-approved fallback:
+OpenClaw's resolved prompt token budget is authoritative. When an older or
+degraded host cannot provide one, Entroly automatically resolves a conservative
+input ceiling from its model registry. Only `verified`, operator-supplied
+`user`, or explicitly `discovered` metadata is accepted; announced and unknown
+records are rejected. The receipt records the model id, trust state, registry
+digest, native window, output reserve, safety reserve, and source.
+
+Context-budget discovery is local and enabled by default. It does not enable
+remote provider discovery or send credentials anywhere. Local Ollama/LM Studio
+and remote OpenRouter discovery remain separate operator opt-ins through
+Entroly's model-registry environment controls. Disable this fallback with
+`autoDiscoverContextBudget: false`.
+
+For a custom model that neither OpenClaw nor trusted registry metadata can
+resolve, configure the model in OpenClaw, provide an `ENTROLY_MODEL_REGISTRY`
+override, or set an explicit last-resort fallback:
 
 ```json5
 {
@@ -83,8 +95,10 @@ set an explicit operator-approved fallback:
 }
 ```
 
-Without either budget, Entroly returns the exact original context with an
-actionable warning instead of risking a provider overflow.
+Without any trusted budget, Entroly returns the exact original context with an
+actionable warning instead of risking a provider overflow. Explicit OpenClaw
+budgets always win, followed by the operator's `fallbackTokenBudget`; automatic
+registry discovery is used only when neither is available.
 
 ## Reproduce the evidence-pinning control
 

--- a/integrations/openclaw/engine.js
+++ b/integrations/openclaw/engine.js
@@ -42,6 +42,9 @@ function statusSnapshot(status) {
     "tokens_saved",
     "evidence_pinned",
     "evidence_pin_blocked",
+    "context_window",
+    "context_output_reserve",
+    "context_safety_tokens",
   ];
   const booleanFields = ["changed", "provider_independent"];
   const stringFields = [
@@ -49,6 +52,9 @@ function statusSnapshot(status) {
     "receipt_id",
     "provider_mode",
     "budget_source",
+    "context_discovery_status",
+    "context_discovery_trust",
+    "context_discovery_model",
     "model",
     "provider_hint",
     "assembly_strategy",
@@ -127,6 +133,7 @@ function resolveAssemblyRuntime({ tokenBudget, model, runtimeSettings, fallbackT
       prompt_token_budget: runtimeBudget ?? null,
       max_output_tokens: positiveInteger(runtimeSettings?.limits?.maxOutputTokens) ?? null,
     },
+    context_discovery: null,
   };
 
   if (explicitBudget !== undefined) {
@@ -158,6 +165,80 @@ function resolveAssemblyRuntime({ tokenBudget, model, runtimeSettings, fallbackT
     budgetSource: "missing",
     model: resolvedModel,
     runtimeMetadata,
+  };
+}
+
+function validateContextBudgetDiscovery(result) {
+  if (!result || result.ok !== true || result.schema_version !== ENTROLY_BRIDGE_SCHEMA) {
+    throw new Error("Entroly bridge returned an invalid context-discovery response");
+  }
+  if (result.status === "unavailable") {
+    return {
+      available: false,
+      metadata: {
+        status: "unavailable",
+        trust: boundedString(result.trust, 32),
+        model_id: boundedString(result.model, 256),
+        exact: null,
+        context_window: null,
+        output_reserve_tokens: null,
+        safety_tokens: null,
+        registry_digest: boundedString(result.registry_digest, 64),
+        source: null,
+      },
+      warning: safeDiagnostic(result.warning ?? "trusted model metadata was unavailable"),
+    };
+  }
+  if (result.status !== "resolved" || result.budget_source !== "entroly_model_registry") {
+    throw new Error("Entroly bridge returned an unknown context-discovery state");
+  }
+  const tokenBudget = positiveInteger(result.token_budget);
+  const contextWindow = positiveInteger(result.context_window);
+  const outputReserve = positiveInteger(result.output_reserve_tokens);
+  const safetyTokens = positiveInteger(result.safety_tokens);
+  const trust = boundedString(result.trust, 32);
+  const modelId = boundedString(result.model_id, 256);
+  const registryDigest = boundedString(result.registry_digest, 64);
+  if (
+    tokenBudget === undefined ||
+    tokenBudget < 1024 ||
+    contextWindow === undefined ||
+    outputReserve === undefined ||
+    safetyTokens === undefined ||
+    !["verified", "user", "discovered"].includes(trust) ||
+    modelId === null ||
+    registryDigest === null ||
+    !/^[0-9a-f]{64}$/.test(registryDigest) ||
+    tokenBudget + outputReserve + safetyTokens > contextWindow
+  ) {
+    throw new Error("Entroly bridge returned unsafe context-discovery limits");
+  }
+  return {
+    available: true,
+    tokenBudget,
+    metadata: {
+      status: "resolved",
+      trust,
+      model_id: modelId,
+      exact: result.exact === true,
+      context_window: contextWindow,
+      output_reserve_tokens: outputReserve,
+      safety_tokens: safetyTokens,
+      registry_digest: registryDigest,
+      source: boundedString(result.source, 512),
+    },
+  };
+}
+
+function applyDiscoveredBudget(runtime, discovery) {
+  return {
+    ...runtime,
+    tokenBudget: discovery.tokenBudget,
+    budgetSource: "entroly_model_registry",
+    runtimeMetadata: {
+      ...runtime.runtimeMetadata,
+      context_discovery: discovery.metadata,
+    },
   };
 }
 
@@ -295,6 +376,14 @@ export function formatEntrolyStatus(status) {
     `Estimated reduction: ${reduction}% (${saved.toLocaleString()} tokens)`,
     `Changed: ${status.changed ? "yes" : "no"}`,
   ];
+  if (status.context_discovery_status === "resolved") {
+    lines.splice(
+      3,
+      0,
+      `Context discovery: ${status.context_discovery_trust ?? "trusted"} metadata for ${status.context_discovery_model ?? "active model"}`,
+      `Discovered window: ${(status.context_window ?? 0).toLocaleString()} tokens (${(status.context_output_reserve ?? 0).toLocaleString()} output reserve + ${(status.context_safety_tokens ?? 0).toLocaleString()} safety reserve)`,
+    );
+  }
   if (status.receipt_id) lines.push(`Receipt: ${boundedString(status.receipt_id, 160)}`);
   if (status.warnings?.length) {
     lines.push(`Warnings: ${status.warnings.map((warning) => safeDiagnostic(warning)).join(" | ")}`);
@@ -390,12 +479,39 @@ export function createEntrolyContextEngine({
         throw error;
       }
       const sourceMessages = messages;
-      const assemblyRuntime = resolveAssemblyRuntime({
+      let assemblyRuntime = resolveAssemblyRuntime({
         tokenBudget,
         model,
         runtimeSettings,
         fallbackTokenBudget: config.fallbackTokenBudget,
       });
+      if (
+        assemblyRuntime.tokenBudget === undefined &&
+        config.autoDiscoverContextBudget !== false &&
+        assemblyRuntime.model
+      ) {
+        try {
+          const discovery = validateContextBudgetDiscovery(
+            await bridge.request({
+              operation: "resolve_context_budget",
+              model: assemblyRuntime.model,
+              provider_hint: assemblyRuntime.runtimeMetadata.model.provider,
+              requested_output_tokens:
+                assemblyRuntime.runtimeMetadata.limits.max_output_tokens,
+            }),
+          );
+          if (discovery.available) {
+            assemblyRuntime = applyDiscoveredBudget(assemblyRuntime, discovery);
+          } else {
+            assemblyRuntime.runtimeMetadata.context_discovery = discovery.metadata;
+            logger.warn?.(`entroly: context auto-discovery unavailable: ${discovery.warning}`);
+          }
+        } catch (error) {
+          logger.warn?.(
+            `entroly: context auto-discovery failed safely: ${safeDiagnostic(error)}`,
+          );
+        }
+      }
       const preserveLastN = positiveInteger(config.preserveLastN) ?? 4;
       let systemPromptAddition;
       try {
@@ -419,6 +535,18 @@ export function createEntrolyContextEngine({
           provider_mode: PROVIDER_MODE,
           provider_independent: true,
           budget_source: assemblyRuntime.budgetSource,
+          context_discovery_status:
+            assemblyRuntime.runtimeMetadata.context_discovery?.status,
+          context_discovery_trust:
+            assemblyRuntime.runtimeMetadata.context_discovery?.trust,
+          context_discovery_model:
+            assemblyRuntime.runtimeMetadata.context_discovery?.model_id,
+          context_window:
+            assemblyRuntime.runtimeMetadata.context_discovery?.context_window,
+          context_output_reserve:
+            assemblyRuntime.runtimeMetadata.context_discovery?.output_reserve_tokens,
+          context_safety_tokens:
+            assemblyRuntime.runtimeMetadata.context_discovery?.safety_tokens,
         });
         return {
           messages: sourceMessages,
@@ -430,7 +558,7 @@ export function createEntrolyContextEngine({
       if (assemblyRuntime.tokenBudget === undefined) {
         return failOpen(
           new Error(
-            "OpenClaw did not provide a positive prompt token budget; configure the model context window or plugins.entries.entroly.config.fallbackTokenBudget",
+            "OpenClaw did not provide a positive prompt token budget and Entroly could not resolve trusted model metadata; configure the model context window or plugins.entries.entroly.config.fallbackTokenBudget",
           ),
         );
       }

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -32,6 +32,10 @@
         "minimum": 1024,
         "maximum": 4000000
       },
+      "autoDiscoverContextBudget": {
+        "type": "boolean",
+        "default": true
+      },
       "receiptDir": {
         "type": "string",
         "minLength": 1
@@ -77,7 +81,11 @@
     },
     "fallbackTokenBudget": {
       "label": "Fallback Prompt Token Budget",
-      "help": "Optional operator-approved budget used only when OpenClaw cannot resolve a finite model prompt budget."
+      "help": "Operator-approved budget used when OpenClaw cannot provide one. It takes precedence over automatic registry discovery."
+    },
+    "autoDiscoverContextBudget": {
+      "label": "Auto-discover Context Budget",
+      "help": "When OpenClaw omits a budget, resolve a conservative input ceiling from verified, user-supplied, or explicitly discovered model metadata. No remote discovery is enabled automatically."
     },
     "receiptDir": {
       "label": "Receipt Directory",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-openclaw",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Provider-independent, auditable context optimization for every OpenClaw model route",
   "type": "module",
   "license": "Apache-2.0",

--- a/integrations/openclaw/test/engine.test.js
+++ b/integrations/openclaw/test/engine.test.js
@@ -269,6 +269,131 @@ test("explicit host budget wins and an operator fallback is opt-in", async () =>
   assert.equal(requests[1].budget_source, "operator_fallback");
 });
 
+test("missing host budget auto-discovers a trusted model ceiling", async () => {
+  const requests = [];
+  const messages = [{ role: "user", content: "use the active model safely" }];
+  const engine = createTestEngine({
+    bridge: {
+      request: async (request) => {
+        requests.push(request);
+        if (request.operation === "resolve_context_budget") {
+          return {
+            schema_version: ENTROLY_BRIDGE_SCHEMA,
+            ok: true,
+            status: "resolved",
+            token_budget: 170000,
+            budget_source: "entroly_model_registry",
+            model_id: "openai/o1",
+            trust: "verified",
+            exact: true,
+            context_window: 200000,
+            output_reserve_tokens: 20000,
+            safety_tokens: 10000,
+            registry_digest: "a".repeat(64),
+            source: "https://platform.openai.com/docs/models",
+          };
+        }
+        return {
+          schema_version: ENTROLY_BRIDGE_SCHEMA,
+          ok: true,
+          messages,
+          estimated_tokens: 8,
+          source_tokens: 8,
+          tokens_saved: 0,
+          changed: false,
+          budget_source: request.budget_source,
+          context_discovery_status: "resolved",
+          context_discovery_trust: "verified",
+          context_discovery_model: "openai/o1",
+          context_window: 200000,
+          context_output_reserve: 20000,
+          context_safety_tokens: 10000,
+        };
+      },
+      dispose: async () => {},
+    },
+  });
+
+  const result = await engine.assemble({
+    sessionId: "auto-budget",
+    messages,
+    model: "openai/o1",
+  });
+
+  assert.equal(result.promptAuthority, "assembled");
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].operation, "resolve_context_budget");
+  assert.equal(requests[0].model, "openai/o1");
+  assert.equal(requests[1].operation, "assemble");
+  assert.equal(requests[1].token_budget, 170000);
+  assert.equal(requests[1].budget_source, "entroly_model_registry");
+  assert.equal(requests[1].openclaw_runtime.context_discovery.trust, "verified");
+  assert.equal(engine.getStatus("auto-budget").context_window, 200000);
+});
+
+test("an explicit operator fallback outranks automatic model discovery", async () => {
+  const requests = [];
+  const messages = [{ role: "user", content: "keep this exact" }];
+  const engine = createTestEngine({
+    bridge: {
+      request: async (request) => {
+        requests.push(request);
+        return {
+          schema_version: ENTROLY_BRIDGE_SCHEMA,
+          ok: true,
+          messages,
+          estimated_tokens: 4,
+          budget_source: request.budget_source,
+        };
+      },
+      dispose: async () => {},
+    },
+    config: { fallbackTokenBudget: 4096 },
+    logger: { warn: () => {} },
+  });
+
+  await engine.assemble({ sessionId: "fallback-after-discovery", messages, model: "future/model" });
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].operation, "assemble");
+  assert.equal(requests[0].token_budget, 4096);
+  assert.equal(requests[0].budget_source, "operator_fallback");
+  assert.equal(requests[0].openclaw_runtime.context_discovery, null);
+});
+
+test("malformed discovery fails open without forwarding context to the bridge", async () => {
+  const messages = [{ role: "user", content: "do not guess" }];
+  let calls = 0;
+  const engine = createTestEngine({
+    bridge: {
+      request: async () => {
+        calls += 1;
+        return {
+          schema_version: ENTROLY_BRIDGE_SCHEMA,
+          ok: true,
+          status: "resolved",
+          token_budget: 999999,
+          budget_source: "entroly_model_registry",
+          model_id: "bad/model",
+          trust: "verified",
+          context_window: 1000,
+          output_reserve_tokens: 100,
+          safety_tokens: 100,
+          registry_digest: "c".repeat(64),
+        };
+      },
+      dispose: async () => {},
+    },
+    logger: { warn: () => {} },
+  });
+
+  const result = await engine.assemble({ sessionId: "bad-discovery", messages, model: "bad/model" });
+
+  assert.strictEqual(result.messages, messages);
+  assert.equal(result.promptAuthority, "preassembly_may_overflow");
+  assert.equal(calls, 1);
+});
+
 test("missing host budget fails open without calling the bridge", async () => {
   const messages = [{ role: "user", content: "never guess my model window" }];
   const warnings = [];

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -2,13 +2,13 @@
 
 The formula in this directory is the canonical source. To make `brew tap juyterman1000/entroly && brew install entroly` work, the formula must live in a separate repo named `juyterman1000/homebrew-entroly`.
 
-Current release example version: `1.0.60`.
+Current release example version: `1.0.61`.
 
 ## Release checklist
 
 1. Copy `packaging/homebrew/entroly.rb` into `juyterman1000/homebrew-entroly/Formula/entroly.rb`.
-2. Set `VER=1.0.60` when preparing this release.
-3. Download the matching PyPI sdist: `entroly-1.0.60.tar.gz`.
+2. Set `VER=1.0.61` when preparing this release.
+3. Download the matching PyPI sdist: `entroly-1.0.61.tar.gz`.
 4. Recalculate the `sha256` for that tarball before publishing the Homebrew tap update.
 5. Verify locally before pushing with `brew install --build-from-source ./Formula/entroly.rb`, `brew test entroly`, and `brew audit --new --strict entroly`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.60"
+version = "1.0.61"
 description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, and SDK helpers."
 readme = "PYPI_README.md"
 license = "Apache-2.0"
@@ -42,14 +42,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.60,<2",
+    "entroly-core>=1.0.61,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.60,<2",
+    "entroly-core>=1.0.61,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/juyterman1000/entroly",
     "source": "github"
   },
-  "version": "1.0.60",
+  "version": "1.0.61",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "entroly",
-      "version": "1.0.60",
+      "version": "1.0.61",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -24,7 +24,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "entroly-mcp",
-      "version": "1.0.60",
+      "version": "1.0.61",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/tests/test_openclaw_bridge.py
+++ b/tests/test_openclaw_bridge.py
@@ -87,7 +87,123 @@ def test_health_contract():
         "provider_mode": "openclaw_managed",
         "provider_independent": True,
         "requires_host_token_budget": True,
+        "supports_context_budget_discovery": True,
         "receipt_commit_protocol": "two_phase",
+    }
+
+
+def test_context_budget_discovery_uses_verified_metadata_and_reserves_output():
+    result = handle_request(
+        {
+            "operation": "resolve_context_budget",
+            "model": "openai/gpt-5.6-sol",
+        }
+    )
+
+    assert result["status"] == "resolved"
+    assert result["budget_source"] == "entroly_model_registry"
+    assert result["trust"] == "verified"
+    assert result["model_id"] == "openai/gpt-5.6-sol"
+    assert result["context_window"] == 1_050_000
+    assert result["output_reserve_tokens"] == 128_000
+    assert result["safety_tokens"] == 52_500
+    assert result["token_budget"] == 869_500
+    assert len(result["registry_digest"]) == 64
+    assert result["source"].startswith("https://")
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-opus-4-6",
+        "google/gemini-2.5-pro",
+        "nvidia/nemotron-3-ultra-550b-a55b",
+    ],
+)
+def test_context_budget_discovery_resolves_verified_openclaw_routes(model):
+    result = handle_request(
+        {"operation": "resolve_context_budget", "model": model}
+    )
+
+    assert result["status"] == "resolved"
+    assert result["trust"] == "verified"
+    assert result["token_budget"] >= 1024
+    assert (
+        result["token_budget"]
+        + result["output_reserve_tokens"]
+        + result["safety_tokens"]
+        <= result["context_window"]
+    )
+
+
+def test_context_budget_discovery_refuses_unknown_and_announced_limits():
+    unknown = handle_request(
+        {"operation": "resolve_context_budget", "model": "private/model-x"}
+    )
+    announced = handle_request(
+        {"operation": "resolve_context_budget", "model": "gpt-4o-mini"}
+    )
+
+    assert unknown["status"] == "unavailable"
+    assert unknown["trust"] == "fallback"
+    assert "token_budget" not in unknown
+    assert announced["status"] == "unavailable"
+    assert announced["trust"] == "announced"
+    assert "token_budget" not in announced
+
+
+def test_discovered_context_budget_provenance_is_bound_into_receipt(tmp_path):
+    discovery = handle_request(
+        {
+            "operation": "resolve_context_budget",
+            "model": "openai/gpt-5.6-sol",
+            "requested_output_tokens": 32_000,
+        }
+    )
+    messages = [{"role": "user", "content": "Explain the current context."}]
+    result = assemble(
+        {
+            "operation": "assemble",
+            "session_id": "auto-discovery",
+            "messages": messages,
+            "token_budget": discovery["token_budget"],
+            "budget_source": discovery["budget_source"],
+            "receipt_dir": str(tmp_path),
+            "receipt_commit_challenge_sha256": _RECEIPT_COMMIT_CHALLENGE,
+            "openclaw_runtime": {
+                "model": {"resolved": "openai/gpt-5.6-sol", "provider": "openai"},
+                "limits": {"max_output_tokens": 32_000},
+                "context_discovery": {
+                    "status": discovery["status"],
+                    "trust": discovery["trust"],
+                    "model_id": discovery["model_id"],
+                    "exact": discovery["exact"],
+                    "context_window": discovery["context_window"],
+                    "output_reserve_tokens": discovery["output_reserve_tokens"],
+                    "safety_tokens": discovery["safety_tokens"],
+                    "registry_digest": discovery["registry_digest"],
+                    "source": discovery["source"],
+                },
+            },
+        }
+    )
+
+    assert result["context_discovery_status"] == "resolved"
+    assert result["context_discovery_trust"] == "verified"
+    assert result["context_window"] == 1_050_000
+    receipt = _commit_and_read_receipt(result, workspace_dir=Path.cwd())
+    assert receipt["budget_authority"] == "entroly_verified_registry"
+    assert receipt["openclaw_runtime"]["context_discovery"] == {
+        "status": "resolved",
+        "trust": "verified",
+        "model_id": "openai/gpt-5.6-sol",
+        "exact": True,
+        "context_window": 1_050_000,
+        "output_reserve_tokens": 32_000,
+        "safety_tokens": 52_500,
+        "registry_digest": discovery["registry_digest"],
+        "source": discovery["source"],
     }
 
 

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-RELEASE_VERSION = "1.0.60"
+RELEASE_VERSION = "1.0.61"
 HOMEBREW_FORMULA_VERSION = "1.0.58"
 HOMEBREW_FORMULA_SHA256 = "f2d561e7316cf12c07ffffadeff0b8f26368538564d776eee86b4b76a896959e"
 CANONICAL_MCP_NAME = "io.github.juyterman1000/entroly"
@@ -66,7 +66,7 @@ def _read_project_metadata(path: str) -> dict[str, object]:
     return metadata
 
 
-def test_public_package_versions_are_1_0_60() -> None:
+def test_public_package_versions_are_1_0_61() -> None:
     assert _read_project_metadata("pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_project_metadata("entroly/pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_json("entroly/npm/package.json")["version"] == RELEASE_VERSION
@@ -79,6 +79,7 @@ def test_public_package_versions_are_1_0_60() -> None:
 
 def test_openclaw_install_metadata_identifies_clawhub_target() -> None:
     package = _read_json("integrations/openclaw/package.json")
+    manifest = _read_json("integrations/openclaw/openclaw.plugin.json")
     openclaw = package["openclaw"]
     install = openclaw["install"]
 
@@ -87,6 +88,11 @@ def test_openclaw_install_metadata_identifies_clawhub_target() -> None:
     assert install["npmSpec"] == package["name"]
     assert install["defaultChoice"] == "npm"
     assert install["minHostVersion"] == openclaw["compat"]["pluginApi"]
+    discovery = manifest["configSchema"]["properties"]["autoDiscoverContextBudget"]
+    assert discovery == {"type": "boolean", "default": True}
+    assert "No remote discovery is enabled automatically" in manifest["uiHints"][
+        "autoDiscoverContextBudget"
+    ]["help"]
 
 
 def test_mcp_registry_manifest_points_at_release_package() -> None:


### PR DESCRIPTION
## Summary

- Auto-discover a conservative OpenClaw prompt budget from Entroly's trusted model registry when the host does not provide one.
- Preserve deterministic precedence: OpenClaw runtime limit, operator fallback, trusted registry, then exact fail-open passthrough.
- Record discovery trust, model identity, registry digest, reserves, and budget authority in status and receipts.
- Add the OpenClaw `anthropic/claude-opus-4-6` route alias and cover trusted, rejected, disabled, fallback, and integration paths.
- Synchronize release metadata to `1.0.61` across the governed Python, Rust, npm, WASM, MCP, and OpenClaw surfaces.

## Why

OpenClaw can route through many providers without always supplying a prompt-token budget. Entroly previously had to rely on a fixed fallback or skip optimization. This change uses only sufficiently trusted local registry evidence, keeps explicit operator limits authoritative, and preserves the original context exactly whenever discovery is unavailable or untrusted.

## Safety and release behavior

- Remote registry discovery is not enabled implicitly.
- Announced, fallback, missing, and unknown model metadata cannot authorize compression.
- Discovery output is validated again at the JavaScript boundary, including trust, digest, positive limits, and reserve arithmetic.
- The Homebrew formula remains pinned to the last live PyPI artifact; its checksum/version should advance only after `1.0.61` is published.

## Validation

- `python -m pytest tests/test_openclaw_bridge.py tests/test_model_registry.py tests/test_release_surface.py -q` — 71 passed, 2 skipped
- `python -m pytest tests/test_release_surface.py tests/test_bump_version.py -q` — 19 passed
- OpenClaw Node/Python integration suite — 27 passed
- `npm test`, `npm run check`, and `npm run pack:check`
- `cargo test --lib` — 531 passed
- `cargo clippy --lib -- -D warnings`
- ClawHub package validation — pass, 0 warnings, 0 issues
- Minimum-supported OpenClaw host install/import smoke
- Python sdist/wheel build and `twine check`
- `python scripts/verify_readme.py` — 31 passed
- `git diff --check`
- Pre-push ruff, clippy, and Rust test hooks passed

A monolithic local `python -m pytest tests -q --tb=short` run exceeded the 15-minute wrapper timeout and was terminated without a final result. It produced no failure output before termination, so this is recorded as inconclusive rather than a pass; the focused functional, packaging, and pre-push gates above passed.