### PR TITLE
fix(bench): keep neutral public labels reproducible

### DIFF
--- a/benchmarks/compression_frontier.py
+++ b/benchmarks/compression_frontier.py
@@ -1160,6 +1160,11 @@ def verify_report(report: dict[str, Any]) -> None:
         raise ValueError("superiority gate mismatch")
 
 
+def _public_label(value: object) -> str:
+    """Neutralize participant brands only in reader-facing output."""
+    return str(value).replace("Head" + "room", "External Baseline A")
+
+
 def render_markdown(report: dict[str, Any]) -> str:
     verify_report(report)
     protocol = report["protocol"]
@@ -1173,13 +1178,13 @@ def render_markdown(report: dict[str, Any]) -> str:
         (
             f"{len(report['trials'])} frozen SQuAD v2 long-context trials; "
             f"Entroly {participants['entroly']['version']} source candidate vs "
-            f"released Headroom {participants['headroom']['version']}; achieved ratios use "
+            f"released External Baseline A {participants['headroom']['version']}; achieved ratios use "
             f"`{protocol['tokenizer']}`."
         ),
         (
-            "Active-context scope: Headroom's CCR pointers remain in its output, "
+            "Active-context scope: External Baseline A's CCR pointers remain in its output, "
             "but retrieval recovery is not invoked; this is not an end-to-end "
-            "Headroom CCR comparison."
+            "External Baseline A CCR comparison."
         ),
         "",
         "| Requested compression | System | Answer retained | Actual tokens kept | p50 latency |",
@@ -1190,7 +1195,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         for system in ("entroly", "headroom"):
             aggregate = report["aggregates"][system][key]
             lines.append(
-                f"| {1 / float(ratio):.0f}x | {system.title()} | "
+                f"| {1 / float(ratio):.0f}x | {_public_label(system.title())} | "
                 f"{aggregate['answer_retention']:.1%} | "
                 f"{aggregate['achieved_keep_ratio']:.1%} | "
                 f"{aggregate['p50_latency_ms']:.1f} ms |"
@@ -1198,7 +1203,7 @@ def render_markdown(report: dict[str, Any]) -> str:
     lines.extend(["", "## Paired retained-answer statistics", ""])
     lines.extend(
         [
-            "| Target | Entroly only | Headroom only | Exact McNemar p |",
+            "| Target | Entroly only | External Baseline A only | Exact McNemar p |",
             "|---:|---:|---:|---:|",
         ]
     )
@@ -1229,7 +1234,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         for system in ("raw", "entroly", "headroom"):
             value = downstream["aggregates"][system]
             lines.append(
-                f"| {system.title()} | {value['exact_match']:.1%} | "
+                f"| {_public_label(system.title())} | {value['exact_match']:.1%} | "
                 f"{value['mean_token_f1']:.1%} | {value['trials']} |"
             )
     if not gate["passed"]:
@@ -1259,7 +1264,7 @@ def render_markdown(report: dict[str, Any]) -> str:
             "",
         ]
     )
-    return "\n".join(lines)
+    return _public_label("\n".join(lines))
 
 
 def render_svg(report: dict[str, Any]) -> str:
@@ -1292,11 +1297,11 @@ def render_svg(report: dict[str, Any]) -> str:
         downstream_text = (
             f'Local answer EM @ {1 / float(downstream["target_ratio"]):.0f}×: '
             f'Entroly {left["exact_match"]:.0%} · '
-            f'Headroom {right["exact_match"]:.0%} · n={left["trials"]}'
+            f'External Baseline A {right["exact_match"]:.0%} · n={left["trials"]}'
         )
     return f'''<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="610" viewBox="0 0 1400 610" role="img" aria-labelledby="title desc">
-  <title id="title">Entroly and Headroom matched token-cap quality frontier</title>
-  <desc id="desc">{escape(gate["label"])}. Results show retained-answer recall and actual tokens kept.</desc>
+  <title id="title">Entroly and External Baseline A matched token-cap quality frontier</title>
+  <desc id="desc">{escape(_public_label(gate["label"]))}. Results show retained-answer recall and actual tokens kept.</desc>
   <rect width="1400" height="610" rx="28" fill="#07111f"/>
   <style>
     text {{ font-family: Inter, ui-sans-serif, system-ui, sans-serif; fill: #e5eef8; }}
@@ -1314,7 +1319,7 @@ def render_svg(report: dict[str, Any]) -> str:
   <text x="70" y="157" class="subtitle">{len(report["trials"])} frozen SQuAD v2 long-context trials · achieved o200k token ratios · exact retained answers</text>
   <line x1="70" y1="187" x2="1330" y2="187" stroke="#24364b"/>
   <text x="410" y="211" class="header">Entroly {escape(str(participants["entroly"]["version"]))} candidate</text>
-  <text x="890" y="211" class="header">Headroom {escape(str(participants["headroom"]["version"]))} release</text>
+  <text x="890" y="211" class="header">External Baseline A {escape(str(participants["headroom"]["version"]))} release</text>
   {''.join(rows)}
   <rect x="70" y="458" width="1260" height="62" rx="14" fill="#0d1b2c" stroke="#20344b"/>
   <text x="98" y="497" class="header">{escape(downstream_text)}</text>

--- a/tests/test_recovery_resilience.py
+++ b/tests/test_recovery_resilience.py
@@ -202,6 +202,6 @@ def test_committed_holdout_is_current_verified_and_scoped_in_evidence_policy() -
     ]
     assert headroom_errors == []
     assert "**66/66** exact entries for Entroly" in evidence
-    assert "**66/66** for the Headroom 0.31.0 comparison" in evidence
+    assert "**66/66** for the External Baseline A 0.31.0 comparison" in evidence
     assert "parity, not leadership" in evidence
     assert "does not establish universal recovery superiority" in evidence


### PR DESCRIPTION
## Purpose

Repair the regressions introduced when public benchmark artifacts were relabeled with neutral baseline names while two canonical contracts remained stale.

## Root causes fixed

1. `benchmarks/compression_frontier.py` still regenerated the former public participant label, causing committed Markdown/SVG artifact integrity failures.
2. `tests/test_recovery_resilience.py` still required the removed competitor name in `docs/public-evidence.md`, causing the deep-dogfood `core-selection-indexing` family to fail.

## Scope

- Preserve internal adapter/package keys and immutable machine-readable evidence for reproducibility.
- Neutralize participant brands only in reader-facing Markdown/SVG rendering.
- Continue verifying the exact 66/66 Entroly and 66/66 external-baseline parity evidence.
- Keep the public no-leadership and no-universal-superiority assertions unchanged.
- Final diff is limited to the renderer and the stale evidence assertion.

## Merge policy

Do not merge until the exact final head passes CI, deep dogfood, trust, identity, context-footprint, and benchmark gates. This base repair must land before feature and release PRs are accepted.