### PR TITLE
fix(mcp): bound optimize_context response metadata

### DIFF
--- a/entroly/provenance.py
+++ b/entroly/provenance.py
@@ -17,8 +17,135 @@ but is purpose-built for the context selection use case.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any
+
+
+_FULL_DIAGNOSTICS_ENV = "ENTROLY_MCP_FULL_DIAGNOSTICS"
+
+# Agent-useful wire fields. The engine can keep a much richer in-process
+# fragment object, but serializing all scoring features for hundreds of
+# fragments makes MCP metadata larger than the selected context itself.
+_WIRE_FRAGMENT_KEYS = (
+    "id",
+    "fragment_id",
+    "source",
+    "content",
+    "text",
+    "token_count",
+    "tokens",
+    "relevance",
+    "relevance_score",
+    "composite_score",
+    "resolution",
+    "retrieval_handle",
+    "content_sha256",
+    "original_tokens",
+    "compressed_tokens",
+    "is_pinned",
+    "start_line",
+    "end_line",
+    "lines",
+    "language",
+    "kind",
+    "role",
+    "quality_issues",
+)
+
+
+def _full_diagnostics_enabled() -> bool:
+    return os.environ.get(_FULL_DIAGNOSTICS_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _compact_fragment_for_wire(raw: Any) -> Any:
+    """Return one canonical, agent-useful fragment representation."""
+    if not isinstance(raw, dict):
+        return raw
+
+    compact: dict[str, Any] = {
+        key: raw[key]
+        for key in _WIRE_FRAGMENT_KEYS
+        if key in raw and raw[key] is not None
+    }
+
+    if "id" not in compact and compact.get("fragment_id"):
+        compact["id"] = compact["fragment_id"]
+
+    # Emit one body field, one score, and one token-count field instead of
+    # preserving aliases from the Rust and Python engine paths.
+    if "content" not in compact and "text" in compact:
+        compact["content"] = compact["text"]
+    compact.pop("text", None)
+
+    if "relevance" not in compact:
+        for key in ("relevance_score", "composite_score"):
+            score = compact.get(key)
+            if isinstance(score, (int, float)):
+                compact["relevance"] = score
+                break
+    compact.pop("relevance_score", None)
+    compact.pop("composite_score", None)
+
+    if "token_count" not in compact and "tokens" in compact:
+        compact["token_count"] = compact["tokens"]
+    compact.pop("tokens", None)
+
+    return compact
+
+
+def compact_optimize_result_for_wire(optimize_result: dict[str, Any]) -> None:
+    """Compact an optimize result in-place immediately before MCP serialization.
+
+    ``selected`` and ``selected_fragments`` are compatibility aliases inside
+    the engine. Sending both over MCP serializes the same fragment bodies and
+    metadata twice. The public wire response keeps ``selected_fragments`` as
+    the canonical key and removes the alias. Compact mode also strips internal
+    scoring vectors while preserving content, source locations, token counts,
+    and CCR exact-recovery handles.
+
+    Set ``ENTROLY_MCP_FULL_DIAGNOSTICS=1`` to retain rich per-fragment fields.
+    The duplicate alias is still removed because it has no diagnostic value.
+    """
+    if not isinstance(optimize_result, dict):
+        return
+
+    selected = optimize_result.get("selected_fragments")
+    if not isinstance(selected, list):
+        fallback = optimize_result.get("selected")
+        selected = fallback if isinstance(fallback, list) else []
+
+    optimize_result.pop("selected", None)
+    if _full_diagnostics_enabled():
+        optimize_result["selected_fragments"] = list(selected)
+        mode = "diagnostics"
+    else:
+        optimize_result["selected_fragments"] = [
+            _compact_fragment_for_wire(fragment) for fragment in selected
+        ]
+        mode = "compact"
+
+    response = optimize_result.get("response")
+    if not isinstance(response, dict):
+        response = {}
+        optimize_result["response"] = response
+    response.update(
+        {
+            "mode": mode,
+            "canonical_selection_key": "selected_fragments",
+            "omitted_duplicate_alias": "selected",
+        }
+    )
+    if mode == "compact":
+        response["diagnostics_hint"] = (
+            f"Set {_FULL_DIAGNOSTICS_ENV}=1 for full fragment scoring fields "
+            "and per-fragment provenance."
+        )
 
 
 @dataclass
@@ -94,8 +221,19 @@ class ContextProvenance:
             return "medium"
         return "low"
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
+    def to_dict(self, *, include_fragments: bool | None = None) -> dict[str, Any]:
+        """Serialize bounded provenance by default.
+
+        The selected fragment list already carries ids, sources, tokens, and
+        content. Repeating a second record for every fragment and a full source
+        set can add tens of thousands of characters without adding evidence.
+        Aggregate provenance remains on the default wire path; full records are
+        opt-in for diagnostics.
+        """
+        if include_fragments is None:
+            include_fragments = _full_diagnostics_enabled()
+
+        payload: dict[str, Any] = {
             "turn": self.turn,
             "query": self.query,
             "refined_query": self.refined_query,
@@ -106,9 +244,12 @@ class ContextProvenance:
             "verified_fraction": round(self.verified_fraction, 3),
             "avg_confidence": round(self.avg_confidence, 3),
             "hallucination_risk": self.hallucination_risk,
-            "source_set": sorted(self.source_set),
             "quality_flagged": self.quality_flagged_sources,
-            "fragments": [
+        }
+
+        if include_fragments:
+            payload["source_set"] = sorted(self.source_set)
+            payload["fragments"] = [
                 {
                     "id": f.fragment_id,
                     "source": f.source,
@@ -120,8 +261,16 @@ class ContextProvenance:
                     **({"quality_issues": f.quality_issues} if f.quality_issues else {}),
                 }
                 for f in self.fragments
-            ],
-        }
+            ]
+        else:
+            payload["details_omitted"] = {
+                "fragment_records": len(self.fragments),
+                "source_set_entries": len(self.source_set),
+                "reason": "duplicated by selected_fragments",
+                "diagnostics_env": _FULL_DIAGNOSTICS_ENV,
+            }
+
+        return payload
 
 
 def build_provenance(
@@ -143,17 +292,22 @@ def build_provenance(
         token_budget:     The budget passed to optimize
         quality_scan_fn:  Optional callable(content, source) -> List[str]
     """
-    selected = optimize_result.get("selected", [])
+    selected = optimize_result.get("selected_fragments")
+    if not isinstance(selected, list):
+        fallback = optimize_result.get("selected")
+        selected = fallback if isinstance(fallback, list) else []
     tokens_used = optimize_result.get("tokens_used", 0)
 
     frag_provenances = []
     for frag in selected:
-        fid        = frag.get("id", frag.get("fragment_id", ""))
-        source     = frag.get("source", "")
+        if not isinstance(frag, dict):
+            continue
+        fid = frag.get("id", frag.get("fragment_id", ""))
+        source = frag.get("source", "")
         confidence = frag.get("composite_score", frag.get("relevance", 0.0))
-        tokens     = frag.get("token_count", frag.get("tokens", 0))
-        is_pinned  = frag.get("is_pinned", False)
-        content    = frag.get("content", "")
+        tokens = frag.get("token_count", frag.get("tokens", 0))
+        is_pinned = frag.get("is_pinned", False)
+        content = frag.get("content", "")
 
         # A fragment is "verified" if it has a non-empty source that looks
         # like a real file path (not "internal_knowledge" or blank)
@@ -174,7 +328,7 @@ def build_provenance(
             quality_issues=issues,
         ))
 
-    return ContextProvenance(
+    provenance = ContextProvenance(
         turn=turn,
         query=query,
         refined_query=refined_query if refined_query != query else None,
@@ -182,3 +336,9 @@ def build_provenance(
         token_budget=token_budget,
         tokens_used=int(tokens_used),
     )
+
+    # Wire-facing callers have already consumed the rich engine result for
+    # learning, CCR capture, causal snapshots, and outcome attribution. Compact
+    # only now, immediately before the response is serialized or rendered.
+    compact_optimize_result_for_wire(optimize_result)
+    return provenance

--- a/tests/test_mcp_payload_bounds.py
+++ b/tests/test_mcp_payload_bounds.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+from entroly.provenance import build_provenance
+
+
+def _fragment(index: int, *, content_size: int = 80) -> dict:
+    content = f"fragment {index} " + ("x" * content_size)
+    return {
+        "id": f"frag-{index}",
+        "fragment_id": f"frag-{index}",
+        "source": f"file:src/module_{index}.py",
+        "content": content,
+        "token_count": max(1, len(content) // 4),
+        "relevance": 0.9,
+        "recency_score": 0.8,
+        "frequency_score": 0.7,
+        "semantic_score": 0.95,
+        "entropy_score": 0.6,
+        "feedback_multiplier": 1.2,
+        "debug_vector": [0.1] * 16,
+        "retrieval_handle": f"ccr:{index:064x}",
+        "content_sha256": f"{index:064x}",
+    }
+
+
+def _result(count: int = 40, *, content_size: int = 80) -> dict:
+    selected = [_fragment(i, content_size=content_size) for i in range(count)]
+    return {
+        "selected_fragments": selected,
+        "selected": selected,
+        "tokens_used": sum(f["token_count"] for f in selected),
+        "token_budget": 8000,
+        "online_prism": {"weights": {"semantic": 0.4}},
+    }
+
+
+def _wire(result: dict) -> dict:
+    provenance = build_provenance(
+        result,
+        query="find root wiring bug",
+        refined_query=None,
+        turn=4,
+        token_budget=8000,
+    )
+    result["provenance"] = provenance.to_dict()
+    return result
+
+
+def test_default_wire_result_removes_alias_and_internal_fragment_fields(monkeypatch) -> None:
+    monkeypatch.delenv("ENTROLY_MCP_FULL_DIAGNOSTICS", raising=False)
+    payload = _wire(_result())
+
+    assert "selected" not in payload
+    assert payload["response"]["canonical_selection_key"] == "selected_fragments"
+    assert payload["selected_fragments"][0]["content"].startswith("fragment 0")
+    assert payload["selected_fragments"][0]["retrieval_handle"].startswith("ccr:")
+    assert "semantic_score" not in payload["selected_fragments"][0]
+    assert "debug_vector" not in payload["selected_fragments"][0]
+    assert "fragments" not in payload["provenance"]
+    assert "source_set" not in payload["provenance"]
+    assert payload["provenance"]["details_omitted"]["fragment_records"] == 40
+
+
+def test_diagnostics_env_preserves_rich_fields_without_duplicate_alias(monkeypatch) -> None:
+    monkeypatch.setenv("ENTROLY_MCP_FULL_DIAGNOSTICS", "1")
+    payload = _wire(_result())
+
+    assert "selected" not in payload
+    assert payload["response"]["mode"] == "diagnostics"
+    assert payload["selected_fragments"][0]["semantic_score"] == 0.95
+    assert len(payload["provenance"]["fragments"]) == 40
+    assert len(payload["provenance"]["source_set"]) == 40
+
+
+def test_dogfood_shape_shrinks_metadata_dominated_response(monkeypatch) -> None:
+    monkeypatch.delenv("ENTROLY_MCP_FULL_DIAGNOSTICS", raising=False)
+    raw = _result(count=395, content_size=50)
+    before = len(json.dumps(raw, ensure_ascii=False, separators=(",", ":")))
+    payload = _wire(raw)
+    after = len(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+
+    assert before > after * 3
+    assert after < 200_000
+    assert payload["tokens_used"] <= payload["token_budget"]
+    assert len(payload["selected_fragments"]) == 395
+
+
+def test_provenance_prefers_canonical_selected_fragments(monkeypatch) -> None:
+    monkeypatch.delenv("ENTROLY_MCP_FULL_DIAGNOSTICS", raising=False)
+    result = _result(count=2)
+    result["selected"] = [{"id": "wrong", "source": "synthetic"}]
+
+    payload = _wire(result)
+
+    assert payload["provenance"]["fragment_count"] == 2
+    assert payload["provenance"]["verified_fraction"] == 1.0


### PR DESCRIPTION
## Dogfood failure

A real `optimize_context(token_budget=8000)` call selected 7,004 tokens correctly but serialized roughly 520,569 characters. The selected context was not over budget; the MCP envelope was.

The dominant causes were:
- `selected_fragments` and `selected` serializing the same fragment list twice
- every internal scoring feature being exposed for hundreds of fragments
- full per-fragment provenance and `source_set` repeating data already present in the selected list

## Fix

- keep `selected_fragments` as the single canonical wire key
- remove the duplicate `selected` alias at the serialization boundary
- preserve agent-useful evidence fields: content, source, ids, token counts, relevance, line metadata, and CCR recovery handles
- default provenance to bounded aggregate risk/verification metadata
- retain full diagnostics with `ENTROLY_MCP_FULL_DIAGNOSTICS=1`
- prefer `selected_fragments` when building provenance so a stale alias cannot corrupt receipts

The engine’s selection, token accounting, learning path, CCR capture, and causal attribution still consume the rich result before compaction.

## Regression evidence

Focused tests cover compact mode, diagnostics mode, canonical-key precedence, and a 395-fragment dogfood-shaped payload.

Synthetic reproduction:
- before: 434,530 characters
- after: 142,516 characters
- reduction: 67.2% (3.05× smaller)
- selected fragments retained: 395 / 395
- selected content and CCR handles retained

Local focused result: `4 passed`.