### PR TITLE
[Superseded by #195] fix(proxy): rescue runaway sessions without cache churn

### DIFF
--- a/.github/workflows/apply-session-rescue-trust-fixes.yml
+++ b/.github/workflows/apply-session-rescue-trust-fixes.yml
@@ -31,7 +31,9 @@ jobs:
                   return False
               count = text.count(old)
               if count != 1:
-                  raise SystemExit(f"{path}: expected one replacement target, found {count}")
+                  raise SystemExit(
+                      f"{path}: expected one replacement target, found {count}"
+                  )
               file_path.write_text(text.replace(old, new, 1), encoding="utf-8")
               return True
 
@@ -46,68 +48,184 @@ jobs:
           )
           changed |= replace_once(
               "entroly/compression_retrieval_store.py",
-              "            content = \\\"\\n\\\".join(lines[start - 1 : end])\n",
-              "            content = \\\"\\\".join(lines[start - 1 : end])\n",
+              '            content = "\\n".join(lines[start - 1 : end])\n',
+              '            content = "".join(lines[start - 1 : end])\n',
           )
           changed |= replace_once(
               "entroly/session_rescue.py",
-              "            compacted, message_receipts = self._compact_message(\n"
-              "                message,\n"
-              "                query=query,\n"
-              "            )\n",
-              "            # Frozen historical bytes must not depend on the newest user\n"
-              "            # query. Otherwise a daemon restart or state eviction can\n"
-              "            # recompress the same old tool output differently and churn the\n"
-              "            # provider-cache prefix. Session rescue is structural, so use a\n"
-              "            # stable query-independent compression contract.\n"
-              "            compacted, message_receipts = self._compact_message(\n"
-              "                message,\n"
-              "                query=\\\"\\\",\n"
-              "            )\n",
+              '''            compacted, message_receipts = self._compact_message(
+                message,
+                query=query,
+            )
+''',
+              '''            # Frozen historical bytes must not depend on the newest user
+            # query. Otherwise a daemon restart or state eviction can
+            # recompress the same old tool output differently and churn the
+            # provider-cache prefix. Session rescue is structural, so use a
+            # stable query-independent compression contract.
+            compacted, message_receipts = self._compact_message(
+                message,
+                query="",
+            )
+''',
           )
           changed |= replace_once(
               "entroly/session_rescue.py",
-              "        span_ids = \\\",\\\".join(span.span_id for span in stored.spans)\n"
-              "        marker = (\n"
-              "            \\\"[entroly-recovery: \\\"\n"
-              "            f\\\"receipt={stored.receipt_id}; spans={span_ids or 'none'}; \\\"\n"
-              "            f\\\"original_sha256={stored.original_hash}]\\\"\n"
-              "        )\n",
-              "        if len(stored.spans) != 1:\n"
-              "            raise RuntimeError(\n"
-              "                \\\"session rescue requires one exact full-original recovery span\\\"\n"
-              "            )\n"
-              "        span_id = stored.spans[0].span_id\n"
-              "        marker = f\\\"[entroly-recovery:{stored.receipt_id}:{span_id}]\\\"\n",
+              '''        span_ids = ",".join(span.span_id for span in stored.spans)
+        marker = (
+            "[entroly-recovery: "
+            f"receipt={stored.receipt_id}; spans={span_ids or 'none'}; "
+            f"original_sha256={stored.original_hash}]"
+        )
+''',
+              '''        if len(stored.spans) != 1:
+            raise RuntimeError(
+                "session rescue requires one exact full-original recovery span"
+            )
+        span_id = stored.spans[0].span_id
+        marker = f"[entroly-recovery:{stored.receipt_id}:{span_id}]"
+''',
           )
 
           test_path = Path("tests/test_session_rescue.py")
           tests = test_path.read_text(encoding="utf-8")
-          marker_assertion = "    assert f\\\"[entroly-recovery:{stored.receipt_id}:{stored.spans[0].span_id}]\\\" in result.messages[1][\\\"content\\\"]\n"
-          anchor = "    assert stored.spans[0].content == tool[\\\"content\\\"]\n"
+          marker_assertion = '''    assert (
+        f"[entroly-recovery:{stored.receipt_id}:{stored.spans[0].span_id}]"
+        in result.messages[1]["content"]
+    )
+'''
+          anchor = '    assert stored.spans[0].content == tool["content"]\n'
           if marker_assertion not in tests:
               if tests.count(anchor) != 1:
-                  raise SystemExit("tests/test_session_rescue.py: marker assertion anchor changed")
+                  raise SystemExit(
+                      "tests/test_session_rescue.py: marker assertion anchor changed"
+                  )
               tests = tests.replace(anchor, anchor + marker_assertion, 1)
               changed = True
 
-          restart_test = '''\n\ndef test_restart_with_different_query_keeps_rescued_prefix_byte_identical(\n    tmp_path: Path, monkeypatch: pytest.MonkeyPatch\n) -> None:\n    import entroly.session_rescue as rescue_module\n\n    class _Receipt:\n        def as_dict(self) -> dict[str, object]:\n            return {\n                "original_tokens": 500,\n                "compressed_tokens": 5,\n                "omitted_spans": [],\n            }\n\n    class _Result:\n        changed = True\n        receipt = _Receipt()\n\n        def __init__(self, query: str) -> None:\n            self.compressed = f"structural-summary query={query}"\n\n        def with_receipt_header(self) -> str:\n            return self.compressed\n\n    def query_sensitive_compressor(\n        _text: str, *, query: str, budget_tokens: int, min_savings: float\n    ) -> _Result:\n        assert budget_tokens > 0\n        assert min_savings > 0\n        return _Result(query)\n\n    monkeypatch.setattr(\n        rescue_module, "compress_evidence_locked", query_sensitive_compressor\n    )\n    first_dir = tmp_path / "first"\n    second_dir = tmp_path / "second"\n    first_dir.mkdir()\n    second_dir.mkdir()\n    policy = {\n        "soft_watermark": 0.20,\n        "hard_watermark": 0.30,\n        "target_watermark": 0.10,\n        "failure_watermark": 0.95,\n        "loop_min_watermark": 0.05,\n        "tail_messages": 2,\n    }\n    first, _ = _controller(first_dir, **policy)\n    restarted, _ = _controller(second_dir, **policy)\n    messages = [\n        {"role": "system", "content": "stable policy"},\n        {"role": "tool", "content": "old tool output " * 500},\n        {"role": "assistant", "content": "checking"},\n        {"role": "user", "content": "continue"},\n    ]\n\n    before_restart = first.rescue(\n        "conv", messages, context_window=4_000, query="payment failure"\n    )\n    after_restart = restarted.rescue(\n        "conv", messages, context_window=4_000, query="unrelated auth question"\n    )\n\n    assert before_restart.messages[1] == after_restart.messages[1]\n    assert before_restart.recovery_receipts == after_restart.recovery_receipts\n    assert "query=" in before_restart.messages[1]["content"]\n    assert "payment failure" not in before_restart.messages[1]["content"]\n    assert "unrelated auth question" not in after_restart.messages[1]["content"]\n'''
+          restart_test = '''
+
+def test_restart_with_different_query_keeps_rescued_prefix_byte_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import entroly.session_rescue as rescue_module
+
+    class _Receipt:
+        def as_dict(self) -> dict[str, object]:
+            return {
+                "original_tokens": 500,
+                "compressed_tokens": 5,
+                "omitted_spans": [],
+            }
+
+    class _Result:
+        changed = True
+        receipt = _Receipt()
+
+        def __init__(self, query: str) -> None:
+            self.compressed = f"structural-summary query={query}"
+
+        def with_receipt_header(self) -> str:
+            return self.compressed
+
+    def query_sensitive_compressor(
+        _text: str, *, query: str, budget_tokens: int, min_savings: float
+    ) -> _Result:
+        assert budget_tokens > 0
+        assert min_savings > 0
+        return _Result(query)
+
+    monkeypatch.setattr(
+        rescue_module, "compress_evidence_locked", query_sensitive_compressor
+    )
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    policy = {
+        "soft_watermark": 0.20,
+        "hard_watermark": 0.30,
+        "target_watermark": 0.10,
+        "failure_watermark": 0.95,
+        "loop_min_watermark": 0.05,
+        "tail_messages": 2,
+    }
+    first, _ = _controller(first_dir, **policy)
+    restarted, _ = _controller(second_dir, **policy)
+    messages = [
+        {"role": "system", "content": "stable policy"},
+        {"role": "tool", "content": "old tool output " * 500},
+        {"role": "assistant", "content": "checking"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    before_restart = first.rescue(
+        "conv", messages, context_window=4_000, query="payment failure"
+    )
+    after_restart = restarted.rescue(
+        "conv", messages, context_window=4_000, query="unrelated auth question"
+    )
+
+    assert before_restart.messages[1] == after_restart.messages[1]
+    assert before_restart.recovery_receipts == after_restart.recovery_receipts
+    assert "query=" in before_restart.messages[1]["content"]
+    assert "payment failure" not in before_restart.messages[1]["content"]
+    assert "unrelated auth question" not in after_restart.messages[1]["content"]
+'''
           restart_anchor = "\n\ndef test_loop_signal_triggers_before_hard_watermark"
-          if "test_restart_with_different_query_keeps_rescued_prefix_byte_identical" not in tests:
+          if (
+              "test_restart_with_different_query_keeps_rescued_prefix_byte_identical"
+              not in tests
+          ):
               if tests.count(restart_anchor) != 1:
-                  raise SystemExit("tests/test_session_rescue.py: restart-test anchor changed")
+                  raise SystemExit(
+                      "tests/test_session_rescue.py: restart-test anchor changed"
+                  )
               tests = tests.replace(restart_anchor, restart_test + restart_anchor, 1)
               changed = True
           test_path.write_text(tests, encoding="utf-8")
 
           store_test_path = Path("tests/test_compression_retrieval_store.py")
           store_tests = store_test_path.read_text(encoding="utf-8")
-          exact_test = '''\n\n@pytest.mark.parametrize(\n    "original",\n    [\n        "line one\\nline two\\n",\n        "line one\\r\\nline two\\r\\n",\n    ],\n)\ndef test_full_span_recovery_preserves_exact_line_endings(\n    tmp_path, original: str\n) -> None:\n    path = tmp_path / "exact-line-endings.json"\n    stored = CompressionRetrievalStore(path).put(\n        original_text=original,\n        compressed_text="[omitted]",\n        receipt={\n            "original_tokens": 10,\n            "compressed_tokens": 2,\n            "omitted_spans": [{"start_line": 1, "end_line": 2}],\n        },\n    )\n\n    assert stored.spans[0].content == original\n    restored = CompressionRetrievalStore(path).get_span(\n        stored.receipt_id, stored.spans[0].span_id\n    )\n    assert restored is not None\n    assert restored.content == original\n'''
+          exact_test = '''
+
+@pytest.mark.parametrize(
+    "original",
+    [
+        "line one\\nline two\\n",
+        "line one\\r\\nline two\\r\\n",
+    ],
+)
+def test_full_span_recovery_preserves_exact_line_endings(
+    tmp_path, original: str
+) -> None:
+    path = tmp_path / "exact-line-endings.json"
+    stored = CompressionRetrievalStore(path).put(
+        original_text=original,
+        compressed_text="[omitted]",
+        receipt={
+            "original_tokens": 10,
+            "compressed_tokens": 2,
+            "omitted_spans": [{"start_line": 1, "end_line": 2}],
+        },
+    )
+
+    assert stored.spans[0].content == original
+    restored = CompressionRetrievalStore(path).get_span(
+        stored.receipt_id, stored.spans[0].span_id
+    )
+    assert restored is not None
+    assert restored.content == original
+'''
           exact_anchor = "\n\ndef test_recovery_store_byte_limit_fails_before_commit"
           if "test_full_span_recovery_preserves_exact_line_endings" not in store_tests:
               if store_tests.count(exact_anchor) != 1:
-                  raise SystemExit("retrieval-store test anchor changed")
-              store_tests = store_tests.replace(exact_anchor, exact_test + exact_anchor, 1)
+                  raise SystemExit(
+                      "retrieval-store test anchor changed"
+                  )
+              store_tests = store_tests.replace(
+                  exact_anchor, exact_test + exact_anchor, 1
+              )
               changed = True
           store_test_path.write_text(store_tests, encoding="utf-8")
 

--- a/.github/workflows/apply-session-rescue-trust-fixes.yml
+++ b/.github/workflows/apply-session-rescue-trust-fixes.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches:
       - fix/session-rescue-cache-stability
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: write
+
+concurrency:
+  group: apply-session-rescue-trust-fixes
+  cancel-in-progress: true
 
 jobs:
   apply-and-verify:
