### PR TITLE
fix(discovery): point homepage to polished landing page

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -103,7 +103,7 @@ claude mcp add entroly -- uvx --from entroly entroly
 ## Links
 
 - Repository: https://github.com/juyterman1000/entroly
-- Documentation: https://juyterman1000.github.io/entroly/
+- Documentation: https://juyterman1000.github.io/entroly/docs/index.html
 - PyPI: https://pypi.org/project/entroly/
 - npm runtime: https://www.npmjs.com/package/entroly
 - npm MCP bridge: https://www.npmjs.com/package/entroly-mcp

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,12 +18,12 @@
   <meta property="og:description"
     content="Select the right evidence, compress context recoverably, inspect omissions and receipts, then verify the answer locally.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://juyterman1000.github.io/entroly/">
+  <meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/index.html">
   <meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Entroly — Auditable Context Engineering for AI Agents">
   <meta name="twitter:description" content="Context selection, recoverable compression, receipts, and local verification for AI agents.">
-  <link rel="canonical" href="https://juyterman1000.github.io/entroly/">
+  <link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/index.html">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -33,7 +33,7 @@
     "applicationCategory": "DeveloperApplication",
     "applicationSubCategory": "AI Agent Context Engineering",
     "description": "Open-source, auditable context engineering for AI agents with context selection, recoverable compression, Context Receipts, MCP tools, and local verification.",
-    "url": "https://juyterman1000.github.io/entroly/",
+    "url": "https://juyterman1000.github.io/entroly/docs/index.html",
     "codeRepository": "https://github.com/juyterman1000/entroly",
     "downloadUrl": "https://pypi.org/project/entroly/",
     "license": "https://opensource.org/licenses/Apache-2.0",

--- a/entroly-core/pyproject.toml
+++ b/entroly-core/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://juyterman1000.github.io/entroly/"
-Documentation = "https://juyterman1000.github.io/entroly/"
+Homepage = "https://juyterman1000.github.io/entroly/docs/index.html"
+Documentation = "https://juyterman1000.github.io/entroly/docs/index.html"
 Source = "https://github.com/juyterman1000/entroly"
 Issues = "https://github.com/juyterman1000/entroly/issues"
 "Release Notes" = "https://github.com/juyterman1000/entroly/releases"

--- a/entroly-wasm/package.json
+++ b/entroly-wasm/package.json
@@ -55,7 +55,7 @@
     "wasm", "webassembly", "information-theory", "knapsack", "entropy", "autotune"
   ],
   "repository": { "type": "git", "url": "https://github.com/juyterman1000/entroly" },
-  "homepage": "https://juyterman1000.github.io/entroly/",
+  "homepage": "https://juyterman1000.github.io/entroly/docs/index.html",
   "bugs": { "url": "https://github.com/juyterman1000/entroly/issues" },
   "author": "entroly",
   "license": "Apache-2.0",

--- a/entroly/npm-alias/package.json
+++ b/entroly/npm-alias/package.json
@@ -22,7 +22,7 @@
     "type": "git",
     "url": "https://github.com/juyterman1000/entroly"
   },
-  "homepage": "https://juyterman1000.github.io/entroly/",
+  "homepage": "https://juyterman1000.github.io/entroly/docs/index.html",
   "bugs": {
     "url": "https://github.com/juyterman1000/entroly/issues"
   },

--- a/entroly/npm/package.json
+++ b/entroly/npm/package.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/juyterman1000/entroly"
   },
-  "homepage": "https://juyterman1000.github.io/entroly/",
+  "homepage": "https://juyterman1000.github.io/entroly/docs/index.html",
   "bugs": {
     "url": "https://github.com/juyterman1000/entroly/issues"
   },

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -61,8 +61,8 @@ test = [
 ]
 
 [project.urls]
-Homepage = "https://juyterman1000.github.io/entroly/"
-Documentation = "https://juyterman1000.github.io/entroly/"
+Homepage = "https://juyterman1000.github.io/entroly/docs/index.html"
+Documentation = "https://juyterman1000.github.io/entroly/docs/index.html"
 Source = "https://github.com/juyterman1000/entroly"
 Issues = "https://github.com/juyterman1000/entroly/issues"
 "Release Notes" = "https://github.com/juyterman1000/entroly/releases"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://juyterman1000.github.io/entroly/"
-Documentation = "https://juyterman1000.github.io/entroly/"
+Homepage = "https://juyterman1000.github.io/entroly/docs/index.html"
+Documentation = "https://juyterman1000.github.io/entroly/docs/index.html"
 Source = "https://github.com/juyterman1000/entroly"
 Issues = "https://github.com/juyterman1000/entroly/issues"
 "Release Notes" = "https://github.com/juyterman1000/entroly/releases"

--- a/tests/test_discovery_metadata.py
+++ b/tests/test_discovery_metadata.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY = "https://github.com/juyterman1000/entroly"
-HOMEPAGE = "https://juyterman1000.github.io/entroly/"
+HOMEPAGE = "https://juyterman1000.github.io/entroly/docs/index.html"
 CATEGORY = "context engineering"
 PACKAGE_KEYWORDS = {
     "ai-agents",


### PR DESCRIPTION
## Summary
- point GitHub, Python, npm/WASM, and package documentation metadata at the verified polished landing page
- align Open Graph, canonical, and JSON-LD URLs with the actual `/docs/index.html` route
- update the discovery contract to prevent the route from drifting back to the generated Pages root

## Verification
- both Pages routes return HTTP 200
- `/docs/index.html` contains the intended hero and proof-first experience; the root does not
- `python -m pytest tests/test_discovery_metadata.py tests/test_release_surface.py tests/test_mcp_registry_manifest.py -q` (21 passed)
- `ruff check tests/test_discovery_metadata.py`
- pre-push ruff, clippy, and 531 Rust library tests passed

No version bump: the 1.0.62 package metadata already points to a valid Pages root. This corrects source metadata for the next release while the live GitHub About link is updated immediately.