### PR TITLE
fix(ci): make release and automation contracts reliable

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,6 +40,9 @@ on:
 permissions:
   contents: read
 
+env:
+  EVIDENCE_TIKTOKEN_VERSION: "0.9.0"
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
@@ -53,7 +56,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
-        run: pip install -e ".[test,benchmark]"
+        run: pip install -e ".[test]" "tiktoken==${EVIDENCE_TIKTOKEN_VERSION}"
 
       - name: Verify compression evidence artifact
         run: |
@@ -115,4 +118,16 @@ jobs:
               sys.exit(1)
 
           print("BENCHMARKS.md is in sync with bench/compare.py output.")
+          PY
+
+      - name: Smoke-test the supported tokenizer ceiling
+        run: |
+          python -m pip install --upgrade "tiktoken>=0.9,<0.14"
+          python - <<'PY'
+          from importlib.metadata import version
+
+          import tiktoken
+
+          assert tiktoken.get_encoding("o200k_base").encode("Entroly")
+          print(f"tiktoken {version('tiktoken')} compatibility smoke passed")
           PY

--- a/.github/workflows/commit-identity-guard.yml
+++ b/.github/workflows/commit-identity-guard.yml
@@ -70,6 +70,86 @@ jobs:
           def git_output(*args: str) -> str:
               return subprocess.check_output(["git", *args], text=True)
 