@@ -220,9 +227,7 @@ def test_full_span_recovery_preserves_exact_line_endings(
           exact_anchor = "\n\ndef test_recovery_store_byte_limit_fails_before_commit"
           if "test_full_span_recovery_preserves_exact_line_endings" not in store_tests:
               if store_tests.count(exact_anchor) != 1:
-                  raise SystemExit(
-                      "retrieval-store test anchor changed"
-                  )
+                  raise SystemExit("retrieval-store test anchor changed")
               store_tests = store_tests.replace(
                   exact_anchor, exact_test + exact_anchor, 1
               )
@@ -242,6 +247,7 @@ def test_full_span_recovery_preserves_exact_line_endings(
           ruff check entroly/session_rescue.py entroly/compression_retrieval_store.py tests/test_session_rescue.py tests/test_compression_retrieval_store.py
 
       - name: Commit verified fixes
+        if: github.event_name == 'push'
         shell: bash
         run: |
           if git diff --quiet; then

--- a/.github/workflows/apply-session-rescue-trust-fixes.yml
+++ b/.github/workflows/apply-session-rescue-trust-fixes.yml
@@ -1,0 +1,138 @@
+name: Apply Session Rescue Trust Fixes
+
+on:
+  push:
+    branches:
+      - fix/session-rescue-cache-stability
+
+permissions:
+  contents: write
+
+jobs:
+  apply-and-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: fix/session-rescue-cache-stability
+          fetch-depth: 0
+
+      - name: Apply exact-recovery and cache-stability fixes
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          def replace_once(path: str, old: str, new: str) -> bool:
+              file_path = Path(path)
+              text = file_path.read_text(encoding="utf-8")
+              if new in text:
+                  return False
+              count = text.count(old)
+              if count != 1:
+                  raise SystemExit(f"{path}: expected one replacement target, found {count}")
+              file_path.write_text(text.replace(old, new, 1), encoding="utf-8")
+              return True
+
+          changed = False
+          changed |= replace_once(
+              "entroly/compression_retrieval_store.py",
+              "        lines = original_text.splitlines()\n",
+              "        # Preserve the original line terminators. Recovery is an integrity\n"
+              "        # boundary: CRLF/LF and a trailing newline are source bytes, not\n"
+              "        # presentation details.\n"
+              "        lines = original_text.splitlines(keepends=True)\n",
+          )
+          changed |= replace_once(
+              "entroly/compression_retrieval_store.py",
+              "            content = \\\"\\n\\\".join(lines[start - 1 : end])\n",
+              "            content = \\\"\\\".join(lines[start - 1 : end])\n",
+          )
+          changed |= replace_once(
+              "entroly/session_rescue.py",
+              "            compacted, message_receipts = self._compact_message(\n"
+              "                message,\n"
+              "                query=query,\n"
+              "            )\n",
+              "            # Frozen historical bytes must not depend on the newest user\n"
+              "            # query. Otherwise a daemon restart or state eviction can\n"
+              "            # recompress the same old tool output differently and churn the\n"
+              "            # provider-cache prefix. Session rescue is structural, so use a\n"
+              "            # stable query-independent compression contract.\n"
+              "            compacted, message_receipts = self._compact_message(\n"
+              "                message,\n"
+              "                query=\\\"\\\",\n"
+              "            )\n",
+          )
+          changed |= replace_once(
+              "entroly/session_rescue.py",
+              "        span_ids = \\\",\\\".join(span.span_id for span in stored.spans)\n"
+              "        marker = (\n"
+              "            \\\"[entroly-recovery: \\\"\n"
+              "            f\\\"receipt={stored.receipt_id}; spans={span_ids or 'none'}; \\\"\n"
+              "            f\\\"original_sha256={stored.original_hash}]\\\"\n"
+              "        )\n",
+              "        if len(stored.spans) != 1:\n"
+              "            raise RuntimeError(\n"
+              "                \\\"session rescue requires one exact full-original recovery span\\\"\n"
+              "            )\n"
+              "        span_id = stored.spans[0].span_id\n"
+              "        marker = f\\\"[entroly-recovery:{stored.receipt_id}:{span_id}]\\\"\n",
+          )
+
+          test_path = Path("tests/test_session_rescue.py")
+          tests = test_path.read_text(encoding="utf-8")
+          marker_assertion = "    assert f\\\"[entroly-recovery:{stored.receipt_id}:{stored.spans[0].span_id}]\\\" in result.messages[1][\\\"content\\\"]\n"
+          anchor = "    assert stored.spans[0].content == tool[\\\"content\\\"]\n"
+          if marker_assertion not in tests:
+              if tests.count(anchor) != 1:
+                  raise SystemExit("tests/test_session_rescue.py: marker assertion anchor changed")
+              tests = tests.replace(anchor, anchor + marker_assertion, 1)
+              changed = True
+
+          restart_test = '''\n\ndef test_restart_with_different_query_keeps_rescued_prefix_byte_identical(\n    tmp_path: Path, monkeypatch: pytest.MonkeyPatch\n) -> None:\n    import entroly.session_rescue as rescue_module\n\n    class _Receipt:\n        def as_dict(self) -> dict[str, object]:\n            return {\n                "original_tokens": 500,\n                "compressed_tokens": 5,\n                "omitted_spans": [],\n            }\n\n    class _Result:\n        changed = True\n        receipt = _Receipt()\n\n        def __init__(self, query: str) -> None:\n            self.compressed = f"structural-summary query={query}"\n\n        def with_receipt_header(self) -> str:\n            return self.compressed\n\n    def query_sensitive_compressor(\n        _text: str, *, query: str, budget_tokens: int, min_savings: float\n    ) -> _Result:\n        assert budget_tokens > 0\n        assert min_savings > 0\n        return _Result(query)\n\n    monkeypatch.setattr(\n        rescue_module, "compress_evidence_locked", query_sensitive_compressor\n    )\n    first_dir = tmp_path / "first"\n    second_dir = tmp_path / "second"\n    first_dir.mkdir()\n    second_dir.mkdir()\n    policy = {\n        "soft_watermark": 0.20,\n        "hard_watermark": 0.30,\n        "target_watermark": 0.10,\n        "failure_watermark": 0.95,\n        "loop_min_watermark": 0.05,\n        "tail_messages": 2,\n    }\n    first, _ = _controller(first_dir, **policy)\n    restarted, _ = _controller(second_dir, **policy)\n    messages = [\n        {"role": "system", "content": "stable policy"},\n        {"role": "tool", "content": "old tool output " * 500},\n        {"role": "assistant", "content": "checking"},\n        {"role": "user", "content": "continue"},\n    ]\n\n    before_restart = first.rescue(\n        "conv", messages, context_window=4_000, query="payment failure"\n    )\n    after_restart = restarted.rescue(\n        "conv", messages, context_window=4_000, query="unrelated auth question"\n    )\n\n    assert before_restart.messages[1] == after_restart.messages[1]\n    assert before_restart.recovery_receipts == after_restart.recovery_receipts\n    assert "query=" in before_restart.messages[1]["content"]\n    assert "payment failure" not in before_restart.messages[1]["content"]\n    assert "unrelated auth question" not in after_restart.messages[1]["content"]\n'''
+          restart_anchor = "\n\ndef test_loop_signal_triggers_before_hard_watermark"
+          if "test_restart_with_different_query_keeps_rescued_prefix_byte_identical" not in tests:
+              if tests.count(restart_anchor) != 1:
+                  raise SystemExit("tests/test_session_rescue.py: restart-test anchor changed")
+              tests = tests.replace(restart_anchor, restart_test + restart_anchor, 1)
+              changed = True
+          test_path.write_text(tests, encoding="utf-8")
+
+          store_test_path = Path("tests/test_compression_retrieval_store.py")
+          store_tests = store_test_path.read_text(encoding="utf-8")
+          exact_test = '''\n\n@pytest.mark.parametrize(\n    "original",\n    [\n        "line one\\nline two\\n",\n        "line one\\r\\nline two\\r\\n",\n    ],\n)\ndef test_full_span_recovery_preserves_exact_line_endings(\n    tmp_path, original: str\n) -> None:\n    path = tmp_path / "exact-line-endings.json"\n    stored = CompressionRetrievalStore(path).put(\n        original_text=original,\n        compressed_text="[omitted]",\n        receipt={\n            "original_tokens": 10,\n            "compressed_tokens": 2,\n            "omitted_spans": [{"start_line": 1, "end_line": 2}],\n        },\n    )\n\n    assert stored.spans[0].content == original\n    restored = CompressionRetrievalStore(path).get_span(\n        stored.receipt_id, stored.spans[0].span_id\n    )\n    assert restored is not None\n    assert restored.content == original\n'''
+          exact_anchor = "\n\ndef test_recovery_store_byte_limit_fails_before_commit"
+          if "test_full_span_recovery_preserves_exact_line_endings" not in store_tests:
+              if store_tests.count(exact_anchor) != 1:
+                  raise SystemExit("retrieval-store test anchor changed")
+              store_tests = store_tests.replace(exact_anchor, exact_test + exact_anchor, 1)
+              changed = True
+          store_test_path.write_text(store_tests, encoding="utf-8")
+
+          if not changed:
+              print("Trust fixes are already applied; no source changes required.")
+          PY
+
+      - name: Run focused trust-contract tests
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-deps -e .
+          pip install "mcp>=1.6.0" "httpx>=0.27" "starlette>=0.37" "uvicorn>=0.30" psutil pytest pytest-timeout ruff
+          pytest tests/test_session_rescue.py tests/test_compression_retrieval_store.py tests/test_proxy_session_rescue.py tests/test_cache_stable_live_zone.py -q --tb=short --timeout=60
+          ruff check entroly/session_rescue.py entroly/compression_retrieval_store.py tests/test_session_rescue.py tests/test_compression_retrieval_store.py
+
+      - name: Commit verified fixes
+        shell: bash
+        run: |
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git diff --check
+          git config user.name "juyterman1000"
+          git config user.email "208309368+juyterman1000@users.noreply.github.com"
+          git add entroly/session_rescue.py entroly/compression_retrieval_store.py tests/test_session_rescue.py tests/test_compression_retrieval_store.py
+          git commit -m "fix(session-rescue): preserve exact cache-stable recovery"
+          git push origin HEAD:fix/session-rescue-cache-stability

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Entroly is a local Context OS for AI agents. It unifies the full lifecycle of th
 | **Remember** | Maintains working, episodic, semantic, checkpoint, and knowledge-vault context locally. |
 | **Trust** | Checks prompts, code, provenance, and generated claims with layered security and verification. |
 | **Recover** | Keeps omitted originals reachable through content-addressed handles and replayable Context Commits. |
-| **Spend** | Preserves cache boundaries, accounts for provider usage, and applies explicit routing and budget policy. |
+| **Spend** | Keeps changing evidence in a live zone after stable history, accounts from provider usage, and applies explicit routing and budget policy. |
 | **Learn** | Uses tests, CI, command exits, edits, and user outcomes to improve guarded local policies and skills. |
 
 Most compression tools shrink whatever text the agent already chose. Entroly starts one step earlier: it chooses the highest-value evidence first, compresses only after selection, keeps originals recoverable, then verifies the answer against the evidence.
@@ -143,7 +143,7 @@ Most compression tools shrink whatever text the agent already chose. Entroly sta
 - **Select** - ranks your repo or document set, then sends the answer-relevant context under a token budget.
 - **Verify** - WITNESS can check an answer against supplied evidence locally, without an additional model call. See the scoped benchmark under [Proof](#proof).
 - **Route** - sends easy, repeated tasks to a cheaper model and keeps the flagship for hard ones (opt-in, fail-closed).
-- **Cache-align** - keeps the injected prefix byte-stable so provider prefix caches can keep hitting where terms and API shape allow it.
+- **Cache-safe live zone** - keeps stable system/history bytes ahead of changing Entroly evidence; exact matches may be reused, but changed evidence is never replaced by a merely similar stale block.
 - **Learn** - adapts local ranking signals from recorded outcomes. No embeddings API or training job is required for that path.
 
 Use it however you work: **wrap** your agent, run it as a **proxy**, plug it in as an **MCP server**, or import the **library**.
@@ -152,7 +152,7 @@ Use it however you work: **wrap** your agent, run it as a **proxy**, plug it in 
 
 | What usually breaks AI coding at scale | What Entroly adds |
 |---|---|
-| Context windows fill with logs, duplicate files, and irrelevant chunks | Budgeted selection that favors answer-critical files, dependency links, failures, and anomalies |
+| Autonomous loops keep appending logs until the provider rejects or the session crashes | An in-proxy high-water guard that compacts old tool output recoverably, preserves the recent tail, and blocks unsafe overflow before it reaches the provider |
 | Token savings look good but quality silently drops | Accuracy-retention benchmarks, receipts, and WITNESS verification |
 | Agents lose the exact line, stack trace, or omitted file they later need | Reversible compressed fragments and retrieval handles |
 | First-time setup depends on one IDE or one provider | CLI, SDK, MCP, proxy, npm, PyPI, Docker, and local simulation paths |
@@ -167,7 +167,7 @@ Entroly ships as a full local runtime, not one proxy command:
 | **CLI** | `attach`, `context-commit`, `verify-claims`, `simulate`, `value`, `perf`, `wrap`, `proxy`, `serve`, `daemon`, `benchmark`, `witness`, `receipt`, `audit`, `doctor`, `health`, `batch`, `learn`, `ravs`, `cache`, and more |
 | **SDK** | `compress`, `compress_messages`, `optimize`, `verify`, hallucination detection, Context Receipts, localizers, cache alignment, cost cortex, Memory OS |
 | **MCP server** | Context optimization, exact retrieval, receipts, recovery, feedback, security scans, codebase health, smart reads, belief verification, response verification |
-| **Proxy** | Anthropic/OpenAI-compatible local optimization path for API-key users and custom apps |
+| **Proxy** | OpenAI, Anthropic, Gemini, and compatible local optimization paths for API-key users and custom apps |
 | **Node/WASM** | `entroly`, `entroly-mcp`, and `entroly-wasm` packages for npm users |
 | **Trust layer** | WITNESS, EICV, STAVE, receipt proofs, provenance checks, prompt-injection scanning, and local verification reports |
 | **Proof-guided recovery** | Durable prepare/advance sessions turn unsupported claims into evidence obligations, recover exact omitted chunks, and stop under explicit round/token bounds |
@@ -198,11 +198,42 @@ your agent  ──►  Entroly (local)  ──►  LLM provider
                  ├─ rank the repo        (BM25 + entropy + dep-graph)
                  ├─ select under budget  (knapsack, reversible)
                  ├─ emit receipt         (included, omitted, risks)
-                 ├─ cache-align prefix    (keep provider cache hot)
+                 ├─ stable prefix + live zone (protect native cache boundaries)
+                 ├─ rescue runaway logs  (recoverable high-water checkpoints)
                  └─ verify the reply      (WITNESS hallucination guard)
 ```
 
 Critical files go in full. Supporting files can become signatures. Other material can become a reference that can be expanded on demand. Exact recovery is available only while the corresponding receipt and recovery store are retained; deleting that state deletes Entroly's recovery path.
+
+### Runaway-session rescue without cache churn
+
+When traffic passes through `entroly proxy`, Entroly now guards every outbound
+request before the provider sees it:
+
+- repetitive terminal, test, and function output is compressed in the live
+  zone while errors, failures, paths, and structural metadata remain visible;
+- the complete original tool block is persisted locally **before** mutation,
+  and the forwarded block carries an `entroly-recovery` receipt/span handle;
+- stable system and historical bytes stay ahead of changing Entroly context,
+  rather than rewriting the system prefix on every turn;
+- at soft pressure, a provider-observed warm cache defers optional reshaping;
+  a detected loop or hard pressure overrides that deferral to prevent overflow;
+- recent user/tool turns are preserved; if recoverable compaction still cannot
+  get below the safety watermark, the proxy returns an actionable `413` instead
+  of forwarding a request that is expected to fail upstream.
+
+The guard supports OpenAI messages and Responses input, Anthropic
+`tool_result`, and known textual Gemini `functionResponse` /
+`codeExecutionResult` fields. Gemini IDs, part order, and thought signatures
+are not rewritten. Unknown or ambiguous structures pass through unchanged and
+can trigger the explicit capacity error rather than being guessed at.
+
+This protects only requests routed through the Entroly proxy; it does not mutate
+an agent application's saved transcript in the background. Provider-reported
+cached-token and cache-write usage remains the source of truth—Entroly does not
+convert an internal exact-match counter into a dollar-savings claim.
+
+[Configuration, recovery, and operational limits](docs/session-rescue.md)
 
 ---
 

--- a/docs/compression-proxy.md
+++ b/docs/compression-proxy.md
@@ -31,21 +31,20 @@ receipt = result.receipt.as_dict()
 
 ## Live HTTP proxy mode
 
-Set these before starting the Entroly proxy:
+The live proxy enables recoverable session rescue by default:
 
 ```bash
-export ENTROLY_COMPRESSION_PROXY_MODE=elc
-export ENTROLY_ELC_BUDGET_TOKENS=1200
-export ENTROLY_COMPRESSION_STORE=.entroly/compression-store.json
+export ENTROLY_SESSION_RESCUE_STORE=.entroly/session_rescue_recovery.json
+export ENTROLY_SESSION_TOOL_BUDGET=1200
 entroly proxy
 ```
 
-When `ENTROLY_COMPRESSION_PROXY_MODE=elc`, Entroly installs the live proxy hook
-at package import time. The hook replaces the existing tool-output compression
-function with the Evidence-Locked Compression proxy surface. If the env var is
-absent or different, nothing changes.
+On every supported outbound request, the proxy compresses eligible textual tool
+output, persists one exact full-original recovery span, evaluates the active
+context against the model window, and either forwards, rescues, or returns an
+actionable capacity error. See [session rescue](session-rescue.md).
 
-Programmatic helper:
+The separate environment-driven programmatic helper remains opt-in:
 
 ```python
 from entroly import compress_proxy_payload_from_env
@@ -63,7 +62,12 @@ By default Entroly compresses:
 - OpenAI `role=tool` messages,
 - OpenAI `role=function` messages,
 - Anthropic `tool_result` blocks,
-- OpenAI Responses-style tool/text blocks when enabled.
+- OpenAI Responses-style tool/text blocks when enabled,
+- known textual fields in Gemini `functionResponse` and
+  `codeExecutionResult` parts.
+
+Gemini function-call IDs, part order, thought signatures, and unknown
+structured fields are preserved. Ambiguous structures pass through unchanged.
 
 Entroly preserves user and assistant text by default because the latest user
 message is usually the semantic target. User-message compression is explicit:
@@ -89,18 +93,24 @@ Every compressed block can emit:
 - omitted spans,
 - recoverability metadata.
 
-When a `CompressionRetrievalStore` is supplied, omitted spans are stored locally.
-The receipt includes:
+When a `CompressionRetrievalStore` is supplied, one span containing the complete
+original textual block is stored locally before the forwarded copy is changed.
+This is stronger than depending on the compressor's bounded diagnostic
+omission list. The receipt includes:
 
 ```json
 {
   "retrieval": {
     "receipt_id": "...",
-    "span_count": 3,
+    "span_count": 1,
     "span_ids": ["..."]
   }
 }
 ```
+
+The forwarded block also contains
+`[entroly-recovery:<receipt-id>:<span-id>]`, so an agent can request the exact
+original without relying on response headers.
 
 Fetch a span:
 
@@ -146,6 +156,9 @@ x-entroly-compressed-tokens
 x-entroly-tokens-saved
 x-entroly-savings-ratio
 x-entroly-compressed-blocks
+X-Entroly-Session-Rescue
+X-Entroly-Session-Recovery-Receipts
+X-Entroly-Context-Injection
 ```
 
 ## Benchmark gate

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -70,6 +70,27 @@ For live traffic, inspect response headers such as:
 Provider invoices and provider usage metadata remain the billing source of
 truth.
 
+## Session Rescue and Cache Safety
+
+Session rescue runs only for traffic routed through `entroly proxy`. It does
+not edit a host application's stored transcript, terminate the host's loop, or
+recover a session that never sends another request through Entroly.
+
+The guard preserves ordinary user messages and recent turns. If old recoverable
+tool output is insufficient to bring a request under the safety watermark, the
+proxy returns an actionable `413` rather than silently deleting user evidence
+or forwarding a likely provider rejection.
+
+Recovery is local, not magic: the session-rescue JSON store contains the full
+original tool output in plaintext. Losing or deleting that store removes
+Entroly's recovery path. Protect it with filesystem permissions, source-control
+exclusions, retention policy, and backups appropriate for the underlying data.
+
+Live-zone layout and exact context matching improve prefix stability but do not
+guarantee provider cache hits or savings. Provider thresholds, TTL, pricing,
+routing, and account behavior remain authoritative. See
+[runaway-session rescue and prompt-cache safety](session-rescue.md).
+
 ## Image Inputs
 
 Image optimization is opt-in. The default behavior is to preserve image bytes

--- a/docs/session-rescue.md
+++ b/docs/session-rescue.md
@@ -1,0 +1,158 @@
+# Runaway-session rescue and prompt-cache safety
+
+Entroly's session rescue is an outbound safety controller inside
+`entroly proxy`. It protects a provider request without mutating the transcript
+stored by Claude Code, Codex, OpenClaw, an IDE, or another agent host.
+
+## Runtime contract
+
+For each supported request, the proxy:
+
+1. detects and compresses heavy textual tool output in the live zone;
+2. writes one exact full-original recovery span before changing that block;
+3. estimates the resulting active context against the resolved model window;
+4. defers optional reshaping at the soft watermark when provider usage has
+   reported a warm cache;
+5. overrides that deferral for a detected loop or the hard watermark;
+6. preserves the configured recent tail and all ordinary user messages;
+7. returns `413 session_context_rescue_required` when the request remains above
+   the failure watermark instead of forwarding a likely provider rejection.
+
+The controller is request-driven because Entroly does not own an agent host's
+saved transcript. It runs automatically on every request routed through the
+long-lived proxy daemon; it cannot rescue traffic that bypasses that proxy.
+
+## Cache behavior
+
+Provider caches require reusable prefixes. Entroly therefore uses two distinct
+zones:
+
+```text
+stable provider system/history | current raw turn | dynamic Entroly context
+```
+
+Changing Entroly evidence is appended after the newest safe user/tool content,
+not prepended to the system prompt. On the next turn, the provider can still
+match the historical prefix up to the previous live-zone boundary. Old tool
+output is compressed deterministically without using the latest query, so the
+same raw block produces the same forwarded bytes.
+
+The cache aligner accepts only an exact SHA-256 match. It never substitutes an
+older context because the token sets merely look similar. A provider cache
+lease is based on provider usage fields, not Entroly's internal match counter.
+
+This layout improves the chance of a cache hit; it does not guarantee one.
+Model thresholds, TTLs, routing, account terms, and provider implementation can
+all affect the result. Inspect provider usage metadata and invoices.
+
+## Recovery
+
+The default recovery store is:
+
+```text
+${ENTROLY_DIR:-~/.entroly}/session_rescue_recovery.json
+```
+
+A compressed block contains a marker such as:
+
+```text
+[entroly-recovery:<receipt-id>:<span-id>]
+```
+
+The span is the complete original textual tool block. Retrieve it
+programmatically:
+
+```python
+from entroly import CompressionRetrievalStore
+
+store = CompressionRetrievalStore(
+    ".entroly/session_rescue_recovery.json"
+)
+span = store.get_span(receipt_id, span_id)
+print(span.content)
+```
+
+Or expose the focused local MCP server:
+
+```bash
+export ENTROLY_COMPRESSION_STORE=.entroly/session_rescue_recovery.json
+entroly-compression-mcp
+```
+
+Its tools include `retrieve_compressed_span`, `search_compressed_spans`, and
+`list_compression_receipts`.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---:|---|
+| `ENTROLY_SESSION_RESCUE` | `1` | Enable the proxy guard |
+| `ENTROLY_SESSION_RESCUE_STORE` | under `ENTROLY_DIR` | Exact recovery-store path |
+| `ENTROLY_SESSION_RESCUE_STORE_MAX_BYTES` | `536870912` | Fail before mutation if the store would exceed 512 MiB |
+| `ENTROLY_SESSION_SOFT_WATERMARK` | `0.70` | Begin normal high-water rescue |
+| `ENTROLY_SESSION_HARD_WATERMARK` | `0.88` | Override cache deferral |
+| `ENTROLY_SESSION_TARGET_WATERMARK` | `0.62` | Target after rescue |
+| `ENTROLY_SESSION_FAILURE_WATERMARK` | `0.98` | Refuse unsafe forward |
+| `ENTROLY_SESSION_LOOP_MIN_WATERMARK` | `0.40` | Minimum pressure for loop rescue |
+| `ENTROLY_SESSION_TAIL_MESSAGES` | `8` | Recent messages that are not compacted |
+| `ENTROLY_SESSION_TOOL_BUDGET` | `1200` | Per-block live-zone token budget |
+| `ENTROLY_CACHE_STABLE_INJECTION` | `1` | Put dynamic context after stable history |
+
+Watermarks must satisfy:
+
+```text
+loop_min <= target < soft < hard < failure
+```
+
+Invalid configuration is reported at startup. If the recovery store cannot be
+initialized, recoverable rescue is disabled with an explicit error rather than
+silently pretending it is active.
+
+## Response signals
+
+Useful response headers include:
+
+```text
+X-Entroly-Session-Rescue
+X-Entroly-Session-Original-Tokens
+X-Entroly-Session-Forwarded-Tokens
+X-Entroly-Session-Tokens-Saved
+X-Entroly-Session-Stable-Prefix-Messages
+X-Entroly-Session-Recovery-Receipts
+X-Entroly-Context-Injection
+x-entroly-compression-mode
+x-entroly-compressed-blocks
+```
+
+`GET /stats` reports controller rescues, cache deferrals, blocks, failures, and
+the last decision. These are local operational signals, not provider billing
+proof.
+
+## Security and limitations
+
+- The JSON recovery store contains raw original tool output. Protect it like
+  build logs or source code: restrict filesystem access, exclude it from source
+  control, and apply an appropriate retention policy.
+- The current token estimator is deterministic but approximate. The provider's
+  tokenizer and usage metadata are authoritative.
+- User messages, multimodal blobs, unknown tool-result schemas, and Gemini
+  thought signatures are never guessed at or destructively compacted.
+- A `413` can still require starting a fresh turn or retrieving exact evidence
+  into a smaller prompt. Entroly does not claim that every overflow can be
+  compressed safely.
+- Bypass mode intentionally leaves the request unchanged except for separately
+  configured outbound security policy.
+
+## Verification
+
+```bash
+python -m pytest \
+  tests/test_session_rescue.py \
+  tests/test_proxy_session_rescue.py \
+  tests/test_cache_stable_live_zone.py \
+  tests/test_compression_proxy.py
+```
+
+The tests cover exact recovery, byte-stable frozen history, loop and hard-water
+activation, cache deferral, explicit overflow blocking, provider message
+shapes, and preservation of Gemini identifiers and thought signatures.

--- a/entroly/cache_aligner.py
+++ b/entroly/cache_aligner.py
@@ -4,17 +4,10 @@ Entroly Cache Aligner — Provider KV Cache Optimization
 
 Stabilizes message prefixes so LLM provider KV caches actually work.
 
-Problem: Anthropic offers a 90% read discount on cached prefixes, and
-OpenAI caches repeated prefixes automatically. But if Entroly injects
-different context on every request, the prefix changes every time and
-the cache never hits.
-
-Solution: CacheAligner hashes the injected context and stabilizes it
-when the content hasn't materially changed. If the new context is
->90% similar to the previous injection for the same client, we reuse
-the previous context verbatim — preserving the provider's cache prefix.
-
-This is free money: same quality, 90% cheaper on cache-hit turns.
+Provider prompt caches match exact prefixes.  Reusing an older context merely
+because its token set is similar can silently hide changed evidence.  This
+aligner therefore reuses a block only when its canonical bytes are identical.
+Provider-reported usage remains the source of truth for cache savings.
 
 Thread-safe. Per-client tracking with LRU eviction.
 """
@@ -22,7 +15,6 @@ Thread-safe. Per-client tracking with LRU eviction.
 from __future__ import annotations
 
 import hashlib
-import re
 import threading
 from collections import OrderedDict
 from typing import Any
@@ -45,15 +37,10 @@ except Exception:
 class CacheAligner:
     """Stabilize context prefixes for LLM provider KV cache optimization.
 
-    Tracks per-client context injections. When a new injection is
-    sufficiently similar to the previous one (>similarity_threshold),
-    the previous injection is reused verbatim to preserve cache hits.
-
-    Similarity is measured by token-level Jaccard coefficient:
-        |A ∩ B| / |A ∪ B|
-
-    This is cheaper than computing embeddings and perfectly adequate
-    for detecting near-identical context blocks.
+    Tracks per-client context injections and returns the previous object only
+    for an exact SHA-256 match.  ``similarity_threshold`` remains accepted for
+    API compatibility, but approximate reuse is intentionally disabled:
+    correctness and fresh evidence take precedence over a speculative cache hit.
     """
 
     def __init__(
@@ -61,6 +48,10 @@ class CacheAligner:
         similarity_threshold: float = 0.90,
         max_clients: int = 100,
     ):
+        if not 0.0 <= similarity_threshold <= 1.0:
+            raise ValueError("similarity_threshold must be between zero and one")
+        if max_clients < 1:
+            raise ValueError("max_clients must be at least one")
         self._threshold = similarity_threshold
         self._max_clients = max_clients
         self._cache: OrderedDict[str, dict[str, Any]] = OrderedDict()
@@ -79,29 +70,25 @@ class CacheAligner:
             (aligned_context, cache_hit): The context to use and whether
             the previous cached version was reused.
         """
-        context_tokens = set(re.findall(r'\w+', context))
+        if not client_key:
+            raise ValueError("client_key is required")
+        if not isinstance(context, str):
+            raise TypeError("context must be a string")
+        digest = hashlib.sha256(context.encode("utf-8")).hexdigest()
 
         with self._lock:
             prev = self._cache.get(client_key)
 
-            if prev is not None:
-                prev_tokens = prev["tokens"]
-
-                # Jaccard similarity
-                intersection = len(context_tokens & prev_tokens)
-                union = len(context_tokens | prev_tokens)
-                similarity = intersection / max(union, 1)
-
-                if similarity >= self._threshold:
-                    # Cache hit — reuse previous context verbatim
-                    self._cache.move_to_end(client_key)
-                    self._hits += 1
-                    return prev["context"], True
+            if prev is not None and prev["digest"] == digest:
+                # Exact hit — reuse the existing string object byte-for-byte.
+                self._cache.move_to_end(client_key)
+                self._hits += 1
+                return prev["context"], True
 
             # Cache miss — store new context
             self._cache[client_key] = {
                 "context": context,
-                "tokens": context_tokens,
+                "digest": digest,
             }
             self._cache.move_to_end(client_key)
             self._misses += 1
@@ -126,5 +113,5 @@ class CacheAligner:
                 "cache_misses": self._misses,
                 "hit_rate": round(self._hits / max(total, 1), 4),
                 "active_clients": len(self._cache),
-                "estimated_savings_pct": round(self._hits * 90 / max(total, 1), 1),
+                "match_policy": "exact_sha256",
             }

--- a/entroly/cache_routing.py
+++ b/entroly/cache_routing.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Iterable, Mapping
 
 from .cache_retention import CacheRetentionForecaster
@@ -201,6 +201,26 @@ class CacheAwareRouter:
             self._leases[conversation_id] = lease
             self._evict(now)
             return lease
+
+    def lease_snapshot(
+        self,
+        conversation_id: str,
+        *,
+        now: float | None = None,
+    ) -> ConversationCacheLease | None:
+        """Return a detached, unexpired provider-observed cache lease.
+
+        Callers use this only as a conservative signal.  A lease never proves
+        that a future request will hit; provider usage metadata remains the
+        source of truth.
+        """
+        if not conversation_id:
+            return None
+        timestamp = time.time() if now is None else float(now)
+        with self._lock:
+            self._evict(timestamp)
+            lease = self._leases.get(conversation_id)
+            return replace(lease) if lease is not None else None
 
     def get_lease(self, conversation_id: str) -> ConversationCacheLease | None:
         with self._lock:

--- a/entroly/compression_proxy.py
+++ b/entroly/compression_proxy.py
@@ -17,6 +17,7 @@ back by receipt/span id.
 
 from __future__ import annotations
 
+import copy
 import os
 import re
 from dataclasses import asdict, dataclass, field
@@ -213,6 +214,19 @@ def compress_proxy_payload(
             compressed_blocks += changed_count
             receipts.extend(block_receipts)
 
+    if "contents" in body and isinstance(body.get("contents"), list):
+        new_contents, changed_count, block_receipts = _compress_gemini_contents(
+            body["contents"],
+            query=query,
+            budget_tokens=budget_tokens,
+            include_receipt_header=include_receipt_header,
+            retrieval_store=retrieval_store,
+        )
+        if changed_count:
+            new_body["contents"] = new_contents
+            compressed_blocks += changed_count
+            receipts.extend(block_receipts)
+
     compressed_tokens = _estimate_body_tokens(new_body)
     saved = max(0, original_tokens - compressed_tokens)
     receipt = ProxyCompressionReceipt(
@@ -324,6 +338,64 @@ def _compress_input_items(
     return out, changed_count, receipts
 
 
+def _compress_gemini_contents(
+    contents: list[Any],
+    *,
+    query: str,
+    budget_tokens: int,
+    include_receipt_header: bool,
+    retrieval_store: CompressionRetrievalStore | None,
+) -> tuple[list[Any], int, list[dict[str, object]]]:
+    """Compress only textual tool-result payloads inside Gemini Parts.
+
+    Function-call IDs, thought signatures, part ordering, and every unsupported
+    field are copied byte-for-byte. Ambiguous structured results are left
+    untouched instead of risking an invalid Gemini request.
+    """
+    output = copy.deepcopy(contents)
+    changed_count = 0
+    receipts: list[dict[str, object]] = []
+    for content in output:
+        if not isinstance(content, dict) or not isinstance(
+            content.get("parts"),
+            list,
+        ):
+            continue
+        for part in content["parts"]:
+            if not isinstance(part, dict):
+                continue
+            targets: list[tuple[dict[str, Any], str]] = []
+            function_response = part.get("functionResponse")
+            if isinstance(function_response, dict):
+                response = function_response.get("response")
+                if isinstance(response, dict):
+                    targets.extend(
+                        (response, key)
+                        for key in ("output", "result", "content", "text")
+                        if isinstance(response.get(key), str)
+                    )
+            code_result = part.get("codeExecutionResult")
+            if isinstance(code_result, dict) and isinstance(
+                code_result.get("output"),
+                str,
+            ):
+                targets.append((code_result, "output"))
+            for container, key in targets:
+                compressed, changed, receipt = _compress_text_block(
+                    container[key],
+                    query=query,
+                    budget_tokens=budget_tokens,
+                    include_receipt_header=include_receipt_header,
+                    retrieval_store=retrieval_store,
+                )
+                if not changed:
+                    continue
+                container[key] = compressed
+                changed_count += 1
+                receipts.append(receipt)
+    return output, changed_count, receipts
+
+
 def _compress_content_blocks(
     blocks: list[Any],
     *,
@@ -392,11 +464,34 @@ def _compress_text_block(
     receipt = result.receipt.as_dict()
     if not result.changed:
         return text, False, receipt
+    rendered = (
+        result.with_receipt_header()
+        if include_receipt_header
+        else result.compressed
+    )
     if retrieval_store is not None:
+        # Reserve enough space for the deterministic recovery marker before
+        # writing anything. Borderline compression must not create an unused
+        # recovery record and then forward the original block.
+        if estimate_tokens(rendered) + 32 >= estimate_tokens(text):
+            return text, False, receipt
+        # The ELC receipt intentionally caps its diagnostic omission list.
+        # A recovery handle must have a stronger contract: one exact span for
+        # the complete original block, regardless of that diagnostic cap.
+        recovery_receipt = dict(receipt)
+        line_count = max(1, text.count("\n") + 1)
+        recovery_receipt["omitted_spans"] = [
+            {
+                "start_line": 1,
+                "end_line": line_count,
+                "line_count": line_count,
+                "reason": "compression_proxy_full_recovery",
+            }
+        ]
         stored = retrieval_store.put(
             original_text=text,
             compressed_text=result.compressed,
-            receipt=receipt,
+            receipt=recovery_receipt,
             metadata={"query": query, "cleaned_query": cleaned_query, "component": "compression_proxy"},
         )
         receipt["retrieval"] = {
@@ -404,7 +499,13 @@ def _compress_text_block(
             "span_count": len(stored.spans),
             "span_ids": [span.span_id for span in stored.spans],
         }
-    rendered = result.with_receipt_header() if include_receipt_header else result.compressed
+        span_id = stored.spans[0].span_id if stored.spans else "none"
+        rendered = (
+            f"{rendered}\n"
+            f"[entroly-recovery:{stored.receipt_id}:{span_id}]"
+        )
+    if estimate_tokens(rendered) >= estimate_tokens(text):
+        return text, False, receipt
     return rendered, True, receipt
 
 

--- a/entroly/compression_retrieval_store.py
+++ b/entroly/compression_retrieval_store.py
@@ -151,13 +151,26 @@ class CompressionRetrievalStore:
         path: str | Path | None = None,
         *,
         optimization_ledger: OptimizationLedger | None = None,
+        max_bytes: int | None = None,
     ) -> None:
         self.path = Path(path) if path is not None else None
         self.optimization_ledger = optimization_ledger
+        if max_bytes is not None and int(max_bytes) < 1:
+            raise ValueError("max_bytes must be positive when configured")
+        self.max_bytes = int(max_bytes) if max_bytes is not None else None
         self._items: dict[str, StoredCompression] = {}
         self._lock = threading.RLock()
         self._disk_signature: tuple[int, int, int] | None = None
         if self.path is not None and self.path.exists():
+            if (
+                self.max_bytes is not None
+                and self.path.stat().st_size > self.max_bytes
+            ):
+                raise OSError(
+                    errno.ENOSPC,
+                    "recovery store already exceeds its configured byte limit",
+                    str(self.path),
+                )
             self._load()
         if self.optimization_ledger is not None:
             for item in self._items.values():
@@ -915,6 +928,16 @@ class CompressionRetrievalStore:
             ],
         }
         serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        serialized_bytes = len(serialized.encode("utf-8"))
+        if self.max_bytes is not None and serialized_bytes > self.max_bytes:
+            raise OSError(
+                errno.ENOSPC,
+                (
+                    "recovery store write would exceed its configured "
+                    f"{self.max_bytes}-byte limit"
+                ),
+                str(self.path),
+            )
         tmp = self.path.with_name(
             f".{self.path.name}.{os.getpid()}.{threading.get_ident()}."
             f"{time.time_ns()}.tmp"

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -55,6 +55,7 @@ from .proxy_transform import (
     format_hierarchical_context,
     inject_context_anthropic,
     inject_context_gemini,
+    inject_context_live_zone,
     inject_context_openai,
     inject_context_responses,
     strip_anthropic_unsupported_params,
@@ -62,6 +63,8 @@ from .proxy_transform import (
 from .behavioral_waste import BehavioralWasteDetector, observe_canonical_messages
 from .cache_aligner import CacheAligner
 from .cache_routing import CacheAwareRouter, CachePrice, ModelCandidate
+from .compression_proxy import compress_proxy_payload
+from .compression_retrieval_store import CompressionRetrievalStore
 from .control_plane import (
     ControlAudit,
     ControlPlaneDecision,
@@ -81,6 +84,11 @@ from .provider_policy import (
 )
 from .optimization_ledger import OptimizationEvent, OptimizationLedger, SavingsTier
 from .stable_prefix import conversation_anchor
+from .session_rescue import (
+    SessionRescueController,
+    SessionRescuePolicy,
+    estimate_message_tokens,
+)
 from .usage_ledger import (
     TokenUsage,
     UsageLedger,
@@ -1054,15 +1062,11 @@ class PromptCompilerProxy:
         self._total_output_original_tokens: int = 0
         self._total_output_compressed_tokens: int = 0
 
-        # ── Cache Aligner ──
-        # Stabilizes Entroly's injected CONTEXT block across turns of the same
-        # conversation so the provider's prefix/KV cache keeps hitting
-        # (Anthropic 90% / OpenAI 50% read discount) on chatty, stable-context
-        # sessions — the dominant cost on large repos. Context-only: it does
-        # not alter the model, generation params, tools, or the user's messages.
-        # Provider terms and data-handling rules still apply to whatever the
-        # user sends through their configured provider. Disable with
-        # ENTROLY_CACHE_ALIGN=0. Fail-open.
+        # ── Exact Context Identity ──
+        # Approximate reuse is forbidden because it can hide changed evidence.
+        # Dynamic context is injected in the live zone, after the stable
+        # provider prefix. Provider usage is the source of truth for savings.
+        # Disable identity tracking with ENTROLY_CACHE_ALIGN=0.
         self._cache_align_enabled = os.environ.get("ENTROLY_CACHE_ALIGN", "1") != "0"
         self._cache_aligner = CacheAligner() if self._cache_align_enabled else None
 
@@ -1100,6 +1104,73 @@ class PromptCompilerProxy:
         self._behavior_findings = 0
         self._behavior_failures = 0
         self._behavior_last: list[dict[str, Any]] = []
+
+        # Active session rescue runs inside the always-on proxy daemon.  It
+        # freezes already-compressed message bytes, persists every omission
+        # before mutation, and refuses an unsafe over-limit forward.
+        self._session_rescue_enabled = (
+            os.environ.get("ENTROLY_SESSION_RESCUE", "1").lower()
+            in {"1", "true", "yes", "on"}
+        )
+        self._session_rescue: SessionRescueController | None = None
+        self._session_rescue_store: CompressionRetrievalStore | None = None
+        self._session_rescue_last: dict[str, Any] | None = None
+        self._session_rescue_init_error = ""
+        if self._session_rescue_enabled:
+            try:
+                rescue_root = Path(
+                    os.environ.get(
+                        "ENTROLY_DIR",
+                        str(Path.home() / ".entroly"),
+                    )
+                )
+                rescue_path = Path(
+                    os.environ.get(
+                        "ENTROLY_SESSION_RESCUE_STORE",
+                        str(rescue_root / "session_rescue_recovery.json"),
+                    )
+                )
+                self._session_rescue_store = CompressionRetrievalStore(
+                    rescue_path,
+                    max_bytes=max(
+                        1,
+                        _env_int(
+                            "ENTROLY_SESSION_RESCUE_STORE_MAX_BYTES",
+                            512 * 1024 * 1024,
+                        ),
+                    ),
+                )
+                self._session_rescue = SessionRescueController(
+                    recovery_store=self._session_rescue_store,
+                    policy=SessionRescuePolicy(
+                        soft_watermark=_env_float(
+                            "ENTROLY_SESSION_SOFT_WATERMARK", 0.70
+                        ),
+                        hard_watermark=_env_float(
+                            "ENTROLY_SESSION_HARD_WATERMARK", 0.88
+                        ),
+                        target_watermark=_env_float(
+                            "ENTROLY_SESSION_TARGET_WATERMARK", 0.62
+                        ),
+                        failure_watermark=_env_float(
+                            "ENTROLY_SESSION_FAILURE_WATERMARK", 0.98
+                        ),
+                        loop_min_watermark=_env_float(
+                            "ENTROLY_SESSION_LOOP_MIN_WATERMARK", 0.40
+                        ),
+                        tail_messages=max(
+                            2,
+                            _env_int("ENTROLY_SESSION_TAIL_MESSAGES", 8),
+                        ),
+                    ),
+                )
+            except Exception as exc:
+                self._session_rescue_init_error = str(exc)
+                logger.error(
+                    "Session rescue disabled because its recoverable store "
+                    "could not be initialized: %s",
+                    exc,
+                )
         optimization_path = os.environ.get(
             "ENTROLY_OPTIMIZATION_LEDGER", ""
         ).strip()
@@ -1916,6 +1987,9 @@ class PromptCompilerProxy:
         usage_dimensions = self._usage_dimensions(headers)
         provider = detect_provider(path, headers, body)
         gateway_adapter = None
+        behavior_findings = ()
+        conversation_id = ""
+        session_rescue_result = None
         try:
             gateway_adapter = canonical_request_from_provider_body(
                 provider,
@@ -1940,6 +2014,7 @@ class PromptCompilerProxy:
                         gateway_adapter.canonical.messages,
                         model=gateway_adapter.canonical.model,
                     )
+                    behavior_findings = findings
                     if findings:
                         rendered_findings = [
                             {
@@ -2003,7 +2078,153 @@ class PromptCompilerProxy:
         except Exception as e:
             logger.debug("Control-plane planning skipped: %s", e)
 
-        if "messages" in body:
+        sequence_key = (
+            "messages"
+            if (
+                isinstance(body.get("messages"), list)
+                and all(isinstance(item, dict) for item in body["messages"])
+            )
+            else "input"
+            if (
+                isinstance(body.get("input"), list)
+                and all(isinstance(item, dict) for item in body["input"])
+            )
+            else "contents"
+            if (
+                provider == "gemini"
+                and isinstance(body.get("contents"), list)
+                and all(isinstance(item, dict) for item in body["contents"])
+            )
+            else ""
+        )
+        if (
+            sequence_key
+            and not self._bypass
+            and self._session_rescue is not None
+            and self._session_rescue_store is not None
+        ):
+            # Live-zone ELC replaces the legacy lossy pruning stack.  It
+            # compresses tool output deterministically, stores every omission,
+            # and leaves normal user text untouched.
+            try:
+                tool_result = compress_proxy_payload(
+                    body,
+                    provider=provider,
+                    # Keep old tool-output bytes independent of each new user
+                    # turn. Evidence anchors remain deterministic; exact full
+                    # recovery is available by handle.
+                    query="",
+                    budget_tokens=max(
+                        64,
+                        _env_int("ENTROLY_SESSION_TOOL_BUDGET", 1200),
+                    ),
+                    mode="elc",
+                    include_receipt_header=True,
+                    compress_user_messages=False,
+                    retrieval_store=self._session_rescue_store,
+                )
+                body = tool_result.body
+                control_headers.update(tool_result.headers())
+            except Exception as exc:
+                logger.warning(
+                    "Recoverable tool-output compression skipped: %s",
+                    exc,
+                )
+                control_headers["X-Entroly-Compression-Error"] = (
+                    "recovery-store-failure"
+                )
+
+            try:
+                if not conversation_id:
+                    conversation_id = self._routing_conversation_id(body, provider)
+                if conversation_id:
+                    lease = self._cache_router.lease_snapshot(conversation_id)
+                    model = extract_model(body, path) or str(body.get("model", ""))
+                    context_window = (
+                        context_window_for_model(model)
+                        if model
+                        else getattr(self.config, "context_window", 128_000)
+                    )
+                    rescue_messages = body[sequence_key]
+                    if sequence_key == "contents":
+                        rescue_messages = []
+                        for item in body["contents"]:
+                            normalized = dict(item)
+                            normalized["content"] = copy.deepcopy(
+                                normalized.pop("parts", [])
+                            )
+                            rescue_messages.append(normalized)
+                    rescue = self._session_rescue.rescue(
+                        conversation_id,
+                        rescue_messages,
+                        context_window=context_window,
+                        query=extract_user_message(body, provider),
+                        loop_detected=bool(behavior_findings),
+                        cache_warm=bool(
+                            lease is not None and lease.cached_prefix_tokens > 0
+                        ),
+                    )
+                    if sequence_key == "contents":
+                        restored_contents = []
+                        for item in rescue.messages:
+                            restored = dict(item)
+                            restored["parts"] = restored.pop("content", [])
+                            restored_contents.append(restored)
+                        body["contents"] = restored_contents
+                    else:
+                        body[sequence_key] = rescue.messages
+                    session_rescue_result = rescue
+                    control_headers.update(rescue.headers())
+                    self._session_rescue_last = {
+                        "action": rescue.action,
+                        "original_tokens": rescue.original_tokens,
+                        "forwarded_tokens": rescue.forwarded_tokens,
+                        "tokens_saved": rescue.tokens_saved,
+                        "stable_prefix_messages": rescue.stable_prefix_messages,
+                        "recovery_receipts": len(rescue.recovery_receipts),
+                        "cache_deferred": rescue.cache_deferred,
+                        "blocked": rescue.blocked,
+                        "error": rescue.error,
+                    }
+                    if rescue.blocked:
+                        return JSONResponse(
+                            {
+                                "error": "session_context_rescue_required",
+                                "detail": rescue.error,
+                                "action": (
+                                    "Start a fresh agent turn or retrieve the "
+                                    "listed local Entroly recovery receipts, "
+                                    "then retry with less active history."
+                                ),
+                                "original_tokens_estimate": rescue.original_tokens,
+                                "forwarded_tokens_estimate": rescue.forwarded_tokens,
+                                "context_window": context_window,
+                                "recovery_receipts": list(
+                                    rescue.recovery_receipts
+                                ),
+                            },
+                            status_code=413,
+                            headers=control_headers,
+                        )
+            except Exception as exc:
+                logger.exception("Session rescue failed before provider forward")
+                return JSONResponse(
+                    {
+                        "error": "session_rescue_failed",
+                        "detail": str(exc),
+                        "action": (
+                            "The original request was not forwarded or discarded. "
+                            "Check the Entroly session-rescue store and retry."
+                        ),
+                    },
+                    status_code=503,
+                    headers=control_headers,
+                )
+        elif (
+            "messages" in body
+            and not self._bypass
+            and not self._session_rescue_enabled
+        ):
             from .proxy_transform import compress_tool_messages
             # Stage 1: age-tiered pruning (collapses old tool outputs to digests).
             # Runs first so content-aware compression in stage 2 only pays for
@@ -2027,7 +2248,12 @@ class PromptCompilerProxy:
             if tool_tokens_saved > 0:
                 logger.info(f"Tool output compression: {tool_tokens_saved} tokens saved")
 
-        if "messages" in body and self.config.enable_conversation_compression:
+        if (
+            "messages" in body
+            and self.config.enable_conversation_compression
+            and not self._session_rescue_enabled
+            and not self._bypass
+        ):
             body["messages"] = compress_conversation_messages(
                 body["messages"],
                 context_window=getattr(self.config, "context_window", 128_000),
@@ -2205,7 +2431,83 @@ class PromptCompilerProxy:
                                 _sanitize_report.matches,
                             )
 
-                    if provider == "gemini":
+                    cache_stable_injection = (
+                        os.environ.get(
+                            "ENTROLY_CACHE_STABLE_INJECTION",
+                            "1",
+                        ).lower()
+                        in {"1", "true", "yes", "on"}
+                    )
+                    if (
+                        cache_stable_injection
+                        and session_rescue_result is not None
+                        and session_rescue_result.cache_deferred
+                    ):
+                        # A provider-reported warm cache is currently worth
+                        # more than a changing optional context suffix.
+                        control_headers[
+                            "X-Entroly-Context-Injection"
+                        ] = "cache-deferred"
+                    elif cache_stable_injection:
+                        live_zone_body, injected = inject_context_live_zone(
+                            body,
+                            context_text,
+                            provider,
+                        )
+                        if injected:
+                            projected_messages = live_zone_body.get("messages")
+                            if projected_messages is None:
+                                projected_messages = live_zone_body.get("input")
+                            if isinstance(projected_messages, str):
+                                projected_messages = [
+                                    {
+                                        "role": "user",
+                                        "content": projected_messages,
+                                    }
+                                ]
+                            if projected_messages is None and isinstance(
+                                live_zone_body.get("contents"),
+                                list,
+                            ):
+                                projected_messages = [
+                                    {
+                                        "role": item.get("role", ""),
+                                        "content": item.get("parts", []),
+                                    }
+                                    for item in live_zone_body["contents"]
+                                    if isinstance(item, dict)
+                                ]
+                            projected_tokens = (
+                                estimate_message_tokens(projected_messages)
+                                if isinstance(projected_messages, list)
+                                else 0
+                            )
+                            model_window = context_window_for_model(
+                                extract_model(body, path) or ""
+                            )
+                            failure_watermark = (
+                                self._session_rescue.policy.failure_watermark
+                                if self._session_rescue is not None
+                                else 0.98
+                            )
+                            if (
+                                projected_tokens
+                                and projected_tokens
+                                >= int(model_window * failure_watermark)
+                            ):
+                                control_headers[
+                                    "X-Entroly-Context-Injection"
+                                ] = "capacity-deferred"
+                            else:
+                                body = live_zone_body
+                                control_headers[
+                                    "X-Entroly-Context-Injection"
+                                ] = "live-zone"
+                        else:
+                            control_headers[
+                                "X-Entroly-Context-Injection"
+                            ] = "shape-deferred"
+                    elif provider == "gemini":
                         body = inject_context_gemini(body, context_text)
                     elif provider == "anthropic":
                         body = inject_context_anthropic(body, context_text)
@@ -2215,7 +2517,10 @@ class PromptCompilerProxy:
                         body = inject_context_openai(body, context_text)
 
                     # Entropic Conversation Pruning
-                    if provider != "gemini":
+                    if (
+                        provider != "gemini"
+                        and not self._session_rescue_enabled
+                    ):
                         try:
                             from .proxy_transform import entropic_conversation_prune
                             from .hardening import ECP_THRASH_GUARD
@@ -2519,14 +2824,16 @@ class PromptCompilerProxy:
                 allow_model_change=_ravs_swapped,
             )
             control_outcome = "optimized" if body != control_before else "observed"
-            control_headers = self._control_headers(
-                control_decision,
-                control_audit,
-                body=body,
-                headers=headers,
-                provider=provider,
-                path=path,
-                outcome=control_outcome,
+            control_headers.update(
+                self._control_headers(
+                    control_decision,
+                    control_audit,
+                    body=body,
+                    headers=headers,
+                    provider=provider,
+                    path=path,
+                    outcome=control_outcome,
+                )
             )
             if not control_audit.compliant:
                 logger.warning(
@@ -2965,15 +3272,10 @@ class PromptCompilerProxy:
                 f"{total_tokens} tokens{ios_str}"
             )
 
-        # ── Cache-aligned context reuse (provider prefix-cache hits) ──
-        # When this turn's injected context block is >=90% similar to the
-        # previous one for the same conversation, reuse the previous block
-        # verbatim so the provider's cached prefix keeps hitting (Anthropic 90%
-        # / OpenAI 50% read discount) — the dominant cost on chatty large-repo
-        # sessions. This rewrites ONLY Entroly's own injected context string;
-        # it never mutates the model, generation params, tools, or the user's
-        # messages. Provider terms and data-handling rules still apply.
-        # Fail-open: on any error the freshly optimized context is used.
+        # ── Exact context identity (no approximate/stale reuse) ──
+        # Exact identity permits byte-for-byte reuse without hiding changed
+        # evidence. ``handle_proxy`` places dynamic context in the live zone so
+        # a changing selection cannot invalidate the provider cache at token 1.
         if context_text and self._cache_aligner is not None:
             try:
                 _ckey = self._conversation_key(body)
@@ -5387,6 +5689,17 @@ async def _proxy_stats(request: Request) -> JSONResponse:
         "failures": proxy._behavior_failures,
         "last_findings": proxy._behavior_last,
         "optimization_ledger_enabled": proxy._optimization_ledger is not None,
+    }
+    stats["session_rescue"] = {
+        "enabled": proxy._session_rescue is not None,
+        "configured": proxy._session_rescue_enabled,
+        "init_error": proxy._session_rescue_init_error or None,
+        "last": proxy._session_rescue_last,
+        **(
+            proxy._session_rescue.stats()
+            if proxy._session_rescue is not None
+            else {}
+        ),
     }
     usage_accounting: dict[str, Any] = {
         "enabled": proxy._usage_ledger is not None,

--- a/entroly/proxy_transform.py
+++ b/entroly/proxy_transform.py
@@ -880,6 +880,98 @@ def inject_context_gemini(
     return body
 
 
+def inject_context_live_zone(
+    body: dict[str, Any],
+    context_text: str,
+    provider: str,
+) -> tuple[dict[str, Any], bool]:
+    """Append dynamic context after the request's stable provider prefix.
+
+    Rewriting a system prompt on every turn invalidates the provider cache from
+    its first token. This helper instead appends Entroly's changing evidence to
+    the newest user/tool turn. On the next request, the raw historical turn
+    still matches up to the point where the prior live-zone suffix began, so
+    the largest safe prefix remains reusable.
+
+    Unsupported or ambiguous message shapes are returned unchanged. A cache
+    optimization must never corrupt provider role/tool sequencing.
+    """
+    if not context_text:
+        return copy.deepcopy(body), False
+    wrapped = (
+        "\n\n<entroly_dynamic_context>\n"
+        f"{context_text}\n"
+        "</entroly_dynamic_context>"
+    )
+    updated = copy.deepcopy(body)
+
+    if provider == "gemini":
+        contents = updated.get("contents")
+        if not isinstance(contents, list):
+            return updated, False
+        for item in reversed(contents):
+            if not isinstance(item, dict) or item.get("role") != "user":
+                continue
+            parts = item.get("parts")
+            if not isinstance(parts, list):
+                return updated, False
+            parts.append({"text": wrapped.lstrip()})
+            return updated, True
+        return updated, False
+
+    if "messages" in updated:
+        messages = updated.get("messages")
+        if not isinstance(messages, list):
+            return updated, False
+        allowed_roles = (
+            {"user"}
+            if provider == "anthropic"
+            else {"user", "tool", "function"}
+        )
+        for message in reversed(messages):
+            if (
+                not isinstance(message, dict)
+                or str(message.get("role", "")) not in allowed_roles
+            ):
+                continue
+            content = message.get("content")
+            if isinstance(content, str):
+                message["content"] = f"{content}{wrapped}"
+                return updated, True
+            if isinstance(content, list) and message.get("role") == "user":
+                content.append({"type": "text", "text": wrapped.lstrip()})
+                return updated, True
+            return updated, False
+        return updated, False
+
+    input_value = updated.get("input")
+    if isinstance(input_value, str):
+        updated["input"] = f"{input_value}{wrapped}"
+        return updated, True
+    if not isinstance(input_value, list):
+        return updated, False
+    for item in reversed(input_value):
+        if not isinstance(item, dict):
+            continue
+        if (
+            item.get("type") == "function_call_output"
+            and isinstance(item.get("output"), str)
+        ):
+            item["output"] = f"{item['output']}{wrapped}"
+            return updated, True
+        if item.get("role") != "user":
+            continue
+        content = item.get("content")
+        if isinstance(content, str):
+            item["content"] = f"{content}{wrapped}"
+            return updated, True
+        if isinstance(content, list):
+            content.append({"type": "input_text", "text": wrapped.lstrip()})
+            return updated, True
+        return updated, False
+    return updated, False
+
+
 # ══════════════════════════════════════════════════════════════════════
 _LANG_MAP = {
     ".py": "python",

--- a/entroly/session_rescue.py
+++ b/entroly/session_rescue.py
@@ -1,0 +1,550 @@
+"""Cache-stable, recoverable rescue for runaway agent conversations.
+
+The proxy daemon sees every outbound model request.  This controller uses that
+position to prevent an append-only agent loop from crossing the provider context
+limit:
+
+* soft pressure starts evidence-locked compression only when no warm provider
+  cache would be sacrificed;
+* a detected retry loop or the hard watermark overrides that deferral;
+* once a message is compacted, its transformed bytes are frozen for the rest of
+  the session, so later turns do not repeatedly rewrite the old prefix;
+* every omitted span is persisted before the outbound copy is changed.
+
+The controller does not mutate the agent application's stored transcript.  It
+rescues the request sent through Entroly and returns explicit recovery handles.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+from .compression_retrieval_store import CompressionRetrievalStore
+from .evidence_locked_compression import compress_evidence_locked, estimate_tokens
+
+
+def _text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            text for item in content if (text := _text_from_content(item))
+        )
+    if isinstance(content, dict):
+        parts: list[str] = []
+        for key in (
+            "text",
+            "content",
+            "output",
+            "result",
+            "response",
+            "parts",
+            "functionResponse",
+            "codeExecutionResult",
+        ):
+            value = content.get(key)
+            if isinstance(value, (str, list, dict)):
+                rendered = _text_from_content(value)
+                if rendered:
+                    parts.append(rendered)
+        return "\n".join(parts)
+    return ""
+
+
+def estimate_message_tokens(messages: Sequence[dict[str, Any]]) -> int:
+    """Conservative, deterministic token estimate including message overhead."""
+    total = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        text = _text_from_content(message.get("content", ""))
+        # ``estimate_tokens`` is the shared Entroly estimator.  The fixed
+        # overhead accounts for role/name/tool-call framing.
+        total += estimate_tokens(text) + 8
+    return total
+
+
+def _message_digest(message: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        message,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class SessionRescuePolicy:
+    soft_watermark: float = 0.70
+    hard_watermark: float = 0.88
+    target_watermark: float = 0.62
+    failure_watermark: float = 0.98
+    loop_min_watermark: float = 0.40
+    tail_messages: int = 8
+    max_sessions: int = 2_000
+    min_message_tokens: int = 80
+    max_block_budget: int = 1_200
+
+    def __post_init__(self) -> None:
+        levels = (
+            self.loop_min_watermark,
+            self.target_watermark,
+            self.soft_watermark,
+            self.hard_watermark,
+            self.failure_watermark,
+        )
+        if not all(0.0 < value < 1.0 for value in levels):
+            raise ValueError("session rescue watermarks must be between zero and one")
+        if not (
+            self.loop_min_watermark
+            <= self.target_watermark
+            < self.soft_watermark
+            < self.hard_watermark
+            < self.failure_watermark
+        ):
+            raise ValueError("session rescue watermarks are not ordered")
+        if self.tail_messages < 2:
+            raise ValueError("tail_messages must be at least two")
+        if self.max_sessions < 1 or self.min_message_tokens < 1:
+            raise ValueError("session rescue bounds must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class SessionRescueResult:
+    messages: list[dict[str, Any]]
+    action: str
+    original_tokens: int
+    forwarded_tokens: int
+    utilization_before: float
+    utilization_after: float
+    tokens_saved: int
+    recovery_receipts: tuple[str, ...] = ()
+    stable_prefix_messages: int = 0
+    cache_deferred: bool = False
+    blocked: bool = False
+    error: str = ""
+
+    def headers(self) -> dict[str, str]:
+        return {
+            "X-Entroly-Session-Rescue": self.action,
+            "X-Entroly-Session-Original-Tokens": str(self.original_tokens),
+            "X-Entroly-Session-Forwarded-Tokens": str(self.forwarded_tokens),
+            "X-Entroly-Session-Tokens-Saved": str(self.tokens_saved),
+            "X-Entroly-Session-Stable-Prefix-Messages": str(
+                self.stable_prefix_messages
+            ),
+            "X-Entroly-Session-Recovery-Receipts": str(
+                len(self.recovery_receipts)
+            ),
+        }
+
+
+@dataclass(slots=True)
+class _SessionState:
+    frozen: dict[str, Any] = field(default_factory=dict)
+    previous_output_digests: tuple[str, ...] = ()
+    active: bool = False
+    checkpoints: int = 0
+
+
+class SessionRescueController:
+    """Bounded, thread-safe controller for outbound conversation rescue."""
+
+    def __init__(
+        self,
+        *,
+        recovery_store: CompressionRetrievalStore,
+        policy: SessionRescuePolicy | None = None,
+    ) -> None:
+        if recovery_store is None:
+            raise ValueError("a recovery_store is required")
+        self.recovery_store = recovery_store
+        self.policy = policy or SessionRescuePolicy()
+        self._states: OrderedDict[str, _SessionState] = OrderedDict()
+        self._lock = threading.RLock()
+        self._rescues = 0
+        self._blocks = 0
+        self._cache_deferrals = 0
+        self._failures = 0
+
+    def rescue(
+        self,
+        conversation_id: str,
+        messages: Sequence[dict[str, Any]],
+        *,
+        context_window: int,
+        query: str = "",
+        loop_detected: bool = False,
+        cache_warm: bool = False,
+    ) -> SessionRescueResult:
+        if not conversation_id:
+            raise ValueError("conversation_id is required")
+        if context_window < 1:
+            raise ValueError("context_window must be positive")
+        source = [dict(message) for message in messages if isinstance(message, dict)]
+        original_tokens = estimate_message_tokens(source)
+        utilization = original_tokens / context_window
+
+        with self._lock:
+            state = self._states.get(conversation_id)
+            if state is None:
+                state = _SessionState()
+                self._states[conversation_id] = state
+            self._states.move_to_end(conversation_id)
+            while len(self._states) > self.policy.max_sessions:
+                self._states.popitem(last=False)
+
+            should_rescue = (
+                state.active
+                or utilization >= self.policy.hard_watermark
+                or (
+                    loop_detected
+                    and utilization >= self.policy.loop_min_watermark
+                )
+                or (
+                    utilization >= self.policy.soft_watermark
+                    and not cache_warm
+                )
+            )
+            if not should_rescue:
+                deferred = (
+                    cache_warm
+                    and utilization >= self.policy.soft_watermark
+                    and utilization < self.policy.hard_watermark
+                )
+                if deferred:
+                    self._cache_deferrals += 1
+                stable = self._stable_prefix_count(state, source)
+                self._remember_output(state, source)
+                return SessionRescueResult(
+                    messages=source,
+                    action="cache-deferred" if deferred else "passthrough",
+                    original_tokens=original_tokens,
+                    forwarded_tokens=original_tokens,
+                    utilization_before=utilization,
+                    utilization_after=utilization,
+                    tokens_saved=0,
+                    stable_prefix_messages=stable,
+                    cache_deferred=deferred,
+                )
+
+            emergency = utilization >= self.policy.hard_watermark
+            target_tokens = max(1, int(context_window * self.policy.target_watermark))
+            working = copy.deepcopy(source)
+            receipt_ids: list[str] = []
+            try:
+                working, receipt_ids = self._compact_candidates(
+                    state,
+                    working,
+                    query=query,
+                    target_tokens=target_tokens,
+                    include_assistant=emergency or loop_detected,
+                )
+            except Exception as exc:
+                self._failures += 1
+                stable = self._stable_prefix_count(state, source)
+                self._remember_output(state, source)
+                return SessionRescueResult(
+                    messages=source,
+                    action="failed",
+                    original_tokens=original_tokens,
+                    forwarded_tokens=original_tokens,
+                    utilization_before=utilization,
+                    utilization_after=utilization,
+                    tokens_saved=0,
+                    stable_prefix_messages=stable,
+                    blocked=utilization >= self.policy.failure_watermark,
+                    error=f"recovery persistence failed: {exc}",
+                )
+
+            forwarded_tokens = estimate_message_tokens(working)
+            after = forwarded_tokens / context_window
+            blocked = after >= self.policy.failure_watermark
+            changed = working != source
+            if blocked:
+                self._blocks += 1
+            else:
+                state.active = True
+                if changed:
+                    state.checkpoints += 1
+                    self._rescues += 1
+            stable = self._stable_prefix_count(state, working)
+            self._remember_output(state, working)
+            return SessionRescueResult(
+                messages=working,
+                action=(
+                    "blocked"
+                    if blocked
+                    else "pressure-observed"
+                    if not changed
+                    else "loop-rescue"
+                    if loop_detected
+                    else "emergency-rescue"
+                    if emergency
+                    else "high-water-rescue"
+                ),
+                original_tokens=original_tokens,
+                forwarded_tokens=forwarded_tokens,
+                utilization_before=utilization,
+                utilization_after=after,
+                tokens_saved=max(0, original_tokens - forwarded_tokens),
+                recovery_receipts=tuple(receipt_ids),
+                stable_prefix_messages=stable,
+                blocked=blocked,
+                error=(
+                    "request still exceeds the safe context watermark after "
+                    "recoverable compression"
+                    if blocked
+                    else ""
+                ),
+            )
+
+    def _compact_candidates(
+        self,
+        state: _SessionState,
+        messages: list[dict[str, Any]],
+        *,
+        query: str,
+        target_tokens: int,
+        include_assistant: bool,
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        cutoff = max(0, len(messages) - self.policy.tail_messages)
+        tool_indices = [
+            index
+            for index, message in enumerate(messages[:cutoff])
+            if str(message.get("role", "")).lower() in {"tool", "function"}
+            or self._has_tool_result(message.get("content"))
+        ]
+        assistant_indices = [
+            index
+            for index, message in enumerate(messages[:cutoff])
+            if str(message.get("role", "")).lower() == "assistant"
+            and index not in tool_indices
+        ]
+        candidates = tool_indices + (assistant_indices if include_assistant else [])
+        receipts: list[str] = []
+        for index in candidates:
+            if estimate_message_tokens(messages) <= target_tokens:
+                break
+            message = messages[index]
+            digest = _message_digest(message)
+            frozen = state.frozen.get(digest)
+            if frozen is not None:
+                messages[index] = copy.deepcopy(frozen)
+                continue
+            compacted, message_receipts = self._compact_message(
+                message,
+                query=query,
+            )
+            if compacted == message:
+                continue
+            state.frozen[digest] = copy.deepcopy(compacted)
+            messages[index] = compacted
+            receipts.extend(message_receipts)
+        return messages, receipts
+
+    def _compact_message(
+        self,
+        message: dict[str, Any],
+        *,
+        query: str,
+    ) -> tuple[dict[str, Any], list[str]]:
+        content = message.get("content")
+        if isinstance(content, str):
+            compacted, receipt_id = self._compact_text(content, query=query)
+            if receipt_id is None:
+                return message, []
+            updated = dict(message)
+            updated["content"] = compacted
+            return updated, [receipt_id]
+        if isinstance(content, list):
+            updated_blocks: list[Any] = []
+            receipt_ids: list[str] = []
+            changed = False
+            for block in content:
+                if not isinstance(block, dict):
+                    updated_blocks.append(block)
+                    continue
+                if block.get("type") == "tool_result":
+                    inner = block.get("content")
+                    if not isinstance(inner, str):
+                        updated_blocks.append(block)
+                        continue
+                    compacted, receipt_id = self._compact_text(inner, query=query)
+                    if receipt_id is None:
+                        updated_blocks.append(block)
+                        continue
+                    updated = dict(block)
+                    updated["content"] = compacted
+                    updated_blocks.append(updated)
+                    receipt_ids.append(receipt_id)
+                    changed = True
+                    continue
+                updated, block_receipts = self._compact_gemini_part(
+                    block,
+                    query=query,
+                )
+                if not block_receipts:
+                    updated_blocks.append(block)
+                    continue
+                updated_blocks.append(updated)
+                receipt_ids.extend(block_receipts)
+                changed = True
+            if changed:
+                updated_message = dict(message)
+                updated_message["content"] = updated_blocks
+                return updated_message, receipt_ids
+        return message, []
+
+    def _compact_gemini_part(
+        self,
+        block: dict[str, Any],
+        *,
+        query: str,
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Compress known textual Gemini tool outputs without touching IDs."""
+        updated = copy.deepcopy(block)
+        targets: list[tuple[dict[str, Any], str]] = []
+        function_response = updated.get("functionResponse")
+        if isinstance(function_response, dict):
+            response = function_response.get("response")
+            if isinstance(response, dict):
+                targets.extend(
+                    (response, key)
+                    for key in ("output", "result", "content", "text")
+                    if isinstance(response.get(key), str)
+                )
+        code_result = updated.get("codeExecutionResult")
+        if isinstance(code_result, dict) and isinstance(
+            code_result.get("output"),
+            str,
+        ):
+            targets.append((code_result, "output"))
+
+        receipts: list[str] = []
+        for container, key in targets:
+            compacted, receipt_id = self._compact_text(
+                container[key],
+                query=query,
+            )
+            if receipt_id is None:
+                continue
+            container[key] = compacted
+            receipts.append(receipt_id)
+        return (updated, receipts) if receipts else (block, [])
+
+    def _compact_text(self, text: str, *, query: str) -> tuple[str, str | None]:
+        original_tokens = estimate_tokens(text)
+        if original_tokens < self.policy.min_message_tokens:
+            return text, None
+        budget = min(
+            self.policy.max_block_budget,
+            max(64, int(original_tokens * 0.30)),
+        )
+        result = compress_evidence_locked(
+            text,
+            query=query,
+            budget_tokens=budget,
+            min_savings=0.08,
+        )
+        if not result.changed:
+            return text, None
+        receipt = result.receipt.as_dict()
+        # A session-rescue handle is a last-resort integrity boundary, not just
+        # an optimization receipt. Persist the complete original as one span so
+        # recovery never depends on a compressor's omission bookkeeping being
+        # exhaustive. The compacted request still carries the exact retained
+        # evidence and the receipt's content hash.
+        line_count = max(1, text.count("\n") + 1)
+        receipt["omitted_spans"] = [
+            {
+                "start_line": 1,
+                "end_line": line_count,
+                "line_count": line_count,
+                "reason": "session_rescue_full_recovery",
+            }
+        ]
+        stored = self.recovery_store.put(
+            original_text=text,
+            compressed_text=result.compressed,
+            receipt=receipt,
+            metadata={
+                "component": "session_rescue",
+                "query_sha256": hashlib.sha256(
+                    query.encode("utf-8", "ignore")
+                ).hexdigest(),
+            },
+        )
+        span_ids = ",".join(span.span_id for span in stored.spans)
+        marker = (
+            "[entroly-recovery: "
+            f"receipt={stored.receipt_id}; spans={span_ids or 'none'}; "
+            f"original_sha256={stored.original_hash}]"
+        )
+        rendered = f"{result.with_receipt_header()}\n{marker}"
+        if estimate_tokens(rendered) >= original_tokens:
+            return text, None
+        return rendered, stored.receipt_id
+
+    @staticmethod
+    def _has_tool_result(content: Any) -> bool:
+        return isinstance(content, list) and any(
+            isinstance(block, dict)
+            and (
+                block.get("type") == "tool_result"
+                or "functionResponse" in block
+                or "codeExecutionResult" in block
+            )
+            for block in content
+        )
+
+    @staticmethod
+    def _stable_prefix_count(
+        state: _SessionState,
+        messages: Sequence[dict[str, Any]],
+    ) -> int:
+        current = tuple(_message_digest(message) for message in messages)
+        stable = 0
+        for previous, candidate in zip(state.previous_output_digests, current):
+            if previous != candidate:
+                break
+            stable += 1
+        return stable
+
+    @staticmethod
+    def _remember_output(
+        state: _SessionState,
+        messages: Sequence[dict[str, Any]],
+    ) -> None:
+        state.previous_output_digests = tuple(
+            _message_digest(message) for message in messages
+        )
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "tracked_sessions": len(self._states),
+                "rescues": self._rescues,
+                "blocked": self._blocks,
+                "cache_deferrals": self._cache_deferrals,
+                "failures": self._failures,
+                "active_sessions": sum(
+                    1 for state in self._states.values() if state.active
+                ),
+            }
+
+
+__all__ = [
+    "SessionRescueController",
+    "SessionRescuePolicy",
+    "SessionRescueResult",
+    "estimate_message_tokens",
+]

--- a/tests/test_cache_stable_live_zone.py
+++ b/tests/test_cache_stable_live_zone.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from entroly.proxy_transform import inject_context_live_zone
+
+
+def test_openai_live_zone_leaves_system_and_raw_turn_prefix_untouched() -> None:
+    body = {
+        "model": "gpt-5",
+        "messages": [
+            {"role": "system", "content": "stable policy"},
+            {"role": "user", "content": "inspect auth"},
+        ],
+    }
+
+    updated, injected = inject_context_live_zone(body, "def authenticate(): ...", "openai")
+
+    assert injected
+    assert updated["messages"][0] == body["messages"][0]
+    assert updated["messages"][1]["content"].startswith("inspect auth")
+    assert "<entroly_dynamic_context>" in updated["messages"][1]["content"]
+    assert body["messages"][1]["content"] == "inspect auth"
+
+
+def test_anthropic_live_zone_preserves_system_and_tool_result_shape() -> None:
+    body = {
+        "model": "claude-sonnet-4-6",
+        "system": [{"type": "text", "text": "stable policy"}],
+        "messages": [
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "t1"}]},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t1",
+                        "content": "raw output",
+                    }
+                ],
+            },
+        ],
+    }
+
+    updated, injected = inject_context_live_zone(body, "relevant source", "anthropic")
+
+    assert injected
+    assert updated["system"] == body["system"]
+    assert updated["messages"][1]["content"][0] == body["messages"][1]["content"][0]
+    suffix = updated["messages"][1]["content"][1]
+    assert suffix["type"] == "text"
+    assert "<entroly_dynamic_context>" in suffix["text"]
+
+
+def test_responses_live_zone_appends_after_function_output() -> None:
+    body = {
+        "model": "gpt-5",
+        "instructions": "stable policy",
+        "input": [
+            {"type": "function_call_output", "call_id": "c1", "output": "raw"}
+        ],
+    }
+
+    updated, injected = inject_context_live_zone(body, "source context", "openai")
+
+    assert injected
+    assert updated["instructions"] == "stable policy"
+    assert updated["input"][0]["output"].startswith("raw")
+    assert "<entroly_dynamic_context>" in updated["input"][0]["output"]
+
+
+def test_gemini_live_zone_does_not_rewrite_system_instruction() -> None:
+    body = {
+        "systemInstruction": {"parts": [{"text": "stable policy"}]},
+        "contents": [{"role": "user", "parts": [{"text": "raw query"}]}],
+    }
+
+    updated, injected = inject_context_live_zone(body, "source context", "gemini")
+
+    assert injected
+    assert updated["systemInstruction"] == body["systemInstruction"]
+    assert updated["contents"][0]["parts"][0]["text"] == "raw query"
+    assert "<entroly_dynamic_context>" in updated["contents"][0]["parts"][1]["text"]
+
+
+def test_live_zone_refuses_ambiguous_assistant_only_shape() -> None:
+    body = {"messages": [{"role": "assistant", "content": "waiting"}]}
+
+    updated, injected = inject_context_live_zone(body, "context", "anthropic")
+
+    assert not injected
+    assert updated == body

--- a/tests/test_compression_proxy.py
+++ b/tests/test_compression_proxy.py
@@ -93,3 +93,48 @@ def test_compression_proxy_off_mode_is_passthrough() -> None:
     assert result.changed is False
     assert result.body == body
     assert result.receipt.tokens_saved == 0
+
+
+def test_compression_proxy_preserves_gemini_function_metadata(tmp_path) -> None:
+    from entroly.compression_retrieval_store import CompressionRetrievalStore
+
+    heavy = "\n".join(
+        ["pytest worker complete" for _ in range(400)]
+        + ["FATAL payment-service E_CONNRESET"]
+    )
+    body = {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "thoughtSignature": "opaque-signature",
+                        "functionResponse": {
+                            "id": "call-1",
+                            "name": "run_tests",
+                            "response": {"output": heavy},
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = compress_proxy_payload(
+        body,
+        provider="gemini",
+        budget_tokens=160,
+        retrieval_store=CompressionRetrievalStore(tmp_path / "store.json"),
+    )
+
+    block = result.body["contents"][0]["parts"][0]
+    assert result.changed
+    assert block["thoughtSignature"] == "opaque-signature"
+    assert block["functionResponse"]["id"] == "call-1"
+    assert block["functionResponse"]["name"] == "run_tests"
+    assert "FATAL payment-service E_CONNRESET" in (
+        block["functionResponse"]["response"]["output"]
+    )
+    assert "[entroly-recovery:" in (
+        block["functionResponse"]["response"]["output"]
+    )

--- a/tests/test_compression_retrieval_store.py
+++ b/tests/test_compression_retrieval_store.py
@@ -123,14 +123,36 @@ def test_retrieval_store_saves_and_fetches_omitted_spans(tmp_path) -> None:
     span = store.get_span(receipt_id, span_id)
 
     assert result.changed
-    assert retrieval["span_count"] >= 1
+    assert retrieval["span_count"] == 1
     assert span is not None
-    assert "background line" in span.content
+    assert span.content == heavy
+    assert f"[entroly-recovery:{receipt_id}:{span_id}]" in (
+        result.body["messages"][1]["content"]
+    )
 
     restored = CompressionRetrievalStore(store_path)
     restored_span = restored.get_span(receipt_id, span_id)
     assert restored_span is not None
     assert restored_span.content == span.content
+
+
+def test_recovery_store_byte_limit_fails_before_commit(tmp_path) -> None:
+    path = tmp_path / "bounded.json"
+    store = CompressionRetrievalStore(path, max_bytes=128)
+
+    with pytest.raises(OSError, match="configured 128-byte limit"):
+        store.put(
+            original_text="sensitive tool output " * 100,
+            compressed_text="short",
+            receipt={
+                "original_tokens": 500,
+                "compressed_tokens": 2,
+                "omitted_spans": [{"start_line": 1, "end_line": 1}],
+            },
+        )
+
+    assert store.list_receipts() == []
+    assert not path.exists()
 
 
 def test_long_lived_reader_observes_another_store_commit(tmp_path) -> None:

--- a/tests/test_proxy_cache_align.py
+++ b/tests/test_proxy_cache_align.py
@@ -56,18 +56,21 @@ def test_conversation_key_empty_without_anchor():
     assert _key({"messages": [{"role": "assistant", "content": "x"}]}) == ""
 
 
-def test_align_reuses_similar_context_verbatim():
-    """An unchanged/near-identical injected block on the next turn is reused
-    byte-for-byte => provider cached prefix hits."""
+def test_align_reuses_only_identical_context_verbatim():
+    """Exact context bytes may be reused; changed evidence must not go stale."""
     a = CacheAligner()
     ctx = "\n".join(f"file{i}.py: def f{i}(): return {i}" for i in range(50))
     out1, hit1 = a.align("conv1", ctx)
     assert out1 == ctx and hit1 is False  # first turn: stored
-    # next turn: one line changed (>=90% Jaccard similar)
+    # A one-line semantic change must be a miss, even when token overlap is high.
     ctx2 = ctx.replace("file49.py: def f49(): return 49", "file49.py: def f49(): return 99")
     out2, hit2 = a.align("conv1", ctx2)
-    assert hit2 is True
-    assert out2 == ctx  # reused verbatim -> stable prefix -> cache hit
+    assert hit2 is False
+    assert out2 == ctx2
+
+    out3, hit3 = a.align("conv1", ctx2)
+    assert hit3 is True
+    assert out3 == ctx2
 
 
 def test_align_does_not_reuse_materially_changed_context():
@@ -82,7 +85,7 @@ def test_align_does_not_reuse_materially_changed_context():
     assert out == different
 
 
-def test_align_treats_code_punctuation_as_token_boundaries():
+def test_align_treats_code_punctuation_as_material_bytes():
     aligner = CacheAligner(similarity_threshold=1.0)
     original = "def calculate_total(items): return sum(items)"
     aligner.align("code", original)
@@ -91,5 +94,16 @@ def test_align_treats_code_punctuation_as_token_boundaries():
         "code", "def calculate_total items return sum items"
     )
 
-    assert hit is True
-    assert aligned == original
+    assert hit is False
+    assert aligned == "def calculate_total items return sum items"
+
+
+def test_align_stats_do_not_invent_provider_savings():
+    aligner = CacheAligner()
+    aligner.align("code", "same")
+    aligner.align("code", "same")
+
+    stats = aligner.stats()
+
+    assert stats["match_policy"] == "exact_sha256"
+    assert "estimated_savings_pct" not in stats

--- a/tests/test_proxy_session_rescue.py
+++ b/tests/test_proxy_session_rescue.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from entroly.proxy import PromptCompilerProxy
+from entroly.proxy_config import ProxyConfig
+
+
+class _EmptyEngine:
+    def advance_turn(self) -> None:
+        return None
+
+    def optimize_context(self, token_budget: int, query: str) -> dict:
+        return {"selected_fragments": [], "query_analysis": {}}
+
+
+def _proxy_config() -> ProxyConfig:
+    config = ProxyConfig(witness_mode="off")
+    config.enable_adaptive_budget = False
+    config.enable_dynamic_budget = False
+    config.enable_hierarchical_compression = False
+    config.enable_passive_feedback = False
+    config.enable_context_scaffold = False
+    return config
+
+
+def test_live_proxy_compresses_tool_output_with_recovery_handle(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+    heavy = "\n".join(
+        [f"2026-07-24 INFO worker={index % 5} complete" for index in range(500)]
+        + ["FATAL payment-service E_CONNRESET"]
+    )
+
+    async def run():
+        proxy = PromptCompilerProxy(_EmptyEngine(), _proxy_config())
+        captured = {}
+
+        async def capture(_url, _headers, body, *_args, **kwargs):
+            captured["body"] = json.loads(json.dumps(body))
+            return JSONResponse(
+                {"ok": True},
+                headers=kwargs.get("extra_headers") or {},
+            )
+
+        proxy._forward_response = capture
+        app = Starlette(
+            routes=[
+                Route(
+                    "/v1/chat/completions",
+                    proxy.handle_proxy,
+                    methods=["POST"],
+                )
+            ]
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"authorization": "Bearer sk-test"},
+                json={
+                    "model": "gpt-4o",
+                    "messages": [
+                        {"role": "user", "content": "why did payment fail?"},
+                        {"role": "tool", "content": heavy},
+                    ],
+                },
+            )
+        return response, captured, proxy
+
+    response, captured, proxy = asyncio.run(run())
+
+    forwarded = captured["body"]["messages"][1]["content"]
+    assert response.status_code == 200
+    assert "FATAL payment-service E_CONNRESET" in forwarded
+    assert "[entroly-recovery:" in forwarded
+    assert response.headers["x-entroly-compression-mode"] == "elc"
+    assert response.headers["x-entroly-session-rescue"] == "passthrough"
+    assert proxy._session_rescue_store is not None
+    assert (tmp_path / "session_rescue_recovery.json").exists()
+
+
+def test_live_proxy_blocks_unrecoverable_overflow_before_upstream(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+
+    async def run():
+        proxy = PromptCompilerProxy(_EmptyEngine(), _proxy_config())
+        forwarded = False
+
+        async def capture(*_args, **_kwargs):
+            nonlocal forwarded
+            forwarded = True
+            return JSONResponse({"unexpected": True})
+
+        proxy._forward_response = capture
+        app = Starlette(
+            routes=[
+                Route(
+                    "/v1/chat/completions",
+                    proxy.handle_proxy,
+                    methods=["POST"],
+                )
+            ]
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"authorization": "Bearer sk-test"},
+                json={
+                    "model": "gpt-4",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "essential user evidence " * 2_000,
+                        }
+                    ],
+                },
+            )
+        return response, forwarded
+
+    response, forwarded = asyncio.run(run())
+
+    assert response.status_code == 413
+    assert response.json()["error"] == "session_context_rescue_required"
+    assert "not forwarded" not in response.json()["action"]
+    assert forwarded is False
+
+
+def test_recovery_store_init_failure_does_not_fall_back_to_lossy_pruning(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store_path = tmp_path / "full-store.json"
+    store_path.write_text("x" * 256, encoding="utf-8")
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+    monkeypatch.setenv("ENTROLY_SESSION_RESCUE_STORE", str(store_path))
+    monkeypatch.setenv("ENTROLY_SESSION_RESCUE_STORE_MAX_BYTES", "128")
+    heavy = "\n".join(f"raw terminal line {index}" for index in range(500))
+
+    async def run():
+        proxy = PromptCompilerProxy(_EmptyEngine(), _proxy_config())
+        captured = {}
+
+        async def capture(_url, _headers, body, *_args, **kwargs):
+            captured["body"] = body
+            return JSONResponse(
+                {"ok": True},
+                headers=kwargs.get("extra_headers") or {},
+            )
+
+        proxy._forward_response = capture
+        app = Starlette(
+            routes=[
+                Route(
+                    "/v1/chat/completions",
+                    proxy.handle_proxy,
+                    methods=["POST"],
+                )
+            ]
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"authorization": "Bearer sk-test"},
+                json={
+                    "model": "gpt-4o",
+                    "messages": [
+                        {"role": "user", "content": "inspect output"},
+                        {"role": "tool", "content": heavy},
+                    ],
+                },
+            )
+        return response, captured["body"], proxy
+
+    response, forwarded, proxy = asyncio.run(run())
+
+    assert response.status_code == 200
+    assert forwarded["messages"][1]["content"] == heavy
+    assert proxy._session_rescue is None
+    assert "exceeds its configured byte limit" in proxy._session_rescue_init_error

--- a/tests/test_session_rescue.py
+++ b/tests/test_session_rescue.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from entroly.cache_routing import CacheAwareRouter
+from entroly.compression_retrieval_store import CompressionRetrievalStore
+from entroly.session_rescue import (
+    SessionRescueController,
+    SessionRescuePolicy,
+    estimate_message_tokens,
+)
+
+
+def _controller(
+    tmp_path: Path,
+    **policy_overrides: float | int,
+) -> tuple[SessionRescueController, CompressionRetrievalStore]:
+    store = CompressionRetrievalStore(tmp_path / "session-rescue.json")
+    policy = SessionRescuePolicy(**policy_overrides)
+    return SessionRescueController(recovery_store=store, policy=policy), store
+
+
+def _noisy_tool_message(name: str, lines: int = 500) -> dict[str, str]:
+    content = "\n".join(
+        f"2026-07-24T08:00:{index:02d}Z INFO worker={index % 5} completed"
+        for index in range(lines)
+    )
+    content += "\n2026-07-24T08:09:59Z FATAL payment-service E_CONNRESET"
+    return {"role": "tool", "name": name, "content": content}
+
+
+def test_policy_rejects_unordered_watermarks() -> None:
+    with pytest.raises(ValueError, match="not ordered"):
+        SessionRescuePolicy(
+            loop_min_watermark=0.4,
+            target_watermark=0.75,
+            soft_watermark=0.70,
+        )
+
+
+def test_soft_pressure_defers_when_provider_cache_is_warm(tmp_path: Path) -> None:
+    controller, _ = _controller(
+        tmp_path,
+        soft_watermark=0.20,
+        hard_watermark=0.90,
+        target_watermark=0.10,
+        failure_watermark=0.98,
+        loop_min_watermark=0.05,
+    )
+    messages = [{"role": "user", "content": "keep exact prefix " * 200}]
+
+    result = controller.rescue(
+        "conv",
+        messages,
+        context_window=4_000,
+        cache_warm=True,
+    )
+
+    assert result.action == "cache-deferred"
+    assert result.cache_deferred is True
+    assert result.messages == messages
+
+
+def test_hard_pressure_overrides_cache_and_persists_recovery(
+    tmp_path: Path,
+) -> None:
+    controller, store = _controller(
+        tmp_path,
+        soft_watermark=0.20,
+        hard_watermark=0.30,
+        target_watermark=0.10,
+        failure_watermark=0.95,
+        loop_min_watermark=0.05,
+        tail_messages=2,
+    )
+    tool = _noisy_tool_message("pytest")
+    messages = [
+        {"role": "system", "content": "You are a coding agent."},
+        tool,
+        {"role": "assistant", "content": "I will inspect the failure."},
+        {"role": "user", "content": "continue"},
+    ]
+
+    result = controller.rescue(
+        "conv",
+        messages,
+        context_window=4_000,
+        cache_warm=True,
+        query="payment-service E_CONNRESET",
+    )
+
+    assert result.action == "emergency-rescue"
+    assert result.tokens_saved > 0
+    assert result.recovery_receipts
+    assert "payment-service E_CONNRESET" in result.messages[1]["content"]
+    assert "[entroly-recovery:" in result.messages[1]["content"]
+    stored = store.get_receipt(result.recovery_receipts[0])
+    assert stored is not None and stored.spans
+    assert stored.spans[0].content == tool["content"]
+
+
+def test_frozen_history_remains_byte_identical_when_turns_append(
+    tmp_path: Path,
+) -> None:
+    controller, _ = _controller(
+        tmp_path,
+        soft_watermark=0.20,
+        hard_watermark=0.30,
+        target_watermark=0.10,
+        failure_watermark=0.95,
+        loop_min_watermark=0.05,
+        tail_messages=2,
+    )
+    base = [
+        {"role": "system", "content": "system"},
+        _noisy_tool_message("cargo-test"),
+        {"role": "assistant", "content": "checking"},
+        {"role": "user", "content": "continue"},
+    ]
+    first = controller.rescue("conv", base, context_window=4_000)
+    grown = [
+        *base,
+        {"role": "assistant", "content": "next step"},
+        {"role": "user", "content": "continue again"},
+    ]
+    second = controller.rescue("conv", grown, context_window=4_000)
+
+    assert first.messages[1] == second.messages[1]
+    assert second.stable_prefix_messages >= 4
+
+
+def test_loop_signal_triggers_before_hard_watermark(tmp_path: Path) -> None:
+    controller, _ = _controller(
+        tmp_path,
+        soft_watermark=0.70,
+        hard_watermark=0.90,
+        target_watermark=0.20,
+        failure_watermark=0.98,
+        loop_min_watermark=0.10,
+        tail_messages=2,
+    )
+    messages = [
+        _noisy_tool_message("retry"),
+        {"role": "assistant", "content": "retrying"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    result = controller.rescue(
+        "loop",
+        messages,
+        context_window=20_000,
+        loop_detected=True,
+    )
+
+    assert result.action == "loop-rescue"
+    assert result.tokens_saved > 0
+
+
+def test_uncompressible_over_limit_request_is_blocked_with_clear_state(
+    tmp_path: Path,
+) -> None:
+    controller, _ = _controller(
+        tmp_path,
+        soft_watermark=0.20,
+        hard_watermark=0.30,
+        target_watermark=0.10,
+        failure_watermark=0.50,
+        loop_min_watermark=0.05,
+        tail_messages=2,
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "essential user evidence " * 1_000},
+        {"role": "user", "content": "latest request " * 100},
+    ]
+
+    result = controller.rescue("conv", messages, context_window=1_000)
+
+    assert result.action == "blocked"
+    assert result.blocked is True
+    assert result.messages == messages
+    assert "safe context watermark" in result.error
+
+
+def test_pressure_without_safe_candidate_is_reported_without_fake_savings(
+    tmp_path: Path,
+) -> None:
+    controller, _ = _controller(
+        tmp_path,
+        soft_watermark=0.20,
+        hard_watermark=0.90,
+        target_watermark=0.10,
+        failure_watermark=0.98,
+        loop_min_watermark=0.05,
+        tail_messages=2,
+    )
+    messages = [{"role": "user", "content": "essential evidence " * 100}]
+
+    result = controller.rescue("conv", messages, context_window=2_000)
+
+    assert result.action == "pressure-observed"
+    assert result.tokens_saved == 0
+    assert result.messages == messages
+    assert controller.stats()["rescues"] == 0
+
+
+def test_anthropic_tool_result_shape_is_preserved(tmp_path: Path) -> None:
+    controller, _ = _controller(
+        tmp_path,
+        soft_watermark=0.20,
+        hard_watermark=0.30,
+        target_watermark=0.10,
+        failure_watermark=0.95,
+        loop_min_watermark=0.05,
+        tail_messages=2,
+    )
+    message = {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": _noisy_tool_message("pytest")["content"],
+            }
+        ],
+    }
+    messages = [
+        message,
+        {"role": "assistant", "content": "checking"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    result = controller.rescue("anthropic", messages, context_window=4_000)
+
+    block = result.messages[0]["content"][0]
+    assert block["type"] == "tool_result"
+    assert block["tool_use_id"] == "toolu_1"
+    assert "[entroly-recovery:" in block["content"]
+
+
+def test_gemini_function_response_preserves_ids_and_thought_signature(
+    tmp_path: Path,
+) -> None:
+    controller, _ = _controller(
+        tmp_path,
+        soft_watermark=0.20,
+        hard_watermark=0.30,
+        target_watermark=0.10,
+        failure_watermark=0.95,
+        loop_min_watermark=0.05,
+        tail_messages=2,
+    )
+    noisy = _noisy_tool_message("gemini")["content"]
+    message = {
+        "role": "user",
+        "content": [
+            {
+                "thoughtSignature": "opaque-signature",
+                "functionResponse": {
+                    "id": "call-1",
+                    "name": "run_tests",
+                    "response": {"output": noisy},
+                },
+            }
+        ],
+    }
+    messages = [
+        message,
+        {"role": "model", "content": [{"text": "checking"}]},
+        {"role": "user", "content": [{"text": "continue"}]},
+    ]
+
+    result = controller.rescue("gemini", messages, context_window=4_000)
+
+    block = result.messages[0]["content"][0]
+    assert block["thoughtSignature"] == "opaque-signature"
+    assert block["functionResponse"]["id"] == "call-1"
+    assert block["functionResponse"]["name"] == "run_tests"
+    assert "[entroly-recovery:" in (
+        block["functionResponse"]["response"]["output"]
+    )
+
+
+def test_cache_router_lease_snapshot_is_detached_and_expires() -> None:
+    router = CacheAwareRouter()
+    observed = router.observe(
+        "conv",
+        model="gpt-5.6",
+        provider="openai",
+        prefix_hash="abc",
+        cached_prefix_tokens=2_000,
+        cache_hit=True,
+        observed_at=10.0,
+        ttl_seconds=5.0,
+    )
+
+    snapshot = router.lease_snapshot("conv", now=11.0)
+    assert snapshot is not None
+    snapshot.cached_prefix_tokens = 0
+    assert observed.cached_prefix_tokens == 2_000
+    assert router.lease_snapshot("conv", now=16.0) is None
+
+
+def test_estimator_counts_structured_tool_content() -> None:
+    plain = estimate_message_tokens([{"role": "tool", "content": "hello"}])
+    structured = estimate_message_tokens(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "content": "hello " * 100}
+                ],
+            }
+        ]
+    )
+    assert structured > plain

--- a/tests/test_zero_token_autonomy.py
+++ b/tests/test_zero_token_autonomy.py
@@ -661,7 +661,7 @@ class TestCacheAligner:
         _, hit = ca.align("client1", "completely different unrelated code block xyz")
         assert not hit  # Very different → cache miss
 
-    def test_similar_context_hits(self):
+    def test_similar_but_changed_context_misses(self):
         ca = self._make_aligner()
         # Use a sufficiently large context so minor change keeps Jaccard > 90%
         base_tokens = ["def", "foo():", "x", "=", "1", "y", "=", "2",
@@ -673,8 +673,9 @@ class TestCacheAligner:
         modified_tokens = base_tokens.copy()
         modified_tokens[5] = "99"  # change "2" → "99"
         modified = " ".join(modified_tokens)
-        _, hit = ca.align("c1", modified)
-        assert hit  # >90% Jaccard → reuse
+        aligned, hit = ca.align("c1", modified)
+        assert not hit
+        assert aligned == modified
 
     def test_stats_tracks_hits_and_misses(self):
         ca = self._make_aligner()


### PR DESCRIPTION
## Summary

P0 fix: a runaway agent session could grow unbounded through the compression proxy, and the mitigations that existed churned the prompt prefix — breaking cache alignment exactly when a long session most needs it.

This adds session rescue that keeps the prefix byte-stable:

- **Runaway-loop rescue** — detects and interrupts unbounded session growth instead of letting it consume the window.
- **Recoverable originals** — rescued content stays traceable back to its source; compression remains reversible, not lossy truncation.
- **Cache-stable live zones** — rescue operates inside a bounded live zone so the cached prefix is not invalidated.
- **Structured tool/log compression** — tool output and logs compress structurally rather than by blind truncation.

## Trust invariants

- Output-only: no request generation parameters are touched.
- Reversibility: rescued/compressed context retains pointers to recoverable originals.
- Cache stability: the prompt prefix stays byte-stable outside the live zone.

## Scope

18 files, +2100/−102, including `entroly/session_rescue.py` and docs (`docs/session-rescue.md`, plus compression-proxy and limitations updates).

## Validation

118 passed, 9 expected native-capability skips, Ruff clean, public-trust verifier passed.

The broad README verifier's SDK smoke hangs (pre-existing, unrelated); it is **not** claimed to pass.
