### PR TITLE
fix(proxy): compress tool output through the codec registry

### DIFF
--- a/benchmarks/codec_ablation.py
+++ b/benchmarks/codec_ablation.py
@@ -178,6 +178,23 @@ def _generic(text: str) -> str:
         return text
 
 
+def _proxy(text: str) -> str:
+    """What the proxy actually does to a tool result today.
+
+    `proxy_transform` has no codec imports: it runs keyword-pattern compressors
+    first and then an ESC fallback. Tool outputs are exactly the shapes the
+    codecs were built and measured on, so this arm shows what the
+    highest-traffic surface gives up by not reaching the registry.
+    """
+    from entroly.proxy_transform import compress_tool_output
+
+    try:
+        compressed, _kind, _savings = compress_tool_output(text)
+        return compressed
+    except Exception:
+        return text
+
+
 def _specialized(text: str, source_id: str):
     from entroly.codec import RecoveryStore
     from entroly.codecs_builtin import default_registry
@@ -220,6 +237,7 @@ def main(argv: list[str]) -> int:
             "full": (text, False),
             "truncate": (text[:budget_chars], False),
             "generic": (_generic(text), False),
+            "proxy": (_proxy(text), False),
             "specialized": (spec_text, recoverable),
         }
         for arm, (out, rec) in arms.items():
@@ -246,7 +264,7 @@ def main(argv: list[str]) -> int:
               f"{r.required_kept:>7}/{r.required_total:<2}{'yes' if r.recoverable else '-':>8}")
 
     print("\n  Per arm, averaged over fixtures:")
-    for arm in ("full", "truncate", "generic", "specialized"):
+    for arm in ("full", "truncate", "generic", "proxy", "specialized"):
         sel = [r for r in rows if r.arm == arm]
         red = sum(r.reduction_pct for r in sel) / len(sel)
         ret = sum(r.retention for r in sel) / len(sel)

--- a/entroly/proxy_transform.py
+++ b/entroly/proxy_transform.py
@@ -1038,8 +1038,65 @@ def _infer_language(source: str) -> str:
 _TOOL_COMPRESS_MIN_CHARS = 500
 
 
+def _codec_tool_output(content: str) -> tuple[str, str, float] | None:
+    """Best specialized-codec rendering of a tool result, or None to fall back.
+
+    Tool results are JSON payloads, logs, shell and test output, and tables --
+    precisely the shapes the codec registry was built and measured on. This
+    surface reached none of it: `proxy_transform` carried no codec import, so
+    the keyword-pattern compressors below ran instead.
+
+    Measured on the `benchmarks/codec_ablation.py` fixtures, that cost evidence
+    without buying tokens: the pattern path reduced 75.1% while retaining 24.0%
+    of required evidence, against 76.9% / 100.0% for the registry -- worse than
+    blind truncation, because the patterns reach their ratio by deleting the
+    failures and identifiers the codecs exist to protect.
+
+    Mirrors the reconciliation already made in `sdk._codec_compressed_text`:
+    prefer a representation that can hand the original back, never emit one
+    larger than the input, and never raise -- a codec fault must not turn a
+    proxy call into an error.
+
+    Set `ENTROLY_PROXY_CODECS=0` to restore the previous behaviour.
+    """
+    flag = _os.environ.get("ENTROLY_PROXY_CODECS", "1").strip().lower()
+    if flag in {"0", "false", "no"}:
+        return None
+    try:
+        from .codec import RecoveryStore
+        from .codecs_builtin import default_registry
+
+        reps = default_registry(RecoveryStore()).representations(
+            content, source_id="", content_type="", query=""
+        )
+    except Exception:  # noqa: BLE001 - fall back rather than fail the call
+        return None
+
+    if not reps:
+        return None
+
+    # A form that dropped content and cannot return it is worse than the
+    # pattern path here, because this surface exposes no recovery handle.
+    usable = [r for r in reps if r.recovery is not None or r.text == content]
+    best = min(usable or reps, key=lambda r: r.token_cost)
+
+    text = best.text
+    if not text or not text.strip():
+        return None
+    if len(text) >= len(content):
+        return None  # never let "specialized" mean "larger"
+
+    savings = 1.0 - len(text) / max(len(content), 1)
+    if savings <= 0.10:
+        return None  # the same floor the pattern path applies
+    return text, "codec", savings
+
+
 def compress_tool_output(content: str) -> tuple[str, str, float]:
-    """Compress a tool/MCP call result using pattern-based rules.
+    """Compress a tool/MCP call result.
+
+    Specialized codecs first -- they preserve identifiers, failures and values
+    structurally -- then the keyword-pattern rules, then ESC.
 
     Returns:
         (compressed_content, compression_type, savings_ratio)
