### PR TITLE
chore(release): validate 1.0.72 version sweep

### DIFF
--- a/.github/release-1.0.72-trigger.txt
+++ b/.github/release-1.0.72-trigger.txt
@@ -1,0 +1,1 @@
+release-1.0.72-delivery


### PR DESCRIPTION
Temporary no-merge delivery harness for the Entroly 1.0.72 release sweep. The guarded workflow applies the signed release-tooling patch, runs the canonical bump script against the actual current tree, verifies at least 45 release targets across at least 28 files, rebuilds the MCP bundle, validates Python/Rust/npm/MCP consistency, and replays only the validated release commit onto `release/1.0.72`.