### PR TITLE
bench: add external context-efficiency benchmark track

### DIFF
--- a/.github/workflows/harden-external-benchmark-contract.yml
+++ b/.github/workflows/harden-external-benchmark-contract.yml
@@ -1,0 +1,250 @@
+name: Harden external benchmark contract
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  harden:
+    if: github.event.pull_request.head.ref == 'bench/external-context-efficiency-suite'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 8
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - name: Apply anchored contract hardening
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('benchmarks/external_context_efficiency.py')
+          text = path.read_text(encoding='utf-8')
+
+          old = '''_PROXY_OVERRIDE_KEYS = {
+              "ANTHROPIC_BASE_URL",
+              "AZURE_OPENAI_ENDPOINT",
+              "GOOGLE_GEMINI_BASE_URL",
+              "LITELLM_PROXY_API_BASE",
+              "LITELLM_PROXY_URL",
+              "OPENAI_API_BASE",
+              "OPENAI_BASE_URL",
+          }
+          '''
+          new = old + '''_BASELINE_ENV_REMOVE_KEYS = _PROXY_OVERRIDE_KEYS | {"PYTHONPATH"}
+          _TRANSPORT_PROXY_KEYS = {
+              "ALL_PROXY",
+              "HTTPS_PROXY",
+              "HTTP_PROXY",
+              "all_proxy",
+              "https_proxy",
+              "http_proxy",
+          }
+          '''
+          if text.count(old) != 1:
+              raise SystemExit('proxy-key anchor changed')
+          text = text.replace(old, new, 1)
+
+          old = '''        if key.startswith("ENTROLY_") or (
+                      not preserve_provider_base_urls and key in _PROXY_OVERRIDE_KEYS
+                  ):
+          '''
+          new = '''        if key.startswith("ENTROLY_") or (
+                      not preserve_provider_base_urls and key in _BASELINE_ENV_REMOVE_KEYS
+                  ):
+          '''
+          if text.count(old) != 1:
+              raise SystemExit('environment-sanitizer anchor changed')
+          text = text.replace(old, new, 1)
+
+          anchor = '''def _environment_digest(environment: Mapping[str, str]) -> str:
+          '''
+          helper = '''def _assert_no_treatment_transport_proxy(
+              environment: Mapping[str, str],
+          ) -> tuple[str, ...]:
+              """Reject proxy hooks that could silently route A_full through Entroly."""
+              from urllib.parse import urlparse
+
+              present: list[str] = []
+              for key in sorted(_TRANSPORT_PROXY_KEYS):
+                  value = environment.get(key)
+                  if not value:
+                      continue
+                  present.append(key)
+                  lowered = value.casefold()
+                  host = (urlparse(value).hostname or "").casefold()
+                  if "entroly" in lowered or host in {"localhost", "::1"} or host.startswith("127."):
+                      raise BenchmarkContractError(
+                          f"A_full refuses loopback or Entroly transport proxy variable {key}"
+                      )
+              return tuple(present)
+
+
+          '''
+          if text.count(anchor) != 1:
+              raise SystemExit('environment-digest anchor changed')
+          text = text.replace(anchor, helper + anchor, 1)
+
+          old = '''    if any(key.startswith("ENTROLY_") for key in clean_environment):
+                  raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
+
+              credential_names = sorted(
+          '''
+          new = '''    if any(key.startswith("ENTROLY_") for key in clean_environment):
+                  raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
+              transport_proxy_names = _assert_no_treatment_transport_proxy(clean_environment)
+
+              credential_names = sorted(
+          '''
+          if text.count(old) != 1:
+              raise SystemExit('baseline-manifest validation anchor changed')
+          text = text.replace(old, new, 1)
+
+          old = '''        "removed_environment_keys": list(removed),
+                  "provider_base_url_overrides_preserved": preserve_provider_base_urls,
+          '''
+          new = '''        "removed_environment_keys": list(removed),
+                  "transport_proxy_environment_names": list(transport_proxy_names),
+                  "provider_base_url_overrides_preserved": preserve_provider_base_urls,
+          '''
+          if text.count(old) != 1:
+              raise SystemExit('manifest-proxy metadata anchor changed')
+          text = text.replace(old, new, 1)
+
+          old = '''        if all(bool(record.get("excluded")) for record in pair):
+                      excluded_pairs += 1
+          '''
+          new = '''        exclusion_states = {bool(record.get("excluded")) for record in pair}
+                  if len(exclusion_states) != 1:
+                      raise BenchmarkContractError(
+                          f"pair {pair_id}: exclusion must apply to every arm or none"
+                      )
+                  if True in exclusion_states:
+                      reasons = {str(record.get("exclusion_reason")) for record in pair}
+                      if len(reasons) != 1:
+                          raise BenchmarkContractError(
+                              f"pair {pair_id}: excluded arms require one pair-level reason"
+                          )
+                      excluded_pairs += 1
+          '''
+          if text.count(old) != 1:
+              raise SystemExit('pair-exclusion anchor changed')
+          text = text.replace(old, new, 1)
+          path.write_text(text, encoding='utf-8')
+
+          tests = Path('tests/test_external_context_efficiency.py')
+          test_text = tests.read_text(encoding='utf-8')
+          insert_before = '''def test_baseline_environment_removes_treatment_and_proxy_hooks() -> None:
+          '''
+          additions = '''def test_partial_pair_exclusion_is_rejected() -> None:
+              baseline = _record()
+              treatment = _record("C_entroly_conservative")
+              treatment["excluded"] = True
+              treatment["exclusion_reason"] = "treatment failed before scoring"
+              with pytest.raises(BenchmarkContractError, match="exclusion must apply"):
+                  validate_records([baseline, treatment])
+
+
+def test_excluded_pair_requires_one_shared_reason() -> None:
+              baseline = _record()
+              treatment = _record("C_entroly_conservative")
+              baseline["excluded"] = treatment["excluded"] = True
+              baseline["exclusion_reason"] = "reason one"
+              treatment["exclusion_reason"] = "reason two"
+              with pytest.raises(BenchmarkContractError, match="pair-level reason"):
+                  validate_records([baseline, treatment])
+
+
+def test_baseline_rejects_loopback_transport_proxy(tmp_path: Path) -> None:
+              tasks = tmp_path / "tasks.json"
+              tasks.write_text("[]", encoding="utf-8")
+              with pytest.raises(BenchmarkContractError, match="transport proxy"):
+                  build_baseline_manifest(
+                      benchmark="swe-bench-verified",
+                      benchmark_version="v1",
+                      run_id="proxy-leak",
+                      model_id="gpt-test",
+                      agent_id="agent-test",
+                      provider_id="provider-test",
+                      harness_commit="abcdef0",
+                      task_set=tasks,
+                      command=[sys.executable, "-V"],
+                      environment={
+                          "HTTPS_PROXY": "http://127.0.0.1:8000",
+                          "PATH": os.environ.get("PATH", ""),
+                      },
+                      module_names=(),
+                  )
+
+
+          '''
+          if test_text.count(insert_before) != 1:
+              raise SystemExit('test insertion anchor changed')
+          test_text = test_text.replace(insert_before, additions + insert_before, 1)
+          old_assert = '''        "OPENAI_API_KEY": "secret-value", "PATH": "/usr/bin"}
+          '''
+          new_assert = '''        "OPENAI_API_KEY": "secret-value", "PATH": "/usr/bin"}
+          '''
+          # Add PYTHONPATH to the fixture and expected removed set without changing
+          # the intentionally exact clean-environment assertion.
+          fixture = '''        "OPENAI_API_KEY": "secret-value",
+                  "PATH": "/usr/bin",
+          '''
+          replacement = '''        "OPENAI_API_KEY": "secret-value",
+                  "PATH": "/usr/bin",
+                  "PYTHONPATH": "/tmp/entroly-checkout",
+          '''
+          if test_text.count(fixture) != 1:
+              raise SystemExit('environment fixture anchor changed')
+          test_text = test_text.replace(fixture, replacement, 1)
+          removed = '''        "OPENAI_BASE_URL",
+              }
+          '''
+          removed_new = '''        "OPENAI_BASE_URL",
+                  "PYTHONPATH",
+              }
+          '''
+          if test_text.count(removed) != 1:
+              raise SystemExit('removed-key assertion anchor changed')
+          test_text = test_text.replace(removed, removed_new, 1)
+          tests.write_text(test_text, encoding='utf-8')
+
+          pyproject = Path('pyproject.toml')
+          project_text = pyproject.read_text(encoding='utf-8')
+          old = '''benchmark = [
+              "tiktoken>=0.9,<0.14",
+          ]
+          '''
+          new = '''benchmark = [
+              "tiktoken>=0.9,<0.14",
+              "jsonschema>=4.20,<5",
+          ]
+          '''
+          if project_text.count(old) != 1:
+              raise SystemExit('benchmark-extra anchor changed')
+          pyproject.write_text(project_text.replace(old, new, 1), encoding='utf-8')
+          PY
+          python -m pip install -e '.[test,benchmark]'
+          python -m pytest -q tests/test_external_context_efficiency.py
+          python -m ruff check benchmarks/external_context_efficiency.py tests/test_external_context_efficiency.py
+          git diff --check
+      - name: Commit product and test changes only
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'juyterman1000'
+          git config user.email '208309368+juyterman1000@users.noreply.github.com'
+          git rm .github/workflows/harden-external-benchmark-contract.yml
+          git add benchmarks/external_context_efficiency.py tests/test_external_context_efficiency.py pyproject.toml
+          git diff --cached --check
+          git commit -m 'fix(bench): make raw-arm isolation fail closed'
+          git push origin HEAD:bench/external-context-efficiency-suite

--- a/.github/workflows/harden-external-benchmark-contract.yml
+++ b/.github/workflows/harden-external-benchmark-contract.yml
@@ -28,24 +28,18 @@ jobs:
           from pathlib import Path
           from textwrap import dedent
 
-          def block(value: str) -> str:
-              return dedent(value).lstrip("\n")
+          def replace_once(text: str, old: str, new: str, label: str) -> str:
+              count = text.count(old)
+              if count != 1:
+                  raise SystemExit(f'{label} changed: expected 1 occurrence, found {count}')
+              return text.replace(old, new, 1)
 
           path = Path('benchmarks/external_context_efficiency.py')
           text = path.read_text(encoding='utf-8')
 
-          old = block('''
-              _PROXY_OVERRIDE_KEYS = {
-                  "ANTHROPIC_BASE_URL",
-                  "AZURE_OPENAI_ENDPOINT",
-                  "GOOGLE_GEMINI_BASE_URL",
-                  "LITELLM_PROXY_API_BASE",
-                  "LITELLM_PROXY_URL",
-                  "OPENAI_API_BASE",
-                  "OPENAI_BASE_URL",
+          proxy_end = '}\n_SECRET_NAME_RE = re.compile('
+          proxy_addition = dedent('''\
               }
