### PR TITLE
chore(ci): validate Python production hardening delivery

### DIFF
--- a/.github/patches/.delivery-guard
+++ b/.github/patches/.delivery-guard
@@ -1,0 +1,2 @@
+base=4506d70e135c8a39eb3bdb5ce1f6f340ccdd6ceb
+patch_blob=c78d66077d0ba999caf34d0dd7b7cd5fdd421d3f

--- a/.github/patches/README.md
+++ b/.github/patches/README.md
@@ -1,0 +1,1 @@
+Temporary delivery metadata for the Python hardening validation branch. Removed after delivery.

--- a/.github/patches/python-hardening-delivery-trigger.txt
+++ b/.github/patches/python-hardening-delivery-trigger.txt
@@ -1,0 +1,1 @@
+python-hardening-delivery

--- a/.github/patches/python-hardening-delivery-trigger.txt
+++ b/.github/patches/python-hardening-delivery-trigger.txt
@@ -1,2 +1,2 @@
 python-hardening-delivery
-retry=1
+retry=2

--- a/.github/patches/python-hardening-delivery-trigger.txt
+++ b/.github/patches/python-hardening-delivery-trigger.txt
@@ -1,2 +1,2 @@
 python-hardening-delivery
-retry=2
+retry=3

--- a/.github/patches/python-hardening-delivery-trigger.txt
+++ b/.github/patches/python-hardening-delivery-trigger.txt
@@ -1,1 +1,2 @@
 python-hardening-delivery
+retry=1

--- a/.github/patches/python-hardening-delivery.json
+++ b/.github/patches/python-hardening-delivery.json
@@ -1,0 +1,1 @@
+{"base":"4506d70e135c8a39eb3bdb5ce1f6f340ccdd6ceb","patch_blob":"c78d66077d0ba999caf34d0dd7b7cd5fdd421d3f","purpose":"temporary validated delivery"}

--- a/.github/patches/python-hardening-delivery.md
+++ b/.github/patches/python-hardening-delivery.md
@@ -1,0 +1,1 @@
+Temporary same-repository delivery trigger for the signed Python hardening patch. This file is removed after the validated code commit is delivered.

--- a/docs/public-evidence.md
+++ b/docs/public-evidence.md
@@ -127,3 +127,4 @@ python scripts/verify_readme.py
 Use `--online` only for bounded destination checks. After publication, `--require-published-version` can require PyPI and npm latest versions to match `server.json`.
 
 <!-- temporary CI synchronization marker; removed after validated patch delivery -->
+<!-- isolated delivery PR trigger; removed after validated patch delivery -->


### PR DESCRIPTION
Temporary same-repository delivery harness for the signed Python hardening patch. It targets `feat/sufficiency-mainline`, runs the guarded Public Trust validation job, and is closed after the validated product commit is delivered. No merge is intended.