### PR TITLE
feat(gateway): add bounded proxy shadow observability

### DIFF
--- a/docs/gateway-provider-boundary.md
+++ b/docs/gateway-provider-boundary.md
@@ -1,7 +1,7 @@
 # Gateway provider boundary
 
 This document defines the safety and claim boundary for
-`GatewayControlPlane` and any future integration with `PromptCompilerProxy`.
+`GatewayControlPlane` and its integration with `PromptCompilerProxy`.
 
 ## Supported execution boundary
 
@@ -33,8 +33,8 @@ caller cannot manufacture extra retry capacity for the same billable target.
 ## Retry boundary
 
 The control plane does not perform network I/O or retries. It exposes
-`GatewayAttemptState` for a future transport integration. Retry is denied by
-default. Automatic retry is permitted only when:
+`GatewayAttemptState` for a future authoritative transport integration. Retry is
+denied by default. Automatic retry is permitted only when:
 
 - the transport explicitly sets `replay_authorized=True` after proving replay is
   safe for this request;
@@ -58,9 +58,53 @@ list as safely replayable.
 Usage from an unplanned target is rejected instead of being silently attributed
 to the run.
 
+## Live shadow integration
+
+`proxy_gateway_shadow.py` connects `GatewayControlPlane` to the live
+`PromptCompilerProxy` as a **non-authoritative observer**. The existing proxy
+continues to choose the provider, model, target URL, credentials, retry behavior,
+and response returned to the client.
+
+For supported JSON requests handled by `PromptCompilerProxy.handle_proxy`,
+shadow mode can record:
+
+- one opaque gateway run ID and attempt ID;
+- the source and planned same-provider model;
+- the routing reason and plan hash;
+- planning and proxy-admission latency;
+- response admission status;
+- how many targets were excluded by policy.
+
+Shadow planning is installed behind the hardened request-body gate. The existing
+transport bounds and caches the body before the observer can parse it, so shadow
+mode cannot bypass the proxy's memory limit.
+
+Shadow records are bounded in memory and contain no prompt, message, tool schema,
+authorization header, API key, or raw request ID. The inbound request ID is kept
+only as a short, process-salted one-way digest for local correlation. The
+protected local `GET /gateway-shadow` sidecar endpoint exposes aggregate counters
+and recent metadata with `Cache-Control: no-store`.
+
+Shadow mode is opt-in:
+
+```text
+ENTROLY_GATEWAY_SHADOW=0
+ENTROLY_GATEWAY_SHADOW_HEADERS=1
+ENTROLY_GATEWAY_SHADOW_MAX_RECORDS=100
+```
+
+Set `ENTROLY_GATEWAY_SHADOW=1` to collect evidence. Set
+`ENTROLY_GATEWAY_SHADOW_HEADERS=0` to keep local observation enabled without
+adding value-free gateway correlation headers to proxy responses.
+
+A shadow recommendation is evidence only. A `would-switch` decision never
+changes the request executed by the existing proxy. It is emitted only when the
+configured pricing catalog contains auditable prices for both the current and
+alternate model; missing pricing fails closed to a stay decision.
+
 ## Evidence
 
-The executable evidence is in `tests/test_gateway_control_plane.py`.
+The control-plane evidence is in `tests/test_gateway_control_plane.py`.
 
 | Invariant | Test evidence |
 | --- | --- |
@@ -74,16 +118,35 @@ The executable evidence is in `tests/test_gateway_control_plane.py`.
 | Usage from a different provider is rejected | `test_observation_rejects_a_different_provider` |
 | Redaction, routing, cache observation, and ledger composition remain intact | `test_control_plane_composes_policy_routing_cache_and_ledger` |
 
-Run the focused evidence suite with:
+The live shadow evidence is in `tests/test_proxy_gateway_shadow.py`.
+
+| Invariant | Test evidence |
+| --- | --- |
+| The original request remains JSON-semantically unchanged for execution | `test_shadow_observation_keeps_the_legacy_proxy_authoritative` |
+| Missing pricing cannot manufacture a model-switch recommendation | `test_shadow_does_not_invent_switch_without_auditable_pricing` |
+| Same-provider alternatives can be reported without execution | `test_shadow_can_report_a_same_provider_would_switch_without_executing_it` |
+| Unknown advanced-capability parity excludes an alternate model | `test_advanced_capability_request_keeps_unknown_alternate_out` |
+| Prompt and authentication content never enter shadow records | `test_shadow_records_do_not_store_prompt_or_authentication_content` |
+| Shadow failures cannot block the authoritative proxy | `test_shadow_failure_never_blocks_the_authoritative_proxy` |
+| Shadow parsing remains behind the bounded transport handler | `test_shadow_installs_behind_the_bounded_transport_handler` |
+
+Run the focused evidence suites with:
 
 ```bash
-python -m pytest -q tests/test_gateway_control_plane.py tests/test_provider_policy.py
-python -m ruff check entroly/gateway_control_plane.py tests/test_gateway_control_plane.py
+python -m pytest -q \
+  tests/test_gateway_control_plane.py \
+  tests/test_provider_policy.py \
+  tests/test_proxy_gateway_shadow.py
+python -m ruff check \
+  entroly/gateway_control_plane.py \
+  entroly/proxy_gateway_shadow.py \
+  tests/test_gateway_control_plane.py \
+  tests/test_proxy_gateway_shadow.py
 ```
 
