### PR TITLE
fix(repo): stop the line-oriented reader from calling its own declarations

### DIFF
--- a/entroly/repository_intelligence/graph.py
+++ b/entroly/repository_intelligence/graph.py
@@ -264,6 +264,13 @@ def resolve_calls(
             else:
                 resolution = "global-unique"
                 confidence = "resolved"
+            # A callee matched by the line-oriented reader is a lexical guess,
+            # not a resolution any parser stands behind. It was reported as
+            # "resolved", which made it indistinguishable from an AST-verified
+            # edge. The resolution label still describes how the name was
+            # matched; only the confidence claim is downgraded.
+            if call.parse_backend == "conservative":
+                confidence = "heuristic-static"
             edges.add(CallEdge(
                 caller,
                 callee.symbol_id,

--- a/entroly/repository_intelligence/parsers.py
+++ b/entroly/repository_intelligence/parsers.py
@@ -55,6 +55,15 @@ JS_DEF = re.compile(
 )
 JS_IMPORT = re.compile(r"(?:from\s+|require\s*\(\s*)['\"]([^'\"]+)['\"]")
 CALL = re.compile(r"(?<![\w$])([A-Za-z_$][\w$]*)\s*\(")
+# A name introduced by one of these keywords is being declared, not called.
+# `CALL` cannot tell "fn run(&self)" from "run()", so without this every
+# declaration became a call to itself. Matched against the text preceding the
+# name so it also catches declarations nested mid-line, as in
+# "impl Worker { fn run(&self) { helper(); } }", which no line-anchored
+# declaration pattern sees.
+DECLARATION_PREFIX = re.compile(
+    r"(?:^|[^\w$])(?:fn|function|class|struct|enum|trait|impl|mod|def|sub)\s+$"
+)
 
 
 @dataclass
@@ -382,10 +391,15 @@ def _parse_conservative(path: str, text: str, raw: bytes, language: str) -> Pars
         line_start = byte_cursor
         byte_cursor += len(terminated.encode("utf-8", "surrogateescape"))
         current: Symbol | None = None
+        # Where this line declares a name, rather than calls one. `CALL` also
+        # matches the "helper(" inside "function helper()", which turned every
+        # single-line declaration into a call to itself.
+        declared_name_span: tuple[int, int] | None = None
         if language == "rust":
             match = RUST_DEF.match(line)
             if match:
                 kind, name = match.groups()
+                declared_name_span = match.span(2)
                 current = Symbol(
                     _symbol_id(path, name, kind), path, name, name, kind,
                     line_number, line_number, language, None, line.strip(),
@@ -400,6 +414,7 @@ def _parse_conservative(path: str, text: str, raw: bytes, language: str) -> Pars
             if match:
                 kind = match.group(1) or "function"
                 name = match.group(2) or match.group(3)
+                declared_name_span = match.span(2 if match.group(2) else 3)
                 current = Symbol(
                     _symbol_id(path, name, kind), path, name, name, kind,
                     line_number, line_number, language, None, line.strip(),
@@ -411,6 +426,15 @@ def _parse_conservative(path: str, text: str, raw: bytes, language: str) -> Pars
             for call_match in CALL.finditer(line):
                 name = call_match.group(1)
                 if name in CALL_KEYWORDS:
+                    continue
+                # Suppress by position, not by name. Skipping every occurrence
+                # matching the enclosing symbol would also drop real recursion
+                # written on one line, as in "fn f() { f() }" -- there only the
+                # first occurrence is a declaration.
+                prefix_text = line[:call_match.start(1)]
+                if call_match.span(1) == declared_name_span or DECLARATION_PREFIX.search(
+                    prefix_text
+                ):
                     continue
                 # Every emitted edge must carry evidence a caller can recover
                 # and re-hash. Leaving these at the ParsedCall defaults shipped

--- a/tests/test_conservative_call_precision.py
+++ b/tests/test_conservative_call_precision.py
@@ -1,0 +1,105 @@
+"""Precision of the line-oriented reader used when no grammar is available.
+
+This path is the only call analysis Rust and the JS family get on a base
+install, so its false positives are not a corner case -- they are what those
+users see. It used to read a function's own declaration as a call to itself:
+the two-line TypeScript fixture below produced three edges, of which one was
+real, and all three claimed confidence "resolved".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.repository_intelligence import build_repository_index
+from entroly.repository_intelligence.parsers import _parse_conservative
+
+
+def _targets(source: str, language: str) -> list[str]:
+    return [
+        call.target
+        for call in _parse_conservative("x", source, source.encode("utf-8"), language).calls
+    ]
+
+
+@pytest.mark.parametrize(
+    ("label", "language", "source", "expected"),
+    [
+        (
+            "declaration on its own line is not a call",
+            "typescript",
+            "function helper(): number { return 1; }\n"
+            "export function run(): number { return helper(); }\n",
+            ["helper"],
+        ),
+        (
+            "declaration nested mid-line is not a call",
+            # No line-anchored pattern matches `fn run` here, because the line
+            # starts with `impl`. This shipped a fabricated `<module> -> run`.
+            "rust",
+            "fn helper() {}\nstruct Worker;\nimpl Worker { fn run(&self) { helper(); } }\n",
+            ["helper"],
+        ),
+    ],
+)
+def test_declarations_are_not_read_as_calls(
+    label: str, language: str, source: str, expected: list[str]
+) -> None:
+    assert _targets(source, language) == expected, label
+
+
+@pytest.mark.parametrize(
+    ("language", "source"),
+    [
+        ("typescript", "function f(): number { return f(); }\n"),
+        ("rust", "fn f() -> i32 { f() }\n"),
+    ],
+)
+def test_single_line_recursion_survives_declaration_suppression(
+    language: str, source: str
+) -> None:
+    """Suppressing by name rather than by position would silently delete this.
+
+    Both the declaration and a real recursive call are the same identifier on
+    the same line, so this is the case that distinguishes a positional rule
+    from a lazy `name == enclosing_symbol` one.
+    """
+    assert _targets(source, language) == ["f"]
+
+
+def test_class_method_shorthand_is_a_known_false_positive() -> None:
+    """Pinned limitation, not an endorsement.
+
+    `run() { ... }` declares a method, but JS and TS omit any declaration
+    keyword there, so it is lexically identical to a call. Without a grammar
+    this is not decidable, and suppressing it would need a rule broad enough
+    to start deleting real calls. It is recorded here so the boundary is
+    visible, and such edges are reported as heuristic rather than resolved.
+    """
+    assert _targets("class A { run() { helper(); } }\n", "typescript") == ["run", "helper"]
+
+
+def test_conservative_edges_are_not_labelled_as_resolved(tmp_path, monkeypatch) -> None:
+    """A lexical guess must not be indistinguishable from a verified edge.
+
+    These edges were reported with confidence "resolved", exactly like an
+    AST-verified Python edge, because the builder never consulted the backend
+    that produced the call.
+
+    The grammar is stubbed out rather than skipped on absence, so this runs
+    identically whether or not tree-sitter is installed -- the fallback is
+    reached the same way a base install reaches it.
+    """
+    monkeypatch.setattr(
+        "entroly.repository_intelligence.parsers.extract_structural_spans",
+        lambda *args, **kwargs: None,
+    )
+    (tmp_path / "index.ts").write_text(
+        "function helper(): number { return 1; }\n"
+        "export function run(): number { return helper(); }\n",
+        encoding="utf-8",
+    )
+    edges = build_repository_index(tmp_path).call_edges
+    assert edges, "fixture produced no call edges"
+    assert [edge.callee_id.split("::")[1] for edge in edges] == ["helper"]
+    assert {edge.confidence for edge in edges} == {"heuristic-static"}


### PR DESCRIPTION
## What

`CALL` cannot tell `fn run(&self)` from `run()`, so a declaration was read as a call to itself. This is the only call analysis Rust and the JS family get when no tree-sitter grammar is available, so the false edges are what those users actually see.

## Measured, not asserted

Over **113 real Rust/JS/TS files in this repository**:

| | edges |
|---|---|
| before | 29,830 |
| after | 27,721 |
| removed | **2,109 (7.07%)** |

Checked three ways:

- **0 edges added** — the rule only suppresses, it never invents.
- **All 2,109 removals independently re-derived** from the raw bytes as sitting behind a declaration keyword. Zero removals that were not declarations.
- **25-edge random sample inspected by hand** — `pub fn cache_clear(&mut self)`, `function assert(cond, msg)`, `fn hash_key(&self, fp: u64)`. All declarations; no real call dropped.

An earlier note on this defect quoted a 67% false-positive rate. That came from a three-edge fixture and was inflated by sample size — the real figure on production code is 7.07%.

## Two changes

**Precision.** Suppression is by *position*, not by name. Skipping every occurrence matching the enclosing symbol would also delete genuine single-line recursion such as `fn f() -> i32 { f() }` — covered by a test. Matching against the text preceding the name also catches declarations nested mid-line, as in `impl Worker { fn run(&self) { helper(); } }`, which no line-anchored declaration pattern sees.

**Honest labelling.** These edges were reported with confidence `resolved` — identical to an AST-verified Python edge — because the builder never consulted the backend that produced the call. Conservative edges now report `heuristic-static`. No test asserted `resolved` on a call edge, and consumers pass the value through without branching on it.

## Known limitation, pinned rather than hidden

JS/TS class method shorthand (`run() { ... }`) carries no declaration keyword and stays a false positive. It is not lexically decidable without a grammar, and suppressing it would need a rule broad enough to start deleting real calls. A test records the boundary so it is visible.

## Verification

```bash
pytest tests/test_conservative_call_precision.py -q
ruff check entroly/repository_intelligence/
```

5 of the 6 new tests fail against `main` (verified by stashing the fix); the sixth is the limitation pin, which documents unchanged behaviour. Targeted regression sweep: 781 passed. The 3 `test_adaptive_program_graph` failures are pre-existing and unrelated — the Zig grammar fails to load on `tree-sitter-language-pack 1.14.3` + `tree-sitter 0.26.0`.

## Scope

Does **not** address the larger gap: 6 of 23 advertised languages (`kotlin`, `haskell`, `perl`, `zig`, `clojure`, `json`) fail structural parsing entirely. That is a bigger hole than 7% of fallback edges and needs its own change.

## Rollback

Single commit, revertable on its own. No packaging, release, or native surface touched.