### PR TITLE
chore: temporary CI failure reproduction export

### DIFF
--- a/.github/workflows/diagnose-python-failures.yml
+++ b/.github/workflows/diagnose-python-failures.yml
@@ -1,0 +1,87 @@
+name: Diagnose Python Failures
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pure-python-first-failure:
+    if: github.head_ref == 'chore/ci-failure-export-temp'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: 5e3368e441ef91d842f0d197eeb5510b855e70fd
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install pure-Python surface
+        run: |
+          pip install --no-deps -e .
+          pip install 'mcp>=1.6.0' 'httpx>=0.27' 'starlette>=0.37' 'uvicorn>=0.30' psutil pytest pytest-timeout
+      - name: Capture first pure-Python failure
+        shell: bash
+        run: |
+          set +e
+          pytest tests/ -v --tb=short --timeout=60 -p no:cacheprovider --maxfail=1 \
+            --ignore=tests/functional_test.py \
+            --ignore=tests/test_e2e.py \
+            --ignore=tests/test_ios.py \
+            --ignore=tests/test_rust_cogops.py \
+            --ignore=tests/test_deep_functional.py \
+            --ignore=tests/test_engine_isolation.py \
+            --ignore=tests/test_localization.py \
+            --ignore=tests/test_benchmark_harness.py \
+            > /tmp/pure.log 2>&1
+          echo $? > /tmp/pure.exit
+          tail -n 240 /tmp/pure.log > /tmp/pure-tail.log
+          exit 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pure-python-first-failure
+          path: |
+            /tmp/pure-tail.log
+            /tmp/pure.exit
+          retention-days: 1
+
+  native-integration-first-failure:
+    if: github.head_ref == 'chore/ci-failure-export-temp'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: 5e3368e441ef91d842f0d197eeb5510b855e70fd
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Build native engine
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install maturin
+          (cd entroly-core && ../.venv/bin/maturin develop --release)
+          .venv/bin/pip install -e . 'mcp>=1.6.0' 'httpx>=0.27' 'starlette>=0.37' 'uvicorn>=0.30' psutil
+      - name: Capture native integration failures
+        shell: bash
+        run: |
+          set +e
+          .venv/bin/python entroly-core/tests/test_integration.py > /tmp/integration.log 2>&1
+          echo $? > /tmp/integration.exit
+          .venv/bin/python entroly-core/tests/test_brutal.py > /tmp/brutal.log 2>&1
+          echo $? > /tmp/brutal.exit
+          tail -n 240 /tmp/integration.log > /tmp/integration-tail.log
+          tail -n 240 /tmp/brutal.log > /tmp/brutal-tail.log
+          exit 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-integration-first-failure
+          path: |
+            /tmp/integration-tail.log
+            /tmp/integration.exit
+            /tmp/brutal-tail.log
+            /tmp/brutal.exit
+          retention-days: 1

--- a/.github/workflows/export-failing-main.yml
+++ b/.github/workflows/export-failing-main.yml
@@ -1,0 +1,40 @@
+name: Export Failing Main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  export-source:
+    if: github.head_ref == 'chore/ci-failure-export-temp'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact failing commit
+        uses: actions/checkout@v6
+        with:
+          ref: 5e3368e441ef91d842f0d197eeb5510b855e70fd
+          fetch-depth: 1
+
+      - name: Record source identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          git rev-parse HEAD > FAILING_SOURCE_SHA.txt
+
+      - name: Build source archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar --exclude=.git -czf "$RUNNER_TEMP/entroly-failing-main.tar.gz" .
+
+      - name: Upload source archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: entroly-failing-main
+          path: ${{ runner.temp }}/entroly-failing-main.tar.gz
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
Temporary draft PR used only to export exact failing main commit `5e3368e441ef91d842f0d197eeb5510b855e70fd` into an isolated workspace for reproducing the shared Python CI failure. No product change is intended; this PR will be closed after transfer.