### PR TITLE
build(deps): batch eight dependency updates

### DIFF
--- a/.github/workflows/agent-integration-contracts.yml
+++ b/.github/workflows/agent-integration-contracts.yml
@@ -46,7 +46,7 @@ jobs:
         python-version: ["3.10", "3.12", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package and test dependencies
@@ -62,7 +62,7 @@ jobs:
           --junitxml=agent-integration-${{ matrix.python-version }}.xml
       - name: Upload machine-readable result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agent-integration-${{ matrix.python-version }}
           path: agent-integration-${{ matrix.python-version }}.xml

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload benchmark evidence diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-evidence-diagnostics
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -125,7 +125,7 @@ jobs:
       - name: Set up Python
         # pyo3 needs libpython at link time when the extension-module feature
         # is off (which it is for `cargo test --lib`).
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -159,7 +159,7 @@ jobs:
           components: clippy
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -207,7 +207,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -269,7 +269,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -243,7 +243,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -273,7 +273,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -428,7 +428,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/public-trust.yml
+++ b/.github/workflows/public-trust.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install package and test dependencies
@@ -58,7 +58,7 @@ jobs:
           --junitxml=public-trust-tests.xml
       - name: Upload public trust diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: public-trust-diagnostics
           path: |
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install package and test dependencies

--- a/.github/workflows/publish-core-wheels.yml
+++ b/.github/workflows/publish-core-wheels.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - uses: PyO3/maturin-action@v1

--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -54,7 +54,7 @@ jobs:
           node-version: "22.19.0"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         # pyo3 needs libpython at link time for the binary (extension-module
         # feature is off here).
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/round7-runtime-repair.yml
+++ b/.github/workflows/round7-runtime-repair.yml
@@ -32,7 +32,7 @@ jobs:
           # job never ran — and it fails outright once that branch is deleted.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/sync-homebrew-formula.yml
+++ b/.github/workflows/sync-homebrew-formula.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/sync-release-version.yml
+++ b/.github/workflows/sync-release-version.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.6.0,<2",
+    "mcp>=1.28.1,<2",
 ]
 
 [project.urls]
@@ -47,9 +47,9 @@ Issues = "https://github.com/juyterman1000/entroly/issues"
 
 [project.optional-dependencies]
 proxy = [
-    "httpx>=0.27",
-    "starlette>=0.37",
-    "uvicorn>=0.30",
+    "httpx>=0.28.1",
+    "starlette>=1.3.1",
+    "uvicorn>=0.51.0",
 ]
 native = [
     "entroly-core>=1.0.66,<2",
@@ -60,9 +60,9 @@ receipt-proof = [
 full = [
     "cryptography>=42",
     "entroly-core>=1.0.66,<2",
-    "httpx>=0.27",
-    "starlette>=0.37",
-    "uvicorn>=0.30",
+    "httpx>=0.28.1",
+    "starlette>=1.3.1",
+    "uvicorn>=0.51.0",
 ]
 test = [
     "pytest>=8,<9",
@@ -71,11 +71,11 @@ benchmark = [
     "tiktoken>=0.9,<0.14",
 ]
 neural = [
-    "sentence-transformers>=5.1,<6",
+    "sentence-transformers>=5.6.1,<6",
 ]
 neural-benchmark = [
     "datasets>=4,<6",
-    "sentence-transformers>=5.1,<6",
+    "sentence-transformers>=5.6.1,<6",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Supersedes #186, #187, #188, #189, #190, #191, #192, #193.

Each of those was individually green but all were `BEHIND` main, and
branch protection sets `strict: true`, so every merge puts the remaining
seven behind again. Merging them one at a time is eight sequential
~10-minute CI cycles. Five touch `pyproject.toml` and two touch the same
workflow files, so they would also conflict pairwise as they landed.

Batching costs one CI cycle and, more importantly, tests the combination
— which is the state `main` actually ends up in and which no individual
PR exercised.

| PR | Package | From | To |
|---|---|---|---|
| #187 | httpx | >=0.27 | >=0.28.1 |
| #189 | starlette | >=0.37 | >=1.3.1 |
| #191 | sentence-transformers | >=5.1,<6 | >=5.6.1,<6 |
| #192 | mcp | >=1.6.0,<2 | >=1.28.1,<2 |
| #193 | uvicorn | >=0.30 | >=0.51.0 |
| #188 | actions/upload-artifact | v4 | v7 (11 sites) |
| #190 | actions/setup-python | v5, v6 | v7 (22 sites) |
| #186 | serde_json | 1.0.149 | 1.0.151 (Cargo.lock) |

`entroly-core/Cargo.lock` is taken from #186 unmodified. Every version
constraint is byte-identical to what dependabot proposed; nothing was
widened or narrowed while combining.

Verified locally before pushing: `pyproject.toml` parses and carries all
five constraints, `cargo metadata` resolves, `ruff check entroly/` clean.

**Worth watching:** `starlette >=0.37 -> >=1.3.1` is a major-version jump
and is the one most likely to surface something. The rest are
within-major. If CI fails, the honest response is to split starlette back
out rather than pin around the failure.

Once this is green and merged, the eight superseded PRs should be closed;
dependabot will not reopen them, since the constraints it wanted are
satisfied.