### PR TITLE
fix(ci): repair main Docker quality gate

### DIFF
--- a/.github/workflows/main-quality-gate-diagnostic.yml
+++ b/.github/workflows/main-quality-gate-diagnostic.yml
@@ -1,0 +1,71 @@
+name: Main Quality Gate Diagnostic
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-quality-gate-diagnostic-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  diagnose:
+    name: Capture exact quality-gate failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Ruff lint
+        run: |
+          python -m pip install ruff==0.12.9
+          ruff check entroly/
+
+      - name: Build entroly-core and install package
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install maturin --timeout 120 --retries 5
+          cd entroly-core && ../.venv/bin/maturin develop --release && cd ..
+          .venv/bin/pip install --timeout 120 --retries 5 -e . \
+            "mcp>=1.6.0" "httpx>=0.27" "starlette>=0.37" \
+            "uvicorn>=0.30" psutil pytest pytest-timeout
+
+      - name: Capture first full-suite failure
+        id: pytest
+        shell: bash
+        run: |
+          set +e
+          log="$RUNNER_TEMP/main-quality-gate.log"
+          .venv/bin/pytest tests/ -vv --tb=long -x --timeout=60 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          echo "$status" > "$RUNNER_TEMP/main-quality-gate.status"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload diagnostic evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-quality-gate-diagnostic
+          path: |
+            ${{ runner.temp }}/main-quality-gate.log
+            ${{ runner.temp }}/main-quality-gate.status
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Record diagnostic result
+        if: always()
+        run: echo "Quality-gate pytest exit status was ${{ steps.pytest.outputs.status }}"

--- a/tests/test_deep_dogfood_runtime.py
+++ b/tests/test_deep_dogfood_runtime.py
@@ -12,6 +12,7 @@ import os
 import queue
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -22,15 +23,35 @@ import pytest
 from entroly import __version__
 
 
+def _installed_entroly_executable() -> str:
+    """Return the real installed console script without requiring activation.
+
+    ``python -m venv .venv`` followed by ``.venv/bin/pytest`` is a valid way to
+    run an isolated environment, but it does not add ``.venv/bin`` to the shell
+    ``PATH``.  The console script is still installed beside the active Python
+    interpreter, so use that exact script as the bounded fallback.  This keeps
+    the dogfood test black-box and still fails when the user-facing entry point
+    was not installed.
+    """
+
+    executable = shutil.which("entroly")
+    if executable:
+        return executable
+
+    script_name = "entroly.exe" if os.name == "nt" else "entroly"
+    candidate = Path(sys.executable).with_name(script_name)
+    assert candidate.is_file(), (
+        "The documented `entroly` console entry point is not installed. "
+        f"PATH lookup failed and no script exists beside {sys.executable!r}."
+    )
+    return str(candidate)
+
+
 class MCPProcess:
     """Small JSON-RPC harness with bounded reads and useful crash diagnostics."""
 
     def __init__(self, cwd: Path, env: dict[str, str] | None = None) -> None:
-        executable = shutil.which("entroly")
-        assert executable, (
-            "The documented `entroly` console entry point is not installed. "
-            "Black-box dogfood tests must exercise the user-facing command."
-        )
+        executable = _installed_entroly_executable()
 
         child_env = {
             **os.environ,
@@ -176,8 +197,7 @@ def _tool_payload(response: dict[str, Any]) -> dict[str, Any]:
 
 
 def test_console_version_matches_imported_package() -> None:
-    executable = shutil.which("entroly")
-    assert executable
+    executable = _installed_entroly_executable()
     completed = subprocess.run(
         [executable, "--version"],
         text=True,


### PR DESCRIPTION
## Purpose

Reproduce and repair the failing `Build and Push Entroly Docker Image / quality-gate` on `main` without changing `main` directly.

## Current diagnostic step

- run the exact quality-gate environment: Python 3.12, Rust native build, package install, and full `pytest -x`
- upload the complete first-failure traceback
- keep this PR draft until the temporary diagnostic workflow is removed and every final-head workflow is green

## Merge gate

Do not merge the diagnostic-only state. Identify the first failure, fix the underlying contract, remove the temporary workflow, and require the complete final-head matrix to pass.