### PR TITLE
chore(release): bring install pins to 1.0.67 and guard against version drift

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -22,7 +22,7 @@ Install the Python engine, then install the publicly verifiable OpenClaw plugin
 package from npm:
 
 ```bash
-pip install "entroly>=1.0.65"
+pip install "entroly>=1.0.67"
 openclaw plugins install npm:entroly-openclaw
 openclaw plugins enable entroly
 openclaw gateway restart
@@ -36,7 +36,7 @@ installable release.
 From an Entroly source checkout:
 
 ```bash
-pip install "entroly>=1.0.65"
+pip install "entroly>=1.0.67"
 openclaw plugins install ./integrations/openclaw
 openclaw plugins enable entroly
 openclaw gateway restart

--- a/tests/test_release_surface_consistency.py
+++ b/tests/test_release_surface_consistency.py
@@ -1,0 +1,111 @@
+"""Every release surface must agree with the master version.
+
+Version drift is silent and only surfaces downstream, usually as a published
+artifact that does not exist. Observed on this repository: the codebase read
+1.0.67 across thirteen surfaces while the Homebrew formula still pointed at
+1.0.64, the OpenClaw install docs told users `pip install "entroly>=1.0.65"`,
+and no `entroly-v1.0.67` tag existed at all -- so PyPI, npm, ClawHub and GitHub
+Releases were all still serving 1.0.66. The first sign of trouble was a ClawHub
+error, three surfaces and one release cycle later.
+
+`entroly/__init__.py` is the master. Anything that pins a version for a user --
+package manifests, install instructions -- must match it.
+
+Two categories are deliberately excluded, because changing them would be wrong
+rather than merely unnecessary:
+
+  * historical records (`docs/releases/*`, benchmark evidence matrices) state
+    which version something was measured or released at; rewriting them would
+    falsify provenance;
+  * the Homebrew formula must reference an sdist that actually exists on PyPI,
+    so it legitimately trails the repository until a release publishes.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _master_version() -> str:
+    text = (ROOT / "entroly" / "__init__.py").read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*["\']([0-9]+\.[0-9]+\.[0-9]+)["\']', text)
+    assert match, "entroly/__init__.py must define __version__"
+    return match.group(1)
+
+
+MASTER = _master_version()
+
+JSON_MANIFESTS = (
+    "entroly/npm/package.json",
+    "entroly/npm-alias/package.json",
+    "entroly-wasm/package.json",
+    "integrations/openclaw/package.json",
+    "server.json",
+)
+
+TOML_MANIFESTS = (
+    "pyproject.toml",
+    "entroly/pyproject.toml",
+    "entroly-core/pyproject.toml",
+    "entroly-core/Cargo.toml",
+    "entroly-qccr/Cargo.toml",
+    "entroly-wasm/Cargo.toml",
+)
+
+
+@pytest.mark.parametrize("relative", JSON_MANIFESTS)
+def test_json_manifest_matches_master_version(relative: str) -> None:
+    path = ROOT / relative
+    if not path.exists():
+        pytest.skip(f"{relative} not present in this checkout")
+    version = json.loads(path.read_text(encoding="utf-8")).get("version")
+    assert version == MASTER, (
+        f"{relative} is {version!r}, entroly/__init__.py is {MASTER!r}"
+    )
+
+
+@pytest.mark.parametrize("relative", TOML_MANIFESTS)
+def test_toml_manifest_matches_master_version(relative: str) -> None:
+    path = ROOT / relative
+    if not path.exists():
+        pytest.skip(f"{relative} not present in this checkout")
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*["\']([0-9]+\.[0-9]+\.[0-9]+)["\']', text, re.M)
+    assert match, f"{relative} has no top-level version"
+    assert match.group(1) == MASTER, (
+        f"{relative} is {match.group(1)!r}, entroly/__init__.py is {MASTER!r}"
+    )
+
+
+def test_native_status_matches_master_version() -> None:
+    text = (ROOT / "entroly" / "native_status.py").read_text(encoding="utf-8")
+    found = set(re.findall(r"1\.0\.[0-9]+", text))
+    stale = {v for v in found if v != MASTER}
+    assert not stale, (
+        f"entroly/native_status.py references {sorted(stale)}, master is {MASTER}"
+    )
+
+
+def test_install_instructions_do_not_pin_an_older_version() -> None:
+    """Docs must not tell users to install a version older than we ship.
+
+    Caught `pip install "entroly>=1.0.65"` in the OpenClaw README two releases
+    after 1.0.65, which silently steers users onto a stale floor.
+    """
+    pattern = re.compile(r'entroly[>=~]+=?["\']?(\d+\.\d+\.\d+)')
+    offenders: list[str] = []
+    for path in ROOT.rglob("*.md"):
+        rel = path.relative_to(ROOT).as_posix()
+        if any(part in rel for part in ("node_modules", "docs/releases/",
+                                        "docs/research", "benchmarks/results")):
+            continue
+        for pinned in pattern.findall(path.read_text(encoding="utf-8", errors="ignore")):
+            if tuple(map(int, pinned.split("."))) < tuple(map(int, MASTER.split("."))):
+                offenders.append(f"{rel}: pins {pinned}, master is {MASTER}")
+    assert not offenders, "stale install pins:\n  " + "\n  ".join(offenders)


### PR DESCRIPTION
Audited every version string in the tree. The codebase is **already
consistent at 1.0.67** across thirteen surfaces — `entroly/__init__.py`,
three `pyproject.toml`, three `Cargo.toml`, three `Cargo.lock` entries,
three `package.json`, `native_status.py`, `server.json`.

Two genuinely stale user-facing pins, now fixed:

```
integrations/openclaw/README.md:25   pip install "entroly>=1.0.65"  ->  >=1.0.67
integrations/openclaw/README.md:39   pip install "entroly>=1.0.65"  ->  >=1.0.67
```

These are the only install pins in the repository.

## Deliberately not changed

Changing these would be wrong, not merely unnecessary:

| location | why it stays |
|---|---|
| `integrations/openclaw/README.md:68` — "Entroly 1.0.64 bridge v2 protocol" | protocol compatibility floor, not a release pin; raising it claims a protocol change that did not happen |
| `docs/benchmarks/competitive-evidence-matrix.md` — 1.0.60, 1.0.65 | records which version each measurement was taken at; rewriting falsifies provenance |
| `docs/releases/*` | historical release notes |
| `.github/workflows/publish-openclaw-clawhub.yml:24` — "for example 1.0.63" | illustrative text in an input description |
| `packaging/homebrew/entroly.rb` | must reference an sdist that exists on PyPI, so it legitimately trails until a release publishes (#211 moves it to 1.0.66, the current published version) |

## The preventive half

`tests/test_release_surface_consistency.py` pins every manifest and every
install pin to `entroly/__init__.py`, with the historical and post-publish
categories excluded by design.

Version drift is silent and only surfaces downstream. Here the codebase read
1.0.67 while Homebrew pointed at 1.0.64 and the install docs at 1.0.65, and
the first visible symptom was a ClawHub error one release cycle later.

Verified non-vacuous: injecting a 1.0.66 npm manifest and a `>=1.0.65`
install pin fails exactly the two relevant cases. 13 pass when clean.

## What this does NOT fix

Published artifacts are still 1.0.66 — PyPI, npm, ClawHub, GitHub Releases.
That is not version drift in the codebase; **no `entroly-v1.0.67` tag
exists**, and the publish workflow triggers on `entroly-v*`. Every
`publish-*` job in the last run shows `Skipped` for exactly that reason.

Tagging is a separate, irreversible step and needs an explicit decision.