### PR TITLE
fix(docker): add entroly-engine to the image build context

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,7 @@ on:
       - 'benchmarks/results/neural_query_shift*.md'
       - 'entroly/**'
       - 'entroly-core/**'
+      - 'entroly-engine/**'
       - 'tests/test_compression_gauntlet.py'
       - 'tests/test_compression_frontier.py'
       - 'tests/test_evidence_locked_compression.py'

--- a/Dockerfile.entroly
+++ b/Dockerfile.entroly
@@ -29,10 +29,14 @@ RUN apt-get update && apt-get install -y curl build-essential libssl-dev pkg-con
 
 RUN pip install --no-cache-dir maturin
 
-# entroly-core path-depends on the shared SSOT crate `entroly-qccr` (and future
-# entroly-* logic crates), so the build context must include it — a manual
-# `maturin build` does not auto-vendor path deps the way an sdist build does.
+# entroly-core path-depends on `entroly-qccr` and `entroly-engine` (the shared
+# compute crate both the PyO3 and WebAssembly builds consume). Every path
+# dependency must be in the build context: a manual `maturin build` does not
+# auto-vendor path deps the way an sdist build does. Adding a new entroly-*
+# crate without a COPY here fails the image build with
+# "failed to read /build/<crate>/Cargo.toml".
 COPY entroly-qccr/ ./entroly-qccr/
+COPY entroly-engine/ ./entroly-engine/
 COPY entroly-core/ ./entroly-core/
 RUN cd entroly-core && maturin build --release -o /build/wheels/
 


### PR DESCRIPTION
## Problem

The Docker image build has been failing on `main` since the shared compute crate was extracted:

```
error: failed to get `entroly-engine` as a dependency of package `entroly-core v1.0.71 (/build/entroly-core)`
  failed to read `/build/entroly-engine/Cargo.toml`
  No such file or directory (os error 2)
```

## Cause

`Dockerfile.entroly` builds from a partial `COPY`, not a full checkout, so every path dependency of `entroly-core` must be listed explicitly. `entroly-qccr` was; `entroly-engine` was not.

The existing comment anticipated exactly this — *"and future entroly-\* logic crates"* — and a crate was added without wiring it up. The comment now names both crates and states the error a missing `COPY` produces.

This is why **only** the Docker build broke while CI stayed green on the same commit: the GitHub workflows use `actions/checkout`, so the whole repository is present and the path dependency resolves. Only the partial-context build was affected.

## Verification

The Docker daemon was unavailable locally, so rather than skip verification this reproduces the failing step: reconstruct the Docker build context (`entroly-qccr`, `entroly-engine`, `entroly-core`, no target dirs) and run the command that failed —

```
cargo metadata --manifest-path entroly-core/Cargo.toml   ->  resolves
```

## Also

Adds `entroly-engine/**` to `benchmark.yml` path filters. That's a trigger, not a build input, so nothing was broken — but a change to the crate holding knapsack, entropy, bm25 and dedup would not have run the benchmarks.