### PR TITLE
fix(release): converge CLI fallback version surface

### DIFF
--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -87,7 +87,7 @@ CARGO_LOCK_PACKAGES: dict[str, tuple[str, ...]] = {
 
 PYTHON_VERSION_PATTERNS: dict[str, str] = {
     "entroly/__init__.py": rf'^__version__\s*=\s*"(?P<version>{SEMVER_TEXT})"',
-    "entroly/cli.py": rf'^\s*__version__\s*=\s*"(?P<version>{SEMVER_TEXT})"',
+    "entroly/cli.py": rf'__version__\s*=\s*"(?P<version>{SEMVER_TEXT})"',
     "entroly/daemon.py": rf'^\s*version:\s*str\s*=\s*"(?P<version>{SEMVER_TEXT})"',
     "entroly/native_status.py": (
         rf'^MIN_ENTROLY_CORE_VERSION\s*=\s*"(?P<version>{SEMVER_TEXT})"'

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -592,3 +592,17 @@ def test_clawhub_reconciliation_is_tag_bound_and_non_destructive_by_default() ->
         "name: clawhub-release-reconciliation-${{ inputs.version }}", 1
     )[1]
     assert 'release.get("moderationReason")' not in text
+
+
+def test_release_sync_accepts_cli_fallback_version() -> None:
+    from scripts.sync_release_version import PYTHON_VERSION_PATTERNS, _replace_versions
+
+    source = '    __version__ = "1.0.67"\\n'
+    updated = _replace_versions(
+        source,
+        PYTHON_VERSION_PATTERNS["entroly/cli.py"],
+        "1.0.68",
+        surface="entroly/cli.py",
+    )
+
+    assert updated == '    __version__ = "1.0.68"\\n'


### PR DESCRIPTION
## Outcome

Keep the one-shot 1.0.68 release synchronizer from failing on the CLI fallback version, so main can converge release metadata without a red guard.

## Changes

- Make the CLI fallback version matcher independent of line anchoring.
- Add a regression test for the fallback assignment.

## Validation

The failing main job was traced to scripts/sync_release_version.py: entroly/cli.py reported zero typed version fields. The focused test exercises the exact fallback shape.

## Rollback

Revert this PR; it only changes the release-surface matcher and its test.