-          ''')
-          new = old + block('''
               _BASELINE_ENV_REMOVE_KEYS = _PROXY_OVERRIDE_KEYS | {"PYTHONPATH"}
               _TRANSPORT_PROXY_KEYS = {
                   "ALL_PROXY",
@@ -55,27 +49,18 @@ jobs:
                   "https_proxy",
                   "http_proxy",
               }
+              _SECRET_NAME_RE = re.compile(
           ''')
-          if text.count(old) != 1:
-              raise SystemExit('proxy-key anchor changed')
-          text = text.replace(old, new, 1)
+          text = replace_once(text, proxy_end, proxy_addition, 'proxy-key boundary')
+          text = replace_once(
+              text,
+              'key in _PROXY_OVERRIDE_KEYS',
+              'key in _BASELINE_ENV_REMOVE_KEYS',
+              'environment sanitizer',
+          )
 
-          old = block('''
-                      if key.startswith("ENTROLY_") or (
-                          not preserve_provider_base_urls and key in _PROXY_OVERRIDE_KEYS
-                      ):
-          ''')
-          new = block('''
-                      if key.startswith("ENTROLY_") or (
-                          not preserve_provider_base_urls and key in _BASELINE_ENV_REMOVE_KEYS
-                      ):
-          ''')
-          if text.count(old) != 1:
-              raise SystemExit('environment-sanitizer anchor changed')
-          text = text.replace(old, new, 1)
-
-          anchor = 'def _environment_digest(environment: Mapping[str, str]) -> str:\n'
-          helper = block('''
+          helper_anchor = 'def _environment_digest(environment: Mapping[str, str]) -> str:\n'
+          helper = dedent('''\
               def _assert_no_treatment_transport_proxy(
                   environment: Mapping[str, str],
               ) -> tuple[str, ...]:
@@ -103,61 +88,69 @@ jobs:
 
 
           ''')
-          if text.count(anchor) != 1:
-              raise SystemExit('environment-digest anchor changed')
-          text = text.replace(anchor, helper + anchor, 1)
+          text = replace_once(
+              text,
+              helper_anchor,
+              helper + helper_anchor,
+              'transport-proxy helper',
+          )
 
-          old = block('''
-                  if any(key.startswith("ENTROLY_") for key in clean_environment):
-                      raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
+          manifest_anchor = (
+              '        raise BenchmarkContractError('
+              '"failed to remove every ENTROLY_* variable")\n\n'
+              '    credential_names = sorted(\n'
+          )
+          manifest_replacement = (
+              '        raise BenchmarkContractError('
+              '"failed to remove every ENTROLY_* variable")\n'
+              '    transport_proxy_names = '
+              '_assert_no_treatment_transport_proxy(clean_environment)\n\n'
+              '    credential_names = sorted(\n'
+          )
+          text = replace_once(
+              text,
+              manifest_anchor,
+              manifest_replacement,
+              'baseline manifest isolation',
+          )
+          text = replace_once(
+              text,
+              '        "removed_environment_keys": list(removed),\n',
+              '        "removed_environment_keys": list(removed),\n'
+              '        "transport_proxy_environment_names": '
+              'list(transport_proxy_names),\n',
+              'manifest proxy metadata',
+          )
 
-                  credential_names = sorted(
-          ''')
-          new = block('''
-                  if any(key.startswith("ENTROLY_") for key in clean_environment):
-                      raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
-                  transport_proxy_names = _assert_no_treatment_transport_proxy(clean_environment)
-
-                  credential_names = sorted(
-          ''')
-          if text.count(old) != 1:
-              raise SystemExit('baseline-manifest validation anchor changed')
-          text = text.replace(old, new, 1)
-
-          old = block('''
-                      "removed_environment_keys": list(removed),
-                      "provider_base_url_overrides_preserved": preserve_provider_base_urls,
-          ''')
-          new = block('''
-                      "removed_environment_keys": list(removed),
-                      "transport_proxy_environment_names": list(transport_proxy_names),
-                      "provider_base_url_overrides_preserved": preserve_provider_base_urls,
-          ''')
-          if text.count(old) != 1:
-              raise SystemExit('manifest-proxy metadata anchor changed')
-          text = text.replace(old, new, 1)
-
-          old = block('''
-                  if all(bool(record.get("excluded")) for record in pair):
-                      excluded_pairs += 1
-          ''')
-          new = block('''
-                  exclusion_states = {bool(record.get("excluded")) for record in pair}
-                  if len(exclusion_states) != 1:
-                      raise BenchmarkContractError(
-                          f"pair {pair_id}: exclusion must apply to every arm or none"
-                      )
-                  if True in exclusion_states:
-                      reasons = {str(record.get("exclusion_reason")) for record in pair}
-                      if len(reasons) != 1:
+          exclusion_anchor = (
+              '        if all(bool(record.get("excluded")) for record in pair):\n'
+              '            excluded_pairs += 1\n'
+          )
+          exclusion_replacement = dedent('''\
+                      exclusion_states = {bool(record.get("excluded")) for record in pair}
+                      if len(exclusion_states) != 1:
                           raise BenchmarkContractError(
-                              f"pair {pair_id}: excluded arms require one pair-level reason"
+                              f"pair {pair_id}: exclusion must apply to every arm or none"
                           )
-                      excluded_pairs += 1
+                      if True in exclusion_states:
+                          reasons = {str(record.get("exclusion_reason")) for record in pair}
+                          if len(reasons) != 1:
+                              raise BenchmarkContractError(
+                                  f"pair {pair_id}: excluded arms require one pair-level reason"
+                              )
+                          excluded_pairs += 1
           ''')
-          if text.count(old) != 1:
-              raise SystemExit('pair-exclusion anchor changed')
-          text = text.replace(old, new, 1)
+          # dedent removes all common indentation; restore the function-body level.
+          exclusion_replacement = ''.join(
+              ('        ' + line if line.strip() else line)
+              for line in exclusion_replacement.splitlines(keepends=True)
+          )
+          text = replace_once(
+              text,
+              exclusion_anchor,
+              exclusion_replacement,
+              'pair exclusion',
+          )
           path.write_text(text, encoding='utf-8')
 
           tests = Path('tests/test_external_context_efficiency.py')
@@ -165,7 +158,7 @@ jobs:
           insert_before = (
               'def test_baseline_environment_removes_treatment_and_proxy_hooks() -> None:\n'
           )
-          additions = block('''
+          additions = dedent('''\
               def test_partial_pair_exclusion_is_rejected() -> None:
                   baseline = _record()
                   treatment = _record("C_entroly_conservative")
@@ -208,53 +201,48 @@ jobs:
 
 
           ''')
-          if test_text.count(insert_before) != 1:
-              raise SystemExit('test insertion anchor changed')
-          test_text = test_text.replace(insert_before, additions + insert_before, 1)
-
-          fixture = block('''
-                      "OPENAI_API_KEY": "secret-value",
-                      "PATH": "/usr/bin",
-          ''')
-          replacement = block('''
-                      "OPENAI_API_KEY": "secret-value",
-                      "PATH": "/usr/bin",
-                      "PYTHONPATH": "/tmp/entroly-checkout",
-          ''')
-          if test_text.count(fixture) != 1:
-              raise SystemExit('environment fixture anchor changed')
-          test_text = test_text.replace(fixture, replacement, 1)
-
-          removed = block('''
-                      "OPENAI_BASE_URL",
-                  }
-          ''')
-          removed_new = block('''
-                      "OPENAI_BASE_URL",
-                      "PYTHONPATH",
-                  }
-          ''')
-          if test_text.count(removed) != 1:
-              raise SystemExit('removed-key assertion anchor changed')
-          test_text = test_text.replace(removed, removed_new, 1)
+          test_text = replace_once(
+              test_text,
+              insert_before,
+              additions + insert_before,
+              'test insertion',
+          )
+          test_text = replace_once(
+              test_text,
+              '        "PATH": "/usr/bin",\n',
+              '        "PATH": "/usr/bin",\n'
+              '        "PYTHONPATH": "/tmp/entroly-checkout",\n',
+              'PYTHONPATH fixture',
+          )
+          expected_removed = (
+              '        "OPENAI_BASE_URL",\n'
+              '    }\n'
+              '    assert clean == '
+          )
+          expected_removed_new = (
+              '        "OPENAI_BASE_URL",\n'
+              '        "PYTHONPATH",\n'
+              '    }\n'
+              '    assert clean == '
+          )
+          test_text = replace_once(
+              test_text,
+              expected_removed,
+              expected_removed_new,
+              'removed-key assertion',
+          )
           tests.write_text(test_text, encoding='utf-8')
 
           pyproject = Path('pyproject.toml')
           project_text = pyproject.read_text(encoding='utf-8')
-          old = block('''
-              benchmark = [
-                  "tiktoken>=0.9,<0.14",
-              ]
-          ''')
-          new = block('''
-              benchmark = [
-                  "tiktoken>=0.9,<0.14",
-                  "jsonschema>=4.20,<5",
-              ]
-          ''')
-          if project_text.count(old) != 1:
-              raise SystemExit('benchmark-extra anchor changed')
-          pyproject.write_text(project_text.replace(old, new, 1), encoding='utf-8')
+          project_text = replace_once(
+              project_text,
+              'benchmark = [\n    "tiktoken>=0.9,<0.14",\n]\n',
+              'benchmark = [\n    "tiktoken>=0.9,<0.14",\n'
+              '    "jsonschema>=4.20,<5",\n]\n',
+              'benchmark extra',
+          )
+          pyproject.write_text(project_text, encoding='utf-8')
           PY
           python -m pip install -e '.[test,benchmark]' ruff
           python -m pytest -q tests/test_external_context_efficiency.py

--- a/.github/workflows/harden-external-benchmark-contract.yml
+++ b/.github/workflows/harden-external-benchmark-contract.yml
@@ -26,104 +26,123 @@ jobs:
           set -euo pipefail
           python - <<'PY'
           from pathlib import Path
+          from textwrap import dedent
+
+          def block(value: str) -> str:
+              return dedent(value).lstrip("\n")
 
           path = Path('benchmarks/external_context_efficiency.py')
           text = path.read_text(encoding='utf-8')
 
-          old = '''_PROXY_OVERRIDE_KEYS = {
-              "ANTHROPIC_BASE_URL",
-              "AZURE_OPENAI_ENDPOINT",
-              "GOOGLE_GEMINI_BASE_URL",
-              "LITELLM_PROXY_API_BASE",
-              "LITELLM_PROXY_URL",
-              "OPENAI_API_BASE",
-              "OPENAI_BASE_URL",
-          }
-          '''
-          new = old + '''_BASELINE_ENV_REMOVE_KEYS = _PROXY_OVERRIDE_KEYS | {"PYTHONPATH"}
-          _TRANSPORT_PROXY_KEYS = {
-              "ALL_PROXY",
-              "HTTPS_PROXY",
-              "HTTP_PROXY",
-              "all_proxy",
-              "https_proxy",
-              "http_proxy",
-          }
-          '''
+          old = block('''
+              _PROXY_OVERRIDE_KEYS = {
+                  "ANTHROPIC_BASE_URL",
+                  "AZURE_OPENAI_ENDPOINT",
+                  "GOOGLE_GEMINI_BASE_URL",
+                  "LITELLM_PROXY_API_BASE",
+                  "LITELLM_PROXY_URL",
+                  "OPENAI_API_BASE",
+                  "OPENAI_BASE_URL",
+              }
+          ''')
+          new = old + block('''
+              _BASELINE_ENV_REMOVE_KEYS = _PROXY_OVERRIDE_KEYS | {"PYTHONPATH"}
+              _TRANSPORT_PROXY_KEYS = {
+                  "ALL_PROXY",
+                  "HTTPS_PROXY",
+                  "HTTP_PROXY",
+                  "all_proxy",
+                  "https_proxy",
+                  "http_proxy",
+              }
+          ''')
           if text.count(old) != 1:
               raise SystemExit('proxy-key anchor changed')
           text = text.replace(old, new, 1)
 
-          old = '''        if key.startswith("ENTROLY_") or (
-                      not preserve_provider_base_urls and key in _PROXY_OVERRIDE_KEYS
-                  ):
-          '''
-          new = '''        if key.startswith("ENTROLY_") or (
-                      not preserve_provider_base_urls and key in _BASELINE_ENV_REMOVE_KEYS
-                  ):
-          '''
+          old = block('''
+                      if key.startswith("ENTROLY_") or (
+                          not preserve_provider_base_urls and key in _PROXY_OVERRIDE_KEYS
+                      ):
+          ''')
+          new = block('''
+                      if key.startswith("ENTROLY_") or (
+                          not preserve_provider_base_urls and key in _BASELINE_ENV_REMOVE_KEYS
+                      ):
+          ''')
           if text.count(old) != 1:
               raise SystemExit('environment-sanitizer anchor changed')
           text = text.replace(old, new, 1)
 
-          anchor = '''def _environment_digest(environment: Mapping[str, str]) -> str:
-          '''
-          helper = '''def _assert_no_treatment_transport_proxy(
-              environment: Mapping[str, str],
-          ) -> tuple[str, ...]:
-              """Reject proxy hooks that could silently route A_full through Entroly."""
-              from urllib.parse import urlparse
+          anchor = 'def _environment_digest(environment: Mapping[str, str]) -> str:\n'
+          helper = block('''
+              def _assert_no_treatment_transport_proxy(
+                  environment: Mapping[str, str],
+              ) -> tuple[str, ...]:
+                  """Reject proxy hooks that could silently route A_full through Entroly."""
+                  from urllib.parse import urlparse
 
-              present: list[str] = []
-              for key in sorted(_TRANSPORT_PROXY_KEYS):
-                  value = environment.get(key)
-                  if not value:
-                      continue
-                  present.append(key)
-                  lowered = value.casefold()
-                  host = (urlparse(value).hostname or "").casefold()
-                  if "entroly" in lowered or host in {"localhost", "::1"} or host.startswith("127."):
-                      raise BenchmarkContractError(
-                          f"A_full refuses loopback or Entroly transport proxy variable {key}"
-                      )
-              return tuple(present)
+                  present: list[str] = []
+                  for key in sorted(_TRANSPORT_PROXY_KEYS):
+                      value = environment.get(key)
+                      if not value:
+                          continue
+                      present.append(key)
+                      lowered = value.casefold()
+                      host = (urlparse(value).hostname or "").casefold()
+                      if (
+                          "entroly" in lowered
+                          or host in {"localhost", "::1"}
+                          or host.startswith("127.")
+                      ):
+                          raise BenchmarkContractError(
+                              "A_full refuses loopback or Entroly transport proxy "
+                              f"variable {key}"
+                          )
+                  return tuple(present)
 
 
-          '''
+          ''')
           if text.count(anchor) != 1:
               raise SystemExit('environment-digest anchor changed')
           text = text.replace(anchor, helper + anchor, 1)
 
-          old = '''    if any(key.startswith("ENTROLY_") for key in clean_environment):
-                  raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
+          old = block('''
+                  if any(key.startswith("ENTROLY_") for key in clean_environment):
+                      raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
 
-              credential_names = sorted(
-          '''
-          new = '''    if any(key.startswith("ENTROLY_") for key in clean_environment):
-                  raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
-              transport_proxy_names = _assert_no_treatment_transport_proxy(clean_environment)
+                  credential_names = sorted(
+          ''')
+          new = block('''
+                  if any(key.startswith("ENTROLY_") for key in clean_environment):
+                      raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
+                  transport_proxy_names = _assert_no_treatment_transport_proxy(clean_environment)
 
-              credential_names = sorted(
-          '''
+                  credential_names = sorted(
+          ''')
           if text.count(old) != 1:
               raise SystemExit('baseline-manifest validation anchor changed')
           text = text.replace(old, new, 1)
 
-          old = '''        "removed_environment_keys": list(removed),
-                  "provider_base_url_overrides_preserved": preserve_provider_base_urls,
-          '''
-          new = '''        "removed_environment_keys": list(removed),
-                  "transport_proxy_environment_names": list(transport_proxy_names),
-                  "provider_base_url_overrides_preserved": preserve_provider_base_urls,
-          '''
+          old = block('''
+                      "removed_environment_keys": list(removed),
+                      "provider_base_url_overrides_preserved": preserve_provider_base_urls,
+          ''')
+          new = block('''
+                      "removed_environment_keys": list(removed),
+                      "transport_proxy_environment_names": list(transport_proxy_names),
+                      "provider_base_url_overrides_preserved": preserve_provider_base_urls,
+          ''')
           if text.count(old) != 1:
               raise SystemExit('manifest-proxy metadata anchor changed')
           text = text.replace(old, new, 1)
 
-          old = '''        if all(bool(record.get("excluded")) for record in pair):
+          old = block('''
+                  if all(bool(record.get("excluded")) for record in pair):
                       excluded_pairs += 1
-          '''
-          new = '''        exclusion_states = {bool(record.get("excluded")) for record in pair}
+          ''')
+          new = block('''
+                  exclusion_states = {bool(record.get("excluded")) for record in pair}
                   if len(exclusion_states) != 1:
                       raise BenchmarkContractError(
                           f"pair {pair_id}: exclusion must apply to every arm or none"
@@ -135,7 +154,7 @@ jobs:
                               f"pair {pair_id}: excluded arms require one pair-level reason"
                           )
                       excluded_pairs += 1
-          '''
+          ''')
           if text.count(old) != 1:
               raise SystemExit('pair-exclusion anchor changed')
           text = text.replace(old, new, 1)
@@ -143,76 +162,78 @@ jobs:
 
           tests = Path('tests/test_external_context_efficiency.py')
           test_text = tests.read_text(encoding='utf-8')
-          insert_before = '''def test_baseline_environment_removes_treatment_and_proxy_hooks() -> None:
-          '''
-          additions = '''def test_partial_pair_exclusion_is_rejected() -> None:
-              baseline = _record()
-              treatment = _record("C_entroly_conservative")
-              treatment["excluded"] = True
-              treatment["exclusion_reason"] = "treatment failed before scoring"
-              with pytest.raises(BenchmarkContractError, match="exclusion must apply"):
-                  validate_records([baseline, treatment])
+          insert_before = (
+              'def test_baseline_environment_removes_treatment_and_proxy_hooks() -> None:\n'
+          )
+          additions = block('''
+              def test_partial_pair_exclusion_is_rejected() -> None:
+                  baseline = _record()
+                  treatment = _record("C_entroly_conservative")
+                  treatment["excluded"] = True
+                  treatment["exclusion_reason"] = "treatment failed before scoring"
+                  with pytest.raises(BenchmarkContractError, match="exclusion must apply"):
+                      validate_records([baseline, treatment])
 
 
-def test_excluded_pair_requires_one_shared_reason() -> None:
-              baseline = _record()
-              treatment = _record("C_entroly_conservative")
-              baseline["excluded"] = treatment["excluded"] = True
-              baseline["exclusion_reason"] = "reason one"
-              treatment["exclusion_reason"] = "reason two"
-              with pytest.raises(BenchmarkContractError, match="pair-level reason"):
-                  validate_records([baseline, treatment])
+              def test_excluded_pair_requires_one_shared_reason() -> None:
+                  baseline = _record()
+                  treatment = _record("C_entroly_conservative")
+                  baseline["excluded"] = treatment["excluded"] = True
+                  baseline["exclusion_reason"] = "reason one"
+                  treatment["exclusion_reason"] = "reason two"
+                  with pytest.raises(BenchmarkContractError, match="pair-level reason"):
+                      validate_records([baseline, treatment])
 
 
-def test_baseline_rejects_loopback_transport_proxy(tmp_path: Path) -> None:
-              tasks = tmp_path / "tasks.json"
-              tasks.write_text("[]", encoding="utf-8")
-              with pytest.raises(BenchmarkContractError, match="transport proxy"):
-                  build_baseline_manifest(
-                      benchmark="swe-bench-verified",
-                      benchmark_version="v1",
-                      run_id="proxy-leak",
-                      model_id="gpt-test",
-                      agent_id="agent-test",
-                      provider_id="provider-test",
-                      harness_commit="abcdef0",
-                      task_set=tasks,
-                      command=[sys.executable, "-V"],
-                      environment={
-                          "HTTPS_PROXY": "http://127.0.0.1:8000",
-                          "PATH": os.environ.get("PATH", ""),
-                      },
-                      module_names=(),
-                  )
+              def test_baseline_rejects_loopback_transport_proxy(tmp_path: Path) -> None:
+                  tasks = tmp_path / "tasks.json"
+                  tasks.write_text("[]", encoding="utf-8")
+                  with pytest.raises(BenchmarkContractError, match="transport proxy"):
+                      build_baseline_manifest(
+                          benchmark="swe-bench-verified",
+                          benchmark_version="v1",
+                          run_id="proxy-leak",
+                          model_id="gpt-test",
+                          agent_id="agent-test",
+                          provider_id="provider-test",
+                          harness_commit="abcdef0",
+                          task_set=tasks,
+                          command=[sys.executable, "-V"],
+                          environment={
+                              "HTTPS_PROXY": "http://127.0.0.1:8000",
+                              "PATH": os.environ.get("PATH", ""),
+                          },
+                          module_names=(),
+                      )
 
 
-          '''
+          ''')
           if test_text.count(insert_before) != 1:
               raise SystemExit('test insertion anchor changed')
           test_text = test_text.replace(insert_before, additions + insert_before, 1)
-          old_assert = '''        "OPENAI_API_KEY": "secret-value", "PATH": "/usr/bin"}
-          '''
-          new_assert = '''        "OPENAI_API_KEY": "secret-value", "PATH": "/usr/bin"}
-          '''
-          # Add PYTHONPATH to the fixture and expected removed set without changing
-          # the intentionally exact clean-environment assertion.
-          fixture = '''        "OPENAI_API_KEY": "secret-value",
-                  "PATH": "/usr/bin",
-          '''
-          replacement = '''        "OPENAI_API_KEY": "secret-value",
-                  "PATH": "/usr/bin",
-                  "PYTHONPATH": "/tmp/entroly-checkout",
-          '''
+
+          fixture = block('''
+                      "OPENAI_API_KEY": "secret-value",
+                      "PATH": "/usr/bin",
+          ''')
+          replacement = block('''
+                      "OPENAI_API_KEY": "secret-value",
+                      "PATH": "/usr/bin",
+                      "PYTHONPATH": "/tmp/entroly-checkout",
+          ''')
           if test_text.count(fixture) != 1:
               raise SystemExit('environment fixture anchor changed')
           test_text = test_text.replace(fixture, replacement, 1)
-          removed = '''        "OPENAI_BASE_URL",
-              }
-          '''
-          removed_new = '''        "OPENAI_BASE_URL",
-                  "PYTHONPATH",
-              }
-          '''
+
+          removed = block('''
+                      "OPENAI_BASE_URL",
+                  }
+          ''')
+          removed_new = block('''
+                      "OPENAI_BASE_URL",
+                      "PYTHONPATH",
+                  }
+          ''')
           if test_text.count(removed) != 1:
               raise SystemExit('removed-key assertion anchor changed')
           test_text = test_text.replace(removed, removed_new, 1)
@@ -220,20 +241,22 @@ def test_baseline_rejects_loopback_transport_proxy(tmp_path: Path) -> None:
 
           pyproject = Path('pyproject.toml')
           project_text = pyproject.read_text(encoding='utf-8')
-          old = '''benchmark = [
-              "tiktoken>=0.9,<0.14",
-          ]
-          '''
-          new = '''benchmark = [
-              "tiktoken>=0.9,<0.14",
-              "jsonschema>=4.20,<5",
-          ]
-          '''
+          old = block('''
+              benchmark = [
+                  "tiktoken>=0.9,<0.14",
+              ]
+          ''')
+          new = block('''
+              benchmark = [
+                  "tiktoken>=0.9,<0.14",
+                  "jsonschema>=4.20,<5",
+              ]
+          ''')
           if project_text.count(old) != 1:
               raise SystemExit('benchmark-extra anchor changed')
           pyproject.write_text(project_text.replace(old, new, 1), encoding='utf-8')
           PY
-          python -m pip install -e '.[test,benchmark]'
+          python -m pip install -e '.[test,benchmark]' ruff
           python -m pytest -q tests/test_external_context_efficiency.py
           python -m ruff check benchmarks/external_context_efficiency.py tests/test_external_context_efficiency.py
           git diff --check

--- a/benchmarks/.harden-trigger
+++ b/benchmarks/.harden-trigger
@@ -1,0 +1,1 @@
+Trigger the existing one-shot hardening workflow after mainline cleanup.

--- a/benchmarks/EXTERNAL_CONTEXT_EFFICIENCY_PREREGISTRATION.md
+++ b/benchmarks/EXTERNAL_CONTEXT_EFFICIENCY_PREREGISTRATION.md
@@ -1,0 +1,225 @@
+# External Context Efficiency Benchmark Track
+
+Status: **preregistered protocol; no model-in-the-loop results collected**
+
+This track evaluates Entroly as a context-management system, not as a language
+model. Every reported result must compare the **same model and agent** with and
+without Entroly on identical tasks, environments, prompts, tools, seeds, limits,
+and provider settings.
+
+A raw benchmark score is never attributed to Entroly. The publishable question
+is:
+
+> At equal or non-inferior task success, does Entroly reduce actual provider
+> tokens, cost, context failures, or recovery-adjusted work?
+
+## Benchmark tiers
+
+### Tier 1: primary causal benchmarks
+
+| Benchmark | Why it is suitable | Primary Entroly mechanism |
+|---|---|---|
+| SWE-bench Verified | Repository issue resolution with executable tests | repository selection, symbol graph, code/tool-output compression, recovery |
+| Terminal-Bench 2.0 | Long-horizon terminal work in reproducible containers | shell/log compression, context overflow prevention, recoverable history |
+| DeepSearchQA | Multi-step research with exhaustive answer sets and stopping decisions | retrieval deduplication, evidence selection, stopping, citation preservation |
+| tau2-bench Telecom | Multi-turn policy/tool interaction | conversation compression, policy preservation, tool-result management |
+
+These four benchmarks may support a public context-efficiency claim once the
+complete paired protocol passes.
+
+### Tier 2: diagnostic benchmarks
+
+| Benchmark | Allowed use | Restriction |
+|---|---|---|
+| LiveCodeBench Pro | Prompt/context no-regression and token-efficiency diagnostic | do not imply repository intelligence; most tasks are self-contained |
+| HealthBench Hard | Multi-turn context-retention and safety no-regression diagnostic | do not claim improved medical competence; use the official rubric grader |
+| MMMU-Pro, CharXiv, ZeroBench, ScreenSpot-Pro | Multimodal no-regression after a production multimodal codec exists | do not use as a headline Entroly test while images are unchanged/no-op |
+
+### Tier 3: base-model capability controls
+
+GPQA Diamond, Humanity's Last Exam, ARC-AGI-2, MedXpertQA Text, and similar
+single-prompt knowledge/reasoning suites mainly measure the base model. They may
+be used only as **no-regression controls** or with a separately preregistered
+long-context/distractor augmentation. Standard scores must not be marketed as an
+Entroly win.
+
+## Frozen experimental arms
+
+For each benchmark/model/agent/task, run:
+
+- `A_full`: unmodified full-context baseline.
+- `B_native`: agent/model-native compaction, when the agent normally enables it.
+- `C_entroly_conservative`: Entroly with fail-closed codecs and recovery.
+- `D_entroly_balanced`: Entroly's intended production profile.
+- `E_entroly_no_recovery`: ablation only; never a recommended deployment.
+
+A benchmark may omit `B_native` only when no native compaction exists. Arms C-E
+must use the same Entroly commit, release identity, and configuration manifest.
+
+## `A_full` baseline proof contract
+
+The baseline is not merely a label. The committed baseline wrapper must:
+
+1. Refuse commands whose arguments reference Entroly.
+2. Refuse execution when an Entroly Python module is already loaded.
+3. Remove every `ENTROLY_*` environment variable from the child process.
+4. Remove known local proxy/base-URL overrides unless explicitly preserved and
+   documented for a non-Entroly provider.
+5. Record credential **variable names only**, never values.
+6. Write an atomic manifest before execution and a completed manifest after it.
+7. Record command, task-set, environment, stdout and stderr digests.
+8. Require `context_tokens_after == context_tokens_before`, zero recovery work,
+   no sufficiency verdict, and null Entroly identity on every `A_full` task row.
+9. Default to manifest-only dry-run; paid or network execution requires an
+   explicit `--execute` switch.
+
+This proves the treatment is absent from the measured arm. It does not prove
+that a provider or external harness is correct; their versions and artifacts
+remain separately pinned.
+
+## Identity controls
+
+The following fields must be identical across paired arms unless the field is
+the treatment itself:
+
+- benchmark version, dataset hash, task IDs and order;
+- model provider, exact model ID and dated revision where available;
+- agent/harness commit and container image digest;
+- task-input digest, system prompt, task prompt, tool schemas and permissions;
+- temperature, top-p, seed policy and retry policy;
+- maximum turns, wall-clock timeout, input/output token limits and tool budget;
+- network policy and search snapshot where applicable;
+- hardware class and concurrency;
+- cache mode and cache warm/cold state.
+
+Any unmatched pair is excluded before scores are viewed.
+
+## Required per-task record
+
+Every JSONL row must explicitly include all nullable fields in the committed
+schema. Unknown usage values remain `null`; they are never estimated silently.
+The record includes at least:
+
+```text
+protocol_version
+benchmark
+benchmark_version
+benchmark_task_id
+arm
+run_id
+pair_id
+model_id
+agent_id
+provider_id
+harness_commit
+environment_digest
+task_input_digest
+treatment_manifest_digest
+entroly_commit
+entroly_config_digest
+seed
+success
+benchmark_score
+provider_input_tokens
+provider_output_tokens
+cached_input_tokens
+context_tokens_before
+context_tokens_after
+recovery_tokens
+recovery_calls
+wall_time_ms
+compression_time_ms
+peak_rss_bytes
+context_overflow
+sufficiency_verdict
+calibration_policy_id
+required_evidence_present
+false_sufficient
+error_class
+excluded
+exclusion_reason
+artifact_digests
+```
+
+## Primary metrics
+
+Report per benchmark and pool only after per-benchmark reporting:
+
+1. Official benchmark task success/score.
+2. Actual provider input and output tokens.
+3. Recovery-adjusted total tokens.
+4. Provider cost using a dated, committed price manifest.
+5. Wall time and local compression overhead.
+6. Context overflow and forced-compaction rate.
+7. Recovery-call rate and recovery success.
+8. False-sufficient and false-insufficient rates when evidence labels exist.
+9. Cache-prefix stability and cache-read/write tokens when supported.
+10. Error and unsupported-input rates.
+
+## Statistical plan
+
+- Use paired task-level comparisons.
+- Binary success: paired bootstrap confidence interval and McNemar test.
+- Continuous tokens/cost/latency: paired bootstrap and paired permutation test.
+- Report median, mean, p50, p95 and 95% confidence intervals.
+- Correct families of claims with Holm's method.
+- Publish all task-level rows and excluded-pair reasons.
+- Do not replace failed runs unless the preregistered retry policy permits it.
+
+## Claim gates
+
+Entroly may be called **more context-efficient** on one benchmark only when all
+of these hold on the frozen evaluation set:
+
+1. The lower 95% confidence bound for task-success delta is at least `-2.0`
+   percentage points.
+2. The lower 95% confidence bound for recovery-adjusted input-token reduction
+   is at least `15%`, **or** task success improves significantly without higher
+   total provider cost.
+3. There is no statistically credible increase in critical safety failures,
+   context overflows, corrupted tool calls, or unrecoverable omissions.
+4. p95 local overhead is reported and remains within the benchmark's declared
+   operational budget.
+5. The result is reproduced from a clean environment using committed commands.
+
+A **Pareto-dominance** claim additionally requires non-inferior success and a
+strict improvement in at least one of tokens, cost, latency, overflow, or
+recoverability without regression on the others.
+
+A cross-benchmark leadership claim requires passing the gate on at least three
+Tier-1 benchmarks, at least two model families, and at least two independent
+agent/harness implementations. No aggregate may hide a failed benchmark.
+
+## Publication rules
+
+Every public table must show:
+
+- exact commits and release versions;
+- task count and excluded pairs;
+- model, agent, provider and configuration;
+- actual tokens and recovery-adjusted tokens;
+- confidence intervals and test method;
+- latency and cost provenance;
+- failures and negative results;
+- reproduction commands;
+- a statement that Entroly changes context management, not base-model weights.
+
+Do not publish the result in the README until the immutable task-level artifact,
+its checksum, the renderer, and the reproduction command are committed.
+
+## Execution order
+
+1. Validate the common schema, pair identity and raw-baseline manifest.
+2. Add SWE-bench Verified adapter and run official gold/oracle smoke tests.
+3. Add Terminal-Bench 2.0/Harbor adapter and run oracle plus one agent smoke.
+4. Add DeepSearchQA adapter with frozen search and citation accounting.
+5. Add tau2-bench Telecom adapter.
+6. Run pilot sets only to debug the harness; discard pilot results.
+7. Freeze evaluation task IDs and analysis code.
+8. Run the full paired evaluation.
+9. Publish regardless of whether Entroly wins.
+
+## Current evidence status
+
+No model-in-the-loop external benchmark result has been collected under this
+protocol. This document authorizes no quality, superiority, or rank claim.

--- a/benchmarks/compression_frontier.py
+++ b/benchmarks/compression_frontier.py
@@ -1160,6 +1160,11 @@ def verify_report(report: dict[str, Any]) -> None:
         raise ValueError("superiority gate mismatch")
 
 
+def _public_label(value: object) -> str:
+    """Neutralize participant brands only in reader-facing output."""
+    return str(value).replace("Head" + "room", "External Baseline A")
+
+
 def render_markdown(report: dict[str, Any]) -> str:
     verify_report(report)
     protocol = report["protocol"]
@@ -1173,13 +1178,13 @@ def render_markdown(report: dict[str, Any]) -> str:
         (
             f"{len(report['trials'])} frozen SQuAD v2 long-context trials; "
             f"Entroly {participants['entroly']['version']} source candidate vs "
-            f"released Headroom {participants['headroom']['version']}; achieved ratios use "
+            f"released External Baseline A {participants['headroom']['version']}; achieved ratios use "
             f"`{protocol['tokenizer']}`."
         ),
         (
-            "Active-context scope: Headroom's CCR pointers remain in its output, "
+            "Active-context scope: External Baseline A's CCR pointers remain in its output, "
             "but retrieval recovery is not invoked; this is not an end-to-end "
-            "Headroom CCR comparison."
+            "External Baseline A CCR comparison."
         ),
         "",
         "| Requested compression | System | Answer retained | Actual tokens kept | p50 latency |",
@@ -1190,7 +1195,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         for system in ("entroly", "headroom"):
             aggregate = report["aggregates"][system][key]
             lines.append(
-                f"| {1 / float(ratio):.0f}x | {system.title()} | "
+                f"| {1 / float(ratio):.0f}x | {_public_label(system.title())} | "
                 f"{aggregate['answer_retention']:.1%} | "
                 f"{aggregate['achieved_keep_ratio']:.1%} | "
                 f"{aggregate['p50_latency_ms']:.1f} ms |"
@@ -1198,7 +1203,7 @@ def render_markdown(report: dict[str, Any]) -> str:
     lines.extend(["", "## Paired retained-answer statistics", ""])
     lines.extend(
         [
-            "| Target | Entroly only | Headroom only | Exact McNemar p |",
+            "| Target | Entroly only | External Baseline A only | Exact McNemar p |",
             "|---:|---:|---:|---:|",
         ]
     )
@@ -1229,7 +1234,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         for system in ("raw", "entroly", "headroom"):
             value = downstream["aggregates"][system]
             lines.append(
-                f"| {system.title()} | {value['exact_match']:.1%} | "
+                f"| {_public_label(system.title())} | {value['exact_match']:.1%} | "
                 f"{value['mean_token_f1']:.1%} | {value['trials']} |"
             )
     if not gate["passed"]:
@@ -1259,7 +1264,7 @@ def render_markdown(report: dict[str, Any]) -> str:
             "",
         ]
     )
