### PR TITLE
fix(release): require public ClawHub publication

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -500,9 +500,10 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.release-metadata.outputs.version }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -531,16 +532,110 @@ jobs:
           CLAWHUB_CONFIG_PATH="$RUNNER_TEMP/clawhub-config.json" \
             clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 
-      - name: Publish Entroly OpenClaw plugin
+      - name: Configure ClawHub trusted publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          clawhub package trusted-publisher set entroly-openclaw \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow-filename "entroly-publish.yml" \
+            --json | tee "$RUNNER_TEMP/clawhub-trusted-publisher.json"
+          rm -f "$CLAWHUB_CONFIG_PATH"
+
+      - name: Publish Entroly OpenClaw plugin with GitHub OIDC
         working-directory: integrations/openclaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          clawhub package publish . \
+            --version "$RELEASE_VERSION" \
+            --tags latest \
+            --source-repo "$GITHUB_REPOSITORY" \
+            --source-commit "$GITHUB_SHA" \
+            --source-ref "entroly-v${RELEASE_VERSION}" \
+            --source-path "integrations/openclaw" \
+            --changelog "GitHub Actions coordinated Entroly ${RELEASE_VERSION} release after live PyPI and npm probes" \
+            --json | tee "$RUNNER_TEMP/clawhub-package-publish.json"
+
+      - name: Verify exact ClawHub version is public
+        id: public
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          name = "entroly-openclaw"
+          expected = os.environ["RELEASE_VERSION"]
+          base = "https://clawhub.ai/api/v1/packages"
+          headers = {"User-Agent": "entroly-clawhub-publisher/1.0"}
+          last_error = "ClawHub did not expose the accepted release"
+
+          def read_json(url: str) -> dict:
+              request = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  if response.status != 200:
+                      raise RuntimeError(f"HTTP {response.status} for {url}")
+                  return json.load(response)
+
+          for attempt in range(1, 61):
+              try:
+                  detail = read_json(f"{base}/{urllib.parse.quote(name, safe='')}")
+                  package = detail.get("package") or {}
+                  if package.get("latestVersion") != expected:
+                      raise RuntimeError(
+                          f"latest version is {package.get('latestVersion')!r}, expected {expected!r}"
+                      )
+                  exact = read_json(
+                      f"{base}/{urllib.parse.quote(name, safe='')}/versions/"
+                      f"{urllib.parse.quote(expected, safe='')}"
+                  )
+                  release = exact.get("version") or {}
+                  artifact = release.get("artifact") or {}
+                  if release.get("version") != expected or not artifact.get("sha256"):
+                      raise RuntimeError("exact public artifact is incomplete")
+                  result = {
+                      "package": name,
+                      "version": expected,
+                      "release_id": release.get("_id"),
+                      "artifact_sha256": artifact["sha256"],
+                      "scan_status": release.get("scanStatus"),
+                  }
+                  with open(
+                      os.path.join(os.environ["RUNNER_TEMP"], "clawhub-public-version.json"),
+                      "w",
+                      encoding="utf-8",
+                  ) as output:
+                      json.dump(result, output, indent=2, sort_keys=True)
+                      output.write("\n")
+                  print(json.dumps(result, indent=2, sort_keys=True))
+                  raise SystemExit(0)
+              except (urllib.error.HTTPError, urllib.error.URLError, ValueError, RuntimeError) as exc:
+                  last_error = str(exc)
+                  print(f"Attempt {attempt}/60: {last_error}")
+                  if attempt < 60:
+                      time.sleep(15)
+          raise SystemExit(last_error)
+          PY
+
+      - name: Record ClawHub moderation state
+        if: always()
         shell: bash
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           set -euo pipefail
-          clawhub package publish . \
-            --manual-override-reason "GitHub Actions coordinated Entroly ${RELEASE_VERSION} release after live PyPI and npm probes" \
-            --json | tee "$RUNNER_TEMP/clawhub-package-publish.json"
+          test -n "$CLAWHUB_TOKEN"
+          CLAWHUB_CONFIG_PATH="$RUNNER_TEMP/clawhub-moderation-config.json" \
+            clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+          CLAWHUB_CONFIG_PATH="$RUNNER_TEMP/clawhub-moderation-config.json" \
+            clawhub package moderation-status entroly-openclaw --json \
+              | tee "$RUNNER_TEMP/clawhub-moderation-status.json"
 
       - name: Upload ClawHub publication evidence
         if: always()
@@ -550,6 +645,9 @@ jobs:
           path: |
             ${{ runner.temp }}/clawhub-package-validate.json
             ${{ runner.temp }}/clawhub-package-publish.json
+            ${{ runner.temp }}/clawhub-trusted-publisher.json
+            ${{ runner.temp }}/clawhub-public-version.json
+            ${{ runner.temp }}/clawhub-moderation-status.json
           if-no-files-found: ignore
 
   publish-binaries:

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -204,6 +204,19 @@ def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> 
     assert "for attempt in $(seq 1 20)" in openclaw_publisher
     assert "waiting for PyPI propagation" in openclaw_publisher
 
+    clawhub_publisher = text.split("  publish-clawhub-openclaw:", 1)[1].split(
+        "  publish-binaries:", 1
+    )[0]
+    assert "id-token: write" in clawhub_publisher
+    assert "package trusted-publisher set entroly-openclaw" in clawhub_publisher
+    assert '--workflow-filename "entroly-publish.yml"' in clawhub_publisher
+    assert "--manual-override-reason" not in clawhub_publisher
+    assert '--source-commit "$GITHUB_SHA"' in clawhub_publisher
+    assert '--source-ref "entroly-v${RELEASE_VERSION}"' in clawhub_publisher
+    assert "Verify exact ClawHub version is public" in clawhub_publisher
+    assert "for attempt in range(1, 61)" in clawhub_publisher
+    assert "package moderation-status entroly-openclaw --json" in clawhub_publisher
+
 
 def test_homebrew_sync_is_single_pinned_release_workflow() -> None:
     assert not (ROOT / ".github/workflows/sync-homebrew-after-release.yml").exists()


### PR DESCRIPTION
ClawHub accepted Entroly 1.0.63 and returned a release ID, but the public package index stayed on 1.0.62. That left the publish job green while the user-visible listing was stale.

This change makes the release path fail only after preserving actionable evidence:

- configures GitHub Actions as the ClawHub trusted publisher;
- publishes with short-lived GitHub OIDC instead of a manual override;
- binds the package to the exact repository, commit, tag, and subdirectory;
- waits for the exact public version and downloadable SHA-256 artifact;
- records authenticated moderation status when publication does not become visible.

Validation: `python -m pytest tests/test_release_surface.py -q` (14 passed), Ruff clean, workflow YAML parsed successfully.