### PR TITLE
fix(release): restore CLI dependency transform syntax

### DIFF
--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -289,7 +289,8 @@ def _transform_surface(surface: str, text: str, target: str) -> str:
         return _replace_cargo_lock_versions(text, target, surface)
 
     if surface == "entroly/cli.py":
-        updated = _replace_cli_fallback_version(text, target, surface)\n        return _replace_native_dependency_minimums(updated, target, surface)
+        updated = _replace_cli_fallback_version(text, target, surface)
+        return _replace_native_dependency_minimums(updated, target, surface)
 
     if surface in PYTHON_VERSION_PATTERNS:
         updated = _replace_versions(


### PR DESCRIPTION
Fix the release synchronizer syntax introduced in the previous CLI dependency-floor patch. The dependency transform now uses a real line break, so the typed 1.0.68 convergence can execute and validate. No runtime behavior changes.