-Before merging a live proxy integration, also run the proxy transport, provider,
-streaming, tool-call, and accounting suites. The focused tests above prove the
-control-plane policy only; they do not prove the complete HTTP execution path.
+Before an authoritative proxy integration, also run the full proxy transport,
+provider, streaming, tool-call, accounting, and user-journey suites. The focused
+tests prove policy and shadow isolation; they do not authorize live routing.
 
 ## Claims this evidence supports
 
@@ -96,7 +159,10 @@ The repository may claim that:
 - provider failure fails closed rather than changing the data recipient;
 - duplicate targets cannot create artificial retry capacity;
 - retry is denied by default and requires explicit replay-safety proof;
-- response accounting rejects provider/model pairs outside the execution plan.
+- response accounting rejects provider/model pairs outside the execution plan;
+- the live proxy can collect bounded gateway shadow evidence without making the
+  gateway planner authoritative;
+- shadow planning failures do not block provider requests.
 
 ## Claims this evidence does not support
 
@@ -108,16 +174,19 @@ This evidence does **not** establish:
 - permission to use consumer subscription credentials as API credentials;
 - safe cross-provider transformation of tools, schemas, vision, reasoning, cache
   controls, or streaming events;
-- production readiness of a future `PromptCompilerProxy` integration.
+- safety of automatic provider switching or automatic retry;
+- production readiness of an authoritative `PromptCompilerProxy` routing
+  integration.
 
 Those claims require separate provider-specific conformance, credential,
-contract, data-residency, and end-to-end transport evidence.
+contract, data-residency, replay-safety, and end-to-end transport evidence.
 
-## Integration requirements
+## Requirements before authoritative routing
 
-A future `PromptCompilerProxy` integration must preserve these rules:
+Any future authoritative `PromptCompilerProxy` integration must preserve these
+rules:
 
-1. Run the gateway in shadow mode before it becomes authoritative.
+1. Review shadow evidence before enabling execution authority.
 2. Keep one routing authority; do not apply both legacy routing and gateway
    routing to the same request.
 3. Pass the adapter-detected provider explicitly as `source_provider`.

--- a/entroly/compression_proxy_live.py
+++ b/entroly/compression_proxy_live.py
@@ -19,14 +19,47 @@ from typing import Any
 # This module is itself optional and imported behind an ImportError guard by the
 # package root. Activating proxy hardening here keeps base MCP/recovery installs
 # independent of HTTP extras while protecting every live proxy construction path.
+# Import order is a security and observability contract: transport and access
+# hardening are installed before the non-authoritative gateway shadow wrapper.
+from . import proxy as _proxy
 from . import proxy_transport_safe as _proxy_transport_safe  # noqa: F401
 from . import proxy_transport_final as _proxy_transport_final  # noqa: F401
 from . import proxy_control_plane_safe as _proxy_control_plane_safe  # noqa: F401
-from . import proxy_access_security as _proxy_access_security  # noqa: F401
+from . import proxy_access_security as _proxy_access_security
+from . import proxy_gateway_shadow as _proxy_gateway_shadow
 from .compression_proxy import compress_proxy_payload_from_env
 
 _INSTALLED = False
 _ORIGINAL: Callable[..., tuple[list[dict[str, Any]], int]] | None = None
+
+
+def _install_gateway_shadow_factory_seam() -> None:
+    """Install the shadow route without replacing the public security factory.
+
+    ``proxy_access_security.create_proxy_app`` is an intentional identity and
+    trust contract.  Its implementation resolves ``_ORIGINAL_CREATE_PROXY_APP``
+    at call time, so the shadow route belongs behind that private seam rather
+    than above the public function.
+    """
+
+    current = _proxy_access_security._ORIGINAL_CREATE_PROXY_APP
+    original = getattr(
+        current,
+        "__entroly_gateway_shadow_original__",
+        current,
+    )
+
+    def shadow_inner_factory(*args: Any, **kwargs: Any):
+        app = original(*args, **kwargs)
+        _proxy_gateway_shadow._install_route(app)
+        return app
+
+    shadow_inner_factory.__entroly_gateway_shadow_original__ = original
+    _proxy_access_security._ORIGINAL_CREATE_PROXY_APP = shadow_inner_factory
+    _proxy.create_proxy_app = _proxy_access_security.create_proxy_app
+
+
+_install_gateway_shadow_factory_seam()
 
 
 def install_live_compression_proxy() -> bool:

--- a/entroly/proxy_gateway_shadow.py
+++ b/entroly/proxy_gateway_shadow.py
@@ -1,0 +1,593 @@
+"""Non-authoritative gateway planning and unified proxy attempt observability.
+
+This module patches the live ``PromptCompilerProxy`` at the same explicit
+hardening seam used by the transport layers.  It observes provider requests,
+runs ``GatewayControlPlane`` in shadow mode, and records bounded metadata only.
+It never mutates the request body, target URL, model, provider, credentials,
+retry behavior, or response body.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from collections import deque
+from dataclasses import asdict, dataclass
+from typing import Any, Awaitable, Callable, Mapping
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from .cache_routing import CacheAwareRouter, CachePrice, ModelCandidate
+from .gateway_control_plane import GatewayControlPlane
+from .provider_adapters import (
+    ProviderRequestAdapterResult,
+    canonical_request_from_provider_body,
+)
+from .provider_policy import Capability, ProviderTarget
+from .proxy_transform import detect_provider
+from .stable_prefix import CanonicalPrefixBuilder, StablePrompt
+
+logger = logging.getLogger("entroly.gateway_shadow")
+
+_SCHEMA_VERSION = "entroly.gateway-shadow.v1"
+_DEFAULT_MAX_RECORDS = 100
+_MAX_RECORDS_LIMIT = 1_000
+_MAX_REQUEST_BYTES = 16 * 1024 * 1024
+_CORRELATION_SALT = os.urandom(32)
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,256}$")
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().casefold()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+    return default
+
+
+def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw = os.environ.get(name)
+    try:
+        value = default if raw is None else int(raw)
+    except (TypeError, ValueError, OverflowError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        value = default
+    return max(minimum, min(value, maximum))
+
+
+def _bounded_identifier(value: object, *, fallback: str) -> str:
+    text = str(value or "").strip()
+    if _SAFE_ID_RE.fullmatch(text):
+        return text
+    return fallback
+
+
+def _correlation_digest(value: str) -> str:
+    return hashlib.sha256(
+        _CORRELATION_SALT + value.encode("utf-8", errors="replace")
+    ).hexdigest()[:16]
+
+
+def _last_user_content(adapter: ProviderRequestAdapterResult) -> Any:
+    for message in reversed(adapter.canonical.messages):
+        if str(message.get("role", "")) == "user":
+            return message.get("content", "")
+    return ""
+
+
+def _stable_prompt(adapter: ProviderRequestAdapterResult) -> StablePrompt:
+    builder = CanonicalPrefixBuilder(
+        namespace="entroly-gateway-shadow",
+        version="1",
+    )
+    for message in adapter.canonical.messages:
+        if str(message.get("role", "")) == "system":
+            builder.add("system", message.get("content", ""), priority=10)
+            break
+    if adapter.canonical.tools:
+        builder.add_tools(adapter.canonical.tools, priority=20)
+    return builder.build(dynamic_tail=_last_user_content(adapter))
+
+
+def _catalog_price(proxy: Any, provider: str, model: str) -> CachePrice | None:
+    catalog = getattr(proxy, "_pricing_catalog", None)
+    pricing = catalog.resolve(provider, model) if catalog is not None else None
+    if pricing is None:
+        return None
+    return CachePrice(
+        input_per_million=float(pricing.input_per_million),
+        cache_read_per_million=float(pricing.cache_read_per_million),
+        output_per_million=float(pricing.output_per_million),
+        cache_write_per_million=float(pricing.cache_write_rate),
+    )
+
+
+def _provider_known_capabilities(provider: str) -> frozenset[Capability]:
+    # Provider-wide declarations are intentionally conservative. Unknown
+    # schema, reasoning, and cache-control parity keeps alternate models out.
+    from .proxy_config import provider_capability
+
+    profile = provider_capability(provider)
+    capabilities = {Capability.CHAT, Capability.STREAMING}
+    if profile.supports_tools:
+        capabilities.add(Capability.TOOLS)
+    if profile.supports_vision:
+        capabilities.add(Capability.VISION)
+    return frozenset(capabilities)
+
+
+def _shadow_candidates_and_targets(
+    proxy: Any,
+    adapter: ProviderRequestAdapterResult,
+) -> tuple[tuple[ModelCandidate, ...], tuple[ProviderTarget, ...]]:
+    provider = adapter.provider
+    current_model = adapter.canonical.model
+    required = adapter.canonical.required_capabilities()
+    current_price = _catalog_price(proxy, provider, current_model)
+
+    candidates = [
+        ModelCandidate(
+            model=current_model,
+            provider=provider,
+            price=(
+                current_price
+                if current_price is not None
+                else CachePrice(0.0, 0.0, 0.0, cache_write_per_million=0.0)
+            ),
+            quality=1.0,
+        )
+    ]
+    targets = [
+        ProviderTarget(
+            provider=provider,
+            model=current_model,
+            capabilities=required,
+            priority=0,
+        )
+    ]
+
+    ladder = getattr(proxy, "_escalation_ladder", {})
+    recommendation = ladder.get(current_model) if isinstance(ladder, Mapping) else None
+    alternate_model = (
+        recommendation[0]
+        if isinstance(recommendation, tuple) and recommendation
+        else ""
+    )
+    alternate_price = (
+        _catalog_price(proxy, provider, alternate_model)
+        if isinstance(alternate_model, str) and alternate_model
+        else None
+    )
+    if (
+        isinstance(alternate_model, str)
+        and alternate_model
+        and alternate_model != current_model
+        and _SAFE_ID_RE.fullmatch(alternate_model)
+        and current_price is not None
+        and alternate_price is not None
+        and required.issubset(_provider_known_capabilities(provider))
+    ):
+        candidates.append(
+            ModelCandidate(
+                model=alternate_model,
+                provider=provider,
+                price=alternate_price,
+                quality=1.0,
+            )
+        )
+        targets.append(
+            ProviderTarget(
+                provider=provider,
+                model=alternate_model,
+                capabilities=_provider_known_capabilities(provider),
+                priority=100,
+            )
+        )
+
+    return tuple(candidates), tuple(targets)
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayShadowTicket:
+    run_id: str
+    attempt_id: str
+    plan_id: str
+    request_correlation: str
+    source_provider: str
+    source_model: str
+    planned_provider: str
+    planned_model: str
+    route_reason: str
+    boundary: str
+    streaming: bool
+    excluded_targets: int
+    cross_provider_excluded: int
+    planning_ms: float
+    started_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayShadowRecord:
+    schema_version: str
+    run_id: str
+    attempt_id: str
+    plan_id: str
+    request_correlation: str
+    source_provider: str
+    source_model: str
+    planned_provider: str
+    planned_model: str
+    route_reason: str
+    boundary: str
+    authoritative_path: str
+    streaming: bool
+    excluded_targets: int
+    cross_provider_excluded: int
+    planning_ms: float
+    proxy_admission_ms: float
+    response_status: int | None
+    outcome: str
+    observed_at: float
+
+
+class GatewayShadowObserver:
+    """Thread-safe bounded store for non-authoritative gateway evidence."""
+
+    def __init__(
+        self,
+        *,
+        control_plane: GatewayControlPlane,
+        enabled: bool = True,
+        emit_headers: bool = True,
+        max_records: int = _DEFAULT_MAX_RECORDS,
+    ) -> None:
+        self.control_plane = control_plane
+        self.enabled = bool(enabled)
+        self.emit_headers = bool(emit_headers)
+        self.max_records = max(1, min(int(max_records), _MAX_RECORDS_LIMIT))
+        self._lock = threading.RLock()
+        self._records: deque[GatewayShadowRecord] = deque(maxlen=self.max_records)
+        self._planned = 0
+        self._completed = 0
+        self._skipped = 0
+        self._failures = 0
+        self._would_switch = 0
+        self._last_error_type = ""
+
+    def observe_request(
+        self,
+        proxy: Any,
+        *,
+        body: Mapping[str, Any],
+        headers: Mapping[str, str],
+        path: str,
+        request_id: str,
+    ) -> GatewayShadowTicket | None:
+        if not self.enabled:
+            return None
+
+        started = time.perf_counter()
+        provider = detect_provider(path, dict(headers), dict(body))
+        adapter = canonical_request_from_provider_body(
+            provider,
+            body,
+            headers=headers,
+            path=path,
+        )
+        if not _SAFE_ID_RE.fullmatch(adapter.provider):
+            raise ValueError("shadow provider identifier is not safe bounded text")
+        if not _SAFE_ID_RE.fullmatch(adapter.canonical.model):
+            raise ValueError("shadow model identifier is not safe bounded text")
+        candidates, targets = _shadow_candidates_and_targets(proxy, adapter)
+        prompt = _stable_prompt(adapter)
+        plan = self.control_plane.plan(
+            adapter.canonical,
+            stable_prompt=prompt,
+            source_provider=adapter.provider,
+            current_model=adapter.canonical.model,
+            candidates=candidates,
+            targets=targets,
+            prefix_tokens=adapter.prefix_tokens_estimate,
+            new_input_tokens=adapter.new_input_tokens_estimate,
+            expected_output_tokens=adapter.expected_output_tokens,
+        )
+        planning_ms = (time.perf_counter() - started) * 1000.0
+        run_id = f"gw_{uuid.uuid4().hex[:16]}"
+        attempt_id = f"{run_id}:0"
+        excluded = dict(plan.failover.excluded)
+        cross_provider_excluded = sum(
+            1 for reason in excluded.values() if reason == "cross_provider_disabled"
+        )
+        plan_material = "\0".join(
+            (
+                plan.conversation_id,
+                plan.source_provider,
+                plan.routing.selected_provider,
+                plan.routing.selected_model,
+                plan.routing.reason,
+                plan.stable_prompt.prefix_hash,
+            )
+        )
+        plan_id = hashlib.sha256(plan_material.encode("utf-8")).hexdigest()[:20]
+        ticket = GatewayShadowTicket(
+            run_id=run_id,
+            attempt_id=attempt_id,
+            plan_id=plan_id,
+            request_correlation=_correlation_digest(request_id),
+            source_provider=plan.source_provider,
+            source_model=adapter.canonical.model,
+            planned_provider=plan.routing.selected_provider,
+            planned_model=plan.routing.selected_model,
+            route_reason=plan.routing.reason[:160],
+            boundary="same-provider",
+            streaming=adapter.canonical.stream,
+            excluded_targets=len(excluded),
+            cross_provider_excluded=cross_provider_excluded,
+            planning_ms=round(planning_ms, 3),
+            started_at=time.perf_counter(),
+        )
+        with self._lock:
+            self._planned += 1
+            if ticket.planned_model != ticket.source_model:
+                self._would_switch += 1
+        return ticket
+
+    def complete(
+        self,
+        ticket: GatewayShadowTicket,
+        *,
+        response_status: int | None,
+        outcome: str,
+    ) -> GatewayShadowRecord:
+        elapsed_ms = (time.perf_counter() - ticket.started_at) * 1000.0
+        record = GatewayShadowRecord(
+            schema_version=_SCHEMA_VERSION,
+            run_id=ticket.run_id,
+            attempt_id=ticket.attempt_id,
+            plan_id=ticket.plan_id,
+            request_correlation=ticket.request_correlation,
+            source_provider=ticket.source_provider,
+            source_model=ticket.source_model,
+            planned_provider=ticket.planned_provider,
+            planned_model=ticket.planned_model,
+            route_reason=ticket.route_reason,
+            boundary=ticket.boundary,
+            authoritative_path="legacy-proxy",
+            streaming=ticket.streaming,
+            excluded_targets=ticket.excluded_targets,
+            cross_provider_excluded=ticket.cross_provider_excluded,
+            planning_ms=ticket.planning_ms,
+            proxy_admission_ms=round(elapsed_ms, 3),
+            response_status=response_status,
+            outcome=outcome[:64],
+            observed_at=time.time(),
+        )
+        with self._lock:
+            self._records.append(record)
+            self._completed += 1
+        return record
+
+    def skip(self) -> None:
+        with self._lock:
+            self._skipped += 1
+
+    def fail(self, exc: BaseException) -> None:
+        with self._lock:
+            self._failures += 1
+            self._last_error_type = type(exc).__name__[:80]
+        logger.debug("Gateway shadow observation skipped: %s", type(exc).__name__)
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            records = [asdict(record) for record in self._records]
+            return {
+                "schema_version": _SCHEMA_VERSION,
+                "mode": "shadow",
+                "enabled": self.enabled,
+                "authoritative_path": "legacy-proxy",
+                "request_mutation": False,
+                "provider_switch_execution": False,
+                "automatic_retry_execution": False,
+                "records_contain_prompt_content": False,
+                "planned": self._planned,
+                "completed": self._completed,
+                "skipped": self._skipped,
+                "failures": self._failures,
+                "would_switch": self._would_switch,
+                "last_error_type": self._last_error_type,
+                "max_records": self.max_records,
+                "recent": records,
+            }
+
+
+def _observer_for_proxy(proxy: Any) -> GatewayShadowObserver:
+    observer = getattr(proxy, "_gateway_shadow_observer", None)
+    if isinstance(observer, GatewayShadowObserver):
+        return observer
+
+    cache_router = getattr(proxy, "_cache_router", None)
+    if not isinstance(cache_router, CacheAwareRouter):
+        cache_router = CacheAwareRouter()
+    redaction_policy = getattr(proxy, "_gateway_redaction", None)
+    control_plane = GatewayControlPlane(
+        cache_router=cache_router,
+        redaction_policy=redaction_policy,
+    )
+    observer = GatewayShadowObserver(
+        control_plane=control_plane,
+        enabled=_env_flag("ENTROLY_GATEWAY_SHADOW", default=False),
+        emit_headers=_env_flag("ENTROLY_GATEWAY_SHADOW_HEADERS", default=True),
+        max_records=_env_int(
+            "ENTROLY_GATEWAY_SHADOW_MAX_RECORDS",
+            _DEFAULT_MAX_RECORDS,
+            minimum=1,
+            maximum=_MAX_RECORDS_LIMIT,
+        ),
+    )
+    proxy._gateway_shadow_observer = observer
+    return observer
+
+
+def _shadow_response_headers(ticket: GatewayShadowTicket) -> dict[str, str]:
+    decision = "would-switch" if ticket.planned_model != ticket.source_model else "stay"
+    return {
+        "X-Entroly-Gateway-Shadow": "observed",
+        "X-Entroly-Gateway-Run-Id": ticket.run_id,
+        "X-Entroly-Gateway-Attempt-Id": ticket.attempt_id,
+        "X-Entroly-Gateway-Plan-Id": ticket.plan_id,
+        "X-Entroly-Gateway-Boundary": ticket.boundary,
+        "X-Entroly-Gateway-Decision": decision,
+        "X-Entroly-Gateway-Authoritative": "legacy-proxy",
+    }
+
+
+async def _run_shadow_handle_proxy(
+    proxy: Any,
+    request: Request,
+    original: Callable[[Any, Request], Awaitable[Response]],
+) -> Response:
+    observer = _observer_for_proxy(proxy)
+    ticket: GatewayShadowTicket | None = None
+    if observer.enabled:
+        try:
+            body_bytes = await request.body()
+            if len(body_bytes) > _MAX_REQUEST_BYTES:
+                observer.skip()
+            else:
+                decoded = json.loads(body_bytes)
+                if isinstance(decoded, dict):
+                    headers = {key: value for key, value in request.headers.items()}
+                    request_id = _bounded_identifier(
+                        headers.get("x-request-id"),
+                        fallback=uuid.uuid4().hex[:12],
+                    )
+                    ticket = observer.observe_request(
+                        proxy,
+                        body=decoded,
+                        headers=headers,
+                        path=request.url.path,
+                        request_id=request_id,
+                    )
+                else:
+                    observer.skip()
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            observer.skip()
+        except Exception as exc:
+            observer.fail(exc)
+
+    try:
+        response = await original(proxy, request)
+    except Exception as exc:
+        if ticket is not None:
+            observer.complete(
+                ticket,
+                response_status=None,
+                outcome=f"proxy_exception:{type(exc).__name__}",
+            )
+        raise
+
+    if ticket is not None:
+        observer.complete(
+            ticket,
+            response_status=int(getattr(response, "status_code", 0) or 0),
+            outcome="response_admitted",
+        )
+        if observer.emit_headers:
+            for name, value in _shadow_response_headers(ticket).items():
+                response.headers.setdefault(name, value)
+    return response
+
+
+async def _gateway_shadow_endpoint(request: Request) -> Response:
+    proxy = request.app.state.proxy
+    observer = _observer_for_proxy(proxy)
+    return JSONResponse(
+        observer.snapshot(),
+        headers={
+            "Cache-Control": "no-store, max-age=0",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+def _install_route(app: Any) -> None:
+    routes = getattr(getattr(app, "router", None), "routes", None)
+    if not isinstance(routes, list):
+        return
+    if any(getattr(route, "path", None) == "/gateway-shadow" for route in routes):
+        return
+    from . import proxy as _proxy
+
+    endpoint = _proxy._sidecar_guard(_gateway_shadow_endpoint)
+    routes.insert(
+        0,
+        Route(
+            "/gateway-shadow",
+            endpoint=endpoint,
+            methods=["GET"],
+            name="gateway-shadow",
+        ),
+    )
+
+
+def install_gateway_shadow() -> None:
+    """Install shadow planning behind the existing bounded transport gate."""
+    from . import proxy as _proxy
+    from . import proxy_transport_safe as _transport
+
+    # Keep ``_safe_handle_proxy`` as the class entrypoint. It validates and
+    # bounds the body before calling this module through its runtime-resolved
+    # core-handler global, so shadow mode can never bypass the memory limit.
+    current_core = _transport._ORIGINAL_HANDLE_PROXY
+    original_core = getattr(
+        current_core,
+        "__entroly_gateway_shadow_original__",
+        current_core,
+    )
+
+    async def shadow_core_handle(self: Any, request: Request) -> Response:
+        return await _run_shadow_handle_proxy(self, request, original_core)
+
+    shadow_core_handle.__entroly_gateway_shadow_original__ = original_core
+    _transport._ORIGINAL_HANDLE_PROXY = shadow_core_handle
+
+    current_factory = _proxy.create_proxy_app
+    original_factory = getattr(
+        current_factory,
+        "__entroly_gateway_shadow_original__",
+        current_factory,
+    )
+
+    def shadow_create_proxy_app(*args: Any, **kwargs: Any):
+        app = original_factory(*args, **kwargs)
+        _install_route(app)
+        return app
+
+    shadow_create_proxy_app.__entroly_gateway_shadow_original__ = original_factory
+    _proxy.create_proxy_app = shadow_create_proxy_app
+
+
+install_gateway_shadow()
+
+
+__all__ = [
+    "GatewayShadowObserver",
+    "GatewayShadowRecord",
+    "GatewayShadowTicket",
+    "_gateway_shadow_endpoint",
+    "_run_shadow_handle_proxy",
+    "install_gateway_shadow",
+]

--- a/tests/test_proxy_gateway_shadow.py
+++ b/tests/test_proxy_gateway_shadow.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from types import SimpleNamespace
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from entroly.cache_routing import CacheAwareRouter
+from entroly.gateway_control_plane import GatewayControlPlane
+from entroly.provider_policy import GatewayRedactionPolicy
+from entroly.proxy_gateway_shadow import (
+    GatewayShadowObserver,
+    _install_route,
+    _run_shadow_handle_proxy,
+)
+from entroly.usage_ledger import UsagePricingCatalog
+
+
+def _request(body: dict, *, path: str = "/v1/chat/completions") -> Request:
+    payload = json.dumps(body).encode("utf-8")
+    delivered = False
+
+    async def receive():
+        nonlocal delivered
+        if delivered:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        delivered = True
+        return {"type": "http.request", "body": payload, "more_body": False}
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": [
+            (b"host", b"127.0.0.1:9377"),
+            (b"content-type", b"application/json"),
+            (b"authorization", b"Bearer secret-api-token"),
+            (b"x-request-id", b"request-123"),
+        ],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 9377),
+    }
+    return Request(scope, receive)
+
+
+def _proxy(*, pricing: UsagePricingCatalog | None = None):
+    router = CacheAwareRouter()
+    observer = GatewayShadowObserver(
+        control_plane=GatewayControlPlane(
+            cache_router=router,
+            redaction_policy=GatewayRedactionPolicy(enabled=False),
+        ),
+        max_records=4,
+    )
+    return SimpleNamespace(
+        _cache_router=router,
+        _pricing_catalog=pricing,
+        _gateway_redaction=GatewayRedactionPolicy(enabled=False),
+        _gateway_shadow_observer=observer,
+        _escalation_ladder={"gpt-4o-mini": ("gpt-4o", 6.0)},
+    )
+
+
+def test_shadow_observation_keeps_the_legacy_proxy_authoritative() -> None:
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [
+            {"role": "system", "content": "Keep answers grounded."},
+            {"role": "user", "content": "Explain the change."},
+        ],
+    }
+    original_body = copy.deepcopy(body)
+    request = _request(body)
+    proxy = _proxy()
+    received: dict = {}
+
+    async def original(_proxy, original_request):
+        received.update(await original_request.json())
+        return JSONResponse({"ok": True}, status_code=201)
+
+    response = asyncio.run(_run_shadow_handle_proxy(proxy, request, original))
+
+    assert received == original_body
+    assert response.status_code == 201
+    assert response.headers["x-entroly-gateway-shadow"] == "observed"
+    assert response.headers["x-entroly-gateway-authoritative"] == "legacy-proxy"
+    snapshot = proxy._gateway_shadow_observer.snapshot()
+    assert snapshot["planned"] == 1
+    assert snapshot["completed"] == 1
+    assert snapshot["request_mutation"] is False
+    assert snapshot["provider_switch_execution"] is False
+    assert snapshot["automatic_retry_execution"] is False
+    assert snapshot["recent"][0]["source_provider"] == "openai"
+    assert snapshot["recent"][0]["planned_model"] == "gpt-4o-mini"
+    assert snapshot["recent"][0]["boundary"] == "same-provider"
+    assert response.headers["x-entroly-gateway-decision"] == "stay"
+
+
+def test_shadow_does_not_invent_switch_without_auditable_pricing() -> None:
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [
+            {"role": "system", "content": "policy " * 2_000},
+            {"role": "user", "content": "routine task"},
+        ],
+        "max_tokens": 2_000,
+    }
+    proxy = _proxy()
+    observer = proxy._gateway_shadow_observer
+
+    ticket = observer.observe_request(
+        proxy,
+        body=body,
+        headers={},
+        path="/v1/chat/completions",
+        request_id="unpriced-case",
+    )
+
+    assert ticket is not None
+    assert ticket.planned_model == "gpt-4o-mini"
+    assert observer.snapshot()["would_switch"] == 0
+
+
+def test_shadow_can_report_a_same_provider_would_switch_without_executing_it() -> None:
+    catalog = UsagePricingCatalog.from_mapping(
+        {
+            "source": "test",
+            "models": {
+                "openai:gpt-4o-mini": {
+                    "input_per_million": 100,
+                    "output_per_million": 100,
+                    "cache_read_per_million": 100,
+                },
+                "openai:gpt-4o": {
+                    "input_per_million": 0.01,
+                    "output_per_million": 0.01,
+                    "cache_read_per_million": 0.01,
+                },
+            },
+        }
+    )
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [
+            {"role": "system", "content": "policy " * 2_000},
+            {"role": "user", "content": "routine task"},
+        ],
+        "max_tokens": 2_000,
+    }
+    proxy = _proxy(pricing=catalog)
+    observer = proxy._gateway_shadow_observer
+
+    ticket = observer.observe_request(
+        proxy,
+        body=body,
+        headers={"x-request-id": "switch-case"},
+        path="/v1/chat/completions",
+        request_id="switch-case",
+    )
+
+    assert ticket is not None
+    assert ticket.source_provider == "openai"
+    assert ticket.planned_provider == "openai"
+    assert ticket.source_model == "gpt-4o-mini"
+    assert ticket.planned_model == "gpt-4o"
+    assert observer.snapshot()["would_switch"] == 1
+
+
+def test_advanced_capability_request_keeps_unknown_alternate_out() -> None:
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Return structured data"}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "answer", "schema": {"type": "object"}},
+        },
+    }
+    proxy = _proxy()
+    observer = proxy._gateway_shadow_observer
+
+    ticket = observer.observe_request(
+        proxy,
+        body=body,
+        headers={},
+        path="/v1/chat/completions",
+        request_id="schema-case",
+    )
+
+    assert ticket is not None
+    assert ticket.planned_model == "gpt-4o-mini"
+    assert ticket.excluded_targets == 0
+
+
+def test_shadow_records_do_not_store_prompt_or_authentication_content() -> None:
+    secret = "super-secret-prompt-value"
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": secret}],
+    }
+    proxy = _proxy()
+    request = _request(body)
+
+    async def original(_proxy, _request):
+        return JSONResponse({"ok": True})
+
+    asyncio.run(_run_shadow_handle_proxy(proxy, request, original))
+    rendered = json.dumps(proxy._gateway_shadow_observer.snapshot(), sort_keys=True)
+
+    assert secret not in rendered
+    assert "secret-api-token" not in rendered
+    assert "request-123" not in rendered
+    assert proxy._gateway_shadow_observer.snapshot()[
+        "records_contain_prompt_content"
+    ] is False
+
+
+def test_shadow_failure_never_blocks_the_authoritative_proxy() -> None:
+    body = {
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    request = _request(body, path="/custom/provider")
+    proxy = _proxy()
+
+    async def original(_proxy, original_request):
+        assert await original_request.json() == body
+        return JSONResponse({"ok": True}, status_code=202)
+
+    response = asyncio.run(_run_shadow_handle_proxy(proxy, request, original))
+
+    assert response.status_code == 202
+    snapshot = proxy._gateway_shadow_observer.snapshot()
+    assert snapshot["failures"] == 1
+    assert snapshot["completed"] == 0
+
+
+def test_shadow_installs_behind_existing_security_boundaries() -> None:
+    from entroly import proxy, proxy_access_security, proxy_transport_safe
+
+    assert (
+        proxy.PromptCompilerProxy.handle_proxy
+        is proxy_transport_safe._safe_handle_proxy
+    )
+    shadow_core = proxy_transport_safe._ORIGINAL_HANDLE_PROXY
+    assert hasattr(shadow_core, "__entroly_gateway_shadow_original__")
+    assert proxy.create_proxy_app is proxy_access_security.create_proxy_app
+    shadow_factory = proxy_access_security._ORIGINAL_CREATE_PROXY_APP
+    assert hasattr(shadow_factory, "__entroly_gateway_shadow_original__")
+
+
+def test_gateway_shadow_sidecar_route_is_installed_once() -> None:
+    app = Starlette()
+
+    _install_route(app)
+    _install_route(app)
+
+    paths = [getattr(route, "path", "") for route in app.router.routes]
+    assert paths.count("/gateway-shadow") == 1


### PR DESCRIPTION
## Summary

- connect `GatewayControlPlane` to `PromptCompilerProxy` as an opt-in, non-authoritative shadow observer
- keep the existing proxy as the only provider/model/URL/credential/retry executor
- install shadow parsing behind the existing bounded request-body handler
- emit opaque run, attempt, plan, boundary, and stay/would-switch response metadata when enabled
- expose a protected local `GET /gateway-shadow` evidence snapshot
- retain only bounded metadata; never store prompt, tool-schema, credential, authorization-header, or raw request-ID content
- require auditable pricing for both models before reporting a same-provider `would-switch` decision
- keep advanced-capability alternates out when parity is not explicitly known

## Safety boundary

This PR does **not**:

- execute a shadow recommendation
- switch providers
- change the request body or target URL
- change credential handling
- add automatic retries
- make `GatewayControlPlane` authoritative
- claim universal provider compatibility or legal compliance

Shadow collection is off by default. Enable it explicitly with:

```bash
ENTROLY_GATEWAY_SHADOW=1
```

Response correlation headers can be disabled independently with:

```bash
ENTROLY_GATEWAY_SHADOW_HEADERS=0
```

## Evidence encoded

Focused tests encode that:

- the legacy proxy receives the original JSON request unchanged
- missing pricing cannot manufacture a model-switch recommendation
- an auditable same-provider alternative can be reported without execution
- unknown advanced-capability parity keeps the alternate out
- prompt, authentication, and raw request-ID content never enter records
- shadow planning failures cannot block the provider request
- shadow parsing remains behind the bounded transport handler
- the protected sidecar route is installed idempotently

## Validation required

```bash
python -m pytest -q \
  tests/test_gateway_control_plane.py \
  tests/test_provider_policy.py \
  tests/test_proxy_gateway_shadow.py
python -m ruff check \
  entroly/gateway_control_plane.py \
  entroly/proxy_gateway_shadow.py \
  tests/test_gateway_control_plane.py \
  tests/test_proxy_gateway_shadow.py
```

The exact pushed Python sources were syntax-checked after matching their Git blob SHAs. The focused pytest suite and repository workflows have not yet completed, so this PR must remain draft and unmerged until the definitive head is green.
