### PR TITLE
fix(ci): add top-level permissions for ghcr.io push

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/entroly


### PR DESCRIPTION
The build-and-push job had job-level packages:write but GitHub Actions requires top-level workflow permissions to propagate the GITHUB_TOKEN scope to docker/login-action.

Error: denied: permission_denied: write_package

## Outcome

<!-- What user-visible problem does this solve? Lead with the outcome. -->

## Changes

<!-- Keep the list focused. Link the issue or discussion when one exists. -->

## Trust and compatibility

- [ ] Receipt honesty and recoverability are preserved or not affected.
- [ ] Verification remains fail-closed where confidence is claimed.
- [ ] No surprise network call or credential persistence was introduced.
- [ ] Provider request, tool, streaming, and cache semantics are preserved.
- [ ] Backward compatibility and migration impact are documented.
- [ ] Public claims include a baseline, workload, budget, and limitations.
- [ ] This change does not affect the checked item(s), explained below.

## Validation

<!-- Paste exact commands and concise results. State incomplete or timed-out checks honestly. -->

```text
command -> result
```

## Release impact

- [ ] No release note or version change required.
- [ ] Release note added or updated.
- [ ] Python, Rust, npm/WASM, MCP, OpenClaw, Docker, and Homebrew surfaces were reviewed as applicable.

## Rollback

<!-- How can maintainers disable or revert this safely? -->
