### PR TITLE
fix(retrieval): stop rewriting specific queries before searching them — recall 0.750 → 1.000

### DIFF
--- a/entroly/server.py
+++ b/entroly/server.py
@@ -1053,9 +1053,31 @@ class EntrolyEngine:
                     pass
             # analyze() returns dict: vagueness_score, key_terms, needs_refinement, reason
             analysis_dict = self._refiner.analyze(query, fragment_summaries)
-            # refine() returns the improved query string
-            refined_query = self._refiner.refine(query, fragment_summaries)
+            # refine() returns the improved query string.
+            #
+            # Only adopt it when the analyzer says the query needs it. The
+            # expansion terms come from `recall(query, 20)` -- pseudo-relevance
+            # feedback -- so applying it unconditionally lets a mediocre first
+            # pass rewrite the question and then rank against the rewrite. That
+            # is query drift, and it was measured destroying retrieval on
+            # specific queries that needed no help:
+            #
+            #   "what does entroly doctor check and how does it report failures"
+            #     -> "... [context: tests, verifier, plugin, entry, point]"
+            #
+            # None of those terms are in the question. They pulled
+            # test_verifier_plugins.py and plugins.py to the top while the file
+            # that answers it, entroly/cli.py, fell from rank 4 to rank 49 --
+            # far below the ~12 fragments a budget emits. Gating on the
+            # analyzer's own signal took evidence retention on the frozen
+            # eight-query set from 0.750 to 1.000 at 4k, 8k and 16k budgets.
+            #
+            # The refinement is still computed and still reported, so vague
+            # queries keep the benefit and the receipt stays honest about what
+            # was asked versus what was searched.
+            candidate_refined = self._refiner.refine(query, fragment_summaries)
             if analysis_dict.get("needs_refinement"):
