### PR TITLE
fix(release): parse CLI fallback version deterministically

### DIFF
--- a/.release-sync-trigger
+++ b/.release-sync-trigger
@@ -1,2 +1,3 @@
 Repair stale active 1.0.68 release surfaces through the permanent typed synchronizer.
 Retry after matching the CLI fallback assignment robustly.
+Retry after deterministic CLI fallback parsing.

--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -144,6 +144,33 @@ def _replace_versions(
     return expression.sub(replacement, text)
 
 
+def _replace_cli_fallback_version(text: str, target: str, surface: str) -> str:
+    """Replace exactly one CLI fallback version without relying on line regex anchors."""
+
+    lines = text.splitlines(keepends=True)
+    matches: list[tuple[int, re.Match[str]]] = []
+    for index, line in enumerate(lines):
+        if "__version__" not in line or "=" not in line:
+            continue
+        left, right = line.split("=", 1)
+        if "__version__" not in left:
+            continue
+        match = re.search(rf"(?P<version>{SEMVER_TEXT})", right)
+        if match:
+            matches.append((index, match))
+
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"{surface}: expected exactly one CLI fallback version, found {len(matches)}"
+        )
+
+    index, match = matches[0]
+    line = lines[index]
+    start, end = match.span("version")
+    lines[index] = line[:start] + target + line[end:]
+    return "".join(lines)
+
+
 def _replace_toml_project_version(text: str, target: str, surface: str) -> str:
     return _replace_versions(
         text,
@@ -258,6 +285,10 @@ def _transform_surface(surface: str, text: str, target: str) -> str:
 
     if surface in CARGO_LOCK_PACKAGES:
         return _replace_cargo_lock_versions(text, target, surface)
+
+    if surface == "entroly/cli.py":
+        updated = _replace_cli_fallback_version(text, target, surface)
+        return _replace_native_dependency_minimums(updated, target, surface)
 
     if surface in PYTHON_VERSION_PATTERNS:
         updated = _replace_versions(

--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -287,8 +287,7 @@ def _transform_surface(surface: str, text: str, target: str) -> str:
         return _replace_cargo_lock_versions(text, target, surface)
 
     if surface == "entroly/cli.py":
-        updated = _replace_cli_fallback_version(text, target, surface)
-        return _replace_native_dependency_minimums(updated, target, surface)
+        return _replace_cli_fallback_version(text, target, surface)
 
     if surface in PYTHON_VERSION_PATTERNS:
         updated = _replace_versions(

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -595,7 +595,11 @@ def test_clawhub_reconciliation_is_tag_bound_and_non_destructive_by_default() ->
 
 
 def test_release_sync_accepts_cli_fallback_version() -> None:
-    from scripts.sync_release_version import PYTHON_VERSION_PATTERNS, _replace_versions
+    from scripts.sync_release_version import (
+        PYTHON_VERSION_PATTERNS,
+        _replace_cli_fallback_version,
+        _replace_versions,
+    )
 
     source = '    __version__ = "1.0.67"\\n'
     updated = _replace_versions(
@@ -606,3 +610,4 @@ def test_release_sync_accepts_cli_fallback_version() -> None:
     )
 
     assert updated == '    __version__ = "1.0.68"\\n'
+    assert _replace_cli_fallback_version(source, "1.0.68", "entroly/cli.py") == updated


### PR DESCRIPTION
## Outcome

Make the 1.0.68 release synchronizer converge reliably on the hosted runner.

## Changes

- Parse the CLI fallback assignment deterministically instead of depending on a fragile multiline regex.
- Require exactly one semantic version token and replace only that token.
- Add direct regression coverage and retrigger the guarded workflow.

## Root cause

Two regex-based matcher revisions still returned zero fields for `entroly/cli.py` in Actions, leaving main red at the convergence step.

## Validation

The test covers both the generic surface matcher and the deterministic CLI parser. The branch is based on current main and includes the workflow trigger path.

## Rollback

Revert this PR; no runtime/provider behavior changes are involved.