@@ -1047,6 +1104,10 @@ def compress_tool_output(content: str) -> tuple[str, str, float]:
     """
     if not content or len(content) < _TOOL_COMPRESS_MIN_CHARS:
         return content, "none", 0.0
+
+    codec_result = _codec_tool_output(content)
+    if codec_result is not None:
+        return codec_result
 
     # Try each compressor in priority order (most specific first)
     for name, fn in _COMPRESSORS:
@@ -1278,15 +1339,37 @@ def _compress_directory_listing(content: str) -> str | None:
     return None
 
 
+# A line that actually looks like a compiler/linter diagnostic. Anchored at a
+# line start (allowing indentation) or after a `file:line:col:` prefix, so a
+# tool name appearing inside a path cannot masquerade as build output.
+_BUILD_DIAGNOSTIC_RE = _re.compile(
+    r"""(?mx)
+      ^\s* (?: error \[ [A-Z]?\d+ \]        # rustc: error[E0499]
+             | (?:error|warning|note)\s*:   # error: / warning: / note:
+             | (?:FAILED|FAIL)\b
+             | \w*(?:Error|Exception)\b\s*:  # SyntaxError: / TypeError:
+             )
+    | ^\s*\S+:\d+:(?:\d+:)?\s*(?:error|warning)\b   # file:12:5: error ...
+    """,
+    _re.IGNORECASE,
+)
+
+
 def _compress_build_errors(content: str) -> str | None:
     """Compress build/lint output: keep only errors and warnings."""
-    # Detect build output
-    is_build = any(kw in content for kw in [
-        "error[E", "error:", "warning:", "Error:", "Warning:",
-        "ERROR", " error ", "SyntaxError", "TypeError",
-        "CompileError", "tsc", "eslint", "ruff",
-    ])
-    if not is_build:
+    # Detection must find a line SHAPED like a diagnostic, not merely a
+    # substring somewhere in the blob.
+    #
+    # The previous test was `any(kw in content for kw in [... "ruff", "tsc",
+    # "eslint", "ERROR" ...])` over the whole string. On a real `git ls-files`
+    # listing -- 1,316 lines, no errors at all -- the single substring "ruff"
+    # in a path flipped the content into build mode. The per-line filter below
+    # then kept the two filenames containing "error" and dropped 1,314 lines,
+    # emitting "[entroly: 2 errors, 0 warnings - 1315 lines compressed]":
+    # 99.7% of the evidence destroyed AND a fabricated error count reported for
+    # content that had none. Anchoring detection to diagnostic shape is what
+    # stops a tool name in a path from rewriting an unrelated tool result.
+    if not _BUILD_DIAGNOSTIC_RE.search(content):
         return None
 
     lines = content.split("\n")

--- a/tests/test_proxy_codec_parity.py
+++ b/tests/test_proxy_codec_parity.py
@@ -1,0 +1,137 @@
+"""The proxy must preserve the evidence the codecs protect.
+
+`proxy_transform` carried no codec import, so tool results -- JSON payloads,
+logs, shell and test output, tables -- were compressed by keyword-pattern rules
+instead of the registry built for exactly those shapes. Measured on the
+`codec_ablation` fixtures, that path reduced 75.1% while retaining **24.0%** of
+required evidence, against 76.9% / 100.0% for the registry: it reached its ratio
+by deleting the failures and identifiers the codecs exist to protect, and was
+worse than blind truncation.
+
+These tests pin the repaired behaviour. They are written against the same
+fixtures and required-evidence lists the codec work used, so a regression here
+means the highest-traffic surface has started dropping evidence again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.codec_ablation import FIXTURES
+from entroly.proxy_transform import _compress_build_errors, compress_tool_output
+
+
+@pytest.mark.parametrize("name", sorted(FIXTURES))
+def test_proxy_preserves_required_evidence(name: str) -> None:
+    """Every load-bearing value survives proxy compression of a tool result."""
+    text, required = FIXTURES[name]()
+    compressed, kind, _savings = compress_tool_output(text)
+
+    missing = [item for item in required if item not in compressed]
+    assert not missing, (
+        f"{name}: proxy compression ({kind}) dropped {len(missing)} of "
+        f"{len(required)} required items: {missing[:3]}"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(FIXTURES))
+def test_proxy_actually_compresses(name: str) -> None:
+    """Preservation must not be bought by declining to compress at all.
+
+    The failure mode the codec work started from was a codec that could only
+    destroy values or refuse, and defaulted to refusing -- invisible, because
+    0% compression raises no alarm.
+    """
+    text, _required = FIXTURES[name]()
+    compressed, _kind, savings = compress_tool_output(text)
+
+    assert len(compressed) < len(text), f"{name}: no compression applied"
+    assert savings > 0.10, f"{name}: savings {savings:.1%} below the 10% floor"
+
+
+def test_codec_fault_falls_back_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A codec fault must not turn a proxy call into an error."""
+    import entroly.codecs_builtin as builtin
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(builtin, "default_registry", boom)
+
+    text, _required = FIXTURES["log_root_cause_flood"]()
+    compressed, kind, _savings = compress_tool_output(text)
+
+    assert isinstance(compressed, str) and compressed
+    assert kind != "codec"
+
+
+def test_rollback_flag_restores_pattern_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`ENTROLY_PROXY_CODECS=0` is the documented rollback for live traffic."""
+    text, _required = FIXTURES["log_root_cause_flood"]()
+
+    monkeypatch.setenv("ENTROLY_PROXY_CODECS", "0")
+    disabled, disabled_kind, _ = compress_tool_output(text)
+
+    monkeypatch.setenv("ENTROLY_PROXY_CODECS", "1")
+    enabled, enabled_kind, _ = compress_tool_output(text)
+
+    assert disabled_kind != "codec"
+    assert enabled_kind == "codec"
+    assert disabled != enabled
+
+
+def test_short_results_are_left_alone() -> None:
+    """Below the minimum length the contract is an untouched passthrough."""
+    tiny = "ok"
+    assert compress_tool_output(tiny) == (tiny, "none", 0.0)
+
+
+# ── build-diagnostic detection must not fire on a tool name in a path ──────
+
+
+def test_file_listing_is_not_treated_as_build_output() -> None:
+    """A path containing a linter's name must not rewrite an unrelated result.
+
+    Detection was `any(kw in content ...)` over the whole blob, including the
+    bare tool names "ruff", "tsc" and "eslint". A real `git ls-files` listing
+    of 1,316 lines -- containing no errors -- matched on the substring "ruff"
+    in a path, kept only the two filenames containing "error", and emitted
+    "[entroly: 2 errors, 0 warnings - 1315 lines compressed]". That is 99.7% of
+    the evidence destroyed and a fabricated error count attached to content
+    that had none.
+    """
+    listing = "\n".join(
+        [
+            "pyproject.toml",
+            "ruff.toml",  # the tool name that used to trigger detection
+            "src/tsconfig.json",
+            "benchmarks/fever_error_analysis.py",  # 'error' inside a filename
+            "tests/test_snapshot_errors.py",
+        ]
+        + [f"src/module_{i}.py" for i in range(300)]
+    )
+
+    assert _compress_build_errors(listing) is None
+
+    compressed, kind, _savings = compress_tool_output(listing)
+    assert kind != "build_errors"
+    assert "0 warnings" not in compressed, "fabricated a diagnostic summary"
+
+
+@pytest.mark.parametrize(
+    "sample",
+    [
+        "error[E0499]: cannot borrow `x` as mutable more than once",
+        "src/lib.rs:42:9: error: mismatched types",
+        "warning: unused variable: `y`",
+        "SyntaxError: invalid syntax",
+    ],
+)
+def test_real_diagnostics_are_still_detected(sample: str) -> None:
+    """Tightening detection must not stop it recognising actual build output."""
+    noise = "\n".join(f"   Compiling dep{i} v0.1.0" for i in range(120))
+    assert _compress_build_errors(f"{sample}\n{noise}") is not None
+
+
+def test_prose_is_not_build_output() -> None:
+    assert _compress_build_errors("hello world\n" * 80) is None


