### PR TITLE
fix(release): preserve CLI fallback assignment

### DIFF
--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -148,7 +148,7 @@ def _replace_cli_fallback_version(text: str, target: str, surface: str) -> str:
     """Replace exactly one CLI fallback version without relying on line regex anchors."""
 
     lines = text.splitlines(keepends=True)
-    matches: list[tuple[int, re.Match[str]]] = []
+    matches: list[tuple[int, re.Match[str], int]] = []
     for index, line in enumerate(lines):
         if "__version__" not in line or "=" not in line:
             continue
@@ -157,16 +157,18 @@ def _replace_cli_fallback_version(text: str, target: str, surface: str) -> str:
             continue
         match = re.search(rf"(?P<version>{SEMVER_TEXT})", right)
         if match:
-            matches.append((index, match))
+            matches.append((index, match, len(left) + 1))
 
     if len(matches) != 1:
         raise RuntimeError(
             f"{surface}: expected exactly one CLI fallback version, found {len(matches)}"
         )
 
-    index, match = matches[0]
+    index, match, offset = matches[0]
     line = lines[index]
     start, end = match.span("version")
+    start += offset
+    end += offset
     lines[index] = line[:start] + target + line[end:]
     return "".join(lines)
 


### PR DESCRIPTION
## Outcome

Fix the typed release synchronizer so the CLI fallback assignment remains valid when updating the release version. The parser matches the version in the right-hand side of the assignment; this patch applies the match offset back to the full source line before replacing it.

## Validation

The previous main run proved the parser reached convergence but failed validation with a corrupted `__version__` line (`1.0.68rsion__`). This patch preserves the complete assignment and unblocks the existing focused release-surface tests.

## Release impact

The existing one-shot `1.0.68` convergence workflow will update the remaining runtime surfaces (`entroly/cli.py`, `entroly/server.py`) and write the release note after this fix lands.

## Rollback

Revert this single parser commit; no provider or runtime behavior changes are introduced.