### PR TITLE
bench(agentic): run the task set that actually requires context

### DIFF
--- a/benchmarks/addressability.py
+++ b/benchmarks/addressability.py
@@ -54,6 +54,7 @@ from benchmarks.graph_lane_quality import (
     _tokens,
     _tracked_python_files,
 )
+from entroly.native_status import native_status
 
 
 def index_of(text: str, rel: str) -> str:
@@ -136,8 +137,19 @@ def run(limit: int, budget: int, seed: int) -> dict[str, Any]:
             "raw_carries": carries(raw_text),
         })
 
+    # qccr delegates span selection to the Rust core, so the selector that ran
+    # is part of the result, not a footnote. A stale artifact once recorded
+    # qccr at 9/12 here; the native engine scores 12/12 on the same budget,
+    # corpus and pairs, and without this field there was no way to tell from
+    # the JSON which selector produced the number.
+    status = native_status()
+    engine = {
+        "native_engine_active": status.ok,
+        "entroly_core_version": status.version,
+        "entroly_core_version_ok": status.version_ok,
+    }
     return {"pinned_ref": payload["pinned_ref"], "budget": budget,
-            "probes": len(rows), "rows": rows}
+            "probes": len(rows), "engine": engine, "rows": rows}
 
 
 def main() -> int:

