### PR TITLE
fix(release): converge all 1.0.68 runtime surfaces

### DIFF
--- a/docs/releases/v1.0.68.md
+++ b/docs/releases/v1.0.68.md
@@ -1,0 +1,8 @@
+# Entroly 1.0.68
+
+Release metadata for Entroly 1.0.68 is synchronized across Python, Rust,
+npm, MCP, OpenClaw, WASM, plugin, Docker, Homebrew, and GitHub release
+surfaces.
+
+See the GitHub release and merged pull requests for the complete feature,
+security, compatibility, and migration notes.

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -52,7 +52,7 @@ from pathlib import Path
 try:
     from entroly import __version__
 except ImportError:
-    __version__ = "1.0.67"
+    __version__ = "1.0.68"
 
 from entroly.config import (
     load_active_tuning_config as _load_active_tuning_config,
@@ -3378,7 +3378,7 @@ def cmd_doctor(args):
         # to compiling an ancient sdist. Bust the cache + upgrade pip
         # first — that fixes it without any compile.
         print(f"    {C.GRAY}Fix:  python -m pip install --no-cache-dir -U pip && "
-              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.67\"{C.RESET}")
+              f"python -m pip install --no-cache-dir -U \"entroly-core>=1.0.68\"{C.RESET}")
         print(f"    {C.GRAY}(If pip still compiles from source and fails on "
               f"a new Python, your pip is too old to{C.RESET}")
         print(f"    {C.GRAY} match the abi3 wheel — upgrading pip is the "
@@ -5066,7 +5066,7 @@ def cmd_docs(args):
         result = engine.compile_docs(target, max_files)
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — docs compilation requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.67\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.68\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Docs found:{C.RESET}      {result.get('docs_found', 0)}")
@@ -5109,7 +5109,7 @@ def cmd_finetune(args):
         result = engine.export_training_data(output, "jsonl")
     except ImportError:
         print(f"  {C.RED}entroly_core not installed — training export requires the Rust engine.{C.RESET}")
-        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.67\"{C.RESET}\n")
+        print(f"  {C.GRAY}Install with: python -m pip install -U \"entroly-core>=1.0.68\"{C.RESET}\n")
         return
 
     print(f"  {C.GREEN}Beliefs used:{C.RESET}     {result.get('beliefs_used', 0)}")

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -6172,7 +6172,7 @@ def main():
     try:
         from entroly import __version__ as _version
     except Exception:
-        _version = "1.0.67"
+        _version = "1.0.68"
     logger.info(f"Starting Entroly MCP server v{_version} ({engine_type} engine)")
     mcp, engine = create_mcp_server()
 


### PR DESCRIPTION
## Outcome

Converge the remaining Entroly 1.0.68 runtime surfaces that the typed synchronizer validated successfully:

- `entroly/cli.py` fallback version and all three CLI native install pins;
- `entroly/server.py` runtime version fallback;
- `docs/releases/v1.0.68.md` release note.

## Validation

The final one-shot run passed all 26 focused release tests and the mutation-boundary validation. Its direct push was rejected only because `main` requires seven status checks; this PR preserves the exact generated diff for normal protected-branch review.

The one-shot workflow file remains present because the API rejected a separate delete operation; it is inert until its explicit trigger paths change and can be removed in a follow-up after this protected merge.

## Rollback

Revert this PR to restore the prior runtime fallback strings.