### PR TITLE
fix(ci): trust scoped Homebrew automation merges

### DIFF
--- a/.github/workflows/commit-identity-guard.yml
+++ b/.github/workflows/commit-identity-guard.yml
@@ -26,7 +26,7 @@ jobs:
           EXPECTED_ACCOUNT_EMAIL: fastrunner10090@gmail.com
         run: |
           python - <<'PY'
-          import json, os, subprocess, sys
+          import json, os, re, subprocess, sys
           from pathlib import Path
 
           expected_login = os.environ["EXPECTED_LOGIN"]
@@ -67,12 +67,101 @@ jobs:
                   or email.endswith("+web-flow@users.noreply.github.com")
               )
 
+          def git_output(*args: str) -> str:
+              return subprocess.check_output(["git", *args], text=True)
+
+          def trusted_homebrew_automation_author(
+              commit: str,
+              author_name: str,
+              author_email: str,
+              committer_name: str,
+              committer_email: str,
+          ) -> bool:
+              # A release workflow opens the Homebrew PR with GITHUB_TOKEN.
+              # GitHub attributes the resulting squash commit to its Actions
+              # bot even though the owner reviewed and merged it. Keep this
+              # exception narrow enough that it cannot authorize general bot
+              # commits or hide unrelated release changes.
+              if event_name != "push" or event.get("ref") != "refs/heads/main":
+                  return False
+              if event.get("sender", {}).get("login") != expected_login:
+                  return False
+              if (
+                  author_name != "github-actions[bot]"
+                  or author_email
+                  != "41898282+github-actions[bot]@users.noreply.github.com"
+                  or not github_service_committer(committer_name, committer_email)
+              ):
+                  return False
+
+              parents = git_output("rev-list", "--parents", "-n", "1", commit).split()
+              if len(parents) != 2:
+                  return False
+
+              message = git_output("show", "-s", "--format=%B", commit)
+              lines = message.splitlines()
+              if not lines:
+                  return False
+              subject_match = re.fullmatch(
+                  r"Update Homebrew formula for (\d+\.\d+\.\d+) \(#\d+\)",
+                  lines[0],
+              )
+              if not subject_match:
+                  return False
+              coauthor_emails = {
+                  match.group(1)
+                  for line in lines[1:]
+                  if (
+                      match := re.fullmatch(
+                          r"Co-authored-by: .+ <([^<>]+)>", line, re.IGNORECASE
+                      )
+                  )
+              }
+              if owner_emails.isdisjoint(coauthor_emails):
+                  return False
+
+              changed_paths = set(
+                  git_output(
+                      "diff-tree", "--no-commit-id", "--name-only", "-r", commit
+                  ).splitlines()
+              )
+              if changed_paths != {
+                  "packaging/homebrew/entroly.rb",
+                  "tests/test_release_surface.py",
+              }:
+                  return False
+
+              version = subject_match.group(1)
+              formula = git_output(
+                  "show", f"{commit}:packaging/homebrew/entroly.rb"
+              )
+              release_test = git_output(
+                  "show", f"{commit}:tests/test_release_surface.py"
+              )
+              formula_sha = re.search(
+                  r'^\s*sha256 "([0-9a-f]{64})"$', formula, re.MULTILINE
+              )
+              test_sha = re.search(
+                  r'^HOMEBREW_FORMULA_SHA256 = "([0-9a-f]{64})"$',
+                  release_test,
+                  re.MULTILINE,
+              )
+              return bool(
+                  f"entroly-{version}.tar.gz" in formula
+                  and f'HOMEBREW_FORMULA_VERSION = "{version}"' in release_test
+                  and formula_sha
+                  and test_sha
+                  and formula_sha.group(1) == test_sha.group(1)
+              )
+
           failures = []
           for row in rows.strip("\x1e\n").split("\x1e"):
               if not row:
                   continue
               commit, an, ae, cn, ce = row.split("\x1f")
-              if not owner_identity(an, ae):
+              if not owner_identity(an, ae) and not trusted_homebrew_automation_author(
+                  commit, an, ae, cn, ce
+              ):
                   failures.append(f"{commit[:12]} author is {an} <{ae}>")
               if not owner_identity(cn, ce) and not github_service_committer(cn, ce):
                   failures.append(f"{commit[:12]} committer is {cn} <{ce}>")

