### PR TITLE
fix(release): give the ClawHub public-index check a realistic window

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -641,6 +641,20 @@ jobs:
           headers = {"User-Agent": "entroly-clawhub-publisher/1.0"}
           last_error = "ClawHub did not expose the accepted release"
 
+          # ClawHub's public index lags acceptance. 1.0.67 published cleanly at
+          # 03:11 and this check's old 60x15s window (15 minutes) expired at
+          # 03:27 with the index still reporting 1.0.66; the version was public
+          # shortly afterwards. A verifier that reliably fails on a successful
+          # publish is worse than none, because it teaches everyone to ignore a
+          # red release.
+          #
+          # Still fail-closed -- the release SHOULD go red if the artifact never
+          # becomes public -- but the window now reflects observed propagation,
+          # with backoff so waiting longer does not mean proportionally more
+          # requests: 15s for the first two minutes, then 60s, ~35 minutes total.
+          # Raise CLAWHUB_VERIFY_ATTEMPTS when re-running by hand.
+          attempts = int(os.environ.get("CLAWHUB_VERIFY_ATTEMPTS") or 40)
+
           def read_json(url: str) -> dict:
               request = urllib.request.Request(url, headers=headers)
               with urllib.request.urlopen(request, timeout=30) as response:
@@ -648,7 +662,7 @@ jobs:
                       raise RuntimeError(f"HTTP {response.status} for {url}")
                   return json.load(response)
 
-          for attempt in range(1, 61):
+          for attempt in range(1, attempts + 1):
               try:
                   detail = read_json(f"{base}/{urllib.parse.quote(name, safe='')}")
                   package = detail.get("package") or {}
@@ -682,9 +696,9 @@ jobs:
                   raise SystemExit(0)
               except (urllib.error.HTTPError, urllib.error.URLError, ValueError, RuntimeError) as exc:
                   last_error = str(exc)
-                  print(f"Attempt {attempt}/60: {last_error}")
-                  if attempt < 60:
-                      time.sleep(15)
+                  print(f"Attempt {attempt}/{attempts}: {last_error}", flush=True)
+                  if attempt < attempts:
+                      time.sleep(15 if attempt <= 8 else 60)
           raise SystemExit(last_error)
           PY
 

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -240,7 +240,16 @@ def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> 
         "Verify exact ClawHub version is public"
     )
     assert "Verify exact ClawHub version is public" in clawhub_publisher
-    assert "for attempt in range(1, 61)" in clawhub_publisher
+    # The public-index check must stay bounded and fail-closed, but the bound
+    # is not a magic number: 60x15s (15 min) expired while ClawHub was still
+    # serving the previous version after a successful 1.0.67 publish, so the
+    # release went red on an artifact that was live. Assert the contract --
+    # a finite retry loop with backoff and an operator override -- rather than
+    # one literal, so tuning the window does not require editing this test.
+    assert "for attempt in range(1, attempts + 1)" in clawhub_publisher
+    assert "CLAWHUB_VERIFY_ATTEMPTS" in clawhub_publisher
+    assert "time.sleep(" in clawhub_publisher
+    assert "raise SystemExit(last_error)" in clawhub_publisher
     assert "package moderation-status entroly-openclaw --json" in clawhub_publisher
     assert "moderation-status entroly-openclaw --json > \"$raw_status\"" in clawhub_publisher
     assert 'release.get("moderationReason")' not in clawhub_publisher


### PR DESCRIPTION
The 1.0.67 release published to ClawHub successfully and the job still went red. Every publish step passed -- validate, authenticate, configure trusted publishing, publish with GitHub OIDC, scrub token, record moderation, upload evidence -- and only "Verify exact ClawHub version is public" failed:

    Attempt 60/60: latest version is '1.0.66', expected '1.0.67'

The publish landed at 03:11 and the 60x15s window expired at 03:27 with ClawHub's public index still serving 1.0.66. It is serving 1.0.67 now, with artifact entroly-openclaw-1.0.67.tgz, so nothing was wrong with the release. The same job failed on 1.0.66 for the same reason.

A verifier that reliably fails on a successful publish is worse than no verifier, because it teaches everyone to ignore a red release -- and that is how a genuinely failed publish gets waved through.

Kept fail-closed: if the artifact never becomes public the release still goes red, which is the point of the check. What changes is the window, now matched to observed propagation, with backoff so a longer wait does not mean proportionally more requests:

    before   60 attempts x 15s              = 15 minutes
    after    8 x 15s, then 32 x 60s         = ~33 minutes

`CLAWHUB_VERIFY_ATTEMPTS` overrides the count when re-running by hand.

Note this is the workflow #210 proposed deleting outright. The check earns its place; only its timeout was wrong.

Verified: workflow parses (15 jobs) and the embedded Python parses.

## Outcome

<!-- What user-visible problem does this solve? Lead with the outcome. -->

## Changes

<!-- Keep the list focused. Link the issue or discussion when one exists. -->

## Trust and compatibility

- [ ] Receipt honesty and recoverability are preserved or not affected.
- [ ] Verification remains fail-closed where confidence is claimed.
- [ ] No surprise network call or credential persistence was introduced.
- [ ] Provider request, tool, streaming, and cache semantics are preserved.
- [ ] Backward compatibility and migration impact are documented.
- [ ] Public claims include a baseline, workload, budget, and limitations.
- [ ] This change does not affect the checked item(s), explained below.

## Validation

<!-- Paste exact commands and concise results. State incomplete or timed-out checks honestly. -->

```text
command -> result
```

## Release impact

- [ ] No release note or version change required.
- [ ] Release note added or updated.
- [ ] Python, Rust, npm/WASM, MCP, OpenClaw, Docker, and Homebrew surfaces were reviewed as applicable.

## Rollback

<!-- How can maintainers disable or revert this safely? -->
