### PR TITLE
fix(gateway): enforce same-provider execution boundary

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -30,6 +30,13 @@ Entroly forwards your optimized prompt to the LLM API **you configured** through
 the proxy base URL. This is the API you already selected; Entroly changes the
 request shape and context size, not the provider's data policy.
 
+The gateway control plane does not automatically move a request to a different
+provider. Its executable plans are restricted to models belonging to the
+original provider. A source-provider failure fails closed instead of selecting
+another data recipient. See
+[`docs/gateway-provider-boundary.md`](docs/gateway-provider-boundary.md) for the
+code-backed boundary and test evidence.
+
 ```text
 Without Entroly:  IDE -> OpenAI (50K tokens)
 With Entroly:     IDE -> localhost:9377 -> compress -> OpenAI (12K tokens)
@@ -67,8 +74,9 @@ local deterministic verification.
 ### RAVS Model Routing (`ENTROLY_RAVS_ROUTER=1`)
 
 Can substitute a lower-cost model after local evidence gates pass. It is off by
-default because changing models can also change provider capabilities, cost, and
-data-handling semantics.
+default because changing models can also change capabilities and cost. The live
+proxy restricts this substitution to the same provider; it does not use RAVS as
+an automatic cross-provider fallback.
 
 ### Federation (`ENTROLY_FEDERATION=1`)
 

--- a/docs/gateway-provider-boundary.md
+++ b/docs/gateway-provider-boundary.md
@@ -1,0 +1,133 @@
+# Gateway provider boundary
+
+This document defines the safety and claim boundary for
+`GatewayControlPlane` and any future integration with `PromptCompilerProxy`.
+
+## Supported execution boundary
+
+`GatewayControlPlane` is a transport-free planner. The caller must pass the
+provider detected from the inbound request as `source_provider`; planning fails
+when that value does not match the current model candidate.
+
+The control plane may select another model only when that model belongs to the
+same source provider. Cross-provider targets are removed from the executable
+attempt list and recorded in `FailoverPlan.excluded` with the reason
+`cross_provider_disabled`.
+
+Examples:
+
+| Planned transition | Result |
+| --- | --- |
+| OpenAI model A -> OpenAI model B | Eligible when capabilities and routing policy permit it |
+| Anthropic model A -> Anthropic model B | Eligible when capabilities and routing policy permit it |
+| Gemini model A -> Gemini model B | Eligible when capabilities and routing policy permit it |
+| OpenAI -> Anthropic | Excluded: `cross_provider_disabled` |
+| Anthropic -> Gemini | Excluded: `cross_provider_disabled` |
+| Gemini -> OpenAI-compatible custom endpoint | Excluded: `cross_provider_disabled` |
+
+Neither lower projected cost nor an explicit `force_model` value can override
+this boundary. A source-provider failure also fails closed instead of activating
+a different provider. Duplicate provider/model target keys are rejected so a
+caller cannot manufacture extra retry capacity for the same billable target.
+
+## Retry boundary
+
+The control plane does not perform network I/O or retries. It exposes
+`GatewayAttemptState` for a future transport integration. Retry is denied by
+default. Automatic retry is permitted only when:
+
+- the transport explicitly sets `replay_authorized=True` after proving replay is
+  safe for this request;
+- the transport explicitly records that no upstream side effect is possible;
+- at least one attempt has completed;
+- another distinct same-provider target remains;
+- no response bytes have started;
+- no tool call has started.
+
+This prevents a transport from treating an unknown outcome, partial stream, tool
+invocation, possibly accepted request, duplicate target, or exhausted attempt
+list as safely replayable.
+
+## Accounting boundary
+
+`observe_response` accepts usage only when both conditions hold:
+
+1. the observed provider equals the plan's source provider;
+2. the observed provider/model pair exists in the executable attempt list.
+
+Usage from an unplanned target is rejected instead of being silently attributed
+to the run.
+
+## Evidence
+
+The executable evidence is in `tests/test_gateway_control_plane.py`.
+
+| Invariant | Test evidence |
+| --- | --- |
+| Adapter-detected source must match the current candidate | `test_source_provider_must_match_current_candidate` |
+| Duplicate target keys cannot inflate retry capacity | `test_duplicate_provider_targets_are_rejected` |
+| Cross-provider targets never become executable | `test_cheaper_cross_provider_target_is_excluded_by_policy` |
+| Explicit model forcing cannot cross the provider boundary | `test_forced_model_cannot_bypass_cross_provider_boundary` |
+| Provider failure does not escape to another provider | `test_provider_failure_does_not_escape_to_another_provider` |
+| Same-provider optimization remains available | `test_same_provider_routed_target_is_first_executable_attempt` |
+| Retry is denied without explicit replay proof | `test_automatic_retry_is_denied_without_explicit_replay_authorization` |
+| Usage from a different provider is rejected | `test_observation_rejects_a_different_provider` |
+| Redaction, routing, cache observation, and ledger composition remain intact | `test_control_plane_composes_policy_routing_cache_and_ledger` |
+
+Run the focused evidence suite with:
+
+```bash
+python -m pytest -q tests/test_gateway_control_plane.py tests/test_provider_policy.py
+python -m ruff check entroly/gateway_control_plane.py tests/test_gateway_control_plane.py
+```
+
+Before merging a live proxy integration, also run the proxy transport, provider,
+streaming, tool-call, and accounting suites. The focused tests above prove the
+control-plane policy only; they do not prove the complete HTTP execution path.
+
+## Claims this evidence supports
+
+The repository may claim that:
+
+- gateway planning requires an explicit source-provider identity;
+- executable gateway plans are same-provider by construction;
+- automatic cross-provider failover is not implemented by this control plane;
+- cost scoring and forced-model input cannot override the provider boundary;
+- provider failure fails closed rather than changing the data recipient;
+- duplicate targets cannot create artificial retry capacity;
+- retry is denied by default and requires explicit replay-safety proof;
+- response accounting rejects provider/model pairs outside the execution plan.
+
+## Claims this evidence does not support
+
+This evidence does **not** establish:
+
+- live connectivity to every provider;
+- universal compatibility across provider APIs;
+- legal compliance for every operator, jurisdiction, contract, or data class;
+- permission to use consumer subscription credentials as API credentials;
+- safe cross-provider transformation of tools, schemas, vision, reasoning, cache
+  controls, or streaming events;
+- production readiness of a future `PromptCompilerProxy` integration.
+
+Those claims require separate provider-specific conformance, credential,
+contract, data-residency, and end-to-end transport evidence.
+
+## Integration requirements
+
+A future `PromptCompilerProxy` integration must preserve these rules:
+
+1. Run the gateway in shadow mode before it becomes authoritative.
+2. Keep one routing authority; do not apply both legacy routing and gateway
+   routing to the same request.
+3. Pass the adapter-detected provider explicitly as `source_provider`.
+4. Keep that source provider fixed for the entire execution plan.
+5. Preserve the existing provider-specific request body and headers.
+6. Never forward credentials through redirects or to a different origin.
+7. Deny retry unless replay safety is explicitly proven in
+   `GatewayAttemptState` and another distinct target remains.
+8. Assign a distinct attempt identifier to every billable attempt.
+9. Record the selected model, route reason, status, latency, usage, and cost.
+10. Fail closed when capability, target, usage, or policy evidence is missing.
+11. Do not describe the feature as cross-provider failover or universal provider
+    compliance.

--- a/docs/provider-adapter-live-gateway.md
+++ b/docs/provider-adapter-live-gateway.md
@@ -1,10 +1,14 @@
 # Production provider adapter seam
 
-The cache-aware gateway control plane is provider-neutral, while the live proxy receives provider-specific JSON payloads and forwards them to provider-specific endpoints. `entroly/provider_adapters.py` is the boundary between those worlds.
+The cache-aware gateway control plane reasons over a canonical request, while
+the live proxy receives provider-specific JSON and forwards it to a
+provider-specific endpoint. `entroly/provider_adapters.py` is the semantic
+boundary between those representations.
 
 ## Adapter responsibilities
 
-The adapter converts supported request bodies into `CanonicalGatewayRequest` for:
+The adapter converts supported request bodies into `CanonicalGatewayRequest`
+for:
 
 - OpenAI Chat Completions
 - OpenAI Responses API
@@ -30,19 +34,37 @@ It also computes the estimates used by cache-aware routing:
 
 ## Same-provider routing
 
-If the target provider is unchanged, the live proxy can preserve the original body and replace only the model. `apply_target_same_provider(...)` validates the target and performs that rewrite. For Gemini, the model is validated and rewritten in the `/models/{model}` path segment.
+When the target provider is unchanged, the live proxy can preserve the original
+body and replace only the model. `apply_target_same_provider(...)` validates the
+target and performs that rewrite. For Gemini, the model is validated and
+rewritten in the `/models/{model}` path segment.
 
-## Cross-provider failover
+## Cross-provider canonical rendering
 
-A cross-provider failover target must not reuse the original provider body. Provider-specific generation controls and tool formats are not interchangeable.
+`render_canonical_request(...)` is a conservative conformance utility. It can
+render a limited text-only canonical request for adapter tests and explicitly
+fails closed for tools, tool-call history, vision, reasoning controls, response
+schemas, and provider-specific controls.
 
-For that reason, cross-provider execution must render from the canonical request using `render_canonical_request(...)`. The current renderer accepts only text chat with portable system, user, and assistant roles. It fails closed for tools, tool-call history, vision, reasoning controls, and response schemas until a dedicated adapter proves equivalent semantics. Provider-specific controls are never silently dropped.
+That renderer is **not** permission to route a live request to another provider.
+It does not establish operator consent, target credential ownership, region,
+retention, contract, billing, or equivalent provider semantics.
+
+`GatewayControlPlane` therefore removes every target whose provider differs
+from the original provider and records `cross_provider_disabled` in the
+failover receipt. A source-provider failure fails closed rather than invoking
+this renderer as an automatic fallback.
 
 ## Production invariant
 
 ```text