+                refined_query = candidate_refined
                 refinement_info = {
                     "original_query":    query,
                     "refined_query":     refined_query,

--- a/tests/test_query_refinement_drift.py
+++ b/tests/test_query_refinement_drift.py
@@ -1,0 +1,106 @@
+"""A specific query must be searched as asked, not as rewritten.
+
+`optimize_context` expanded every query with terms mined from an initial
+`recall(query, 20)` pass -- pseudo-relevance feedback -- and then ranked against
+the expansion. When the first pass is mediocre the rewrite inherits its mistakes
+and the second pass amplifies them. Classic query drift, applied unconditionally.
+
+Measured on this repository:
+
+    asked:    "what does entroly doctor check and how does it report failures"
+    searched: "... [context: tests, verifier, plugin, entry, point]"
+
+None of the injected terms appear in the question. They pulled
+test_verifier_plugins.py and plugins.py to the top, while entroly/cli.py -- which
+contains cmd_doctor and is the only file that answers it -- fell from rank 4 to
+rank 49, far below the ~12 fragments an 8k budget emits. Evidence retention on
+the frozen eight-query set was stuck at 0.750 for this reason alone; gating the
+rewrite on the analyzer's own `needs_refinement` signal took it to 1.000 at 4k,
+8k and 16k.
+
+The analyzer already computed that signal. It gated whether the refinement was
+*reported*, not whether it was *used*.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _Refiner:
+    """Stands in for QueryRefiner with a controllable verdict."""
+
+    def __init__(self, needs: bool) -> None:
+        self.needs = needs
+        self.refined = "REWRITTEN [context: tests, verifier, plugin]"
+
+    def analyze(self, query, summaries):
+        return {
+            "vagueness_score": 0.9 if self.needs else 0.1,
+            "key_terms": [],
+            "needs_refinement": self.needs,
+            "reason": "stub",
+        }
+
+    def refine(self, query, summaries):
+        return self.refined
+
+
+def _searched_query(monkeypatch, tmp_path, needs_refinement: bool) -> str:
+    """Return the query the retrieval layer actually searched with."""
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    from entroly.server import EntrolyConfig, EntrolyEngine
+
+    engine = EntrolyEngine(config=EntrolyConfig())
+    engine._refiner = _Refiner(needs_refinement)
+    engine.ingest_fragment(
+        content="def cmd_doctor(args):\n    checks_failed = 0\n    return checks_failed\n",
+        source="file:entroly/cli.py",
+        token_count=40,
+        is_pinned=False,
+    )
+    engine.ingest_fragment(
+        content="def test_verifier_plugin_entry_point():\n    assert True\n",
+        source="file:tests/test_verifier_plugins.py",
+        token_count=30,
+        is_pinned=False,
+    )
+
+    seen: list[str] = []
+    import entroly.qccr as qccr
+
+    original = qccr._rust_select
+
+    def spy(slim, budget, query, overrides, preferred):
+        seen.append(query)
+        return original(slim, budget, query, overrides, preferred)
+
+    monkeypatch.setattr(qccr, "_rust_select", spy)
+    engine.optimize_context(2000, "what does entroly doctor check and how does it report failures")
+    if not seen:
+        pytest.skip("selection did not route through qccr in this configuration")
+    return seen[0]
+
+
+def test_specific_query_is_searched_as_asked(monkeypatch, tmp_path):
+    """The guard: a query the analyzer deems specific must not be rewritten.
+
+    Reverting to an unconditional `refined_query = self._refiner.refine(...)`
+    fails this.
+    """
+    searched = _searched_query(monkeypatch, tmp_path, needs_refinement=False)
+    assert "REWRITTEN" not in searched, (
+        f"a specific query was silently rewritten before retrieval: {searched!r}"
+    )
+    assert "[context:" not in searched, (
+        "pseudo-relevance feedback terms leaked into a query that did not need them"
+    )
+    assert "doctor" in searched
+
+
+def test_vague_query_still_benefits_from_refinement(monkeypatch, tmp_path):
+    """The fix must not disable refinement -- only stop applying it blindly."""
+    searched = _searched_query(monkeypatch, tmp_path, needs_refinement=True)
+    assert "REWRITTEN" in searched, (
+        "refinement must still apply when the analyzer says the query needs it"
+    )


### PR DESCRIPTION
Evidence retention on the frozen eight-query set was stuck at **0.750**.
Ranking, budget starvation, chunk handling, force-pinning, stemming,
definition-site boosting and the test penalty were each measured and ruled
out. The cause was upstream of all of them: **the query being searched was
not the query being asked.**

## The defect

`optimize_context` expanded every query with terms mined from an initial
`recall(query, 20)` pass, then ranked against the expansion. That is
pseudo-relevance feedback applied unconditionally, so a mediocre first pass
rewrites the question and the second pass amplifies its mistakes — query
drift.

```
asked:    "what does entroly doctor check and how does it report failures"
searched: "... [context: tests, verifier, plugin, entry, point]"
```

None of the injected terms are in the question. They pulled
`test_verifier_plugins.py` and `plugins.py` to the top — files matching
`verifier` and `plugin`, not `doctor` — while `entroly/cli.py`, which defines
`cmd_doctor` and is the only file that answers it, fell from **rank 4 to rank
49**. An 8k budget emits ~12 fragments, so rank 49 is unreachable.
`auto_index.py` was at rank 41 for its own query.

## The fix

The analyzer already computed the signal needed to prevent this.
`needs_refinement` gated whether the refinement was *reported*, not whether it
was *used* — `refined_query` was assigned unconditionally one line above the
guard. It is now adopted only when the analyzer says the query needs it.

The refinement is still computed and still reported, so vague queries keep the
benefit and the receipt still shows what was asked versus what was searched.

## Result

Frozen evaluation, fresh deterministic index, same harness and budgets as the
recorded baseline:

| budget | before | after |
|---|---|---|
| 4,000 | 0.750 | **1.000** |
| 8,000 | 0.750 | **1.000** |
| 16,000 | 0.750 | **1.000** |

All eight gold files retained at every budget. Verdict moves from
`PARTIAL — evidence lost on some tasks` to `USEFUL SAVING PROVEN`.

This is a retrieval-quality fix, and unlike the pin/protection split it does
move recall. It also directly addresses the original complaint that started
this work — that savings were partly coming from returning unrelated context.
The retriever was answering a question the user never asked.

## Verification

* regression test proven non-vacuous: reverting to the unconditional
  assignment fails `test_specific_query_is_searched_as_asked`, while
  `test_vague_query_still_benefits_from_refinement` still passes, so the fix
  cannot be mistaken for disabling refinement
* 161 related tests pass (`-k "refin or qccr or retriev or recall or pin or
  reindex or chunk or no_match"`)
* `tests/test_mcp_protocol.py::test_mcp_retrieve_round_trip` fails identically
  with and without this change — verified by stashing the fix — and is not
  caused by it