### PR TITLE
fix(release): synchronize CLI native dependency floor

### DIFF
--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -289,7 +289,7 @@ def _transform_surface(surface: str, text: str, target: str) -> str:
         return _replace_cargo_lock_versions(text, target, surface)
 
     if surface == "entroly/cli.py":
-        return _replace_cli_fallback_version(text, target, surface)
+        updated = _replace_cli_fallback_version(text, target, surface)\n        return _replace_native_dependency_minimums(updated, target, surface)
 
     if surface in PYTHON_VERSION_PATTERNS:
         updated = _replace_versions(


### PR DESCRIPTION
## Outcome

Complete the typed 1.0.68 release convergence for `entroly/cli.py`. After safely replacing the fallback `__version__` assignment, apply the existing native dependency-floor transform to the CLI module as well.

## Evidence

The corrected parser run reached convergence but the focused invariant still found `entroly-core>=1.0.67,<2` in `entroly/cli.py`; the existing tests require that floor to match the package release. This patch addresses that exact mismatch.

## Validation

The existing release-sync safety, version-sync, and release-surface suites already cover the expected CLI assignment and dependency floor.

## Rollback

Revert this parser-only change; no runtime provider behavior is changed.