### PR TITLE
fix(bench): keep agentic task validation self-contained

### DIFF
--- a/benchmarks/agentic_task_miner.py
+++ b/benchmarks/agentic_task_miner.py
@@ -118,8 +118,10 @@ def _run_tests(workdir: Path, test_files: list[str],
     existing = [f for f in test_files if (workdir / f).exists()]
     if not existing:
         return False, 0.0
-    cmd = [sys.executable, "-m", "pytest", *existing, "-x", "-q",
-           "--timeout", str(min(timeout, 120))]
+    # Keep the miner self-contained: the outer subprocess timeout provides the
+    # hard execution bound, so do not require the optional pytest-timeout plugin
+    # inside every historical worktree being evaluated.
+    cmd = [sys.executable, "-m", "pytest", *existing, "-x", "-q"]
     t0 = time.perf_counter()
     try:
         proc = subprocess.run(cmd, cwd=workdir, capture_output=True,

--- a/tests/test_agentic_task_miner.py
+++ b/tests/test_agentic_task_miner.py
@@ -77,7 +77,11 @@ def test_discover_finds_only_the_fix_commit(mined_repo):
     assert fix.test_files == ["test_calc.py"]
 
 
-def test_validate_proves_fail_to_pass_for_the_fix(mined_repo):
+def test_validate_proves_fail_to_pass_for_the_fix(mined_repo, monkeypatch):
+    # Historical worktrees cannot be assumed to have pytest-timeout or any
+    # other third-party plugin installed. The miner's subprocess timeout must
+    # remain sufficient on its own.
+    monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
     candidates = discover(mined_repo, max_commits=50)
     fix = next(c for c in candidates if "fix: add()" in c.subject)
 


### PR DESCRIPTION
## Problem

The agentic task miner passed pytest's `--timeout` option inside historical worktrees without declaring or guaranteeing the `pytest-timeout` plugin. Clean environments therefore rejected the test command before evaluating the mined task.

## Fix

- Rely on the miner's existing `subprocess.run(..., timeout=...)` hard timeout.
- Remove the undeclared pytest plugin requirement.
- Add a regression test with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` so the validation path is proven independent of third-party pytest plugins.

## Validation

```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_agentic_task_miner.py -q
3 passed
```

Draft until hosted checks complete. Do not merge on local evidence alone.