### PR TITLE
fix(release): verify existing ClawHub versions on retry

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -574,7 +574,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          clawhub package publish . \
+          publish_stdout="$RUNNER_TEMP/clawhub-package-publish.json"
+          publish_stderr="$RUNNER_TEMP/clawhub-package-publish.stderr"
+          if clawhub package publish . \
             --version "$RELEASE_VERSION" \
             --tags latest \
             --source-repo "$GITHUB_REPOSITORY" \
@@ -583,7 +585,34 @@ jobs:
             --source-path "integrations/openclaw" \
             --changelog "GitHub Actions coordinated Entroly ${RELEASE_VERSION} release after live PyPI and npm probes" \
             --manual-override-reason "Coordinated release from entroly-publish.yml after quality gate, PyPI probe, and npm probe" \
-            --json | tee "$RUNNER_TEMP/clawhub-package-publish.json"
+            --json >"$publish_stdout" 2>"$publish_stderr"
+          then
+            cat "$publish_stdout"
+          elif grep -Fq "Version ${RELEASE_VERSION} already exists" "$publish_stderr"; then
+            cat "$publish_stderr" >&2
+            PUBLISH_STDOUT="$publish_stdout" python - <<'PY'
+          import json
+          import os
+
+          with open(os.environ["PUBLISH_STDOUT"], "w", encoding="utf-8") as output:
+              json.dump(
+                  {
+                      "status": "already_exists",
+                      "version": os.environ["RELEASE_VERSION"],
+                      "action": "verify_public_immutable_artifact",
+                  },
+                  output,
+                  indent=2,
+                  sort_keys=True,
+              )
+              output.write("\n")
+          PY
+            echo "ClawHub version ${RELEASE_VERSION} already exists; continuing to exact public artifact verification."
+          else
+            cat "$publish_stderr" >&2
+            exit 1
+          fi
+          rm -f "$publish_stderr"
 
       # The authenticated session (RUNNER_TEMP config) must survive until after
       # the publish step above; deleting it earlier made `clawhub package

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -232,6 +232,13 @@ def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> 
     )
     assert '--source-commit "$GITHUB_SHA"' in clawhub_publisher
     assert '--source-ref "entroly-v${RELEASE_VERSION}"' in clawhub_publisher
+    assert 'grep -Fq "Version ${RELEASE_VERSION} already exists"' in clawhub_publisher
+    assert '"status": "already_exists"' in clawhub_publisher
+    assert '"action": "verify_public_immutable_artifact"' in clawhub_publisher
+    assert "continuing to exact public artifact verification" in clawhub_publisher
+    assert clawhub_publisher.index("already exists") < clawhub_publisher.index(
+        "Verify exact ClawHub version is public"
+    )
     assert "Verify exact ClawHub version is public" in clawhub_publisher
     assert "for attempt in range(1, 61)" in clawhub_publisher
     assert "package moderation-status entroly-openclaw --json" in clawhub_publisher


### PR DESCRIPTION
## What changed
- treat ClawHub's immutable `Version <version> already exists` response as a retry path
- continue into the existing exact-version, artifact-hash, and moderation verification gates
- preserve a structured publication evidence record for the already-existing path
- fail normally for every other publishing error

## Why
Release run 30081552994 successfully published and probed PyPI, npm, OpenClaw, Docker/GHCR, native wheels, binaries, and GitHub Release. Its ClawHub retry then failed solely because 1.0.66 was already public. The same job subsequently confirmed that public release as version 1.0.66, scan status clean, and not blocked from download.

Release retries must be idempotent: an immutable existing version should be verified, not overwritten or treated as an unexplained failure.

## Validation
- release-surface contract test now requires the existing-version branch to precede exact public artifact verification
- all non-duplicate ClawHub failures still exit nonzero
- existing public verification still requires latest version equality and a non-empty artifact SHA-256