### PR TITLE
fix(release): accept CLI native pins without upper bound

### DIFF
--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -264,7 +264,7 @@ def _replace_native_dependency_minimums(
 ) -> str:
     return _replace_versions(
         text,
-        rf'entroly-core>=(?P<version>{SEMVER_TEXT}),<2',
+        rf'entroly-core>=(?P<version>{SEMVER_TEXT})(?:,<2)?',
         target,
         surface=surface,
         minimum=1,


### PR DESCRIPTION
The typed release synchronizer must update the CLI's user-facing `entroly-core>=...` install pins, which intentionally omit `,<2`. Make the upper bound optional while preserving the existing bounded dependency behavior and focused release tests.