--- a/benchmarks/agentic_null_control.py
+++ b/benchmarks/agentic_null_control.py
@@ -31,6 +31,7 @@ from benchmarks.agentic_tasks_run import (  # noqa: E402
     DEFAULT_BASE_URL,
     PROMPT,
     Task,
+    build_dependency_tasks,
     build_tasks,
     call_model,
     extract_source,
@@ -93,6 +94,9 @@ def main() -> int:
     parser.add_argument("--seed", type=int, default=7)
     parser.add_argument("--timeout", type=float, default=300.0)
     parser.add_argument(
+        "--task-set", choices=("dependency", "self-contained"), default="dependency"
+    )
+    parser.add_argument(
         "--out",
         type=Path,
         default=REPO_ROOT / "benchmarks" / "results"
@@ -100,7 +104,12 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    tasks = build_tasks(args.distractors)
+    # Must validate the same set the comparison runs, or it certifies nothing.
+    tasks = (
+        build_dependency_tasks(args.distractors)
+        if args.task_set == "dependency"
+        else build_tasks(args.distractors)
+    )
     rows: list[dict[str, Any]] = []
     for task in tasks:
         print(f"  {task.task_id:22} {NULL_ARM:22} ...", end="", flush=True)

--- a/benchmarks/agentic_null_control.py
+++ b/benchmarks/agentic_null_control.py
@@ -31,6 +31,7 @@ from benchmarks.agentic_tasks_run import (  # noqa: E402
     DEFAULT_BASE_URL,
     PROMPT,
     Task,
+    _engine_provenance,
     build_dependency_tasks,
     build_tasks,
     call_model,
@@ -138,6 +139,7 @@ def main() -> int:
             "arm": NULL_ARM,
             "token_source": "provider prompt_eval_count / eval_count",
             "oracle": "pytest exit code",
+            "engine": _engine_provenance(),
         },
         "summary": {
             "tasks": len(rows),

--- a/benchmarks/agentic_tasks_run.py
+++ b/benchmarks/agentic_tasks_run.py
@@ -39,6 +39,30 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from entroly.native_status import native_status
+
+
+def _engine_provenance() -> dict[str, Any]:
+    """Which selector actually ran this comparison.
+
+    A stale entroly_core in the interpreter's site-packages downgrades
+    silently to the pure-Python fallback -- a WARNING-level log line easy to
+    lose among a long run's other output, or filtered out entirely by a
+    caller piping through `grep -v` to cut noise, which is exactly how this
+    ran unnoticed for most of a session: every artifact from that stretch
+    compared the fallback selector, not the one users get by default. Fixed
+    on the same real inputs, the native engine compressed harder (1,063 vs
+    1,613 tokens) and kept a task the fallback dropped, so which one ran is
+    not a footnote. Recorded here so it is asserted from the artifact
+    itself, not reconstructed from logs after the fact.
+    """
+    status = native_status()
+    return {
+        "native_engine_active": status.ok,
+        "entroly_core_version": status.version,
+        "entroly_core_version_ok": status.version_ok,
+    }
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -563,6 +587,7 @@ def main() -> int:
             "simulated": False,
             "token_source": "ollama prompt_eval_count / eval_count",
             "oracle": "pytest exit code",
+            "engine": _engine_provenance(),
         },
         "summary": summary,
         "paired": {

--- a/benchmarks/agentic_tasks_run.py
+++ b/benchmarks/agentic_tasks_run.py
@@ -68,13 +68,25 @@ class Task:
     test_file: str
     test_source: str
     distractors: dict[str, str] = field(default_factory=dict)
+    # Set only for dependency-bearing tasks. The fix cannot be written without
+    # reading this file, so dropping it is the failure this benchmark exists to
+    # detect. Empty for the self-contained set, where no such file exists.
+    dependency_file: str = ""
+    dependency_source: str = ""
+    hidden_shape: str = ""
 
     def fragments(self) -> list[Fragment]:
         """Everything a naive agent would put in context, in a fixed order."""
         items = [Fragment(source=self.target_file, content=self.broken_source)]
+        # The dependency is ordered among the distractors rather than placed
+        # directly after the target. Privileging its position would let a
+        # selector score well by accident of ordering instead of by relevance.
+        pool = dict(self.distractors)
+        if self.dependency_file:
+            pool[self.dependency_file] = self.dependency_source
         items.extend(
             Fragment(source=name, content=body)
-            for name, body in sorted(self.distractors.items())
+            for name, body in sorted(pool.items())
         )
         return items
 
@@ -147,8 +159,44 @@ def _distractors(count: int) -> dict[str, str]:
     return {name: bodies[name] for name in names[:count]}
 
 
+def build_dependency_tasks(distractor_count: int) -> list[Task]:
+    """Tasks whose fix cannot be written without reading another file.
+
+    The self-contained set below cannot measure context selection: its null
+    control passes 4/4, because each bug is decidable from the query and the
+    broken function alone. Parity between arms on those tasks is guaranteed no
+    matter what the selector delivers, so it is not evidence about compression.
+
+    These come from ``agentic_task_set``, which was written for exactly this
+    and had no consumer. Each carries a ``hidden_shape`` -- a fact that appears
+    only in the dependency file -- so an arm that drops the dependency should
+    fail the oracle, which is what makes a difference between arms detectable.
+    """
+    from benchmarks.agentic_task_set import build_dependent_tasks
+
+    return [
+        Task(
+            task_id=item.task_id,
+            query=item.query,
+            target_file=item.target_file,
+            broken_source=item.broken_source,
+            test_file=item.test_file,
+            test_source=item.test_source,
+            distractors=dict(item.distractors),
+            dependency_file=item.dependency_file,
+            dependency_source=item.dependency_source,
+            hidden_shape=item.hidden_shape,
+        )
+        for item in build_dependent_tasks(distractor_count)
+    ]
+
+
 def build_tasks(distractor_count: int) -> list[Task]:
-    """Small, deterministic bugs whose tests are unambiguous oracles."""
+    """Small, deterministic bugs whose tests are unambiguous oracles.
+
+    Retained as a harness-validation set only. Its null control passes 4/4, so
+    it must not be used for context-quality claims -- see build_dependency_tasks.
+    """
     shared = _distractors(distractor_count)
     return [
         Task(
@@ -357,7 +405,14 @@ def run_oracle(task: Task, patched_source: str) -> tuple[bool, str]:
                 break
             (parent / "__init__.py").write_text("", encoding="utf-8")
 
-        for name, body in task.distractors.items():
+        written = dict(task.distractors)
+        if task.dependency_file:
+            # Always written, regardless of whether the arm put it in context.
+            # The oracle measures whether the model's patch is correct, and the
+            # patch can only be correct if the dependency was read -- so the
+            # dependency must exist at test time even when context omitted it.
+            written[task.dependency_file] = task.dependency_source
+        for name, body in written.items():
             path = root / name
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(body, encoding="utf-8")
@@ -424,6 +479,17 @@ def main() -> int:
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
     parser.add_argument("--budget", type=int, default=220)
     parser.add_argument("--distractors", type=int, default=6)
+    parser.add_argument(
+        "--task-set",
+        choices=("dependency", "self-contained"),
+        default="dependency",
+        help=(
+            "dependency (default): the fix requires reading another file, so "
+            "dropping it is detectable. self-contained: harness validation "
+            "only -- its null control passes 4/4 and it cannot support a "
+            "context-quality claim."
+        ),
+    )
     parser.add_argument("--seed", type=int, default=7)
     parser.add_argument("--timeout", type=float, default=300.0)
     parser.add_argument("--out", type=Path,
@@ -431,7 +497,11 @@ def main() -> int:
                         / "agentic_tasks_pilot.json")
     args = parser.parse_args()
 
-    tasks = build_tasks(args.distractors)
+    tasks = (
+        build_dependency_tasks(args.distractors)
+        if args.task_set == "dependency"
+        else build_tasks(args.distractors)
+    )
     arms = [Arm.RAW, Arm.COMPRESS]
     rows: list[dict[str, Any]] = []
 
@@ -489,6 +559,7 @@ def main() -> int:
             "seed": args.seed,
             "budget": args.budget,
             "distractors": args.distractors,
+            "task_set": args.task_set,
             "simulated": False,
             "token_source": "ollama prompt_eval_count / eval_count",
             "oracle": "pytest exit code",

--- a/benchmarks/results/addressability.json
+++ b/benchmarks/results/addressability.json
@@ -2,6 +2,11 @@
   "pinned_ref": "16934bf85b3346793ec6664b3b0d1d67cfd02156",
   "budget": 6157,
   "probes": 12,
+  "engine": {
+    "native_engine_active": true,
+    "entroly_core_version": "1.0.76",
+    "entroly_core_version_ok": true
+  },
   "rows": [
     {
       "caller": "_start_background_services",
@@ -11,9 +16,9 @@
         "project_dir",
         "force"
       ],
-      "index_tokens": 5903,
-      "qccr_tokens": 5592,
-      "raw_tokens": 261206,
+      "index_tokens": 6063,
+      "qccr_tokens": 4637,
+      "raw_tokens": 250267,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true
@@ -25,9 +30,9 @@
         "request",
         "target"
       ],
-      "index_tokens": 6157,
-      "qccr_tokens": 5967,
-      "raw_tokens": 182303,
+      "index_tokens": 6293,
+      "qccr_tokens": 6014,
+      "raw_tokens": 204114,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true
@@ -39,9 +44,9 @@
         "similarity_threshold",
         "max_clients"
       ],
-      "index_tokens": 6339,
-      "qccr_tokens": 5626,
-      "raw_tokens": 194405,
+      "index_tokens": 6680,
+      "qccr_tokens": 5307,
+      "raw_tokens": 278960,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true
@@ -54,9 +59,9 @@
         "symbols",
         "limits"
       ],
-      "index_tokens": 5759,
-      "qccr_tokens": 4949,
-      "raw_tokens": 186299,
+      "index_tokens": 6083,
+      "qccr_tokens": 5466,
+      "raw_tokens": 208191,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true
@@ -69,11 +74,11 @@
         "project_dir",
         "force"
       ],
-      "index_tokens": 7025,
-      "qccr_tokens": 5623,
-      "raw_tokens": 321984,
+      "index_tokens": 5799,
+      "qccr_tokens": 5436,
+      "raw_tokens": 243742,
       "index_carries": true,
-      "qccr_carries": false,
+      "qccr_carries": true,
       "raw_carries": true
     },
     {
@@ -83,11 +88,11 @@
         "root",
         "candidate"
       ],
-      "index_tokens": 6763,
-      "qccr_tokens": 4581,
-      "raw_tokens": 249709,
+      "index_tokens": 5852,
+      "qccr_tokens": 4078,
+      "raw_tokens": 235778,
       "index_carries": true,
-      "qccr_carries": false,
+      "qccr_carries": true,
       "raw_carries": true
     },
     {
@@ -98,9 +103,9 @@
         "query",
         "token_budget"
       ],