-same provider  -> preserve body + validated model rewrite
-cross provider -> render from canonical request only
+same provider  -> preserve provider body + validated model rewrite
+cross provider -> non-executable target (`cross_provider_disabled`)
 ```
 
-This prevents silent semantic drift while still allowing a future enterprise transport layer to execute capability-safe cross-provider failover.
+Any future cross-provider product would require a separate operator-authorized
+credential, data-policy, contract, region, conformance, and execution boundary.
+It must not be introduced by weakening the current gateway invariant.
+
+See [`gateway-provider-boundary.md`](gateway-provider-boundary.md) for the
+executable evidence and supported claim boundary.

--- a/entroly/gateway_control_plane.py
+++ b/entroly/gateway_control_plane.py
@@ -1,4 +1,4 @@
-"""Composable control plane for cache-aware gateway execution."""
+"""Composable, same-provider control plane for cache-aware gateway execution."""
 
 from __future__ import annotations
 
@@ -26,21 +26,92 @@ from .usage_ledger import (
 )
 
 
+_CROSS_PROVIDER_DISABLED = "cross_provider_disabled"
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayAttemptState:
+    """Execution progress used to decide whether an automatic retry is safe.
+
+    Retry is denied by default. A transport must explicitly authorize replay
+    after proving that the request is replay-safe and that the previous attempt
+    could not have produced an upstream side effect.
+    """
+
+    replay_authorized: bool = False
+    response_started: bool = False
+    tool_call_started: bool = False
+    side_effect_possible: bool = True
+
+    def __post_init__(self) -> None:
+        values = (
+            self.replay_authorized,
+            self.response_started,
+            self.tool_call_started,
+            self.side_effect_possible,
+        )
+        if any(not isinstance(value, bool) for value in values):
+            raise TypeError("gateway attempt state values must be booleans")
+
+    @property
+    def automatic_retry_allowed(self) -> bool:
+        return self.replay_authorized and not (
+            self.response_started
+            or self.tool_call_started
+            or self.side_effect_possible
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class GatewayExecutionPlan:
     conversation_id: str
+    source_provider: str
     request: CanonicalGatewayRequest
     stable_prompt: StablePrompt
     failover: FailoverPlan
     routing: CacheRoutingDecision
     redaction: RedactionReceipt
 
+    @property
+    def cross_provider_routing(self) -> bool:
+        """Return whether an executable target escaped the provider boundary."""
+        return any(
+            target.provider != self.source_provider
+            for target in self.failover.attempts
+        )
+
+    def allows_automatic_retry(
+        self,
+        state: GatewayAttemptState,
+        *,
+        attempts_completed: int,
+    ) -> bool:
+        """Allow retry only when an authorized pristine attempt can continue."""
+        if (
+            isinstance(attempts_completed, bool)
+            or not isinstance(attempts_completed, int)
+            or attempts_completed < 0
+        ):
+            raise ValueError("attempts_completed must be a non-negative integer")
+        return (
+            0 < attempts_completed < len(self.failover.attempts)
+            and state.automatic_retry_allowed
+        )
+
 
 class GatewayControlPlane:
     """Coordinate redaction, capabilities, cache routing, and accounting.
 
-    The class performs no network I/O. A transport executes the failover targets
-    in order, then feeds provider-reported usage into observe_response.
+    The class performs no network I/O. It intentionally produces executable
+    plans containing targets from the original provider only. A transport may
+    execute those targets in order and feed provider-reported usage into
+    :meth:`observe_response`, but it must also honor
+    :class:`GatewayAttemptState` before retrying.
+
+    Cross-provider routing is deliberately outside this control plane. Moving a
+    request to another provider changes the credential, data recipient, terms,
+    retention, region, and billing boundary and therefore requires a separate,
+    explicit operator-authorized feature rather than an automatic fallback.
     """
 
     def __init__(
@@ -56,11 +127,55 @@ class GatewayControlPlane:
         self.redaction_policy = redaction_policy or GatewayRedactionPolicy()
         self.usage_ledger = usage_ledger
 
+    def _same_provider_failover(
+        self,
+        request: CanonicalGatewayRequest,
+        targets: Iterable[ProviderTarget],
+        *,
+        source_provider: str,
+        preferred_key: str,
+        excluded_keys: Iterable[str] = (),
+    ) -> FailoverPlan:
+        """Build a failover plan without crossing the provider boundary."""
+        target_choices = list(targets)
+        target_keys = [target.key for target in target_choices]
+        if len(set(target_keys)) != len(target_keys):
+            raise ValueError("provider target keys must be unique")
+
+        same_provider = [
+            target
+            for target in target_choices
+            if target.provider == source_provider
+        ]
+        cross_provider_excluded = {
+            target.key: _CROSS_PROVIDER_DISABLED
+            for target in target_choices
+            if target.provider != source_provider
+        }
+        if not same_provider:
+            raise RuntimeError(
+                "no same-provider target is available; "
+                "cross-provider routing is disabled"
+            )
+
+        plan = self.failover_planner.plan(
+            request,
+            same_provider,
+            preferred_key=preferred_key,
+            excluded_keys=excluded_keys,
+        )
+        return FailoverPlan(
+            attempts=plan.attempts,
+            excluded={**cross_provider_excluded, **dict(plan.excluded)},
+            required_capabilities=plan.required_capabilities,
+        )
+
     def plan(
         self,
         request: CanonicalGatewayRequest,
         *,
         stable_prompt: StablePrompt,
+        source_provider: str,
         current_model: str,
         candidates: Iterable[ModelCandidate],
         targets: Iterable[ProviderTarget],
@@ -73,6 +188,9 @@ class GatewayControlPlane:
         provider_failed: bool = False,
         now: float | None = None,
     ) -> GatewayExecutionPlan:
+        if not isinstance(source_provider, str) or not source_provider.strip():
+            raise ValueError("source_provider is required")
+
         redacted_request, request_receipt = self.redaction_policy.apply(request)
         redacted_prefix, prefix_receipt = self.redaction_policy.redact_text(
             stable_prompt.stable_prefix
@@ -81,17 +199,30 @@ class GatewayControlPlane:
             stable_prompt.dynamic_tail
         )
         prompt_findings = prefix_receipt.findings + tail_receipt.findings
-        if redacted_prefix != stable_prompt.stable_prefix or redacted_tail != stable_prompt.dynamic_tail:
+        if (
+            redacted_prefix != stable_prompt.stable_prefix
+            or redacted_tail != stable_prompt.dynamic_tail
+        ):
             stable_prompt = StablePrompt(
                 stable_prefix=redacted_prefix,
                 dynamic_tail=redacted_tail,
-                prefix_hash=hashlib.sha256(redacted_prefix.encode("utf-8")).hexdigest(),
+                prefix_hash=hashlib.sha256(
+                    redacted_prefix.encode("utf-8")
+                ).hexdigest(),
                 version=stable_prompt.version,
                 section_names=stable_prompt.section_names,
             )
         redaction_receipt = RedactionReceipt(
-            enabled=request_receipt.enabled or prefix_receipt.enabled or tail_receipt.enabled,
-            changed=request_receipt.changed or prefix_receipt.changed or tail_receipt.changed,
+            enabled=(
+                request_receipt.enabled
+                or prefix_receipt.enabled
+                or tail_receipt.enabled
+            ),
+            changed=(
+                request_receipt.changed
+                or prefix_receipt.changed
+                or tail_receipt.changed
+            ),
             findings=request_receipt.findings + prompt_findings,
         )
         choices = list(candidates)
@@ -102,11 +233,21 @@ class GatewayControlPlane:
         if len(current_matches) != 1:
             raise ValueError("current_model must identify exactly one candidate")
         current = current_matches[0]
+        if current.provider != source_provider:
+            raise ValueError(
+                "source_provider does not match the current model candidate"
+            )
 
-        failover = self.failover_planner.plan(
+        if provider_failed:
+            raise RuntimeError(
+                "source provider failed; cross-provider routing is disabled"
+            )
+
+        failover = self._same_provider_failover(
             redacted_request,
             target_choices,
-            preferred_key=f"{current.provider}:{current.model}",
+            source_provider=source_provider,
+            preferred_key=f"{source_provider}:{current.model}",
         )
         compatible = {target.key for target in failover.attempts}
         routed_candidates = [
@@ -139,35 +280,39 @@ class GatewayControlPlane:
             risk=risk,
             expected_turns=expected_turns,
             force_model=force_model,
-            provider_failed=provider_failed,
+            provider_failed=False,
             now=now,
         )
-        failed_provider_keys = (
-            {
-                target.key
-                for target in target_choices
-                if provider_failed and target.provider == current.provider
-            }
-        )
-        failover = self.failover_planner.plan(
+        if routing.selected_provider != source_provider:
+            raise RuntimeError("cross-provider routing is disabled")
+
+        failover = self._same_provider_failover(
             redacted_request,
             target_choices,
-            preferred_key=f"{routing.selected_provider}:{routing.selected_model}",
-            excluded_keys=failed_provider_keys,
+            source_provider=source_provider,
+            preferred_key=(
+                f"{routing.selected_provider}:{routing.selected_model}"
+            ),
         )
         if failover.primary.key != (
             f"{routing.selected_provider}:{routing.selected_model}"
         ):
-            raise RuntimeError("routed model is absent from the executable failover plan")
+            raise RuntimeError(
+                "routed model is absent from the executable failover plan"
+            )
 
-        return GatewayExecutionPlan(
+        plan = GatewayExecutionPlan(
             conversation_id=conversation_id,
+            source_provider=source_provider,
             request=redacted_request,
             stable_prompt=stable_prompt,
             failover=failover,
             routing=routing,
             redaction=redaction_receipt,
         )
+        if plan.cross_provider_routing:
+            raise RuntimeError("cross-provider executable target escaped policy")
+        return plan
 
     def observe_response(
         self,
@@ -185,6 +330,15 @@ class GatewayControlPlane:
         project: str = "",
         metadata: Mapping[str, Any] | None = None,
     ) -> UsageEvent:
+        if provider != plan.source_provider:
+            raise ValueError(
+                "response provider does not match the plan source provider"
+            )
+        observed_key = f"{provider}:{model}"
+        executable_keys = {target.key for target in plan.failover.attempts}
+        if observed_key not in executable_keys:
+            raise ValueError("response target was not present in the execution plan")
+
         usage = parse_provider_usage(provider, usage_payload)
         timestamp = time.time() if observed_at is None else observed_at
         self.cache_router.observe(
@@ -234,4 +388,8 @@ class GatewayControlPlane:
         )
 
 
-__all__ = ["GatewayControlPlane", "GatewayExecutionPlan"]
+__all__ = [
+    "GatewayAttemptState",
+    "GatewayControlPlane",
+    "GatewayExecutionPlan",
+]

--- a/tests/test_gateway_control_plane.py
+++ b/tests/test_gateway_control_plane.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
 from entroly.cache_routing import CachePrice, ModelCandidate
-from entroly.gateway_control_plane import GatewayControlPlane
+from entroly.gateway_control_plane import (
+    GatewayAttemptState,
+    GatewayControlPlane,
+)
 from entroly.provider_policy import (
     CanonicalGatewayRequest,
     Capability,
@@ -50,6 +55,7 @@ def test_control_plane_composes_policy_routing_cache_and_ledger() -> None:
     plan = control.plan(
         request,
         stable_prompt=prompt,
+        source_provider="openai",
         current_model="primary",
         candidates=candidates,
         targets=targets,
@@ -59,6 +65,11 @@ def test_control_plane_composes_policy_routing_cache_and_ledger() -> None:
     )
     assert "[REDACTED_EMAIL]" in plan.request.messages[1]["content"]
     assert plan.redaction.changed
+    assert plan.source_provider == "openai"
+    assert not plan.cross_provider_routing
+    assert plan.failover.excluded["anthropic:backup"] == (
+        "cross_provider_disabled"
+    )
 
     event = control.observe_response(
         plan,
@@ -88,7 +99,202 @@ def test_control_plane_composes_policy_routing_cache_and_ledger() -> None:
     ledger.close()
 
 
-def test_routed_target_is_first_executable_attempt() -> None:
+def test_same_provider_routed_target_is_first_executable_attempt() -> None:
+    control = GatewayControlPlane()
+    request = CanonicalGatewayRequest(
+        model="primary",
+        messages=({"role": "user", "content": "routine task"},),
+    )
+    prompt = CanonicalPrefixBuilder().add("policy", "stable").build()
+    candidates = [
+        ModelCandidate(
+            "primary",
+            "openai",
+            CachePrice(20, 2, 40),
+            quality=1.0,
+        ),
+        ModelCandidate(
+            "backup",
+            "openai",
+            CachePrice(1, 0.1, 2),
+            quality=1.0,
+        ),
+    ]
+    targets = [
+        ProviderTarget("openai", "primary", frozenset({Capability.CHAT})),
+        ProviderTarget("openai", "backup", frozenset({Capability.CHAT})),
+    ]
+
+    plan = control.plan(
+        request,
+        stable_prompt=prompt,
+        source_provider="openai",
+        current_model="primary",
+        candidates=candidates,
+        targets=targets,
+        prefix_tokens=10_000,
+        new_input_tokens=100,
+        expected_output_tokens=100,
+    )
+
+    assert plan.routing.selected_model == "backup"
+    assert plan.failover.primary.key == "openai:backup"
+    assert not plan.cross_provider_routing
+
+
+def test_source_provider_must_match_current_candidate() -> None:
+    control = GatewayControlPlane()
+    request = CanonicalGatewayRequest(
+        model="primary",
+        messages=({"role": "user", "content": "routine task"},),
+    )
+    prompt = CanonicalPrefixBuilder().add("policy", "stable").build()
+    candidate = ModelCandidate(
+        "primary",
+        "openai",
+        CachePrice(10, 1, 20),
+        quality=1.0,
+    )
+    target = ProviderTarget(
+        "openai",
+        "primary",
+        frozenset({Capability.CHAT}),
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        control.plan(
+            request,
+            stable_prompt=prompt,
+            source_provider="anthropic",
+            current_model="primary",
+            candidates=[candidate],
+            targets=[target],
+        )
+
+
+def test_duplicate_provider_targets_are_rejected() -> None:
+    control = GatewayControlPlane()
+    request = CanonicalGatewayRequest(
+        model="primary",
+        messages=({"role": "user", "content": "routine task"},),
+    )
+    prompt = CanonicalPrefixBuilder().add("policy", "stable").build()
+    candidate = ModelCandidate(
+        "primary",
+        "openai",
+        CachePrice(10, 1, 20),
+        quality=1.0,
+    )
+    duplicate = ProviderTarget(
+        "openai",
+        "primary",
+        frozenset({Capability.CHAT}),
+    )
+
+    with pytest.raises(ValueError, match="keys must be unique"):
+        control.plan(
+            request,
+            stable_prompt=prompt,
+            source_provider="openai",
+            current_model="primary",
+            candidates=[candidate],
+            targets=[duplicate, duplicate],
+        )
+
+
+def test_cheaper_cross_provider_target_is_excluded_by_policy() -> None:
+    control = GatewayControlPlane()
+    request = CanonicalGatewayRequest(
+        model="primary",
+        messages=({"role": "user", "content": "routine task"},),
+    )
+    prompt = CanonicalPrefixBuilder().add("policy", "stable").build()
+    candidates = [
+        ModelCandidate(
+            "primary",
+            "openai",
+            CachePrice(20, 2, 40),
+            quality=1.0,
+        ),
+        ModelCandidate(
+            "cheap-backup",
+            "anthropic",
+            CachePrice(0.1, 0.01, 0.2),
+            quality=1.0,
+        ),
+    ]
+    targets = [
+        ProviderTarget("openai", "primary", frozenset({Capability.CHAT})),
+        ProviderTarget(
+            "anthropic",
+            "cheap-backup",
+            frozenset({Capability.CHAT}),
+        ),
+    ]
+
+    plan = control.plan(
+        request,
+        stable_prompt=prompt,
+        source_provider="openai",
+        current_model="primary",
+        candidates=candidates,
+        targets=targets,
+        prefix_tokens=10_000,
+        new_input_tokens=100,
+        expected_output_tokens=100,
+    )
+
+    assert plan.routing.selected_provider == "openai"
+    assert plan.routing.selected_model == "primary"
+    assert [target.provider for target in plan.failover.attempts] == ["openai"]
+    assert plan.failover.excluded["anthropic:cheap-backup"] == (
+        "cross_provider_disabled"
+    )
+
+
+def test_forced_model_cannot_bypass_cross_provider_boundary() -> None:
+    control = GatewayControlPlane()
+    request = CanonicalGatewayRequest(
+        model="primary",
+        messages=({"role": "user", "content": "routine task"},),
+    )
+    prompt = CanonicalPrefixBuilder().add("policy", "stable").build()
+    candidates = [
+        ModelCandidate(
+            "primary",
+            "openai",
+            CachePrice(20, 2, 40),
+            quality=1.0,
+        ),
+        ModelCandidate(
+            "forced-backup",
+            "anthropic",
+            CachePrice(1, 0.1, 2),
+            quality=1.0,
+        ),
+    ]
+    targets = [
+        ProviderTarget("openai", "primary", frozenset({Capability.CHAT})),
+        ProviderTarget(
+            "anthropic",
+            "forced-backup",
+            frozenset({Capability.CHAT}),
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="not an eligible candidate"):
+        control.plan(
+            request,
+            stable_prompt=prompt,
+            source_provider="openai",
+            current_model="primary",
+            candidates=candidates,
+            targets=targets,
+            force_model="forced-backup",
+        )
+
+
+def test_provider_failure_does_not_escape_to_another_provider() -> None:
     control = GatewayControlPlane()
     request = CanonicalGatewayRequest(
         model="primary",
@@ -114,19 +320,142 @@ def test_routed_target_is_first_executable_attempt() -> None:
         ProviderTarget("anthropic", "backup", frozenset({Capability.CHAT})),
     ]
 
+    with pytest.raises(RuntimeError, match="cross-provider routing is disabled"):
+        control.plan(
+            request,
+            stable_prompt=prompt,
+            source_provider="openai",
+            current_model="primary",
+            candidates=candidates,
+            targets=targets,
+            provider_failed=True,
+        )
+
+
+def test_automatic_retry_is_denied_without_explicit_replay_authorization() -> None:
+    control = GatewayControlPlane()
+    request = CanonicalGatewayRequest(
+        model="primary",
+        messages=({"role": "user", "content": "routine task"},),
+    )
+    prompt = CanonicalPrefixBuilder().add("policy", "stable").build()
+    candidates = [
+        ModelCandidate(
+            "primary",
+            "openai",
+            CachePrice(20, 2, 40),
+            quality=1.0,
+        ),
+        ModelCandidate(
+            "backup",
+            "openai",
+            CachePrice(1, 0.1, 2),
+            quality=1.0,
+        ),
+    ]
+    targets = [
+        ProviderTarget("openai", "primary", frozenset({Capability.CHAT})),
+        ProviderTarget("openai", "backup", frozenset({Capability.CHAT})),
+    ]
     plan = control.plan(
         request,
         stable_prompt=prompt,
+        source_provider="openai",
         current_model="primary",
         candidates=candidates,
         targets=targets,
-        prefix_tokens=10_000,
-        new_input_tokens=100,
-        expected_output_tokens=100,
+    )
+    explicitly_safe = GatewayAttemptState(
+        replay_authorized=True,
+        side_effect_possible=False,
     )
 
-    assert plan.routing.selected_model == "backup"
-    assert plan.failover.primary.key == "anthropic:backup"
+    assert not plan.allows_automatic_retry(
+        GatewayAttemptState(),
+        attempts_completed=1,
+    )
+    assert not plan.allows_automatic_retry(
+        explicitly_safe,
+        attempts_completed=0,
+    )
+    assert plan.allows_automatic_retry(
+        explicitly_safe,
+        attempts_completed=1,
+    )
+    assert not plan.allows_automatic_retry(
+        explicitly_safe,
+        attempts_completed=2,
+    )
+    assert not plan.allows_automatic_retry(
+        GatewayAttemptState(
+            replay_authorized=True,
+            response_started=True,
+            side_effect_possible=False,
+        ),
+        attempts_completed=1,
+    )
+    assert not plan.allows_automatic_retry(
+        GatewayAttemptState(
+            replay_authorized=True,
+            tool_call_started=True,
+            side_effect_possible=False,
+        ),
+        attempts_completed=1,
+    )
+    assert not plan.allows_automatic_retry(
+        GatewayAttemptState(replay_authorized=True),
+        attempts_completed=1,
+    )
+    for invalid in (-1, 1.5, True):
+        with pytest.raises(ValueError, match="non-negative integer"):
+            plan.allows_automatic_retry(
+                explicitly_safe,
+                attempts_completed=invalid,
+            )
+    with pytest.raises(TypeError, match="must be booleans"):
+        GatewayAttemptState(replay_authorized=1)
+
+
+def test_observation_rejects_a_different_provider() -> None:
+    control = GatewayControlPlane()
+    request = CanonicalGatewayRequest(
+        model="primary",
+        messages=({"role": "user", "content": "routine task"},),
+    )
+    prompt = CanonicalPrefixBuilder().add("policy", "stable").build()
+    candidate = ModelCandidate(
+        "primary",
+        "openai",
+        CachePrice(10, 1, 20),
+        quality=1.0,
+    )
+    target = ProviderTarget(
+        "openai",
+        "primary",
+        frozenset({Capability.CHAT}),
+    )
+    plan = control.plan(
+        request,
+        stable_prompt=prompt,
+        source_provider="openai",
+        current_model="primary",
+        candidates=[candidate],
+        targets=[target],
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        control.observe_response(
+            plan,
+            request_id="wrong-provider",
+            provider="anthropic",
+            model="backup",
+            usage_payload={"usage": {}},
+            pricing=UsagePricing.from_values(
+                input_per_million=1,
+                cache_read_per_million=1,
+                output_per_million=1,
+            ),
+        )
 
 
 def test_redaction_covers_stable_and_dynamic_prompt_content() -> None:
@@ -157,6 +486,7 @@ def test_redaction_covers_stable_and_dynamic_prompt_content() -> None:
     plan = control.plan(
         request,
         stable_prompt=original,
+        source_provider="openai",
         current_model="primary",
         candidates=[candidate],
         targets=[target],
@@ -191,6 +521,7 @@ def test_cache_creation_observation_warms_next_turn() -> None:
     plan = control.plan(
         request,
         stable_prompt=prompt,
+        source_provider="anthropic",
         current_model="claude",
         candidates=[candidate],
         targets=[target],


### PR DESCRIPTION
## Summary

- constrain `GatewayControlPlane` executable attempts to the inbound request's explicitly identified provider
- record every removed cross-provider target as `cross_provider_disabled`
- fail closed when the source provider is marked failed
- reject source-provider mismatches, duplicate provider/model targets, and cross-provider `force_model` attempts
- reject usage observations from an unplanned provider/model target
- deny retry by default; require explicit replay-safety authorization, no possible side effect, no response/tool progress, and a distinct target remaining
- add an evidence ledger and align provider/privacy documentation with the enforced behavior

## Why

The control plane already had capability-aware planning, cache economics, redaction, and usage accounting, but a future live proxy integration could otherwise interpret its target list as permission to move data between providers or replay a request whose outcome is uncertain. Either behavior can change the data recipient, credential, contract, retention, region, billing, or side-effect boundary.

This PR deliberately does **not** wire the control plane into `PromptCompilerProxy`, enable cross-provider routing, change provider credentials, or publish a release.

## Evidence encoded

Focused regression tests encode these invariants:

- the adapter-detected source provider must match the current candidate
- duplicate targets cannot manufacture retry capacity
- a cheaper cross-provider target remains non-executable
- `force_model` cannot cross the provider boundary
- provider failure does not escape to another provider
- same-provider optimization remains available
- retry is denied without explicit replay-safety proof
- retry remains denied after response/tool progress, possible side effects, or target exhaustion
- accounting rejects an unplanned provider
- existing redaction, cache observation, and ledger composition remain intact

See `docs/gateway-provider-boundary.md` for the exact supported claims and non-claims.

## Validation required

```bash
python -m pytest -q tests/test_gateway_control_plane.py tests/test_provider_policy.py
python -m ruff check entroly/gateway_control_plane.py tests/test_gateway_control_plane.py
```

The PR must remain draft and unmerged until the focused tests and repository CI are green. I could not execute the suite locally in the current environment because outbound DNS access to GitHub is unavailable, so this PR does not claim test success yet.
