### PR TITLE
fix(code-intel): multi-language symbol extraction — 32 of 41 languages audited

### DIFF
--- a/entroly/tree_sitter_support.py
+++ b/entroly/tree_sitter_support.py
@@ -57,6 +57,20 @@ _DECLARATION_HINTS = frozenset({
     "macro", "procedure", "subroutine", "routine", "type_alias",
 })
 
+# Grammars whose declaration nodes the generic heuristic cannot match, keyed by
+# language so the names cannot leak across grammars. These were read from the
+# real parse trees, not guessed: Haskell names a definition `function` (bare,
+# with a `name` field), Perl a sub `subroutine_declaration_statement` (ends in
+# `_statement`, so the suffix rule skips it). Both carry a `name` field, so the
+# existing name/kind extraction handles them unchanged. The names are
+# deliberately NOT added to the global set: JavaScript and TypeScript both emit
+# a bare `function` node for function expressions, and matching those globally
+# would invent named declarations from anonymous expressions.
+_LANGUAGE_DECLARATION_TYPES: dict[str, frozenset[str]] = {
+    "haskell": frozenset({"function", "data_type"}),
+    "perl": frozenset({"subroutine_declaration_statement"}),
+}
+
 _KIND_HINTS = (
     ("method", "method"), ("function", "function"), ("constructor", "constructor"),
     ("class", "class"), ("struct", "struct"), ("enum", "enum"),
@@ -257,6 +271,14 @@ def _first_identifier(node: Any) -> Any | None:
     stack = [node]
     while stack:
         current = stack.pop()
+        # Error-recovery subtrees hold fragments in the wrong place: a dense
+        # one-line `class W{ fun run(){} }` mis-parses, and descending into the
+        # ERROR node returns an inner function name as the class name. Skipping
+        # them keeps resolution on the real, well-formed structure.
+        if str(getattr(current, "type", "")) == "ERROR" or bool(
+            getattr(current, "is_error", False)
+        ):
+            continue
         if getattr(current, "type", "") in {
             "identifier", "type_identifier", "field_identifier", "property_identifier",
             "constant", "operator_name", "name",
@@ -266,7 +288,34 @@ def _first_identifier(node: Any) -> Any | None:
     return None
 
 
-def _name_node(node: Any) -> Any | None:
+# Grammars that name a declaration with a bare positional child and expose no
+# `name` field for it. The value is the child node type that holds the name, and
+# only a DIRECT child is taken: Kotlin's `function_declaration` lists
+# `simple_identifier` (the name), `function_value_parameters`, `user_type` (the
+# return type) and `function_body` as siblings with no fields, so the generic
+# `_first_identifier` descends into the return type and returns `Int` for
+# `fun helper(): Int`, and finds nothing for a body-less nested `fun run()`.
+# Taking the first direct `simple_identifier` returns the real name and cannot
+# reach a parameter (nested in function_value_parameters) or a return type
+# (nested in user_type). A class uses `type_identifier`, not `simple_identifier`,
+# so this does not fire for it and the existing resolution still applies.
+_LANGUAGE_NAME_CHILD_TYPE: dict[str, str] = {
+    "kotlin": "simple_identifier",
+}
+
+# Grammars whose pack structure processing returns partial declarations (a named
+# class but null-named functions, no method descent), where the name-resolving
+# tree walk is more complete. Add a language only after verifying the walk does
+# strictly better for it, since the walk's own per-grammar coverage varies.
+_PACK_STRUCTURE_UNRELIABLE: frozenset[str] = frozenset({"kotlin"})
+
+
+def _name_node(node: Any, language: str = "") -> Any | None:
+    preferred = _LANGUAGE_NAME_CHILD_TYPE.get(language) if language else None
+    if preferred:
+        for child in getattr(node, "children", ()):
+            if str(getattr(child, "type", "")) == preferred:
+                return child
     field = getattr(node, "child_by_field_name", None)
     if callable(field):
         named = field("name")
@@ -289,7 +338,24 @@ def _kind(node_type: str) -> str:
     return "declaration"
 
 
-def _is_declaration_type(node_type: str) -> bool:
+def _language_scoped_node_ok(node: Any, node_type: str, language: str) -> bool:
+    """A language-scoped declaration must carry an explicit `name` field.
+
+    The scoped node names are broad on purpose, and some are overloaded within
+    their own grammar: Haskell's `function` denotes both a definition
+    (`helper x = x + 1`, which has a `name`) and a function TYPE (`Int -> Int`,
+    which has none). Requiring the field keeps the definition and rejects the
+    type, without which the walk would emit `Int` as a function.
+    """
+    if node_type not in _LANGUAGE_DECLARATION_TYPES.get(language, ()):
+        return True
+    field = getattr(node, "child_by_field_name", None)
+    return callable(field) and field("name") is not None
+
+
+def _is_declaration_type(node_type: str, language: str = "") -> bool:
+    if language and node_type in _LANGUAGE_DECLARATION_TYPES.get(language, ()):
+        return True
     lowered = node_type.lower()
     if lowered in _DECLARATION_TYPES:
         return True
@@ -424,13 +490,22 @@ def _spans_from_tree(
     state = _TraversalState()
     for node in _walk(tree.root_node, max_nodes, state):
         node_type = str(getattr(node, "type", ""))
-        if not _is_declaration_type(node_type) or bool(getattr(node, "is_error", False)):
+        if not _is_declaration_type(node_type, language) or bool(getattr(node, "is_error", False)):
+            continue
+        if not _language_scoped_node_ok(node, node_type, language):
+            continue
+        # A declaration with a direct ERROR child was recovered from a syntax
+        # error, so its own structure is unreliable -- a dense `class W{ ... }`
+        # can otherwise take an inner method name as the class name. Skipping it
+        # keeps a malformed span out rather than emitting a mislabelled one; the
+        # well-formed declarations in the same file are unaffected.
+        if any(str(getattr(c, "type", "")) == "ERROR" for c in getattr(node, "children", ())):
             continue
         start = int(getattr(node, "start_byte", 0))
         end = int(getattr(node, "end_byte", 0))
         if end <= start or end > len(raw):
             continue
-        name_node = _name_node(node)
+        name_node = _name_node(node, language)
         if name_node is None:
             continue
         name = raw[int(name_node.start_byte):int(name_node.end_byte)].decode(
@@ -561,7 +636,9 @@ def extract_structural_profiles_report(
     state = _TraversalState()
     for node in _walk(tree.root_node, max_nodes, state):
         node_type = str(getattr(node, "type", ""))
-        if not _is_declaration_type(node_type) or bool(getattr(node, "is_error", False)):
+        if not _is_declaration_type(node_type, language) or bool(getattr(node, "is_error", False)):
+            continue
+        if not _language_scoped_node_ok(node, node_type, language):
             continue
         if not any(hint in node_type.lower() for hint in (
             "function", "method", "constructor", "procedure", "subroutine",
@@ -685,7 +762,19 @@ def extract_structural_spans_report(
     if parsed is None:
         return None
     raw, tree, language = parsed
-    normalized = _pack_structure_spans(source, file_path, raw, language)
+    # The pack's structure processing under-resolves some grammars: for Kotlin
+    # it returns the top-level `fun` with a null name (dropped for lack of a
+    # name) and omits a class's own methods entirely, yielding just the class.
+    # For these the name-resolving tree walk below is strictly more complete, so
+    # the pack path is skipped rather than trusted for its partial output. Kept
+    # to an explicit set: forcing the fallback generally regressed JavaScript,
+    # whose anonymous arrow is legitimately nameless and whose pack result is
+    # already correct.
+    normalized = (
+        None
+        if language in _PACK_STRUCTURE_UNRELIABLE
+        else _pack_structure_spans(source, file_path, raw, language)
+    )
     if normalized:
         # Registry processing owns its traversal and provides exact spans. Keep
         # the raw parser's node count only as a bounded completeness check.

--- a/entroly/tree_sitter_support.py
+++ b/entroly/tree_sitter_support.py
@@ -83,6 +83,38 @@ _LANGUAGE_DECLARATION_TYPES: dict[str, frozenset[str]] = {
     "zig": frozenset({"FnProto"}),
     # Protobuf `message` names via a `message_name` child, no `name` field.
     "proto": frozenset({"message", "enum"}),
+    # SQL names a created object in an `object_reference` child, no `name` field.
+    "sql": frozenset({"create_function", "create_procedure", "create_table", "create_view"}),
+}
+
+# Node types to NOT treat as declarations for a language, overriding the generic
+# rule. R has no standalone function declaration: a function is an anonymous
+# value bound by assignment, so the `function_definition` node itself carries no
+# name and the generic rule emitted the keyword `function`. The binding is
+# matched by predicate below instead.
+_LANGUAGE_SUPPRESS_TYPES: dict[str, frozenset[str]] = {
+    "r": frozenset({"function_definition"}),
+}
+
+
+def _r_binds_function(node: Any) -> bool:
+    """An R assignment whose right-hand side is a function definition.
+
+    `helper <- function(x) x + 1` parses as a `binary_operator` with the name
+    on the left, an assignment operator, and the function on the right. This is
+    the only place an R function acquires a name, so it is the declaration.
+    """
+    if str(getattr(node, "type", "")) != "binary_operator":
+        return False
+    children = list(getattr(node, "children", ()))
+    if not any(str(getattr(c, "type", "")) in {"<-", "=", "<<-"} for c in children):
+        return False
+    return any(str(getattr(c, "type", "")) == "function_definition" for c in children)
+
+
+# Node-level predicates for declarations the type name alone cannot identify.
+_LANGUAGE_DECLARATION_PREDICATE: dict[str, Any] = {
+    "r": _r_binds_function,
 }
 
 _KIND_HINTS = (
@@ -317,6 +349,9 @@ _LANGUAGE_NAME_CHILD_TYPE: dict[str, str] = {
     "kotlin": "simple_identifier",
     "zig": "IDENTIFIER",
     "proto": "message_name",
+    "sql": "object_reference",
+    # An R function binding names itself with the identifier left of the arrow.
+    "r": "identifier",
 }
 
 # Grammars whose pack structure processing returns partial declarations (a named
@@ -324,7 +359,7 @@ _LANGUAGE_NAME_CHILD_TYPE: dict[str, str] = {
 # tree walk is more complete. Add a language only after verifying the walk does
 # strictly better for it, since the walk's own per-grammar coverage varies.
 _PACK_STRUCTURE_UNRELIABLE: frozenset[str] = frozenset(
-    {"kotlin", "dart", "go", "solidity"}
+    {"kotlin", "dart", "go", "solidity", "r"}
 )
 
 
@@ -517,9 +552,16 @@ def _spans_from_tree(
     spans: list[StructuralSpan] = []
     seen: set[tuple[int, int, str]] = set()
     state = _TraversalState()
+    suppressed = _LANGUAGE_SUPPRESS_TYPES.get(language, frozenset())
+    predicate = _LANGUAGE_DECLARATION_PREDICATE.get(language)
     for node in _walk(tree.root_node, max_nodes, state):
         node_type = str(getattr(node, "type", ""))
-        if not _is_declaration_type(node_type, language) or bool(getattr(node, "is_error", False)):
+        if bool(getattr(node, "is_error", False)):
+            continue
+        is_declaration = (
+            node_type not in suppressed and _is_declaration_type(node_type, language)
+        ) or (predicate is not None and predicate(node))
+        if not is_declaration:
             continue
         if not _language_scoped_node_ok(node, node_type, language):
             continue
@@ -579,6 +621,69 @@ def _spans_from_tree(
         max_nodes=max_nodes,
         backend="tree-sitter-raw",
     )
+
+
+# Single-file-component languages whose script is embedded as opaque text, and
+# the language to parse that text as. Svelte and Vue keep the script inside a
+# `script_element` whose only child is a `raw_text` node -- the grammar does not
+# descend into it, so the component's functions are invisible until that text is
+# re-parsed as JavaScript and its spans are shifted back to file coordinates.
+_EMBEDDED_SCRIPT_LANGUAGES: dict[str, str] = {
+    "svelte": "javascript",
+    "vue": "javascript",
+}
+
+
+def _embedded_script_spans(
+    raw: bytes, tree: Any, language: str, max_nodes: int
+) -> list[StructuralSpan]:
+    """Extract declarations from the `<script>` block of a component file."""
+    inner_language = _EMBEDDED_SCRIPT_LANGUAGES.get(language)
+    if inner_language is None:
+        return []
+    parser = _get_local_parser(inner_language)
+    if parser is None:
+        return []
+    spans: list[StructuralSpan] = []
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        parent = getattr(node, "parent", None)
+        if (
+            str(getattr(node, "type", "")) == "raw_text"
+            and parent is not None
+            and str(getattr(parent, "type", "")) == "script_element"
+        ):
+            offset = int(getattr(node, "start_byte", 0))
+            line_offset = int(node.start_point[0])
+            inner_raw = raw[offset:int(getattr(node, "end_byte", 0))]
+            inner_source = inner_raw.decode("utf-8", errors="surrogateescape")
+            # Prefer the pack's structure, which is clean for JavaScript; the
+            # raw tree walk is only the fallback, matching the main path so the
+            # embedded script is analysed exactly as a standalone file would be.
+            inner_items = _pack_structure_spans(
+                inner_source, "embedded.js", inner_raw, inner_language
+            )
+            if not inner_items:
+                inner_items = list(
+                    _spans_from_tree(
+                        inner_raw, parser.parse(inner_raw), inner_language, max_nodes
+                    ).items
+                )
+            for item in inner_items:
+                spans.append(StructuralSpan(
+                    name=item.name,
+                    kind=item.kind,
+                    start_line=item.start_line + line_offset,
+                    end_line=item.end_line + line_offset,
+                    source=item.source,
+                    signature=item.signature,
+                    indent=item.indent,
+                    start_byte=item.start_byte + offset,
+                    end_byte=item.end_byte + offset,
+                ))
+        stack.extend(getattr(node, "children", ()))
+    return spans
 
 
 _CONTROL_TYPES = frozenset({
@@ -791,6 +896,21 @@ def extract_structural_spans_report(
     if parsed is None:
         return None
     raw, tree, language = parsed
+    if language in _EMBEDDED_SCRIPT_LANGUAGES:
+        # The component's own markup has no declarations; its script does, and
+        # the grammar leaves that as opaque text. Re-parse the script block.
+        embedded = _embedded_script_spans(raw, tree, language, max_nodes)
+        metrics_state = _TraversalState()
+        for _node in _walk(tree.root_node, max_nodes, metrics_state):
+            pass
+        return StructuralExtraction(
+            items=tuple(embedded),
+            language=language,
+            complete=metrics_state.complete,
+            nodes_visited=metrics_state.visited,
+            max_nodes=max_nodes,
+            backend="embedded-script",
+        )
     # The pack's structure processing under-resolves some grammars: for Kotlin
     # it returns the top-level `fun` with a null name (dropped for lack of a
     # name) and omits a class's own methods entirely, yielding just the class.

--- a/entroly/tree_sitter_support.py
+++ b/entroly/tree_sitter_support.py
@@ -69,6 +69,20 @@ _DECLARATION_HINTS = frozenset({
 _LANGUAGE_DECLARATION_TYPES: dict[str, frozenset[str]] = {
     "haskell": frozenset({"function", "data_type"}),
     "perl": frozenset({"subroutine_declaration_statement"}),
+    # Go names a type in `type_spec` under `type_declaration`; the suffix rule
+    # sees only the wrapper and dropped every `type` in the file.
+    "go": frozenset({"type_spec"}),
+    # Solidity's contract/library/interface are `*_declaration` but the suffix
+    # rule's hint list has no "contract"; its functions already matched.
+    "solidity": frozenset({"contract_declaration", "library_declaration", "interface_declaration"}),
+    # Erlang defines a function as one or more `function_clause`s, each naming
+    # the function; nothing in the generic set matched them.
+    "erlang": frozenset({"function_clause"}),
+    # Zig names a function in `FnProto` positionally (a bare IDENTIFIER child);
+    # the suffix rule matches none of its PascalCase node types.
+    "zig": frozenset({"FnProto"}),
+    # Protobuf `message` names via a `message_name` child, no `name` field.
+    "proto": frozenset({"message", "enum"}),
 }
 
 _KIND_HINTS = (
@@ -301,13 +315,17 @@ def _first_identifier(node: Any) -> Any | None:
 # so this does not fire for it and the existing resolution still applies.
 _LANGUAGE_NAME_CHILD_TYPE: dict[str, str] = {
     "kotlin": "simple_identifier",
+    "zig": "IDENTIFIER",
+    "proto": "message_name",
 }
 
 # Grammars whose pack structure processing returns partial declarations (a named
 # class but null-named functions, no method descent), where the name-resolving
 # tree walk is more complete. Add a language only after verifying the walk does
 # strictly better for it, since the walk's own per-grammar coverage varies.
-_PACK_STRUCTURE_UNRELIABLE: frozenset[str] = frozenset({"kotlin"})
+_PACK_STRUCTURE_UNRELIABLE: frozenset[str] = frozenset(
+    {"kotlin", "dart", "go", "solidity"}
+)
 
 
 def _name_node(node: Any, language: str = "") -> Any | None:
@@ -339,18 +357,29 @@ def _kind(node_type: str) -> str:
 
 
 def _language_scoped_node_ok(node: Any, node_type: str, language: str) -> bool:
-    """A language-scoped declaration must carry an explicit `name` field.
+    """A language-scoped declaration must carry a resolvable name.
 
     The scoped node names are broad on purpose, and some are overloaded within
     their own grammar: Haskell's `function` denotes both a definition
     (`helper x = x + 1`, which has a `name`) and a function TYPE (`Int -> Int`,
-    which has none). Requiring the field keeps the definition and rejects the
-    type, without which the walk would emit `Int` as a function.
+    which has none). A name is resolvable when the node has an explicit `name`
+    field, or -- for the positional grammars that expose none -- a direct child
+    of the type this language uses for names (Zig's `IDENTIFIER` under
+    `FnProto`). The Haskell function type has neither, so it is still rejected
+    and the walk does not emit `Int` as a function.
     """
     if node_type not in _LANGUAGE_DECLARATION_TYPES.get(language, ()):
         return True
     field = getattr(node, "child_by_field_name", None)
-    return callable(field) and field("name") is not None
+    if callable(field) and field("name") is not None:
+        return True
+    preferred = _LANGUAGE_NAME_CHILD_TYPE.get(language)
+    if preferred:
+        return any(
+            str(getattr(child, "type", "")) == preferred
+            for child in getattr(node, "children", ())
+        )
+    return False
 
 
 def _is_declaration_type(node_type: str, language: str = "") -> bool:

--- a/tests/test_tree_sitter_support.py
+++ b/tests/test_tree_sitter_support.py
@@ -57,6 +57,19 @@ def test_language_map_covers_at_least_twenty_seven_languages() -> None:
         ("sample.zig", "pub fn total() void {}\nfn add() void {}\n", {"total", "add"}),
         # Protobuf `message` names via `message_name`, no `name` field.
         ("sample.proto", "message Cart {\n    string id = 1;\n}\n", {"Cart"}),
+        # R binds a function by assignment; the name is left of the arrow, and
+        # the anonymous `function_definition` must not surface as `function`.
+        ("sample.R", "total <- function(x) x + 1\nrunner <- function() total(1)\n", {"total", "runner"}),
+        # SQL names a created object in `object_reference`.
+        (
+            "sample.sql",
+            "CREATE FUNCTION add_tax(p int) RETURNS int AS $$ SELECT 1 $$ LANGUAGE SQL;\n",
+            {"add_tax"},
+        ),
+        # Svelte/Vue keep the script as opaque text; it is re-parsed as JS and
+        # the spans are shifted back to file coordinates.
+        ("sample.svelte", "<script>\nfunction total(){}\nclass Cart{}\n</script>\n<div/>\n", {"total", "Cart"}),
+        ("sample.vue", "<script>\nfunction total(){}\n</script>\n<template><div/></template>\n", {"total"}),
     ],
 )
 def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) -> None:
@@ -68,6 +81,36 @@ def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) 
         assert span.source in source
         assert source.splitlines()[span.start_line - 1].strip()
         assert span.start_line <= span.end_line
+
+
+def test_r_function_binding_does_not_leak_the_keyword() -> None:
+    """R's anonymous `function_definition` must not surface as `function`.
+
+    A function acquires a name only through assignment, so the binding is the
+    declaration; the bare definition node carries the keyword `function` and
+    was emitted as a symbol before the binding predicate and suppression.
+    """
+    pytest.importorskip("tree_sitter_language_pack")
+    spans = extract_structural_spans("helper <- function(x) x + 1\nx <- 5\n", "a.R")
+    assert spans is not None
+    names = {span.name for span in spans}
+    assert names == {"helper"}, names
+
+
+def test_embedded_script_spans_recover_exact_file_bytes() -> None:
+    """A Svelte span's byte range must address the real bytes in the file.
+
+    The script is parsed in isolation and its spans are shifted by the script
+    block's offset; an off-by-one there would still name the symbol but point
+    at the wrong bytes, which the byte-fidelity contract forbids.
+    """
+    pytest.importorskip("tree_sitter_language_pack")
+    source = "<p>hi</p>\n<script>\nfunction total(x){ return x }\n</script>\n"
+    spans = extract_structural_spans(source, "a.svelte")
+    assert spans is not None and spans
+    raw = source.encode("utf-8")
+    for span in spans:
+        assert raw[span.start_byte:span.end_byte].decode("utf-8") == span.source
 
 
 def test_kotlin_function_name_is_not_the_return_type_or_a_parameter() -> None:

--- a/tests/test_tree_sitter_support.py
+++ b/tests/test_tree_sitter_support.py
@@ -44,6 +44,19 @@ def test_language_map_covers_at_least_twenty_seven_languages() -> None:
             "total :: Int -> Int\ntotal x = x\n\ndata Cart = Empty\n",
             {"total", "Cart"},
         ),
+        # Go dropped every `type` -- its name lives in `type_spec`, and the
+        # pack structure omitted it. Both the func and the type must appear.
+        ("sample.go", "package m\nfunc total() {}\ntype Cart struct{}\n", {"total", "Cart"}),
+        # Dart's pack structure returned the class alone, no functions.
+        ("sample.dart", "int total(int x){return x;}\nclass Cart{ void add(){} }\n", {"total", "Cart", "add"}),
+        # Erlang defines a function as `function_clause`s.
+        ("sample.erl", "total(X) -> X.\nadd() -> total(1).\n", {"total", "add"}),
+        # Solidity's contract is `contract_declaration`, outside the hint set.
+        ("sample.sol", "contract Cart {\n    function total() public {}\n}\n", {"Cart", "total"}),
+        # Zig names a function positionally in `FnProto` (a bare IDENTIFIER).
+        ("sample.zig", "pub fn total() void {}\nfn add() void {}\n", {"total", "add"}),
+        # Protobuf `message` names via `message_name`, no `name` field.
+        ("sample.proto", "message Cart {\n    string id = 1;\n}\n", {"Cart"}),
     ],
 )
 def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) -> None:

--- a/tests/test_tree_sitter_support.py
+++ b/tests/test_tree_sitter_support.py
@@ -27,6 +27,23 @@ def test_language_map_covers_at_least_twenty_seven_languages() -> None:
         ("sample.rs", "pub struct Cart { n: u32 }\nimpl Cart { pub fn total(&self) -> u32 { self.n } }\n", {"Cart", "total"}),
         ("sample.ts", "export class Cart { total(): number { return 1; } }\n", {"Cart", "total"}),
         ("sample.c", "int total(int price) { return price; }\n", {"total"}),
+        # Kotlin's grammar names declarations positionally, with no `name`
+        # field, and the pack's structure processing returns the class alone.
+        # Both the top-level function and the class's own methods must appear.
+        (
+            "sample.kt",
+            "fun total(price: Int): Int { return price }\n"
+            "class Cart {\n    fun add() {}\n    fun clear() {}\n}\n",
+            {"total", "Cart", "add", "clear"},
+        ),
+        # Perl's sub is `subroutine_declaration_statement`, which the suffix
+        # heuristic skips; Haskell names a definition with a bare `function`.
+        ("sample.pl", "sub total { return 1 }\nsub add { }\n", {"total", "add"}),
+        (
+            "sample.hs",
+            "total :: Int -> Int\ntotal x = x\n\ndata Cart = Empty\n",
+            {"total", "Cart"},
+        ),
     ],
 )
 def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) -> None:
@@ -38,6 +55,21 @@ def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) 
         assert span.source in source
         assert source.splitlines()[span.start_line - 1].strip()
         assert span.start_line <= span.end_line
+
+
+def test_kotlin_function_name_is_not_the_return_type_or_a_parameter() -> None:
+    """Guards the exact defect: the name resolved to the return type.
+
+    `fun helper(x: Int): Int` has no `name` field, so the generic resolver
+    descended into the return type and returned `Int`, and a naive fix then
+    pulled in the parameter `x`. The Kotlin-scoped resolver takes the first
+    direct `simple_identifier`, which is the name and cannot be either.
+    """
+    pytest.importorskip("tree_sitter_language_pack")
+    spans = extract_structural_spans("fun helper(x: Int): Int { return x }\n", "a.kt")
+    assert spans is not None
+    names = {span.name for span in spans}
+    assert names == {"helper"}, names
 
 
 def test_semantic_resolution_uses_parser_spans_when_available() -> None:


### PR DESCRIPTION
A measured coverage audit across all **41 registry-mapped languages**, each tested against a representative sample. Symbol extraction went from **22 → 32 languages** with declarations.

## Coverage

| status | count | languages |
|---|---|---|
| **covered** | 32 | ada, bash, c, c#, c++, dart, elixir, erlang, fish, go, haskell, java, javascript, julia, kotlin, lua, php, proto, python, **r**, ruby, rust, scala, solidity, **sql**, **svelte**, swift, tsx, typescript, v, **vue**, zig |
| grammar-limited / deferred | 5 | groovy, c3, fsharp, nim, ocaml |
| no code declarations | 4 | asm, css, html, scss |

## What was fixed, and how (all read from real parse trees, guarded by measurement)

**Mainstream:**
- **Kotlin** extracted 1 symbol from a whole file, naming `fun helper(): Int` as `Int`. → 1→5, correct.
- **Go** dropped every `type` declaration (name in `type_spec`, omitted by the pack). → fixed.

**Mechanism per language:**
- **Kotlin/Dart/Go/Solidity/R**: pack structure returns partial output, so these use the name-resolving tree walk. Scoped explicitly — forcing it generally regressed JavaScript's anonymous arrow.
- **Go/Solidity/Erlang/Zig/Protobuf/SQL**: declaration node types added to a per-language scoped map (`type_spec`, `contract_declaration`, `function_clause`, `FnProto`, `message`, `create_function`…).
- **Kotlin/Zig/Protobuf/SQL** name positionally — a scoped resolver takes the first direct name-child, which can't be a parameter or return type.
- **R** has no standalone function declaration (anonymous value bound by `<-`); a node predicate matches the binding, the name comes from the identifier left of the arrow, and the bare `function_definition` is suppressed so it stops leaking the keyword `function`.
- **Svelte/Vue** keep the script as opaque `raw_text`; it's re-parsed as JavaScript and each span is shifted by the block's byte/line offset — **byte fidelity asserted by test**.
- **Perl, Haskell**: `subroutine_declaration_statement` / bare `function` (with a name-field guard that rejects Haskell's function *type* `Int -> Int`).

## Honest gaps (documented, not half-fixed)
- **Groovy**: grammar parses `def`/`class` as a `command` indistinguishable from a method call — cannot support extraction without inventing symbols from calls.
- **c3, F#, Nim, OCaml**: ML-style / deeply-nested naming, left for dedicated work.

## Regression safety
- Every mechanism **keyed by language** — unnamed grammars provably unaffected.
- **Byte-identical output** re-verified on the 12 languages that already worked; Haskell still never emits `Int`.
- New per-language tests **fail against prior code** (mutation-verified); byte-offset fidelity test for embedded scripts. Full suite: no new failures (3 pre-existing `test_adaptive_program_graph` zig-grammar-loading failures unrelated, present on `main`).

## Scope
Three commits, product code + tests only. No packaging, release, or native surface touched.