### PR TITLE
fix(release): honor explicit sync trigger file

### DIFF
--- a/.github/workflows/apply-release-sync-once.yml
+++ b/.github/workflows/apply-release-sync-once.yml
@@ -9,6 +9,7 @@ on:
       - main
     paths:
       - '.github/workflows/apply-release-sync-once.yml'
+      - '.release-sync-trigger'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Outcome

Make the existing `.release-sync-trigger` operational and rerun the corrected typed 1.0.68 release synchronizer on main.

## Changes

- Add `.release-sync-trigger` to the one-shot workflow path filter.
- Preserve the workflow-file path trigger for direct maintenance changes.

## Root cause

PR #223 added the trigger file, but the workflow listened only to its own YAML path, so the trigger commit could never start the job.

## Validation

The workflow remains restricted to `main` and now responds to both explicit trigger commits and workflow maintenance changes.

## Rollback

Revert this one-line path-filter change; release publication remains otherwise unchanged.