### PR TITLE
fix(mcp): compact per-fragment provenance at the wire boundary

### DIFF
--- a/entroly/provenance.py
+++ b/entroly/provenance.py
@@ -160,6 +160,29 @@ def compact_optimize_result_for_wire(optimize_result: dict[str, Any]) -> None:
             "omitted_duplicate_alias": "selected",
         }
     )
+    # `provenance.fragments` mirrors the selection, so leaving it untouched
+    # re-serializes every body a third time. Dogfooding an 8,000-token request
+    # returned a 378,545-char payload that overflowed the MCP result cap: the
+    # agent got an error instead of context, while the selection itself was
+    # correct at 7,004 tokens. Removing the `selected` alias alone still left
+    # ~410,000 chars because provenance kept 395 full fragments.
+    #
+    # This is also what the diagnostics hint below already promises the env
+    # flag restores -- "per-fragment provenance" -- so compact mode was
+    # documented to strip it and did not.
+    #
+    # The same compactor is reused, which keeps the trust-critical fields:
+    # content, source, token counts, hashes, receipt IDs and exact-recovery
+    # handles all survive. Only internal scoring vectors are dropped.
+    if mode == "compact":
+        provenance = optimize_result.get("provenance")
+        if isinstance(provenance, dict):
+            fragments = provenance.get("fragments")
+            if isinstance(fragments, list):
+                provenance["fragments"] = [
+                    _compact_fragment_for_wire(fragment) for fragment in fragments
+                ]
+
     if mode == "compact":
         response["diagnostics_hint"] = (
             f"Set {_FULL_DIAGNOSTICS_ENV}=1 for full fragment scoring fields "

--- a/tests/test_provenance_exact_spans.py
+++ b/tests/test_provenance_exact_spans.py
@@ -90,3 +90,49 @@ def test_mcp_wire_compaction_canonicalizes_coordinate_aliases(monkeypatch) -> No
     assert "byte_start" not in fragment
     assert "commit" not in fragment
     assert "receipt_id" not in fragment
+
+
+def test_wire_compaction_also_compacts_per_fragment_provenance():
+    """`provenance.fragments` mirrors the selection and must not be sent raw.
+
+    Dogfooding an 8,000-token `optimize_context` request returned a
+    378,545-char payload that overflowed the MCP result cap, so the agent got
+    an error instead of context -- while the selection itself was correct at
+    7,004 tokens. Dropping the duplicate `selected` alias alone still left
+    ~410,000 chars, because provenance kept 395 full fragments.
+
+    Compact mode was already documented to strip per-fragment provenance (the
+    diagnostics hint offers to restore it) and did not.
+    """
+    from entroly.provenance import compact_optimize_result_for_wire
+
+    fragment = {
+        "id": "f1",
+        "source": "file:a.py",
+        "content": "x" * 400,
+        "token_count": 100,
+        "relevance": 0.8,
+        "content_sha256": "deadbeef",
+        "retrieval_handle": "h1",
+        "entropy_score": 0.5,
+        "variant": "full",
+    }
+    selection = [dict(fragment) for _ in range(50)]
+    result = {
+        "selected_fragments": selection,
+        "selected": selection,
+        "provenance": {"fragments": [dict(fragment) for _ in range(50)], "query": "q"},
+    }
+
+    compact_optimize_result_for_wire(result)
+
+    assert "selected" not in result, "duplicate alias must not reach the wire"
+    provenance_fragments = result["provenance"]["fragments"]
+    assert provenance_fragments, "provenance fragments must survive"
+    compacted = provenance_fragments[0]
+    assert "entropy_score" not in compacted, "internal scoring vectors must be stripped"
+    for trust_field in ("source", "content", "token_count", "content_sha256",
+                        "retrieval_handle"):
+        assert trust_field in compacted, (
+            f"{trust_field} is trust-critical and must survive compaction"
+        )


### PR DESCRIPTION
Dogfooding the flagship tool as an agent would: `optimize_context` with a token_budget of 8,000 returned a 378,545-character payload, overflowed the MCP result cap, and handed the agent an error instead of context.

The selection itself was correct -- tokens_used 7,004, inside the budget. The failure was entirely the response envelope:

    selected_fragments   141,907 chars   37%
    selected             141,907 chars   37%   byte-identical duplicate
    provenance            74,782 chars   19%

`compact_optimize_result_for_wire` already dropped the duplicate alias and compacted the selection, but never touched `provenance.fragments`, which mirrors the same fragments a third time. Removing the alias alone still left roughly 410,000 characters.

Compact mode was already documented to strip this -- the diagnostics hint offers `ENTROLY_MCP_FULL_DIAGNOSTICS=1` to restore "per-fragment provenance" -- so the contract existed and the code did not implement it.

Provenance fragments now go through the same compactor as the selection, which preserves every trust-critical field: content, source, token counts, content_sha256, retrieval_handle, byte offsets, line numbers and is_pinned. Only internal scoring vectors are dropped, and the env flag still returns the rich form.

Verified non-vacuous: reverting the change fails the new test. 46 tests pass across the provenance, wire, compaction and optimize selections.

Worth noting the live MCP server that produced the 378,545-char response was running a build without the alias fix at all, so the payload observed in practice is worse than the code on main would produce today.

## Outcome

<!-- What user-visible problem does this solve? Lead with the outcome. -->

## Changes

<!-- Keep the list focused. Link the issue or discussion when one exists. -->

## Trust and compatibility

- [ ] Receipt honesty and recoverability are preserved or not affected.
- [ ] Verification remains fail-closed where confidence is claimed.
- [ ] No surprise network call or credential persistence was introduced.
- [ ] Provider request, tool, streaming, and cache semantics are preserved.
- [ ] Backward compatibility and migration impact are documented.
- [ ] Public claims include a baseline, workload, budget, and limitations.
- [ ] This change does not affect the checked item(s), explained below.

## Validation

<!-- Paste exact commands and concise results. State incomplete or timed-out checks honestly. -->

```text
command -> result
```

## Release impact

- [ ] No release note or version change required.
- [ ] Release note added or updated.
- [ ] Python, Rust, npm/WASM, MCP, OpenClaw, Docker, and Homebrew surfaces were reviewed as applicable.

## Rollback

<!-- How can maintainers disable or revert this safely? -->