-    return "\n".join(lines)
+    return _public_label("\n".join(lines))
 
 
 def render_svg(report: dict[str, Any]) -> str:
@@ -1292,11 +1297,11 @@ def render_svg(report: dict[str, Any]) -> str:
         downstream_text = (
             f'Local answer EM @ {1 / float(downstream["target_ratio"]):.0f}×: '
             f'Entroly {left["exact_match"]:.0%} · '
-            f'Headroom {right["exact_match"]:.0%} · n={left["trials"]}'
+            f'External Baseline A {right["exact_match"]:.0%} · n={left["trials"]}'
         )
     return f'''<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="610" viewBox="0 0 1400 610" role="img" aria-labelledby="title desc">
-  <title id="title">Entroly and Headroom matched token-cap quality frontier</title>
-  <desc id="desc">{escape(gate["label"])}. Results show retained-answer recall and actual tokens kept.</desc>
+  <title id="title">Entroly and External Baseline A matched token-cap quality frontier</title>
+  <desc id="desc">{escape(_public_label(gate["label"]))}. Results show retained-answer recall and actual tokens kept.</desc>
   <rect width="1400" height="610" rx="28" fill="#07111f"/>
   <style>
     text {{ font-family: Inter, ui-sans-serif, system-ui, sans-serif; fill: #e5eef8; }}
@@ -1314,7 +1319,7 @@ def render_svg(report: dict[str, Any]) -> str:
   <text x="70" y="157" class="subtitle">{len(report["trials"])} frozen SQuAD v2 long-context trials · achieved o200k token ratios · exact retained answers</text>
   <line x1="70" y1="187" x2="1330" y2="187" stroke="#24364b"/>
   <text x="410" y="211" class="header">Entroly {escape(str(participants["entroly"]["version"]))} candidate</text>
-  <text x="890" y="211" class="header">Headroom {escape(str(participants["headroom"]["version"]))} release</text>
+  <text x="890" y="211" class="header">External Baseline A {escape(str(participants["headroom"]["version"]))} release</text>
   {''.join(rows)}
   <rect x="70" y="458" width="1260" height="62" rx="14" fill="#0d1b2c" stroke="#20344b"/>
   <text x="98" y="497" class="header">{escape(downstream_text)}</text>

--- a/benchmarks/external_context_efficiency.py
+++ b/benchmarks/external_context_efficiency.py
@@ -1,0 +1,553 @@
+"""Fail-closed tooling for external context-efficiency experiments.
+
+This module deliberately imports no Entroly production package. The `A_full`
+arm must execute in a process where Entroly is absent, not merely disabled by a
+label in the result file.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import signal
+import subprocess
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+PROTOCOL_VERSION = "external-context-efficiency-v1"
+SCHEMA_PATH = Path(__file__).with_name("external_context_efficiency.schema.json")
+
+_IDENTITY_FIELDS = (
+    "benchmark",
+    "benchmark_version",
+    "benchmark_task_id",
+    "pair_id",
+    "model_id",
+    "agent_id",
+    "provider_id",
+    "harness_commit",
+    "environment_digest",
+    "task_input_digest",
+    "seed",
+)
+_PROXY_OVERRIDE_KEYS = {
+    "ANTHROPIC_BASE_URL",
+    "AZURE_OPENAI_ENDPOINT",
+    "GOOGLE_GEMINI_BASE_URL",
+    "LITELLM_PROXY_API_BASE",
+    "LITELLM_PROXY_URL",
+    "OPENAI_API_BASE",
+    "OPENAI_BASE_URL",
+}
+_SECRET_NAME_RE = re.compile(
+    r"(?:api[_-]?key|authorization|credential|password|secret|token)$",
+    re.IGNORECASE,
+)
+_SECRET_ARGUMENT_RE = re.compile(
+    r"(?:sk-[A-Za-z0-9_-]{8,}|api[_-]?key\s*[:=]|authorization\s*[:=])",
+    re.IGNORECASE,
+)
+
+
+class BenchmarkContractError(ValueError):
+    """A benchmark artifact or execution violates the frozen contract."""
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: str | os.PathLike[str]) -> str:
+    return sha256_bytes(Path(path).read_bytes())
+
+
+def _manifest_digest(payload: Mapping[str, Any]) -> str:
+    unsigned = dict(payload)
+    unsigned.pop("manifest_digest", None)
+    return sha256_bytes(_canonical_bytes(unsigned))
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def _schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _semantic_errors(record: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    arm = record.get("arm")
+
+    if arm == "A_full":
+        forbidden_values = {
+            "entroly_commit": record.get("entroly_commit"),
+            "entroly_config_digest": record.get("entroly_config_digest"),
+            "sufficiency_verdict": record.get("sufficiency_verdict"),
+            "calibration_policy_id": record.get("calibration_policy_id"),
+            "false_sufficient": record.get("false_sufficient"),
+        }
+        for field, value in forbidden_values.items():
+            if value is not None:
+                errors.append(f"A_full requires {field}=null")
+        for field in ("compression_time_ms", "recovery_tokens", "recovery_calls"):
+            if record.get(field) not in (None, 0, 0.0):
+                errors.append(f"A_full requires {field} to be zero or null")
+        before = record.get("context_tokens_before")
+        after = record.get("context_tokens_after")
+        if before is not None and after is not None and before != after:
+            errors.append("A_full requires context_tokens_after == context_tokens_before")
+
+    if arm == "E_entroly_no_recovery":
+        for field in ("recovery_tokens", "recovery_calls"):
+            if record.get(field) not in (None, 0):
+                errors.append(f"E_entroly_no_recovery requires {field}=0 or null")
+
+    verdict = record.get("sufficiency_verdict")
+    evidence_present = record.get("required_evidence_present")
+    false_sufficient = record.get("false_sufficient")
+    if false_sufficient is True and verdict != "sufficient_calibrated":
+        errors.append(
+            "false_sufficient=true requires sufficiency_verdict=sufficient_calibrated"
+        )
+    if verdict == "sufficient_calibrated" and evidence_present is False:
+        if false_sufficient is not True:
+            errors.append(
+                "calibrated sufficiency with missing evidence requires false_sufficient=true"
+            )
+
+    if record.get("excluded") is False and record.get("exclusion_reason") is not None:
+        errors.append("non-excluded records require exclusion_reason=null")
+
+    return errors
+
+
+def validate_record(record: Mapping[str, Any]) -> None:
+    """Validate one row against JSON Schema plus semantic invariants."""
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError as exc:  # pragma: no cover - installation contract
+        raise RuntimeError("jsonschema is required to validate benchmark rows") from exc
+
+    schema_errors = sorted(
+        Draft202012Validator(_schema()).iter_errors(dict(record)),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    errors = [
+        f"{'/'.join(str(part) for part in error.absolute_path) or '<root>'}: "
+        f"{error.message}"
+        for error in schema_errors
+    ]
+    errors.extend(_semantic_errors(record))
+    if errors:
+        raise BenchmarkContractError("; ".join(errors))
+
+
+def load_jsonl(path: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(
+        Path(path).read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not raw_line.strip():
+            continue
+        try:
+            value = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise BenchmarkContractError(
+                f"line {line_number}: invalid JSON: {exc.msg}"
+            ) from exc
+        if not isinstance(value, dict):
+            raise BenchmarkContractError(f"line {line_number}: row must be an object")
+        records.append(value)
+    if not records:
+        raise BenchmarkContractError("result JSONL contains no records")
+    return records
+
+
+def validate_records(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    required_arms: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Validate rows, pairing, treatment identity, and task-input equality."""
+    groups: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for index, record in enumerate(records):
+        try:
+            validate_record(record)
+        except BenchmarkContractError as exc:
+            raise BenchmarkContractError(f"record {index}: {exc}") from exc
+        groups[str(record["pair_id"])].append(record)
+
+    required = set(required_arms)
+    arm_counts: Counter[str] = Counter()
+    excluded_pairs = 0
+    for pair_id, pair in sorted(groups.items()):
+        by_arm: dict[str, Mapping[str, Any]] = {}
+        for record in pair:
+            arm = str(record["arm"])
+            if arm in by_arm:
+                raise BenchmarkContractError(
+                    f"pair {pair_id}: duplicate result for arm {arm}"
+                )
+            by_arm[arm] = record
+            arm_counts[arm] += 1
+
+        if required - set(by_arm):
+            missing = ", ".join(sorted(required - set(by_arm)))
+            raise BenchmarkContractError(f"pair {pair_id}: missing required arms: {missing}")
+        if len(by_arm) > 1 and "A_full" not in by_arm:
+            raise BenchmarkContractError(
+                f"pair {pair_id}: compared treatment arms require A_full"
+            )
+
+        reference = by_arm.get("A_full") or next(iter(by_arm.values()))
+        for arm, record in sorted(by_arm.items()):
+            for field in _IDENTITY_FIELDS:
+                if record.get(field) != reference.get(field):
+                    raise BenchmarkContractError(
+                        f"pair {pair_id}: {field} differs in arm {arm}"
+                    )
+            baseline_tokens = reference.get("context_tokens_before")
+            treatment_tokens = record.get("context_tokens_before")
+            if (
+                baseline_tokens is not None
+                and treatment_tokens is not None
+                and baseline_tokens != treatment_tokens
+            ):
+                raise BenchmarkContractError(
+                    f"pair {pair_id}: context_tokens_before differs in arm {arm}"
+                )
+
+        if all(bool(record.get("excluded")) for record in pair):
+            excluded_pairs += 1
+
+    canonical = [dict(record) for record in records]
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "records": len(records),
+        "pairs": len(groups),
+        "excluded_pairs": excluded_pairs,
+        "arms": dict(sorted(arm_counts.items())),
+        "artifact_digest": sha256_bytes(_canonical_bytes(canonical)),
+    }
+
+
+def validate_jsonl(
+    path: str | os.PathLike[str],
+    *,
+    required_arms: Iterable[str] = (),
+) -> dict[str, Any]:
+    return validate_records(load_jsonl(path), required_arms=required_arms)
+
+
+def _is_secret_name(name: str) -> bool:
+    return bool(_SECRET_NAME_RE.search(name))
+
+
+def sanitize_baseline_environment(
+    environment: Mapping[str, str] | None = None,
+    *,
+    preserve_provider_base_urls: bool = False,
+) -> tuple[dict[str, str], tuple[str, ...]]:
+    """Remove Entroly and local-proxy hooks from a child environment."""
+    clean = dict(os.environ if environment is None else environment)
+    removed: list[str] = []
+    for key in sorted(tuple(clean)):
+        if key.startswith("ENTROLY_") or (
+            not preserve_provider_base_urls and key in _PROXY_OVERRIDE_KEYS
+        ):
+            removed.append(key)
+            clean.pop(key, None)
+    return clean, tuple(removed)
+
+
+def _environment_digest(environment: Mapping[str, str]) -> str:
+    safe_values = {
+        key: "<set>" if _is_secret_name(key) else value
+        for key, value in sorted(environment.items())
+    }
+    return sha256_bytes(_canonical_bytes(safe_values))
+
+
+def _assert_baseline_command(command: Sequence[str]) -> None:
+    if not command:
+        raise BenchmarkContractError("baseline command is empty")
+    for argument in command:
+        if "entroly" in argument.casefold():
+            raise BenchmarkContractError(
+                "A_full command must not reference Entroly executables or modules"
+            )
+        if _SECRET_ARGUMENT_RE.search(argument):
+            raise BenchmarkContractError(
+                "credentials must be passed through environment variables, not arguments"
+            )
+
+
+def _assert_no_entroly_modules(module_names: Iterable[str] | None = None) -> None:
+    names = sys.modules if module_names is None else module_names
+    loaded = sorted(
+        name for name in names if name == "entroly" or name.startswith("entroly.")
+    )
+    if loaded:
+        preview = ", ".join(loaded[:5])
+        raise BenchmarkContractError(
+            f"A_full process already loaded Entroly modules: {preview}"
+        )
+
+
+def build_baseline_manifest(
+    *,
+    benchmark: str,
+    benchmark_version: str,
+    run_id: str,
+    model_id: str,
+    agent_id: str,
+    provider_id: str | None,
+    harness_commit: str | None,
+    task_set: str | os.PathLike[str],
+    command: Sequence[str],
+    environment: Mapping[str, str] | None = None,
+    preserve_provider_base_urls: bool = False,
+    module_names: Iterable[str] | None = None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Build a secret-safe manifest proving the raw arm configuration."""
+    _assert_baseline_command(command)
+    _assert_no_entroly_modules(module_names)
+    task_path = Path(task_set).expanduser().resolve(strict=True)
+    clean_environment, removed = sanitize_baseline_environment(
+        environment,
+        preserve_provider_base_urls=preserve_provider_base_urls,
+    )
+    if any(key.startswith("ENTROLY_") for key in clean_environment):
+        raise BenchmarkContractError("failed to remove every ENTROLY_* variable")
+
+    credential_names = sorted(
+        key for key, value in clean_environment.items() if value and _is_secret_name(key)
+    )
+    manifest: dict[str, Any] = {
+        "schema_version": "entroly.external-baseline-manifest.v1",
+        "protocol_version": PROTOCOL_VERSION,
+        "arm": "A_full",
+        "treatment": "none",
+        "status": "planned",
+        "benchmark": benchmark,
+        "benchmark_version": benchmark_version,
+        "run_id": run_id,
+        "model_id": model_id,
+        "agent_id": agent_id,
+        "provider_id": provider_id,
+        "harness_commit": harness_commit,
+        "task_set_digest": sha256_file(task_path),
+        "task_set_name": task_path.name,
+        "command": list(command),
+        "command_digest": sha256_bytes(_canonical_bytes(list(command))),
+        "environment_digest": _environment_digest(clean_environment),
+        "credential_environment_names": credential_names,
+        "removed_environment_keys": list(removed),
+        "provider_base_url_overrides_preserved": preserve_provider_base_urls,
+        "entroly_modules_loaded": [],
+        "entroly_environment_keys": [],
+        "working_directory": ".",
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "created_unix_ms": int(time.time() * 1_000),
+    }
+    manifest["manifest_digest"] = _manifest_digest(manifest)
+    return manifest, clean_environment
+
+
+def _terminate(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+            process.wait(timeout=5)
+            return
+        except (OSError, subprocess.TimeoutExpired):
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                pass
+    else:  # pragma: no cover - platform dependent
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+            return
+        except subprocess.TimeoutExpired:
+            process.kill()
+    process.wait()
+
+
+def run_baseline(
+    *,
+    output_directory: str | os.PathLike[str],
+    execute: bool,
+    timeout_seconds: float,
+    **manifest_arguments: Any,
+) -> dict[str, Any]:
+    """Write a manifest and optionally execute the raw external harness."""
+    manifest, environment = build_baseline_manifest(**manifest_arguments)
+    output = Path(output_directory).expanduser().resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    manifest_path = output / "a_full_manifest.json"
+    _atomic_write_json(manifest_path, manifest)
+    if not execute:
+        return manifest
+
+    stdout_path = output / "a_full.stdout"
+    stderr_path = output / "a_full.stderr"
+    started = time.perf_counter()
+    process: subprocess.Popen[bytes] | None = None
+    status = "failed"
+    error_class: str | None = None
+    exit_code: int | None = None
+    try:
+        with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+            process = subprocess.Popen(
+                list(manifest_arguments["command"]),
+                cwd=Path.cwd(),
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout,
+                stderr=stderr,
+                shell=False,
+                start_new_session=(os.name == "posix"),
+            )
+            try:
+                exit_code = process.wait(timeout=timeout_seconds)
+                status = "completed" if exit_code == 0 else "failed"
+            except subprocess.TimeoutExpired:
+                status = "timeout"
+                error_class = "TimeoutExpired"
+                _terminate(process)
+                exit_code = process.returncode
+    except BaseException as exc:
+        error_class = type(exc).__name__
+        if process is not None:
+            _terminate(process)
+        raise
+    finally:
+        finished = dict(manifest)
+        finished.update(
+            {
+                "status": status,
+                "exit_code": exit_code,
+                "error_class": error_class,
+                "wall_time_ms": round((time.perf_counter() - started) * 1_000, 3),
+                "stdout_digest": (
+                    sha256_file(stdout_path) if stdout_path.exists() else None
+                ),
+                "stderr_digest": (
+                    sha256_file(stderr_path) if stderr_path.exists() else None
+                ),
+                "stdout_bytes": (
+                    stdout_path.stat().st_size if stdout_path.exists() else 0
+                ),
+                "stderr_bytes": (
+                    stderr_path.stat().st_size if stderr_path.exists() else 0
+                ),
+            }
+        )
+        finished["manifest_digest"] = _manifest_digest(finished)
+        _atomic_write_json(manifest_path, finished)
+        manifest = finished
+    return manifest
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate paired external results or prepare a raw A_full run."
+    )
+    subparsers = parser.add_subparsers(dest="command_name", required=True)
+
+    validate = subparsers.add_parser("validate", help="validate task-level JSONL")
+    validate.add_argument("results", type=Path)
+    validate.add_argument("--require-arm", action="append", default=[])
+
+    baseline = subparsers.add_parser(
+        "baseline",
+        help="write a no-Entroly manifest and optionally execute a harness",
+    )
+    baseline.add_argument("--benchmark", required=True)
+    baseline.add_argument("--benchmark-version", required=True)
+    baseline.add_argument("--run-id", required=True)
+    baseline.add_argument("--model-id", required=True)
+    baseline.add_argument("--agent-id", required=True)
+    baseline.add_argument("--provider-id")
+    baseline.add_argument("--harness-commit")
+    baseline.add_argument("--task-set", required=True, type=Path)
+    baseline.add_argument("--output-directory", required=True, type=Path)
+    baseline.add_argument("--timeout-seconds", type=float, default=3_600.0)
+    baseline.add_argument("--preserve-provider-base-urls", action="store_true")
+    baseline.add_argument("--execute", action="store_true")
+    baseline.add_argument("harness_command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command_name == "validate":
+            summary = validate_jsonl(
+                args.results,
+                required_arms=args.require_arm,
+            )
+        else:
+            command = list(args.harness_command)
+            if command and command[0] == "--":
+                command = command[1:]
+            summary = run_baseline(
+                output_directory=args.output_directory,
+                execute=bool(args.execute),
+                timeout_seconds=float(args.timeout_seconds),
+                benchmark=args.benchmark,
+                benchmark_version=args.benchmark_version,
+                run_id=args.run_id,
+                model_id=args.model_id,
+                agent_id=args.agent_id,
+                provider_id=args.provider_id,
+                harness_commit=args.harness_commit,
+                task_set=args.task_set,
+                command=command,
+                preserve_provider_base_urls=bool(
+                    args.preserve_provider_base_urls
+                ),
+            )
+    except (BenchmarkContractError, OSError, RuntimeError) as exc:
+        print(
+            json.dumps(
+                {"ok": False, "error": type(exc).__name__, "detail": str(exc)},
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps({"ok": True, **summary}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/external_context_efficiency.schema.json
+++ b/benchmarks/external_context_efficiency.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://entroly.dev/schemas/external-context-efficiency-v1.json",
+  "title": "Entroly External Context Efficiency Task Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "protocol_version",
+    "benchmark",
+    "benchmark_version",
+    "benchmark_task_id",
+    "arm",
+    "run_id",
+    "pair_id",
+    "model_id",
+    "agent_id",
+    "provider_id",
+    "harness_commit",
+    "environment_digest",
+    "task_input_digest",
+    "treatment_manifest_digest",
+    "entroly_commit",
+    "entroly_config_digest",
+    "seed",
+    "success",
+    "benchmark_score",
+    "provider_input_tokens",
+    "provider_output_tokens",
+    "cached_input_tokens",
+    "context_tokens_before",
+    "context_tokens_after",
+    "recovery_tokens",
+    "recovery_calls",
+    "wall_time_ms",
+    "compression_time_ms",
+    "peak_rss_bytes",
+    "context_overflow",
+    "sufficiency_verdict",
+    "calibration_policy_id",
+    "required_evidence_present",
+    "false_sufficient",
+    "error_class",
+    "excluded",
+    "exclusion_reason",
+    "artifact_digests"
+  ],
+  "properties": {
+    "protocol_version": {"const": "external-context-efficiency-v1"},
+    "benchmark": {
+      "enum": [
+        "swe-bench-verified",
+        "terminal-bench-2",
+        "deepsearchqa",
+        "tau2-telecom",
+        "livecodebench-pro",
+        "healthbench-hard",
+        "mmmu-pro",
+        "charxiv",
+        "zerobench",
+        "screenspot-pro",
+        "gpqa-diamond",
+        "humanitys-last-exam",
+        "arc-agi-2",
+        "medxpertqa-text"
+      ]
+    },
+    "benchmark_version": {"type": "string", "minLength": 1, "maxLength": 200},
+    "benchmark_task_id": {"type": "string", "minLength": 1, "maxLength": 500},
+    "arm": {
+      "enum": [
+        "A_full",
+        "B_native",
+        "C_entroly_conservative",
+        "D_entroly_balanced",
+        "E_entroly_no_recovery"
+      ]
+    },
+    "run_id": {"type": "string", "minLength": 1, "maxLength": 200},
+    "pair_id": {"type": "string", "minLength": 1, "maxLength": 500},
+    "model_id": {"type": "string", "minLength": 1, "maxLength": 300},
+    "agent_id": {"type": "string", "minLength": 1, "maxLength": 300},
+    "provider_id": {"type": ["string", "null"], "maxLength": 200},
+    "harness_commit": {"type": ["string", "null"], "pattern": "^[0-9a-f]{7,64}$"},
+    "environment_digest": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+    "task_input_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "treatment_manifest_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "entroly_commit": {"type": ["string", "null"], "pattern": "^[0-9a-f]{7,64}$"},
+    "entroly_config_digest": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+    "seed": {"type": ["integer", "null"]},
+    "success": {"type": "boolean"},
+    "benchmark_score": {"type": ["number", "null"]},
+    "provider_input_tokens": {"type": ["integer", "null"], "minimum": 0},
+    "provider_output_tokens": {"type": ["integer", "null"], "minimum": 0},
+    "cached_input_tokens": {"type": ["integer", "null"], "minimum": 0},
+    "context_tokens_before": {"type": ["integer", "null"], "minimum": 0},
+    "context_tokens_after": {"type": ["integer", "null"], "minimum": 0},
+    "recovery_tokens": {"type": ["integer", "null"], "minimum": 0},
+    "recovery_calls": {"type": ["integer", "null"], "minimum": 0},
+    "wall_time_ms": {"type": "number", "minimum": 0},
+    "compression_time_ms": {"type": ["number", "null"], "minimum": 0},
+    "peak_rss_bytes": {"type": ["integer", "null"], "minimum": 0},
+    "context_overflow": {"type": "boolean"},
+    "sufficiency_verdict": {
+      "type": ["string", "null"],
+      "enum": [
+        null,
+        "collecting",
+        "no_detected_gap_uncalibrated",
+        "sufficient_calibrated",
+        "degraded",
+        "expand_required",
+        "insufficient",
+        "preserve_original"
+      ]
+    },
+    "calibration_policy_id": {"type": ["string", "null"], "maxLength": 200},
+    "required_evidence_present": {"type": ["boolean", "null"]},
+    "false_sufficient": {"type": ["boolean", "null"]},
+    "error_class": {"type": ["string", "null"], "maxLength": 200},
+    "excluded": {"type": "boolean"},
+    "exclusion_reason": {"type": ["string", "null"], "maxLength": 1000},
+    "artifact_digests": {
+      "type": "object",
+      "additionalProperties": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"arm": {"const": "A_full"}}, "required": ["arm"]},
+      "then": {
+        "properties": {
+          "entroly_commit": {"const": null},
+          "entroly_config_digest": {"const": null},
+          "recovery_tokens": {"enum": [0, null]},
+          "recovery_calls": {"enum": [0, null]},
+          "compression_time_ms": {"enum": [0, null]},
+          "sufficiency_verdict": {"const": null},
+          "calibration_policy_id": {"const": null},
+          "false_sufficient": {"const": null}
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "arm": {
+            "enum": [
+              "C_entroly_conservative",
+              "D_entroly_balanced",
+              "E_entroly_no_recovery"
+            ]
+          }
+        },
+        "required": ["arm"]
+      },
+      "then": {
+        "properties": {
+          "entroly_commit": {"type": "string"},
+          "entroly_config_digest": {"type": "string"}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"excluded": {"const": true}}, "required": ["excluded"]},
+      "then": {
+        "properties": {"exclusion_reason": {"type": "string", "minLength": 1}}
+      },
+      "else": {"properties": {"exclusion_reason": {"const": null}}}
+    },
+    {
+      "if": {"properties": {"false_sufficient": {"const": true}}, "required": ["false_sufficient"]},
+      "then": {
+        "properties": {"required_evidence_present": {"const": false}},
+        "required": ["sufficiency_verdict", "required_evidence_present"]
+      }
+    }
+  ]
+}

--- a/tests/test_external_context_efficiency.py
+++ b/tests/test_external_context_efficiency.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from benchmarks.external_context_efficiency import (
+    BenchmarkContractError,
+    build_baseline_manifest,
+    run_baseline,
+    sanitize_baseline_environment,
+    sha256_bytes,
+    validate_jsonl,
+    validate_record,
+    validate_records,
+)
+
+
+def _digest(label: str) -> str:
+    return sha256_bytes(label.encode("utf-8"))
+
+
+def _record(arm: str = "A_full") -> dict[str, object]:
+    uses_entroly = arm.startswith(("C_", "D_", "E_"))
+    return {
+        "protocol_version": "external-context-efficiency-v1",
+        "benchmark": "swe-bench-verified",
+        "benchmark_version": "v1@abcdef0",
+        "benchmark_task_id": "django__django-12345",
+        "arm": arm,
+        "run_id": f"run-{arm}",
+        "pair_id": "swe:django__django-12345:seed-1",
+        "model_id": "gpt-test-2026-08-01",
+        "agent_id": "agent@abcdef0",
+        "provider_id": "provider-test",
+        "harness_commit": "abcdef0",
+        "environment_digest": _digest("environment"),
+        "task_input_digest": _digest("task-input"),
+        "treatment_manifest_digest": _digest(f"manifest-{arm}"),
+        "entroly_commit": "1234567" if uses_entroly else None,
+        "entroly_config_digest": _digest("config") if uses_entroly else None,
+        "seed": 1,
+        "success": True,
+        "benchmark_score": 1.0,
+        "provider_input_tokens": 120,
+        "provider_output_tokens": 20,
+        "cached_input_tokens": 0,
+        "context_tokens_before": 100,
+        "context_tokens_after": 70 if uses_entroly else 100,
+        "recovery_tokens": 0,
+        "recovery_calls": 0,
+        "wall_time_ms": 1000.0,
+        "compression_time_ms": 5.0 if uses_entroly else 0.0,
+        "peak_rss_bytes": 100_000,
+        "context_overflow": False,
+        "sufficiency_verdict": (
+            "no_detected_gap_uncalibrated" if uses_entroly else None
+        ),
+        "calibration_policy_id": None,
+        "required_evidence_present": True,
+        "false_sufficient": False if uses_entroly else None,
+        "error_class": None,
+        "excluded": False,
+        "exclusion_reason": None,
+        "artifact_digests": {"stdout": _digest(f"stdout-{arm}")},
+    }
+
+
+def test_valid_a_full_record_passes_strict_contract() -> None:
+    validate_record(_record())
+
+
+def test_a_full_cannot_hide_context_changes() -> None:
+    record = _record()
+    record["context_tokens_after"] = 99
+    with pytest.raises(BenchmarkContractError, match="context_tokens_after"):
+        validate_record(record)
+
+
+def test_a_full_cannot_carry_entroly_identity() -> None:
+    record = _record()
+    record["entroly_commit"] = "1234567"
+    with pytest.raises(BenchmarkContractError, match="entroly_commit"):
+        validate_record(record)
+
+
+def test_false_sufficient_requires_calibrated_sufficiency() -> None:
+    record = _record("C_entroly_conservative")
+    record["required_evidence_present"] = False
+    record["false_sufficient"] = True
+    with pytest.raises(BenchmarkContractError, match="sufficient_calibrated"):
+        validate_record(record)
+
+
+def test_compared_treatment_requires_full_context_pair() -> None:
+    with pytest.raises(BenchmarkContractError, match="require A_full"):
+        validate_records([_record("C_entroly_conservative")])
+
+
+def test_pair_identity_mismatch_fails_before_scoring() -> None:
+    baseline = _record()
+    treatment = _record("C_entroly_conservative")
+    treatment["model_id"] = "different-model"
+    with pytest.raises(BenchmarkContractError, match="model_id differs"):
+        validate_records([baseline, treatment])
+
+
+def test_duplicate_arm_is_rejected() -> None:
+    first = _record()
+    second = dict(first)
+    second["run_id"] = "duplicate-run"
+    with pytest.raises(BenchmarkContractError, match="duplicate result"):
+        validate_records([first, second])
+
+
+def test_jsonl_validator_reports_stable_summary(tmp_path: Path) -> None:
+    records = [_record(), _record("C_entroly_conservative")]
+    path = tmp_path / "results.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    summary = validate_jsonl(
+        path,
+        required_arms=("A_full", "C_entroly_conservative"),
+    )
+    assert summary["records"] == 2
+    assert summary["pairs"] == 1
+    assert summary["arms"] == {
+        "A_full": 1,
+        "C_entroly_conservative": 1,
+    }
+    assert str(summary["artifact_digest"]).startswith("sha256:")
+
+
+def test_baseline_environment_removes_treatment_and_proxy_hooks() -> None:
+    clean, removed = sanitize_baseline_environment(
+        {
+            "ENTROLY_AIR_GAP": "1",
+            "ENTROLY_PROXY": "http://localhost:8000",
+            "OPENAI_BASE_URL": "http://localhost:8000/v1",
+            "OPENAI_API_KEY": "secret-value",
+            "PATH": "/usr/bin",
+        }
+    )
+    assert set(removed) == {
+        "ENTROLY_AIR_GAP",
+        "ENTROLY_PROXY",
+        "OPENAI_BASE_URL",
+    }
+    assert clean == {"OPENAI_API_KEY": "secret-value", "PATH": "/usr/bin"}
+
+
+def test_manifest_records_secret_names_never_values(tmp_path: Path) -> None:
+    tasks = tmp_path / "tasks.json"
+    tasks.write_text("[]\n", encoding="utf-8")
+    manifest, child_environment = build_baseline_manifest(
+        benchmark="swe-bench-verified",
+        benchmark_version="v1",
+        run_id="baseline-smoke",
+        model_id="gpt-test",
+        agent_id="agent-test",
+        provider_id="provider-test",
+        harness_commit="abcdef0",
+        task_set=tasks,
+        command=[sys.executable, "-V"],
+        environment={
+            "ENTROLY_PROXY": "http://localhost:8000",
+            "OPENAI_API_KEY": "never-write-this-value",
+            "PATH": os.environ.get("PATH", ""),
+        },
+        module_names=(),
+    )
+    rendered = json.dumps(manifest, sort_keys=True)
+    assert "never-write-this-value" not in rendered
+    assert manifest["credential_environment_names"] == ["OPENAI_API_KEY"]
+    assert manifest["removed_environment_keys"] == ["ENTROLY_PROXY"]
+    assert child_environment["OPENAI_API_KEY"] == "never-write-this-value"
+    assert manifest["arm"] == "A_full"
+    assert manifest["treatment"] == "none"
+
+
+def test_baseline_rejects_entroly_command(tmp_path: Path) -> None:
+    tasks = tmp_path / "tasks.json"
+    tasks.write_text("[]", encoding="utf-8")
+    with pytest.raises(BenchmarkContractError, match="must not reference Entroly"):
+        build_baseline_manifest(
+            benchmark="swe-bench-verified",
+            benchmark_version="v1",
+            run_id="bad-command",
+            model_id="gpt-test",
+            agent_id="agent-test",
+            provider_id=None,
+            harness_commit=None,
+            task_set=tasks,
+            command=[sys.executable, "-m", "entroly"],
+            module_names=(),
+        )
+
+
+def test_baseline_rejects_loaded_entroly_module(tmp_path: Path) -> None:
+    tasks = tmp_path / "tasks.json"
+    tasks.write_text("[]", encoding="utf-8")
+    with pytest.raises(BenchmarkContractError, match="already loaded"):
+        build_baseline_manifest(
+            benchmark="swe-bench-verified",
+            benchmark_version="v1",
+            run_id="bad-process",
+            model_id="gpt-test",
+            agent_id="agent-test",
+            provider_id=None,
+            harness_commit=None,
+            task_set=tasks,
+            command=[sys.executable, "-V"],
+            module_names=("entroly", "entroly.sdk"),
+        )
+
+
+def test_manifest_only_mode_does_not_execute_command(tmp_path: Path) -> None:
+    tasks = tmp_path / "tasks.json"
+    tasks.write_text("[]", encoding="utf-8")
+    marker = tmp_path / "must-not-exist"
+    script = tmp_path / "write_marker.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('ran', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "output"
+    manifest = run_baseline(
+        output_directory=output,
+        execute=False,
+        timeout_seconds=10,
+        benchmark="swe-bench-verified",
+        benchmark_version="v1",
+        run_id="dry-run",
+        model_id="gpt-test",
+        agent_id="agent-test",
+        provider_id=None,
+        harness_commit=None,
+        task_set=tasks,
+        command=[sys.executable, str(script)],
+        environment={"PATH": os.environ.get("PATH", "")},
+        module_names=(),
+    )
+    assert manifest["status"] == "planned"
+    assert not marker.exists()
+    persisted = json.loads(
+        (output / "a_full_manifest.json").read_text(encoding="utf-8")
+    )
+    assert persisted["manifest_digest"] == manifest["manifest_digest"]
+
+
+def test_executed_baseline_child_has_no_entroly_or_proxy_hooks(tmp_path: Path) -> None:
+    tasks = tmp_path / "tasks.json"
+    tasks.write_text("[]", encoding="utf-8")
+    script = tmp_path / "inspect_environment.py"
+    script.write_text(
+        "import os, json\n"
+        "print(json.dumps({\n"
+        "  'entroly': sorted(k for k in os.environ if k.startswith('ENTROLY_')),\n"
+        "  'base_url': os.environ.get('OPENAI_BASE_URL'),\n"
+        "  'has_key': bool(os.environ.get('OPENAI_API_KEY')),\n"
+        "}, sort_keys=True))\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "output"
+    manifest = run_baseline(
+        output_directory=output,
+        execute=True,
+        timeout_seconds=10,
+        benchmark="swe-bench-verified",
+        benchmark_version="v1",
+        run_id="execute-smoke",
+        model_id="gpt-test",
+        agent_id="agent-test",
+        provider_id="provider-test",
+        harness_commit="abcdef0",
+        task_set=tasks,
+        command=[sys.executable, str(script)],
+        environment={
+            "ENTROLY_PROXY": "http://localhost:8000",
+            "OPENAI_BASE_URL": "http://localhost:8000/v1",
+            "OPENAI_API_KEY": "child-secret",
+            "PATH": os.environ.get("PATH", ""),
+        },
+        module_names=(),
+    )
+    assert manifest["status"] == "completed"
+    assert manifest["exit_code"] == 0
+    child = json.loads((output / "a_full.stdout").read_text(encoding="utf-8"))
+    assert child == {"base_url": None, "entroly": [], "has_key": True}
+    rendered_manifest = (output / "a_full_manifest.json").read_text(
+        encoding="utf-8"
+    )
+    assert "child-secret" not in rendered_manifest


### PR DESCRIPTION
## Purpose

Add a preregistered external context-efficiency track that measures Entroly as a context-management treatment—not as a model—and establishes the no-Entroly baseline before any paid model call.

## Implemented scope

- Rebuilt cleanly from current `main`; stale-base failures removed.
- Preregistered Tier-1, diagnostic, and base-model-control benchmark roles.
- Strict task-level JSON Schema with explicit nullable fields.
- Task-input and treatment-manifest digests.
- Semantic validation for raw, Entroly, no-recovery, exclusion, and false-sufficiency records.
- Pair identity checks that fail before scores are viewed.
- Executable `A_full` wrapper that:
  - refuses Entroly commands and loaded Entroly modules;
  - strips every `ENTROLY_*` variable and known proxy/base-URL overrides;
  - records credential environment names but never values;
  - writes atomic planned/completed manifests;
  - defaults to manifest-only mode and requires `--execute` for network/paid runs;
  - records command, task-set, environment, stdout, and stderr digests.
- Adversarial tests for hidden context changes, treatment leakage, pair mismatch, duplicate arms, secret handling, dry-run safety, and child-process isolation.

## Evidence status

No model-in-the-loop result has been collected. No superiority or rank claim is authorized.

## Next gates

1. Full repository CI on one unchanged head.
2. Official SWE-bench gold/oracle smoke adapter.
3. Terminal-Bench/Harbor oracle smoke adapter.
4. Freeze task IDs and analysis code.
5. Run `A_full` only after a project-scoped provider key is configured outside GitHub history/chat.

**Draft. Do not merge or publish benchmark claims until adapters, smoke tests, external runs, and independent review are complete.**