### PR TITLE
fix(release): make 1.0.68 synchronization converge

### DIFF
--- a/.release-sync-trigger
+++ b/.release-sync-trigger
@@ -1,1 +1,2 @@
 Repair stale active 1.0.68 release surfaces through the permanent typed synchronizer.
+Retry after matching the CLI fallback assignment robustly.

--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -87,7 +87,7 @@ CARGO_LOCK_PACKAGES: dict[str, tuple[str, ...]] = {
 
 PYTHON_VERSION_PATTERNS: dict[str, str] = {
     "entroly/__init__.py": rf'^__version__\s*=\s*"(?P<version>{SEMVER_TEXT})"',
-    "entroly/cli.py": rf'__version__\s*=\s*"(?P<version>{SEMVER_TEXT})"',
+    "entroly/cli.py": rf'__version__[^\r\n]*?(?P<version>{SEMVER_TEXT})',
     "entroly/daemon.py": rf'^\s*version:\s*str\s*=\s*"(?P<version>{SEMVER_TEXT})"',
     "entroly/native_status.py": (
         rf'^MIN_ENTROLY_CORE_VERSION\s*=\s*"(?P<version>{SEMVER_TEXT})"'


### PR DESCRIPTION
## Outcome

Make the 1.0.68 release synchronizer converge on main and keep the explicit trigger operational.

## Changes

- Match the CLI fallback version by its assignment line and numeric semantic version, independent of quote/whitespace layout.
- Retain regression coverage for the fallback assignment.
- Touch the existing trigger file so the corrected workflow runs immediately.

## Root cause

The prior matcher still reported zero fields for `entroly/cli.py` in the hosted runner, and the earlier trigger PR was based on stale main and reverted the parser fix when merged.

## Validation

The regression test exercises the exact fallback assignment. This branch is based on current main and includes the trigger path already wired into the workflow.

## Rollback

Revert this PR; no provider or runtime behavior changes are involved.