### PR TITLE
feat(discovery): make Entroly easier to find

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "description": "Token-saving proxy and context compression engine for AI coding agents. 38 supported tools, MCP-native, deterministic Rust core.",
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",

--- a/.mcpb-build/manifest.json
+++ b/.mcpb-build/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "entroly",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "description": "Open-source context control plane for AI coding agents. Compresses prompts 70-95%, stabilizes KV-cache prefixes, routes tasks to cheaper models, and verifies answers locally with WITNESS.",
   "author": {
     "name": "juyterman1000",

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -2,12 +2,15 @@
   <img src="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/entroly_wordmark.svg" width="760" alt="Entroly">
 </p>
 
+<h1 align="center">Entroly — Auditable Context Engineering for AI Agents</h1>
+
 <p align="center"><b>Know exactly what your AI agent saw.</b></p>
 
-Entroly is a local context control plane for AI coding agents. It selects the
-highest-value evidence under a token budget, records what was selected and
-omitted, keeps compressed context recoverable, and produces verifiable Context
-Commits and receipts.
+Entroly is an open-source, auditable context engineering control plane for AI
+agents. It selects the highest-value evidence under a token budget, compresses
+selected context when useful, records what was selected and omitted, keeps
+compressed context recoverable, and produces verifiable Context Commits and
+receipts.
 
 ## Install
 
@@ -44,8 +47,8 @@ image by default. For the installed Python runtime in an interactive shell, use
 `ENTROLY_NO_DOCKER=1 entroly serve` on macOS/Linux or set
 `ENTROLY_NO_DOCKER=1` in the client environment.
 
-Entroly works with GitHub Copilot in VS Code, Claude Code, Cursor, Windsurf,
-Cline, Continue, Zed, and other MCP-compatible clients.
+Entroly works with Claude Code, Codex, OpenClaw, GitHub Copilot in VS Code,
+Cursor, Windsurf, Cline, Continue, Zed, and other MCP-compatible clients.
 
 ### GitHub Copilot / VS Code
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
   <img src="docs/assets/entroly_wordmark.svg" width="820" alt="Entroly">
 </p>
 
+<h1 align="center">Entroly — Auditable Context Engineering for AI Agents</h1>
+
 <p align="center"><b>Know exactly what your AI agent saw.</b><br>
 Entroly creates replayable <b>Context Commits</b>: content-addressed proof of the evidence selected, omitted, and kept recoverable for each model request.</p>
 
 <p align="center">
-  <sub>Integrates with Cursor, Claude Code, Codex, Aider, OpenClaw, MCP clients, and custom provider applications. Choose the supported setup path for your client.</sub>
+  <sub>Integrates with Claude Code, Codex, OpenClaw, GitHub Copilot, Cursor, Aider, MCP clients, and custom provider applications. Choose the supported setup path for your client.</sub>
 </p>
 
 <p align="center">
-  <sub>Auditable context control plane · receipt-producing selection paths record what was used, what was omitted, and residual risks · local-first · Python with optional Rust acceleration · Node/WASM runtime</sub>
+  <sub>Context selection + recoverable compression · receipts record what was used, omitted, and risky · local-first · Python with optional Rust acceleration · Node/WASM runtime</sub>
 </p>
 
 <!-- Distribution and licensing: registry badges report live package metadata. -->
@@ -60,7 +62,7 @@ Entroly creates replayable <b>Context Commits</b>: content-addressed proof of th
 
 ## What it does
 
-Entroly is an auditable context control plane for AI agents. It decides what context to send, records what it left out, and produces a receipt you can inspect before trusting a hard multi-file answer.
+Entroly is an open-source, auditable context engineering control plane for AI agents. It decides what context to send, compresses selected evidence when useful, records what it left out, and produces a receipt you can inspect before trusting a hard multi-file answer.
 
 **OpenClaw runs the agents and conversations. Entroly controls, remembers, verifies, and proves the context those agents received.** The same boundary applies to Claude Code and Codex: Entroly augments the agent you already use instead of becoming another chat client.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,20 +9,20 @@
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Entroly — Context Engineering Engine for AI Coding Agents</title>
+  <title>Entroly — Auditable Context Engineering for AI Agents</title>
   <meta name="description"
-    content="Your AI sees only a slice of your codebase and can hallucinate the rest. Entroly helps with context compression and evidence checks. Works with Cursor, Claude Code, Windsurf, and Cline.">
+    content="Auditable context engineering for AI agents: select evidence, compress context, recover omissions, emit receipts, and verify answers with MCP integrations.">
   <meta name="keywords"
-    content="context engineering, AI coding, token optimization, context window, Cursor, Claude Code, Windsurf, Cline, AI hallucination, code context, LLM context, token savings, MCP server, AI developer tools, context compression">
-  <meta property="og:title" content="Entroly — Local Context OS for AI Coding Agents">
+    content="context engineering, AI agents, AI coding agents, context compression, context optimization, context management, context window, token optimization, MCP server, Model Context Protocol, Claude Code, Codex, OpenClaw, GitHub Copilot, Cursor, hallucination detection">
+  <meta property="og:title" content="Entroly — Auditable Context Engineering for AI Agents">
   <meta property="og:description"
-    content="Entroly selects the right evidence first, compresses safely, keeps exact recovery handles, and verifies answers locally. Prove value before connecting a paid model.">
+    content="Select the right evidence, compress context recoverably, inspect omissions and receipts, then verify the answer locally.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://juyterman1000.github.io/entroly/">
   <meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Entroly — Context Engineering for AI Coding">
-  <meta name="twitter:description" content="Local context optimization, receipts, recovery, and verification for AI coding agents.">
+  <meta name="twitter:title" content="Entroly — Auditable Context Engineering for AI Agents">
+  <meta name="twitter:description" content="Context selection, recoverable compression, receipts, and local verification for AI agents.">
   <link rel="canonical" href="https://juyterman1000.github.io/entroly/">
   <script type="application/ld+json">
   {
@@ -31,8 +31,11 @@
     "name": "Entroly",
     "operatingSystem": "Windows, macOS, Linux",
     "applicationCategory": "DeveloperApplication",
-    "applicationSubCategory": "AI Developer Tools & Prompt Optimization",
-    "description": "Open-source local context OS for AI coding agents: token optimization, Context Receipts, exact recovery, MCP tools, proxy mode, and local verification.",
+    "applicationSubCategory": "AI Agent Context Engineering",
+    "description": "Open-source, auditable context engineering for AI agents with context selection, recoverable compression, Context Receipts, MCP tools, and local verification.",
+    "url": "https://juyterman1000.github.io/entroly/",
+    "codeRepository": "https://github.com/juyterman1000/entroly",
+    "downloadUrl": "https://pypi.org/project/entroly/",
     "license": "https://opensource.org/licenses/Apache-2.0",
     "offers": {
       "@type": "Offer",
@@ -942,7 +945,7 @@
     <div class="hero-glow"></div>
     <div class="badge">Open Source Context Engineering</div>
     <h1>Your AI needs the <span>right evidence</span>.<br>Prove it locally first.</h1>
-    <p>Entroly is a local context OS for AI coding agents: selected context, exact recovery, receipts, memory, gateway controls, and verification with fewer input tokens.
+    <p>Entroly is an auditable context engineering control plane for AI agents: evidence selection, recoverable compression, receipts, memory, gateway controls, and local verification.
     </p>
 
     <div id="install" class="install-cmd"
@@ -953,7 +956,7 @@
     </div>
 
     <div style="margin-top: 16px; font-size: 13px; color: var(--muted);">
-      Works with <b>Cursor</b> · <b>Claude Code</b> · <b>Windsurf</b> · <b>Cline</b>
+      Works with <b>Claude Code</b> · <b>Codex</b> · <b>OpenClaw</b> · <b>GitHub Copilot</b> · <b>Cursor</b> · other <b>MCP clients</b>
     </div>
 
     <div style="margin-top: 12px; font-size: 13px; color: var(--muted); max-width: 620px;">

--- a/docs/releases/v1.0.62.md
+++ b/docs/releases/v1.0.62.md
@@ -1,0 +1,18 @@
+# Entroly 1.0.62
+
+Entroly 1.0.62 makes the project easier to find and evaluate without changing
+its context-selection or compression behavior.
+
+- Names the product category consistently as **auditable context engineering
+  for AI agents** across the README, PyPI, npm/WASM, MCP Registry, OpenClaw,
+  and the documentation homepage.
+- Adds searchable, verified integration terms for Claude Code, Codex,
+  OpenClaw, GitHub Copilot, Cursor, and MCP clients.
+- Adds canonical homepage, documentation, source, issue, and release links to
+  Python and npm package metadata.
+- Adds an offline discovery-metadata contract so public descriptions,
+  keywords, and trust links cannot silently drift apart.
+
+No runtime API, data format, provider route, or trust invariant changed in
+this release. Homebrew remains pinned to the last published sdist until the
+1.0.62 PyPI artifact is available and its SHA-256 is verified.

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "entroly-core"
-version = "1.0.61"
+version = "1.0.62"
 dependencies = [
  "entroly-qccr",
  "flate2",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.61"
+version = "1.0.62"
 dependencies = [
  "regex",
  "serde",

--- a/entroly-core/Cargo.toml
+++ b/entroly-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-core"
-version = "1.0.61"
+version = "1.0.62"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-core/README.md
+++ b/entroly-core/README.md
@@ -17,7 +17,7 @@ Provides high-performance PyO3 bindings for:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -U "entroly-core>=1.0.61"
+python -m pip install --no-cache-dir -U "entroly-core>=1.0.62"
 ```
 
 Prebuilt abi3 wheels are published for Linux, macOS, and Windows. One

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "entroly-core"
-version = "1.0.61"
-description = "Rust core for Entroly: Context Receipts, deterministic ingestion/ranking, dependency audits, and local context optimization"
+version = "1.0.62"
+description = "Rust core for Entroly context engineering: deterministic selection, recoverable compression, Context Receipts, and verification"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 authors = [
     { name = "entroly", email = "fastrunner10090@gmail.com" },
 ]
-keywords = ["mcp", "context-receipts", "context-control-plane", "context-optimization", "knapsack", "entropy", "rust", "pyo3"]
+keywords = ["ai-agents", "context-engineering", "context-compression", "context-receipts", "context-control-plane", "context-optimization", "mcp", "knapsack", "entropy", "rust", "pyo3"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -28,8 +28,11 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/juyterman1000/entroly"
-Repository = "https://github.com/juyterman1000/entroly"
+Homepage = "https://juyterman1000.github.io/entroly/"
+Documentation = "https://juyterman1000.github.io/entroly/"
+Source = "https://github.com/juyterman1000/entroly"
+Issues = "https://github.com/juyterman1000/entroly/issues"
+"Release Notes" = "https://github.com/juyterman1000/entroly/releases"
 
 [tool.maturin]
 features = ["extension-module"]

--- a/entroly-qccr/Cargo.lock
+++ b/entroly-qccr/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.61"
+version = "1.0.62"
 dependencies = [
  "regex",
  "regex-lite",

--- a/entroly-qccr/Cargo.toml
+++ b/entroly-qccr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-qccr"
-version = "1.0.61"
+version = "1.0.62"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/Cargo.lock
+++ b/entroly-wasm/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-qccr"
-version = "1.0.61"
+version = "1.0.62"
 dependencies = [
  "regex-lite",
  "serde",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "entroly-wasm"
-version = "1.0.61"
+version = "1.0.62"
 dependencies = [
  "entroly-qccr",
  "flate2",

--- a/entroly-wasm/Cargo.toml
+++ b/entroly-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entroly-wasm"
-version = "1.0.61"
+version = "1.0.62"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/juyterman1000/entroly"

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entroly-wasm",
-  "version": "1.0.61",
-  "description": "Pure WebAssembly local context OS for AI agents: context receipts, local optimization, MCP, app SDK helpers, and no Python dependency.",
+  "version": "1.0.62",
+  "description": "WebAssembly context engineering for AI agents: local compression, MCP tools, recovery, receipts, and verification without Python.",
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {
@@ -51,10 +51,12 @@
     "test": "node test_wasm_e2e.js"
   },
   "keywords": [
-    "entroly", "context-receipts", "context-control-plane", "local-context-os", "context-optimization", "mcp", "mcp-server", "ai", "agents",
+    "entroly", "ai-agents", "ai-coding-agents", "context-engineering", "context-compression", "context-management", "context-receipts", "context-control-plane", "context-optimization", "mcp", "mcp-server", "model-context-protocol", "claude-code", "codex", "openclaw",
     "wasm", "webassembly", "information-theory", "knapsack", "entropy", "autotune"
   ],
   "repository": { "type": "git", "url": "https://github.com/juyterman1000/entroly" },
+  "homepage": "https://juyterman1000.github.io/entroly/",
+  "bugs": { "url": "https://github.com/juyterman1000/entroly/issues" },
   "author": "entroly",
   "license": "Apache-2.0",
   "engines": { "node": ">=16.0.0" }

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -24,7 +24,7 @@ Quick Setup (Claude Code)::
 
 """
 
-__version__ = "1.0.61"
+__version__ = "1.0.62"
 
 try:
     from .sdk import compress, compress_messages, verify  # noqa: F401

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -51,7 +51,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "1.0.61"
+    __version__ = "1.0.62"
 
 from entroly.config import (
     load_active_tuning_config as _load_active_tuning_config,
@@ -3189,7 +3189,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.61\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.62\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -4707,7 +4707,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.61\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.62\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -4750,7 +4750,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.61\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.62\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/daemon.py
+++ b/entroly/daemon.py
@@ -69,7 +69,7 @@ class EntrolyDaemonState:
     The dashboard polls it via /api/control/status.
     """
     status: str = "stopped"  # stopped | starting | running | stopping
-    version: str = "1.0.61"
+    version: str = "1.0.62"
     started_at: float | None = None
 
     # Feature flags

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -7,7 +7,7 @@ from importlib import metadata
 from types import ModuleType
 
 
-MIN_ENTROLY_CORE_VERSION = "1.0.61"
+MIN_ENTROLY_CORE_VERSION = "1.0.62"
 QCCR_SYMBOLS = (
     "py_qccr_expand_query",
     "py_qccr_rank_files",

--- a/entroly/npm-alias/README.md
+++ b/entroly/npm-alias/README.md
@@ -1,6 +1,7 @@
 # entroly
 
-Node/WASM package for Entroly, the local context OS for AI coding agents.
+Node/WASM package for Entroly, an auditable context engineering control plane
+for AI agents with local compression, recovery, receipts, and verification.
 
 This package installs the current Node/WebAssembly Entroly runtime by depending
 on [`entroly-wasm`](https://www.npmjs.com/package/entroly-wasm), then exposes a

--- a/entroly/npm-alias/package.json
+++ b/entroly/npm-alias/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entroly",
-  "version": "1.0.61",
-  "description": "Node/WASM Entroly runtime: local context optimization, MCP server tools, receipts, recovery, and verification without Python.",
+  "version": "1.0.62",
+  "description": "Node/WASM context engineering for AI agents: local compression, MCP tools, recovery, receipts, and verification without Python.",
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {
@@ -16,22 +16,34 @@
     "README.md"
   ],
   "dependencies": {
-    "entroly-wasm": "1.0.61"
+    "entroly-wasm": "1.0.62"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/juyterman1000/entroly"
   },
+  "homepage": "https://juyterman1000.github.io/entroly/",
+  "bugs": {
+    "url": "https://github.com/juyterman1000/entroly/issues"
+  },
   "keywords": [
     "entroly",
     "entroly-wasm",
+    "context-engineering",
+    "context-compression",
+    "context-management",
     "context-optimization",
     "context-receipts",
-    "local-context-os",
     "mcp",
     "mcp-server",
+    "model-context-protocol",
     "ai",
     "agents",
+    "ai-agents",
+    "ai-coding-agents",
+    "claude-code",
+    "codex",
+    "openclaw",
     "webassembly"
   ],
   "author": "entroly",

--- a/entroly/npm/README.md
+++ b/entroly/npm/README.md
@@ -1,8 +1,9 @@
 # entroly-mcp
 
-An NPX MCP bridge for Entroly, the local context OS for AI coding agents.
-Entroly gives AI workflows selected context, exact recovery handles, Context
-Receipts, local verification, and token optimization.
+An NPX MCP bridge for Entroly, an auditable context engineering control plane
+for AI agents. Entroly gives Claude Code, Codex, OpenClaw, GitHub Copilot,
+Cursor, and other MCP clients selected context, recoverable compression,
+Context Receipts, and local verification.
 
 ## Which package should I use?
 

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -1,8 +1,8 @@
 {
   "name": "entroly-mcp",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "mcpName": "io.github.juyterman1000/entroly",
-  "description": "NPX MCP bridge for Entroly, the local context OS with receipts, recovery, verification, and token optimization for AI coding agents.",
+  "description": "NPX MCP bridge for Entroly: auditable AI agent context engineering with compression, recovery, receipts, and verification.",
   "main": "index.js",
   "bin": {
     "entroly-mcp": "./bin/entroly-mcp.js"
@@ -21,16 +21,29 @@
     "type": "git",
     "url": "https://github.com/juyterman1000/entroly"
   },
+  "homepage": "https://juyterman1000.github.io/entroly/",
+  "bugs": {
+    "url": "https://github.com/juyterman1000/entroly/issues"
+  },
   "keywords": [
     "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "context-engineering",
+    "context-compression",
+    "context-management",
     "context-receipts",
     "context-control-plane",
-    "local-context-os",
     "context-optimization",
     "entroly",
     "ai",
     "agents",
+    "ai-agents",
+    "ai-coding-agents",
     "claude-code",
+    "codex",
+    "openclaw",
+    "github-copilot",
     "cursor"
   ],
   "author": "entroly",

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.61"
+version = "1.0.62"
 
-description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, HTTP proxy, and Python SDK."
+description = "Auditable context engineering for AI agents: select evidence, compress context, recover omissions, emit receipts, and verify answers."
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
@@ -14,9 +14,11 @@ authors = [
     { name = "entroly", email = "fastrunner10090@gmail.com" },
 ]
 keywords = [
-    "mcp", "context-optimization", "token-cost", "local-context-os", "agentic-ai",
-    "knapsack", "entropy", "deduplication", "checkpoint",
-    "cursor", "claude-code", "copilot", "llm", "hallucination-detection",
+    "ai-agents", "ai-coding-agents", "context-engineering", "context-management",
+    "context-optimization", "context-compression", "prompt-compression", "token-optimization",
+    "context-window", "context-receipts", "mcp", "mcp-server", "model-context-protocol",
+    "github-copilot", "cursor", "claude-code", "codex", "openclaw", "agent-memory",
+    "llm", "hallucination-detection",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -42,14 +44,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.61,<2",
+    "entroly-core>=1.0.62,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.61,<2",
+    "entroly-core>=1.0.62,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",
@@ -59,10 +61,11 @@ test = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/juyterman1000/entroly"
-Documentation = "https://github.com/juyterman1000/entroly#readme"
-Repository = "https://github.com/juyterman1000/entroly"
-"Bug Tracker" = "https://github.com/juyterman1000/entroly/issues"
+Homepage = "https://juyterman1000.github.io/entroly/"
+Documentation = "https://juyterman1000.github.io/entroly/"
+Source = "https://github.com/juyterman1000/entroly"
+Issues = "https://github.com/juyterman1000/entroly/issues"
+"Release Notes" = "https://github.com/juyterman1000/entroly/releases"
 
 [project.scripts]
 entroly = "entroly._docker_launcher:launch"

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -5061,7 +5061,7 @@ def main():
     try:
         from entroly import __version__ as _version
     except Exception:
-        _version = "1.0.61"
+        _version = "1.0.62"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -4,7 +4,7 @@
     "onStartup": true
   },
   "name": "Entroly Context Engine",
-  "description": "Provider-independent context assembly for every OpenClaw model route, with protected blocks, recovery delegation, and local audit receipts.",
+  "description": "Provider-independent context engineering for every OpenClaw model route, with protected blocks, recovery delegation, and local audit receipts.",
   "icon": "https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/entroly_wordmark.svg",
   "configSchema": {
     "type": "object",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entroly-openclaw",
-  "version": "1.0.61",
-  "description": "Provider-independent, auditable context optimization for every OpenClaw model route",
+  "version": "1.0.62",
+  "description": "Provider-independent, auditable context engineering for every OpenClaw model route",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://github.com/juyterman1000/entroly#entroly-for-openclaw",
@@ -13,6 +13,16 @@
   "bugs": {
     "url": "https://github.com/juyterman1000/entroly/issues"
   },
+  "keywords": [
+    "openclaw",
+    "openclaw-plugin",
+    "ai-agents",
+    "context-engineering",
+    "context-compression",
+    "context-optimization",
+    "context-receipts",
+    "model-context-protocol"
+  ],
   "engines": {
     "node": ">=22.19"
   },

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -2,13 +2,13 @@
 
 The formula in this directory is the canonical source. To make `brew tap juyterman1000/entroly && brew install entroly` work, the formula must live in a separate repo named `juyterman1000/homebrew-entroly`.
 
-Current release example version: `1.0.61`.
+Current release example version: `1.0.62`.
 
 ## Release checklist
 
 1. Copy `packaging/homebrew/entroly.rb` into `juyterman1000/homebrew-entroly/Formula/entroly.rb`.
-2. Set `VER=1.0.61` when preparing this release.
-3. Download the matching PyPI sdist: `entroly-1.0.61.tar.gz`.
+2. Set `VER=1.0.62` when preparing this release.
+3. Download the matching PyPI sdist: `entroly-1.0.62.tar.gz`.
 4. Recalculate the `sha256` for that tarball before publishing the Homebrew tap update.
 5. Verify locally before pushing with `brew install --build-from-source ./Formula/entroly.rb`, `brew test entroly`, and `brew audit --new --strict entroly`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "entroly"
-version = "1.0.61"
-description = "Local context OS for AI coding agents: token optimization, MCP tools, receipts, exact recovery, verification, and SDK helpers."
+version = "1.0.62"
+description = "Auditable context engineering for AI agents: select evidence, compress context, recover omissions, emit receipts, and verify answers."
 readme = "PYPI_README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
@@ -15,9 +15,10 @@ authors = [
     { name = "entroly", email = "fastrunner10090@gmail.com" },
 ]
 keywords = [
-    "context-receipts", "context-control-plane", "local-context-os", "token-saving", "context-compression", "reduce-llm-costs", "llm-proxy",
-    "mcp", "mcp-server", "github-copilot", "agentic-ai", "cursor", "claude-code", "copilot", "llm",
-    "knapsack", "entropy", "context-optimization", "token-reduction", "hallucination-detection"
+    "ai-agents", "ai-coding-agents", "context-engineering", "context-management", "context-optimization", "context-compression",
+    "prompt-compression", "token-optimization", "context-window", "context-receipts", "context-control-plane", "llm-proxy",
+    "mcp", "mcp-server", "model-context-protocol", "github-copilot", "cursor", "claude-code", "codex", "openclaw",
+    "hallucination-detection", "agent-memory", "llm"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -35,6 +36,13 @@ dependencies = [
     "mcp>=1.6.0,<2",
 ]
 
+[project.urls]
+Homepage = "https://juyterman1000.github.io/entroly/"
+Documentation = "https://juyterman1000.github.io/entroly/"
+Source = "https://github.com/juyterman1000/entroly"
+Issues = "https://github.com/juyterman1000/entroly/issues"
+"Release Notes" = "https://github.com/juyterman1000/entroly/releases"
+
 [project.optional-dependencies]
 proxy = [
     "httpx>=0.27",
@@ -42,14 +50,14 @@ proxy = [
     "uvicorn>=0.30",
 ]
 native = [
-    "entroly-core>=1.0.61,<2",
+    "entroly-core>=1.0.62,<2",
 ]
 receipt-proof = [
     "cryptography>=42",
 ]
 full = [
     "cryptography>=42",
-    "entroly-core>=1.0.61,<2",
+    "entroly-core>=1.0.62,<2",
     "httpx>=0.27",
     "starlette>=0.37",
     "uvicorn>=0.30",

--- a/server.json
+++ b/server.json
@@ -2,19 +2,19 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.juyterman1000/entroly",
   "title": "Entroly",
-  "description": "Local context OS for AI agents with token optimization, receipts, memory, and verification.",
+  "description": "Auditable context engineering for AI agents with compression, recovery, receipts, and verification.",
   "websiteUrl": "https://github.com/juyterman1000/entroly",
   "repository": {
     "url": "https://github.com/juyterman1000/entroly",
     "source": "github"
   },
-  "version": "1.0.61",
+  "version": "1.0.62",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "entroly",
-      "version": "1.0.61",
+      "version": "1.0.62",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -24,7 +24,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "entroly-mcp",
-      "version": "1.0.61",
+      "version": "1.0.62",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/tests/test_discovery_metadata.py
+++ b/tests/test_discovery_metadata.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY = "https://github.com/juyterman1000/entroly"
+HOMEPAGE = "https://juyterman1000.github.io/entroly/"
+CATEGORY = "context engineering"
+PACKAGE_KEYWORDS = {
+    "ai-agents",
+    "context-engineering",
+    "context-compression",
+    "context-management",
+    "context-optimization",
+    "mcp",
+    "model-context-protocol",
+}
+
+
+def _text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _json(path: str) -> dict:
+    return json.loads(_text(path))
+
+
+def _toml_section(path: str, section: str) -> str:
+    match = re.search(
+        rf"(?ms)^\[{re.escape(section)}\]\s*(.*?)(?=^\[|\Z)",
+        _text(path),
+    )
+    assert match is not None, f"{path} is missing [{section}]"
+    return match.group(1)
+
+
+def test_readme_first_fold_names_the_category_and_supported_clients() -> None:
+    for path in ("README.md", "PYPI_README.md"):
+        first_fold = _text(path)[:5_000].casefold()
+        assert "entroly — auditable context engineering for ai agents" in first_fold
+        assert "context compression" in first_fold or "compress" in first_fold
+        for client in ("claude code", "codex", "openclaw", "github copilot", "mcp"):
+            assert client in first_fold, f"{path} does not identify {client} above the fold"
+
+
+def test_python_package_metadata_is_searchable_and_connected() -> None:
+    for path in ("pyproject.toml", "entroly/pyproject.toml"):
+        project = _toml_section(path, "project").casefold()
+        urls = _toml_section(path, "project.urls")
+
+        assert CATEGORY in project
+        assert "ai agents" in project
+        for keyword in PACKAGE_KEYWORDS:
+            assert f'"{keyword}"' in project, f"{path} is missing keyword {keyword}"
+        assert f'Homepage = "{HOMEPAGE}"' in urls
+        assert f'Source = "{REPOSITORY}"' in urls
+        assert f'Issues = "{REPOSITORY}/issues"' in urls
+        assert f'"Release Notes" = "{REPOSITORY}/releases"' in urls
+
+
+def test_npm_packages_share_discovery_terms_and_trust_links() -> None:
+    for path in (
+        "entroly/npm/package.json",
+        "entroly/npm-alias/package.json",
+        "entroly-wasm/package.json",
+    ):
+        package = _json(path)
+        description = package["description"].casefold()
+        keywords = set(package["keywords"])
+
+        assert CATEGORY in description
+        assert "ai agent" in description
+        assert PACKAGE_KEYWORDS <= keywords
+        assert package["repository"]["url"] == REPOSITORY
+        assert package["homepage"] == HOMEPAGE
+        assert package["bugs"]["url"] == f"{REPOSITORY}/issues"
+
+
+def test_mcp_and_docs_metadata_use_the_same_verified_positioning() -> None:
+    manifest = _json("server.json")
+    description = manifest["description"]
+    homepage = _text("docs/index.html")
+
+    assert len(description) <= 100
+    assert CATEGORY in description.casefold()
+    assert "recovery" in description.casefold()
+    assert "receipts" in description.casefold()
+    assert "verification" in description.casefold()
+    assert "<title>Entroly — Auditable Context Engineering for AI Agents</title>" in homepage
+    assert f'"codeRepository": "{REPOSITORY}"' in homepage
+    assert 'content="Auditable context engineering for AI agents:' in homepage
+
+
+def test_openclaw_listing_names_its_category_without_provider_overclaims() -> None:
+    package = _json("integrations/openclaw/package.json")
+    manifest = _json("integrations/openclaw/openclaw.plugin.json")
+
+    assert CATEGORY in package["description"].casefold()
+    assert CATEGORY in manifest["description"].casefold()
+    assert "provider-independent" in package["description"].casefold()
+    assert {
+        "openclaw",
+        "openclaw-plugin",
+        "ai-agents",
+        "context-engineering",
+        "context-compression",
+        "context-receipts",
+    } <= set(package["keywords"])

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-RELEASE_VERSION = "1.0.61"
+RELEASE_VERSION = "1.0.62"
 HOMEBREW_FORMULA_VERSION = "1.0.61"
 HOMEBREW_FORMULA_SHA256 = "163ce55a49337324def6aeca8904bda69fe07615ee20180c9f6ab0cd62f36580"
 CANONICAL_MCP_NAME = "io.github.juyterman1000/entroly"
@@ -66,7 +66,7 @@ def _read_project_metadata(path: str) -> dict[str, object]:
     return metadata
 
 
-def test_public_package_versions_are_1_0_61() -> None:
+def test_public_package_versions_are_1_0_62() -> None:
     assert _read_project_metadata("pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_project_metadata("entroly/pyproject.toml")["version"] == RELEASE_VERSION
     assert _read_json("entroly/npm/package.json")["version"] == RELEASE_VERSION


### PR DESCRIPTION
## Summary
- align Entroly's category and supported-client language across GitHub, PyPI, npm/WASM, MCP Registry, OpenClaw, and the docs homepage
- add canonical homepage, source, issue, and release links plus focused package keywords
- add an offline discovery-metadata contract and prepare coordinated release 1.0.62

## Why
GitHub's About metadata already described the trust wedge clearly, but package and docs surfaces still used older `local context OS` copy. This made Entroly less relevant for searches such as `AI agent context compression`, `context engineering`, and `MCP context optimization`, and gave first-time readers inconsistent positioning.

The new copy stays evidence-bound: it names shipped selection, recoverable compression, receipts, verification, and verified integrations. It adds no universal performance or superiority claims.

## Verification
- `ruff check tests/test_discovery_metadata.py`
- `python scripts/verify_readme.py` (31 passed)
- `python scripts/verify_public_trust.py`
- `python -m pytest tests/test_discovery_metadata.py tests/test_release_surface.py tests/test_release_version_sync.py tests/test_mcp_registry_manifest.py tests/test_public_trust.py tests/test_cli_audit.py -q` (70 passed)
- `python -m build` + `python -m twine check` (wheel and sdist passed)
- `npm pack --dry-run --ignore-scripts` for `entroly`, `entroly-mcp`, and `entroly-openclaw`

## Release safety
Homebrew intentionally remains on verified 1.0.61 until PyPI publishes the 1.0.62 sdist and the automation can update its SHA-256 atomically.