+          def changed_paths(commit: str) -> set[str]:
+              return set(
+                  git_output(
+                      "diff-tree", "--no-commit-id", "--name-only", "-r", commit
+                  ).splitlines()
+              )
+
+          def dependency_path(path: str) -> bool:
+              dependency_files = {
+                  "Cargo.lock",
+                  "Cargo.toml",
+                  "Pipfile",
+                  "Pipfile.lock",
+                  "go.mod",
+                  "go.sum",
+                  "package-lock.json",
+                  "package.json",
+                  "pnpm-lock.yaml",
+                  "poetry.lock",
+                  "pyproject.toml",
+                  "requirements-dev.txt",
+                  "requirements.txt",
+                  "uv.lock",
+                  "yarn.lock",
+              }
+              name = Path(path).name
+              return (
+                  name in dependency_files
+                  or name.startswith("requirements")
+                  and name.endswith(".txt")
+                  or path.startswith(".github/workflows/")
+                  and Path(path).suffix in {".yml", ".yaml"}
+                  or path == ".github/dependabot.yml"
+              )
+
+          def trusted_dependabot_author(
+              commit: str,
+              author_name: str,
+              author_email: str,
+              committer_name: str,
+              committer_email: str,
+          ) -> bool:
+              if (
+                  author_name != "dependabot[bot]"
+                  or author_email
+                  != "49699333+dependabot[bot]@users.noreply.github.com"
+                  or not github_service_committer(committer_name, committer_email)
+              ):
+                  return False
+
+              paths = changed_paths(commit)
+              if not paths or not all(dependency_path(path) for path in paths):
+                  return False
+
+              if event_name == "pull_request":
+                  pull_request = event.get("pull_request", {})
+                  head = pull_request.get("head", {})
+                  head_repository = head.get("repo") or {}
+                  return (
+                      (pull_request.get("user") or {}).get("login")
+                      == "dependabot[bot]"
+                      and str(head.get("ref", "")).startswith("dependabot/")
+                      and head_repository.get("full_name")
+                      == os.environ["GITHUB_REPOSITORY"]
+                  )
+
+              if event_name != "push" or event.get("ref") != "refs/heads/main":
+                  return False
+              if event.get("sender", {}).get("login") != expected_login:
+                  return False
+              subject = git_output("show", "-s", "--format=%s", commit)
+              return bool(
+                  re.fullmatch(
+                      r"(?:build\(deps(?:-[^)]+)?\): (?:bump|update)|Bump|Update) "
+                      r".+ \(#\d+\)",
+                      subject,
+                      re.IGNORECASE,
+                  )
+              )
+
           def trusted_homebrew_automation_author(
               commit: str,
               author_name: str,
@@ -120,12 +200,7 @@ jobs:
               if owner_emails.isdisjoint(coauthor_emails):
                   return False
 
-              changed_paths = set(
-                  git_output(
-                      "diff-tree", "--no-commit-id", "--name-only", "-r", commit
-                  ).splitlines()
-              )
-              if changed_paths != {
+              if changed_paths(commit) != {
                   "packaging/homebrew/entroly.rb",
                   "tests/test_release_surface.py",
               }:
@@ -159,8 +234,12 @@ jobs:
               if not row:
                   continue
               commit, an, ae, cn, ce = row.split("\x1f")
-              if not owner_identity(an, ae) and not trusted_homebrew_automation_author(
-                  commit, an, ae, cn, ce
+              if (
+                  not owner_identity(an, ae)
+                  and not trusted_dependabot_author(commit, an, ae, cn, ce)
+                  and not trusted_homebrew_automation_author(
+                      commit, an, ae, cn, ce
+                  )
               ):
                   failures.append(f"{commit[:12]} author is {an} <{ae}>")
               if not owner_identity(cn, ce) and not github_service_committer(cn, ce):
@@ -169,6 +248,10 @@ jobs:
           if failures:
               print("Commit identity guard failed.")
               print(f"Required author account: {expected_login} via a verified owner email")
+              print(
+                  "Allowed automation: path-scoped Dependabot PRs and reviewed "
+                  "Homebrew release updates"
+              )
               print("Allowed committers: the owner account or GitHub's web-flow service identity")
               for failure in failures:
                   print(f"  - {failure}")

--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -47,6 +49,7 @@ jobs:
           DISPATCH_VERSION: ${{ github.event.inputs.release_version }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+          BEFORE_SHA: ${{ github.event.before }}
           REF_NAME_SAFE: ${{ github.ref_name }}
           REF_SAFE: ${{ github.ref }}
         run: |
@@ -60,8 +63,29 @@ jobs:
           elif [[ "$REF_SAFE" == refs/tags/entroly-v* ]]; then
             VERSION="${REF_NAME_SAFE#entroly-v}"
             SHOULD_PUBLISH=true
-          elif [[ "$EVENT_NAME" == "push" && "$HEAD_MESSAGE" == "Release v${PACKAGE_VERSION}" ]]; then
-            SHOULD_PUBLISH=true
+          elif [[ "$EVENT_NAME" == "push" && "$REF_SAFE" == "refs/heads/main" ]]; then
+            if [[ -n "$BEFORE_SHA" && ! "$BEFORE_SHA" =~ ^0+$ ]] \
+              && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+              BEFORE_VERSION="$(
+                git show "${BEFORE_SHA}:pyproject.toml" \
+                  | python -c 'import sys, tomllib; print(tomllib.loads(sys.stdin.read())["project"]["version"])'
+              )"
+              if [[ "$BEFORE_VERSION" != "$PACKAGE_VERSION" ]]; then
+                python - "$BEFORE_VERSION" "$PACKAGE_VERSION" <<'PY'
+          import sys
+
+          before = tuple(int(part) for part in sys.argv[1].split("."))
+          after = tuple(int(part) for part in sys.argv[2].split("."))
+          if after <= before:
+              raise SystemExit(
+                  f"refusing non-increasing release transition: {sys.argv[1]} -> {sys.argv[2]}"
+              )
+          PY
+                SHOULD_PUBLISH=true
+              fi
+            else
+              echo "Previous main commit is unavailable; refusing automatic publication." >&2
+            fi
           fi
           SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
+import sys
+import textwrap
 import zipfile
 from pathlib import Path
 
@@ -269,7 +273,10 @@ def test_release_artifacts_have_one_quality_gated_publisher() -> None:
     assert "needs: [release-metadata, quality-gate, release-anchor]" in coordinated
     assert "needs: [release-metadata, quality-gate, github-release]" in coordinated
     assert "tag: ${{ needs.release-metadata.outputs.tag }}" in coordinated
-    assert '"Release v${PACKAGE_VERSION}"' in coordinated
+    assert "BEFORE_SHA: ${{ github.event.before }}" in coordinated
+    assert 'git show "${BEFORE_SHA}:pyproject.toml"' in coordinated
+    assert "refusing non-increasing release transition" in coordinated
+    assert "Previous main commit is unavailable; refusing automatic publication." in coordinated
     assert "group: entroly-production-publication" in coordinated
     assert "Create or verify the canonical release tag" in coordinated
     assert "GitHub Actions coordinated Entroly" in coordinated
@@ -288,6 +295,164 @@ def test_release_artifacts_have_one_quality_gated_publisher() -> None:
         assert "workflow_call:" in triggers
         assert "\n  push:" not in triggers
         assert "\n  workflow_dispatch:" not in triggers
+
+
+def test_commit_identity_guard_scopes_dependabot_to_dependency_paths() -> None:
+    guard = (ROOT / ".github/workflows/commit-identity-guard.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "trusted_dependabot_author" in guard
+    assert '== "dependabot[bot]"' in guard
+    assert 'str(head.get("ref", "")).startswith("dependabot/")' in guard
+    assert 'head_repository.get("full_name")' in guard
+    assert 'os.environ["GITHUB_REPOSITORY"]' in guard
+    assert "all(dependency_path(path) for path in paths)" in guard
+    assert 'path.startswith(".github/workflows/")' in guard
+    assert 'event.get("sender", {}).get("login") != expected_login' in guard
+
+
+def test_commit_identity_guard_accepts_only_path_scoped_dependabot(
+    tmp_path: Path,
+) -> None:
+    guard = (ROOT / ".github/workflows/commit-identity-guard.yml").read_text(
+        encoding="utf-8"
+    )
+    embedded = guard.split("          python - <<'PY'\n", 1)[1].split(
+        "\n          PY", 1
+    )[0]
+    script = textwrap.dedent(embedded)
+    compile(script, "commit-identity-guard", "exec")
+
+    repository = tmp_path / "repo"
+    repository.mkdir()
+
+    def git(*args: str, env: dict[str, str] | None = None) -> str:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=repository,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    owner_env = os.environ.copy()
+    owner_env.update(
+        {
+            "GIT_AUTHOR_NAME": "juyterman1000",
+            "GIT_AUTHOR_EMAIL": "208309368+juyterman1000@users.noreply.github.com",
+            "GIT_COMMITTER_NAME": "juyterman1000",
+            "GIT_COMMITTER_EMAIL": (
+                "208309368+juyterman1000@users.noreply.github.com"
+            ),
+        }
+    )
+    bot_env = os.environ.copy()
+    bot_env.update(
+        {
+            "GIT_AUTHOR_NAME": "dependabot[bot]",
+            "GIT_AUTHOR_EMAIL": (
+                "49699333+dependabot[bot]@users.noreply.github.com"
+            ),
+            "GIT_COMMITTER_NAME": "GitHub",
+            "GIT_COMMITTER_EMAIL": "noreply@github.com",
+        }
+    )
+
+    git("init", "-b", "main")
+    (repository / "pyproject.toml").write_text(
+        '[project]\nname = "entroly"\nversion = "1.0.66"\n',
+        encoding="utf-8",
+    )
+    git("add", "pyproject.toml")
+    git("commit", "-m", "initial", env=owner_env)
+    base = git("rev-parse", "HEAD")
+
+    (repository / "pyproject.toml").write_text(
+        '[project]\nname = "entroly"\nversion = "1.0.66"\n'
+        '[project.optional-dependencies]\nbenchmark = ["tiktoken>=0.9,<0.14"]\n',
+        encoding="utf-8",
+    )
+    git("add", "pyproject.toml")
+    git(
+        "commit",
+        "-m",
+        "build(deps-dev): update tiktoken requirement",
+        env=bot_env,
+    )
+    trusted_head = git("rev-parse", "HEAD")
+
+    event_path = tmp_path / "event.json"
+
+    def run_guard(base_sha: str, head_sha: str) -> subprocess.CompletedProcess[str]:
+        event_path.write_text(
+            json.dumps(
+                {
+                    "pull_request": {
+                        "base": {"sha": base_sha},
+                        "head": {
+                            "sha": head_sha,
+                            "ref": "dependabot/pip/tiktoken",
+                            "repo": {"full_name": "juyterman1000/entroly"},
+                        },
+                        "user": {"login": "dependabot[bot]"},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        guard_env = os.environ.copy()
+        guard_env.update(
+            {
+                "EXPECTED_LOGIN": "juyterman1000",
+                "EXPECTED_NOREPLY_EMAIL": (
+                    "208309368+juyterman1000@users.noreply.github.com"
+                ),
+                "EXPECTED_ACCOUNT_EMAIL": "fastrunner10090@gmail.com",
+                "GITHUB_EVENT_NAME": "pull_request",
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GITHUB_REPOSITORY": "juyterman1000/entroly",
+            }
+        )
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=repository,
+            env=guard_env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    trusted = run_guard(base, trusted_head)
+    assert trusted.returncode == 0, trusted.stdout + trusted.stderr
+
+    (repository / "entroly").mkdir()
+    (repository / "entroly" / "server.py").write_text(
+        "UNRELATED_CODE = True\n",
+        encoding="utf-8",
+    )
+    git("add", "entroly/server.py")
+    git("commit", "-m", "build(deps): change runtime code", env=bot_env)
+    untrusted_head = git("rev-parse", "HEAD")
+
+    untrusted = run_guard(trusted_head, untrusted_head)
+    assert untrusted.returncode != 0
+    assert "Commit identity guard failed." in untrusted.stdout
+
+
+def test_benchmark_verifies_frozen_evidence_before_latest_tokenizer_smoke() -> None:
+    benchmark = (ROOT / ".github/workflows/benchmark.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'EVIDENCE_TIKTOKEN_VERSION: "0.9.0"' in benchmark
+    assert '"tiktoken==${EVIDENCE_TIKTOKEN_VERSION}"' in benchmark
+    assert 'python -m pip install --upgrade "tiktoken>=0.9,<0.14"' in benchmark
+    assert benchmark.index("Verify compression evidence artifact") < benchmark.index(
+        "Smoke-test the supported tokenizer ceiling"
+    )
 
 
 def test_release_version_dispatch_input_is_validated_via_environment() -> None:


### PR DESCRIPTION
## Outcome

Makes the open PR queue mergeable without weakening Entroly's release, benchmark, or commit-identity guarantees.

## Changes

- trigger automatic publication only when `main` moves to a strictly higher committed package version; tags and explicit dispatch remain the recovery paths
- replace the broad release-message regex with a version-delta contract and fail closed when the previous commit is unavailable
- allow Dependabot only for same-repository `dependabot/*` PRs, exact bot identity, GitHub service commits, and dependency/workflow paths
- preserve the frozen `tiktoken==0.9.0` evidence verifier, then separately smoke-test the supported `<0.14` compatibility ceiling
- add executable guard coverage proving a dependency edit passes and a runtime-code edit from the bot fails

## Validation

- workflow YAML parsing — passed
- `pytest tests/test_release_surface.py -q` — 18 passed
- `pytest tests/test_release_version_sync.py tests/test_bump_version.py -q` — 8 passed
- focused benchmark tests — 48 passed
- `ruff check --no-cache tests/test_release_surface.py` — passed
- `git diff --check` — passed

## Rollback

Revert this PR. Manual version publication remains available through the release workflow dispatch and canonical release tag paths.