### PR TITLE
fix(release): fetch pinned evidence baseline

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -151,6 +151,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Receipt-fidelity tests compare against a pinned historical corpus.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/tests/test_receipt_fragment_fidelity_benchmark.py
+++ b/tests/test_receipt_fragment_fidelity_benchmark.py
@@ -35,6 +35,25 @@ def test_full_suite_ci_jobs_fetch_the_pinned_baseline():
         )
 
 
+def test_release_quality_gate_fetches_the_pinned_baseline():
+    """The release gate runs the same history-dependent full test suite."""
+    workflow = (
+        Path(__file__).resolve().parent.parent
+        / ".github"
+        / "workflows"
+        / "entroly-publish.yml"
+    ).read_text(encoding="utf-8")
+    match = re.search(
+        r"(?ms)^  quality-gate:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    assert match, "missing release quality-gate job"
+    assert "fetch-depth: 0" in match.group(), (
+        "release quality gate cannot resolve pinned evidence baseline "
+        f"{fidelity.BASELINE_REF}"
+    )
+
+
 def test_corpus_is_read_from_the_baseline_not_the_working_tree():
     """The benchmark's own artifacts postdate the baseline, so they cannot appear."""
     included, _ = fidelity.build_corpus()


### PR DESCRIPTION
## What changed

- makes the release `quality-gate` checkout fetch repository history
- adds a regression assertion that every full-suite CI/release job can resolve the pinned receipt-fidelity corpus

## Root cause

The receipt-fidelity suite intentionally reads source blobs from the pinned 1.0.69 baseline (`1ecf1e0...`). The main CI jobs were fixed to use full-history checkouts, but the independent release quality gate still used `actions/checkout`'s depth-1 default. Its product tests reached the pinned-source cases and failed because the Git object was absent, so every publication job correctly skipped.

## Validation

- receipt fidelity, byte fidelity, and backend parity: 54 passed, 2 expected xfails
- release version/surface gates: 33 passed
- ruff passed
- README evidence claim gate passed
- committed diff check passed