--- a/tests/test_commit_identity_guard.py
+++ b/tests/test_commit_identity_guard.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "commit-identity-guard.yml"
+OWNER_EMAIL = "208309368+juyterman1000@users.noreply.github.com"
+BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+
+def _guard_script() -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    marker = "          python - <<'PY'\n"
+    script = workflow.split(marker, 1)[1].split("\n          PY", 1)[0]
+    return textwrap.dedent(script)
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _identity_env(
+    *, author_name: str, author_email: str, committer_name: str, committer_email: str
+) -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": author_name,
+        "GIT_AUTHOR_EMAIL": author_email,
+        "GIT_COMMITTER_NAME": committer_name,
+        "GIT_COMMITTER_EMAIL": committer_email,
+    }
+
+
+def _write_release_files(repo: Path, version: str, sha256: str) -> None:
+    formula = repo / "packaging" / "homebrew" / "entroly.rb"
+    release_test = repo / "tests" / "test_release_surface.py"
+    formula.parent.mkdir(parents=True, exist_ok=True)
+    release_test.parent.mkdir(parents=True, exist_ok=True)
+    formula.write_text(
+        "\n".join(
+            (
+                "class Entroly < Formula",
+                f'  url "https://files.pythonhosted.org/packages/source/e/entroly/entroly-{version}.tar.gz"',
+                f'  sha256 "{sha256}"',
+                "end",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    release_test.write_text(
+        "\n".join(
+            (
+                f'HOMEBREW_FORMULA_VERSION = "{version}"',
+                f'HOMEBREW_FORMULA_SHA256 = "{sha256}"',
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+
+def _init_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _write_release_files(repo, "1.0.60", "a" * 64)
+    _git(repo, "add", ".")
+    owner = _identity_env(
+        author_name="juyterman1000",
+        author_email=OWNER_EMAIL,
+        committer_name="juyterman1000",
+        committer_email=OWNER_EMAIL,
+    )
+    _git(repo, "commit", "-m", "Release baseline", env=owner)
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def _homebrew_bot_commit(
+    repo: Path,
+    *,
+    include_owner_trailer: bool = True,
+    include_unrelated_path: bool = False,
+) -> str:
+    _write_release_files(repo, "1.0.61", "b" * 64)
+    if include_unrelated_path:
+        (repo / "README.md").write_text("unexpected\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    args = ["commit", "-m", "Update Homebrew formula for 1.0.61 (#141)"]
+    if include_owner_trailer:
+        args.extend(["-m", f"Co-authored-by: juyterman1000 <{OWNER_EMAIL}>"])
+    bot = _identity_env(
+        author_name="github-actions[bot]",
+        author_email=BOT_EMAIL,
+        committer_name="GitHub",
+        committer_email="noreply@github.com",
+    )
+    _git(repo, *args, env=bot)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _run_guard(
+    repo: Path,
+    tmp_path: Path,
+    *,
+    event_name: str,
+    event: dict[str, object],
+) -> subprocess.CompletedProcess[str]:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+    env = {
+        **os.environ,
+        "EXPECTED_LOGIN": "juyterman1000",
+        "EXPECTED_NOREPLY_EMAIL": OWNER_EMAIL,
+        "EXPECTED_ACCOUNT_EMAIL": "fastrunner10090@gmail.com",
+        "GITHUB_EVENT_NAME": event_name,
+        "GITHUB_EVENT_PATH": str(event_path),
+    }
+    return subprocess.run(
+        [sys.executable, "-c", _guard_script()],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _push_event(before: str, after: str, *, sender: str = "juyterman1000") -> dict[str, object]:
+    return {
+        "before": before,
+        "after": after,
+        "ref": "refs/heads/main",
+        "sender": {"login": sender},
+    }
+
+
+def test_owner_merged_homebrew_automation_commit_is_allowed(tmp_path: Path) -> None:
+    repo, before = _init_repo(tmp_path)
+    after = _homebrew_bot_commit(repo)
+
+    result = _run_guard(
+        repo,
+        tmp_path,
+        event_name="push",
+        event=_push_event(before, after),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Commit identity OK" in result.stdout
+
+
+def test_homebrew_automation_commit_cannot_change_an_unrelated_path(tmp_path: Path) -> None:
+    repo, before = _init_repo(tmp_path)
+    after = _homebrew_bot_commit(repo, include_unrelated_path=True)
+
+    result = _run_guard(
+        repo,
+        tmp_path,
+        event_name="push",
+        event=_push_event(before, after),
+    )
+
+    assert result.returncode == 1
+    assert "author is github-actions[bot]" in result.stdout
+
+
+def test_homebrew_automation_commit_requires_owner_coauthor(tmp_path: Path) -> None:
+    repo, before = _init_repo(tmp_path)
+    after = _homebrew_bot_commit(repo, include_owner_trailer=False)
+
+    result = _run_guard(
+        repo,
+        tmp_path,
+        event_name="push",
+        event=_push_event(before, after),
+    )
+
+    assert result.returncode == 1
+    assert "author is github-actions[bot]" in result.stdout
+
+
+def test_homebrew_automation_commit_requires_owner_triggered_main_push(tmp_path: Path) -> None:
+    repo, before = _init_repo(tmp_path)
+    after = _homebrew_bot_commit(repo)
+
+    result = _run_guard(
+        repo,
+        tmp_path,
+        event_name="push",
+        event=_push_event(before, after, sender="github-actions[bot]"),
+    )
+
+    assert result.returncode == 1
+    assert "author is github-actions[bot]" in result.stdout
+
+
+def test_bot_author_exception_is_never_used_for_pull_requests(tmp_path: Path) -> None:
+    repo, before = _init_repo(tmp_path)
+    after = _homebrew_bot_commit(repo)
+    event = {
+        "pull_request": {
+            "base": {"sha": before},
+            "head": {"sha": after},
+        }
+    }
+
+    result = _run_guard(
+        repo,
+        tmp_path,
+        event_name="pull_request",
+        event=event,
+    )
+
+    assert result.returncode == 1
+    assert "author is github-actions[bot]" in result.stdout


### PR DESCRIPTION
## Summary

- allow the repository Homebrew release bot as a commit author only for an owner-triggered squash merge to `main`
- require the exact two generated release files, canonical versioned subject, owner co-author trailer, matching formula/test version, and matching SHA-256
- keep all pull-request bot authors and unrelated bot changes rejected
- execute the real inline workflow script in hermetic git-repository tests

## Why

GitHub attributes squash merges of the release-generated Homebrew PR to `github-actions[bot]`. The guard therefore marked successful release synchronization merges red even after their PR matrix passed. This preserves the guard while removing that false failure.

## Validation

- `python -m pytest tests/test_commit_identity_guard.py -q` (5 passed)
- `python -m pytest tests/test_release_surface.py -q` (13 passed)
- `python -m ruff check tests/test_commit_identity_guard.py`
- pre-push: ruff, clippy, 531 Rust tests