-      "index_tokens": 5668,
-      "qccr_tokens": 5923,
-      "raw_tokens": 239099,
+      "index_tokens": 6414,
+      "qccr_tokens": 5887,
+      "raw_tokens": 215195,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true
@@ -112,9 +117,9 @@
         "claim",
         "evidence"
       ],
-      "index_tokens": 7495,
-      "qccr_tokens": 6036,
-      "raw_tokens": 277474,
+      "index_tokens": 6241,
+      "qccr_tokens": 5870,
+      "raw_tokens": 248422,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true
@@ -128,11 +133,11 @@
         "hallucination_cost",
         "r_floor"
       ],
-      "index_tokens": 6167,
-      "qccr_tokens": 4229,
-      "raw_tokens": 234351,
+      "index_tokens": 5376,
+      "qccr_tokens": 3969,
+      "raw_tokens": 169744,
       "index_carries": true,
-      "qccr_carries": false,
+      "qccr_carries": true,
       "raw_carries": true
     },
     {
@@ -142,9 +147,9 @@
         "claim_text",
         "evidence_text"
       ],
-      "index_tokens": 5920,
-      "qccr_tokens": 5863,
-      "raw_tokens": 194114,
+      "index_tokens": 6374,
+      "qccr_tokens": 5355,
+      "raw_tokens": 271490,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true
@@ -156,9 +161,9 @@
         "root",
         "candidate"
       ],
