### PR TITLE
chore(release): validate exact 1.0.74 main tip

### DIFF
--- a/docs/releases/v1.0.74.md
+++ b/docs/releases/v1.0.74.md
@@ -21,3 +21,10 @@ workflows.
 The canonical Homebrew formula remains pinned to the last verified published
 sdist until the post-publication workflow can update its URL and checksum
 atomically.
+
+## Main-branch verification ledger
+
+The `1.0.74` release tree was validated before merge across the complete required
+pull-request matrix. This follow-up ledger commit is intentionally tested as an
+exact fast-forward candidate for `main`, avoiding a new untested squash or merge
+commit at the default-branch tip. It changes no package or runtime version.


### PR DESCRIPTION
## Purpose

Make the default branch point directly to an unchanged commit whose complete applicable check suite passed.

PR #272 repaired the evidence contracts and synchronized `1.0.74` across approved release surfaces. This follow-up changes only the `1.0.74` release-note validation ledger and is applied by ordinary non-force fast-forward, so `main` points to the exact tested SHA rather than a newly created squash or merge commit.

## Exact validated head

`43ffa50d96c526d9a95873c483a27a1f66fa163a`

## Completed checks on this unchanged head

- [x] CI top-level success.
- [x] Wheel builds, functional tests, Python suites, and native integration tests on Python 3.10, 3.11, 3.12, 3.13, and 3.14.
- [x] Pure-Python fallback with the Rust extension genuinely absent.
- [x] Rust tests and Clippy.
- [x] WASM build, Clippy, host tests, and drift guard.
- [x] Single-binary proxy.
- [x] OpenClaw context-engine bridge and minimum-host tests.
- [x] MemoryOS production gate and Ruff.
- [x] Deep Dogfood Runtime, including release artifact, security/dependency audit, MCP entrypoints, Node/WASM/OpenClaw packages, provider gateway, receipts, recovery, indexing, integrations, learning, multimodal, and verification families.
- [x] User Journey Trust Gate across fresh-wheel onboarding, Linux, Windows, and macOS.
- [x] Context Footprint.
- [x] Commit Identity Guard.
- [x] Native Dogfood Diagnostic intentionally skipped by workflow conditions.

## Version contract

- No package, runtime, dependency, manifest, or lockfile version changed in this follow-up.
- Entroly remains synchronized at `1.0.74`.
- The complete release/version/evidence matrix already passed on the unchanged parent release tree from #272.

Ready for exact non-force fast-forward to `main`.