### PR DESCRIPTION
## Problem

`proxy_transform` carried **zero codec imports**. Tool results — JSON payloads, logs, shell and test output, tables — were compressed by keyword-pattern rules instead of the registry built for exactly those shapes.

Measured on the existing `codec_ablation` fixtures:

| arm | reduction | evidence retained |
|---|---|---|
| truncate (blind) | 76.9% | 75.3% |
| **proxy (before)** | **75.1%** | **24.0%** |
| **proxy (after)** | **76.9%** | **100.0%** |

The proxy compressed *no harder* than the codec path while retaining a quarter of the load-bearing evidence — **worse than blind truncation**, because the patterns reached their ratio by deleting the failures and identifiers the codecs exist to protect.

## Second, worse defect: a fabricated diagnostic

`_compress_build_errors` detected build output with `any(kw in content ...)` over the whole blob, including the bare tool names `"ruff"`, `"tsc"`, `"eslint"`.

A real 1,316-line `git ls-files` listing matched on **`"ruff"` inside a path**, kept the two filenames containing "error", dropped 1,314 lines, and emitted:

```
[entroly: 2 errors, 0 warnings - 1315 lines compressed]
```

**99.7% of evidence destroyed, plus an untrue error count asserted about content with no errors.** An agent asking "what files are in this repo" received two filenames and a false diagnostic summary. Detection is now anchored to diagnostic *shape*.

## Scope caveat

On six captured **real** tool outputs the registry claims only **1 of 5**. The ablation fixtures were authored for the codecs, so the 24%→100% figure describes codec-claimable content, not proxy traffic overall. The honest headline for this PR is the fabrication fix.

## Safety

- Codecs are tried first and **fall through** when none claims the content, so behaviour is byte-identical wherever no codec applies.
- `ENTROLY_PROXY_CODECS=0` restores the previous path (verified: restores 75.1% / 24.0% exactly).
- A codec fault falls back rather than raising.

## Verification

- 19 new tests in `tests/test_proxy_codec_parity.py`, **mutation-checked** — with the flag off, all 5 evidence tests fail naming the specific dropped items.
- `ruff` clean.

## Follow-up (not in this PR)

Every other detector in `_COMPRESSORS` uses the same substring-over-whole-blob shape and is unaudited. This one was caught only because it fabricated a *visible* summary; a detector that silently drops 99% leaves no tell.