-      "index_tokens": 5372,
-      "qccr_tokens": 4984,
-      "raw_tokens": 171868,
+      "index_tokens": 5285,
+      "qccr_tokens": 5133,
+      "raw_tokens": 230615,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true
@@ -170,9 +175,9 @@
         "claim",
         "context"
       ],
-      "index_tokens": 5703,
-      "qccr_tokens": 5918,
-      "raw_tokens": 211739,
+      "index_tokens": 6383,
+      "qccr_tokens": 5927,
+      "raw_tokens": 247706,
       "index_carries": true,
       "qccr_carries": true,
       "raw_carries": true


### PR DESCRIPTION
## The problem

The agentic runner built its own self-contained bugs — each decidable from the query and the broken function alone. Its **null control passes 4/4 with an empty context field**, so both arms were always going to pass.

That means the recorded result — *4/4 raw against 4/4 compressed at 65.8% token reduction* — measured nothing about context selection. Reproduced before changing anything, on `qwen2.5-coder:1.5b`:

```
null control: 4/4 passed WITHOUT context   (0/4 diagnostic)
comparison  : raw 4/4   compressed 4/4
```

`agentic_task_set.build_dependent_tasks` was written for exactly this case and **had no consumer at all** — its own module was the only reference in the repo. Each of its tasks carries a `hidden_shape`: a fact appearing only in a dependency file, so an arm that drops the dependency should fail the oracle.

## The change

Wires the runner *and* the null control to that set, defaulting to it.

- The dependency becomes a **retrievable fragment**, ordered among the distractors rather than placed after the target, so a selector cannot score well by accident of ordering.
- It is **always written into the oracle worktree**, regardless of what the arm put in context — the patch is only correct if the dependency was read, so the file must exist at test time even when context omitted it.
- The null control takes the same `--task-set` flag. Validating a different set than the comparison runs certifies nothing.
- The self-contained set stays available under `--task-set self-contained`, documented as unusable for context-quality claims.

## Result

```
null control: 0/4 passed without context   (4/4 diagnostic)
```

**The benchmark can now fail** — the prerequisite for any claim about compression. Oracle validated in both directions: broken source fails, fixed source passes.

## The first valid run is not usable, and is recorded as such

| arm | passed | input tokens | latency |
|---|---|---|---|
| raw | 1/4 | 2,248 | 11.44s |
| entroly_compress_only | 1/4 | 1,063 | 6.79s |

n=4, **McNemar p = 1.0**. The raw arm returns `wrong_fix` on 3 of 4 tasks *with full context*, so a floor effect has replaced the ceiling effect. Nothing here supports a claim.

Two further confounds found while running it, both worth knowing:

1. **Answer extraction still eats results.** Losses classified `unusable_output` are parsing failures, not evidence about context sufficiency. The harness already separates these — do not conflate them.
2. **Interpreter shadowing.** A stale pure-Python `entroly_core` 1.0.75 in system site-packages silently shadows the native build, announced only by a log line. Measured on the same tasks: the fallback selector compressed 2,248 → 1,613 while the native engine compressed the identical inputs to 1,063 and kept the task the fallback lost. Benchmarks must assert `_use_rust` or they may be measuring the wrong engine.

## Verification

```bash
python benchmarks/agentic_null_control.py --model qwen2.5-coder:1.5b   # expect 0/4 without context
python benchmarks/agentic_tasks_run.py    --model qwen2.5-coder:1.5b
python benchmarks/agentic_null_control.py --model qwen2.5-coder:1.5b --task-set self-contained  # expect 4/4
```

`ruff` clean. No product code touched — benchmarks only.

## Scope

Does **not** deliver a defensible number. The preregistration requires n ≥ 400 mined repository tasks with a dev/holdout split; this makes n=4 measurable, which it previously was not.