### PR TITLE
Add auditable Context Health dashboard

### DIFF
--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -132,7 +132,7 @@ Core protections include:
 
 ## Observability and cost
 
-The dashboard and receipts can show source tokens, selected tokens, cache signals, model identity, and modeled cost. A modeled dollar value depends on the configured price table and is not a provider invoice.
+The dashboard and receipts can show source tokens, selected tokens, cache signals, model identity, and modeled cost. Its Context Health panel separately reports measured net tokens after re-expansion, recovery tax, receipt integrity, omission recoverability, and observed unsupported-claim suppressions. The privacy-safe share text contains aggregate counters only. A modeled dollar value depends on the configured price table and is not a provider invoice; unmeasured source freshness remains `unavailable`.
 
 No-provider-call paths still use local CPU, memory, storage, and operator time. Public copy should say “no additional provider call” rather than “free.”
 

--- a/docs/context-control-plane.md
+++ b/docs/context-control-plane.md
@@ -74,9 +74,18 @@ The dashboard is an evidence viewer rather than another chat UI. It provides:
 - a selected-versus-omitted context ring;
 - receipt and chain-integrity status;
 - bounded evidence excerpts and an omitted-evidence explorer;
-- model, context, output, and cost information when the receipt contains enough data.
+- model, context, output, and cost information when the receipt contains enough data;
+- a content-blind Context Health summary for measured net tokens after
+  re-expansion, recovery tax, receipt integrity, omission recoverability, and
+  observed WITNESS suppressions.
 
 Unknown values stay `Unknown`; Entroly does not invent usage or cost. Cost estimates identify their basis and exclude cache discounts, long-context tiers, provider routing, and negotiated pricing.
+
+The Context Health share text contains aggregate counters only—never prompts,
+code, paths, queries, model names, receipt identifiers, or pseudonyms. A zero
+counter means no event was observed, not that Entroly eliminated the risk.
+Receipt-chain integrity does not imply source freshness; that dimension remains
+explicitly unavailable until a source check supplies direct evidence.
 
 The scanner is read-only and bounded by file count, file size, directory depth, and excerpt size. Corrupt, conflicting, oversized, or incomplete artifacts appear as diagnostics.
 

--- a/entroly/context_health.py
+++ b/entroly/context_health.py
@@ -1,0 +1,238 @@
+"""Evidence-classified aggregate context health for the local dashboard.
+
+The dashboard must not turn architectural capabilities into outcome claims.
+This module reports only counters that can be derived from local receipts,
+the optimization ledger, and the value tracker.  It never reads or returns
+prompt, code, path, query, model, receipt, or pseudonymous identifiers.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "entroly.context-health.v1"
+
+
+def _nonnegative_int(value: object) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _signed_int(value: object) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _nonnegative_float(value: object) -> float:
+    try:
+        number = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    return number if number >= 0.0 and number < float("inf") else 0.0
+
+
+def default_ledger_path() -> Path:
+    configured = os.environ.get("ENTROLY_OPTIMIZATION_LEDGER", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    state = Path(os.environ.get("ENTROLY_DIR", ".entroly")).expanduser()
+    return state / "optimization-ledger.sqlite3"
+
+
+def _ledger_summary(path: Path) -> tuple[dict[str, int], bool]:
+    if not path.is_file():
+        return {}, False
+    from .optimization_ledger import OptimizationLedger
+
+    return OptimizationLedger(path).summary().as_dict(), True
+
+
+def _session_summary(index: Any) -> dict[str, Any]:
+    listed = index.list_sessions(limit=100)
+    sessions = listed.get("sessions", []) if isinstance(listed, Mapping) else []
+    diagnostics = listed.get("diagnostics", []) if isinstance(listed, Mapping) else []
+    result = {
+        "available": bool(sessions),
+        "sessions_total": _nonnegative_int(
+            listed.get("total", len(sessions)) if isinstance(listed, Mapping) else 0
+        ),
+        "sessions_sampled": 0,
+        "valid_sessions": 0,
+        "invalid_sessions": 0,
+        "receipts_sampled": 0,
+        "selected_tokens": 0,
+        "omitted_tokens": 0,
+        "omitted_items": 0,
+        "recoverable_omitted_items": 0,
+        "diagnostics": min(len(diagnostics), 20),
+    }
+    for summary in sessions:
+        if not isinstance(summary, Mapping):
+            continue
+        session = index.get_session(str(summary.get("key", "")))
+        if not isinstance(session, Mapping):
+            continue
+        result["sessions_sampled"] += 1
+        integrity = session.get("integrity", {})
+        if isinstance(integrity, Mapping) and integrity.get("valid") is True:
+            result["valid_sessions"] += 1
+        else:
+            result["invalid_sessions"] += 1
+        receipts = session.get("receipts", [])
+        if not isinstance(receipts, list):
+            continue
+        for receipt in receipts:
+            if not isinstance(receipt, Mapping):
+                continue
+            result["receipts_sampled"] += 1
+            result["selected_tokens"] += _nonnegative_int(
+                receipt.get("selected_tokens")
+            )
+            result["omitted_tokens"] += _nonnegative_int(receipt.get("omitted_tokens"))
+            omitted = receipt.get("omitted", [])
+            if not isinstance(omitted, list):
+                continue
+            for item in omitted:
+                if not isinstance(item, Mapping):
+                    continue
+                result["omitted_items"] += 1
+                if item.get("recoverable") is True:
+                    result["recoverable_omitted_items"] += 1
+
+    sampled = result["sessions_sampled"]
+    omitted_items = result["omitted_items"]
+    result["integrity_pct"] = (
+        round(result["valid_sessions"] * 100.0 / sampled, 1) if sampled else None
+    )
+    result["recoverability_pct"] = (
+        round(result["recoverable_omitted_items"] * 100.0 / omitted_items, 1)
+        if omitted_items
+        else None
+    )
+    return result
+
+
+def build_context_health(
+    *,
+    index: Any | None = None,
+    ledger_path: str | Path | None = None,
+    value_confidence: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a content-blind, locally derived context-health snapshot."""
+    if index is None:
+        from .context_sessions import ContextSessionIndex
+
+        index = ContextSessionIndex()
+    if value_confidence is None:
+        from .value_tracker import get_tracker
+
+        tracker = get_tracker()
+        tracker.reload_if_changed()
+        value_confidence = tracker.get_confidence()
+
+    sessions = _session_summary(index)
+    path = Path(ledger_path).expanduser() if ledger_path else default_ledger_path()
+    ledger, ledger_available = _ledger_summary(path)
+
+    lifetime = value_confidence.get("lifetime", {})
+    if not isinstance(lifetime, Mapping):
+        lifetime = {}
+    provider_tokens = _nonnegative_int(lifetime.get("tokens_saved"))
+    provider_cost = _nonnegative_float(lifetime.get("cost_saved_usd"))
+    unsupported_blocked = _nonnegative_int(lifetime.get("hallucinations_blocked"))
+    gross = _nonnegative_int(ledger.get("measured_gross_tokens"))
+    reexpanded = _nonnegative_int(ledger.get("measured_reexpanded_tokens"))
+    # Re-expansion can exceed gross reduction. Preserve that negative result:
+    # hiding a token-negative or cost-negative session would make the dashboard
+    # a marketing counter rather than an accounting surface.
+    net = _signed_int(ledger.get("measured_net_tokens"))
+    net_micro_usd = _signed_int(ledger.get("measured_net_micro_usd"))
+    recovery_tax_pct = round(reexpanded * 100.0 / gross, 1) if gross else None
+
+    integrity_status = "measured" if sessions["sessions_sampled"] else "unavailable"
+    recovery_status = (
+        "measured" if ledger_available and gross else
+        "available_no_measured_events" if ledger_available else
+        "unavailable"
+    )
+    share_parts = ["Entroly Context Health"]
+    if provider_tokens:
+        share_parts.append(f"{provider_tokens:,} provider-bound input tokens reduced")
+    if provider_cost:
+        share_parts.append(f"${provider_cost:.4f} modeled input cost avoided")
+    if sessions["sessions_sampled"]:
+        share_parts.append(
+            f"{sessions['valid_sessions']}/{sessions['sessions_sampled']} receipt chains verified"
+        )
+    if recovery_tax_pct is not None:
+        share_parts.append(f"{recovery_tax_pct:.1f}% measured recovery tax")
+    if unsupported_blocked:
+        share_parts.append(f"{unsupported_blocked} unsupported claims blocked")
+    share_parts.append("local aggregate only; no prompts, code, paths, or queries")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": time.time(),
+        "privacy": {
+            "content_blind": True,
+            "contains_user_content": False,
+            "contains_identifiers": False,
+            "leaves_machine": False,
+        },
+        "value": {
+            "provider_bound_tokens_reduced": provider_tokens,
+            "modeled_provider_cost_avoided_usd": round(provider_cost, 6),
+            "modeled_cost_basis": "configured input rates; not a provider invoice",
+            "ledger_status": recovery_status,
+            "measured_gross_tokens": gross,
+            "measured_reexpanded_tokens": reexpanded,
+            "measured_net_tokens": net,
+            "measured_net_usd": round(net_micro_usd / 1_000_000.0, 6),
+            "recovery_tax_pct": recovery_tax_pct,
+        },
+        "evidence": sessions,
+        "protections": {
+            "confusion": {
+                "label": "Unsupported-claim protection",
+                "status": "observed" if unsupported_blocked else "no_events_observed",
+                "unsupported_claims_blocked": unsupported_blocked,
+                "scope": "WITNESS suppressions only; not proof that every answer is correct",
+            },
+            "rot": {
+                "label": "Recoverability and re-expansion",
+                "status": recovery_status,
+                "recoverability_pct": sessions["recoverability_pct"],
+                "recovery_tax_pct": recovery_tax_pct,
+                "scope": "omitted-evidence recovery; not a universal context-rot cure",
+            },
+            "drift": {
+                "label": "Receipt-chain integrity",
+                "status": integrity_status,
+                "integrity_pct": sessions["integrity_pct"],
+                "invalid_sessions": sessions["invalid_sessions"],
+                "source_freshness": "unavailable",
+                "scope": "receipt-chain drift only; source freshness is not measured here",
+            },
+        },
+        "share": {
+            "safe_to_share": True,
+            "text": " • ".join(share_parts),
+        },
+        "limitations": [
+            "Provider cost is modeled from configured rates and is not an invoice.",
+            "A zero counter means no event was observed, not that the risk was eliminated.",
+            "Source freshness and counterfactual answer quality are not inferred.",
+            "Receipt aggregates are bounded to the newest 100 locally discoverable sessions.",
+        ],
+    }
+
+
+__all__ = ["SCHEMA_VERSION", "build_context_health", "default_ledger_path"]

--- a/entroly/dashboard.py
+++ b/entroly/dashboard.py
@@ -711,8 +711,12 @@ tr:hover td{background:rgba(255,255,255,0.015);}
 .evidence-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;}.evidence-item{padding:11px;border:1px solid var(--border);border-radius:10px;background:var(--glass);min-width:0;}
 .evidence-path{font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--blue);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}.evidence-reason{font-size:10px;color:var(--dim);margin-top:5px;}.evidence-excerpt{font-size:11px;color:#aab2c0;margin-top:8px;line-height:1.45;white-space:pre-wrap;max-height:90px;overflow:auto;}
 .context-diagnostic{padding:10px 12px;margin:10px;border:1px solid rgba(251,191,36,.3);background:var(--amber-glow);color:var(--amber);border-radius:9px;font-size:11px;}
+.context-health-panel{margin-bottom:20px;padding:20px;border:1px solid rgba(34,211,238,.22);border-radius:14px;background:linear-gradient(145deg,rgba(34,211,238,.055),rgba(139,92,246,.035));}
+.context-health-head{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:16px}.context-health-head h2{margin:0 0 5px;font-size:18px}.context-health-head p{margin:0;color:var(--dim);font-size:11px;line-height:1.45;max-width:760px}
+.context-health-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}.context-health-card{padding:14px;border:1px solid var(--border);border-radius:11px;background:var(--glass)}.context-health-card label{display:block;color:var(--dim);font-size:9px;text-transform:uppercase;letter-spacing:1px}.context-health-card strong{display:block;margin-top:7px;font-size:21px}.context-health-card small{display:block;margin-top:6px;color:var(--dim2);font-size:9px;line-height:1.4}
+.context-protections{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:10px}.context-protection{padding:13px;border:1px solid var(--border);border-radius:11px;background:rgba(7,11,20,.42)}.context-protection b{display:block;font-size:12px}.context-protection span{display:block;margin-top:6px;color:var(--dim);font-size:10px;line-height:1.45}.context-share{border:1px solid rgba(52,211,153,.35);background:rgba(52,211,153,.09);color:var(--emerald);padding:8px 12px;border-radius:8px;font-size:11px;font-weight:700;cursor:pointer;white-space:nowrap}.context-share:hover{background:rgba(52,211,153,.15)}
 @media(max-width:1100px){.hero-metrics{grid-template-columns:1fr 1fr;}.grid3{grid-template-columns:1fr 1fr;}.ba-panel{grid-template-columns:1fr;}.cache-kpis{grid-template-columns:1fr 1fr;}.cache-split{grid-template-columns:1fr;}}
-@media(max-width:900px){.context-grid{grid-template-columns:1fr}.context-list{border-right:0;border-bottom:1px solid var(--border);max-height:240px}.context-overview{grid-template-columns:1fr}.context-ring{margin:auto}.context-kpis{grid-template-columns:1fr 1fr}}
+@media(max-width:900px){.context-grid{grid-template-columns:1fr}.context-list{border-right:0;border-bottom:1px solid var(--border);max-height:240px}.context-overview{grid-template-columns:1fr}.context-ring{margin:auto}.context-kpis{grid-template-columns:1fr 1fr}.context-health-grid{grid-template-columns:1fr 1fr}.context-protections{grid-template-columns:1fr}}
 @media(max-width:768px){.hero-metrics,.grid2,.grid3,.cache-kpis{grid-template-columns:1fr;}.main{padding:16px;}.hero-big{font-size:48px;}.context-head{align-items:flex-start;flex-direction:column}.context-search{width:100%}.evidence-grid{grid-template-columns:1fr}.topbar{padding:12px 16px;gap:8px}.brand{gap:8px}.brand h1{font-size:20px}.brand .btag{font-size:9px;padding:3px 7px}.topbar>div:last-child{gap:8px;flex-wrap:wrap;justify-content:flex-end}.live{display:none}.whisper{display:block;line-height:1.55;overflow-wrap:anywhere}.whisper code{display:inline;white-space:normal;overflow-wrap:anywhere}.whisper .dismiss{float:right;margin-left:8px}}
 </style>
 </head>
@@ -738,6 +742,7 @@ tr:hover td{background:rgba(255,255,255,0.015);}
     </div>
     <div class="context-grid"><div id="contextList" class="context-list"><div class="empty">Loading context receipts…</div></div><div id="contextDetail" class="context-detail"><div class="empty">Select a session to inspect its context proof.</div></div></div>
   </section>
+  <section id="contextHealth" class="context-health-panel" aria-live="polite"><div class="empty">Loading aggregate context health…</div></section>
   <div class="hero" id="hero"></div>
   <div id="valueTrends"></div>
   <div id="ba"></div>
@@ -1061,6 +1066,42 @@ function renderContextSession(data){
   const issues=(integrity.issues||[]).map(x=>escHtml(x)).join(' · ');
   document.getElementById('contextDetail').innerHTML='<div class="context-overview"><div class="context-ring" style="--ring:'+ratio+'%"><div class="context-ring-value">'+ratio+'%<small>CONTEXT KEPT</small></div></div><div><div style="font-size:18px;font-weight:800;margin-bottom:4px">'+escHtml(summary.query||summary.session_id)+'</div><div style="font-size:11px;color:'+(integrity.valid?'var(--emerald)':'var(--rose)')+'">'+(integrity.valid?'Chain and receipt integrity verified':'Integrity requires attention: '+issues)+'</div><div class="context-kpis" style="margin-top:13px"><div class="context-kpi"><label>Model</label><strong title="'+escHtml(model.model||'Unknown')+'">'+escHtml(model.model||'Unknown')+'</strong>'+(model.model?'':'<small>'+escHtml(model.warning||'No model provenance was recorded.')+'</small>')+'</div><div class="context-kpi"><label>Selected / budget</label><strong>'+fmt(latest.selected_tokens||0)+' / '+fmt(latest.token_budget||0)+'</strong></div><div class="context-kpi"><label>Omitted evidence</label><strong>'+fmt(latest.omitted_count||0)+' items · '+fmt(latest.omitted_tokens||0)+'</strong></div><div class="context-kpi"><label>Cost</label><strong title="'+escHtml(model.pricing_note||'')+'">'+cost+'</strong>'+(cost==='Unknown'&&model.pricing_note?'<small>'+escHtml(model.pricing_note)+'</small>':'')+'</div></div></div></div><div class="context-section"><h3>Receipt timeline</h3><div class="receipt-turns">'+(turns||'<span class="empty">No receipt links</span>')+'</div></div><div class="context-section"><h3>Selected evidence</h3><div class="evidence-grid">'+(selected||'<div class="empty">No selected evidence body stored.</div>')+'</div></div><div class="context-section"><h3>Omitted-evidence explorer</h3><div class="evidence-grid">'+(omitted||'<div class="empty">No omitted evidence recorded.</div>')+'</div></div>';
 }
+let contextHealthShare='';
+function healthValue(value,suffix=''){
+  return value==null?'Not measured':String(value)+suffix;
+}
+async function copyContextHealth(){
+  if(!contextHealthShare)return;
+  try{await navigator.clipboard.writeText(contextHealthShare);const b=document.getElementById('contextShare');if(b){b.textContent='Copied aggregate proof';setTimeout(()=>b.textContent='Copy privacy-safe proof',1800);}}
+  catch(error){console.error('Copy context health:',error);}
+}
+function renderContextHealth(data){
+  const el=document.getElementById('contextHealth');if(!el)return;
+  const value=data.value||{},evidence=data.evidence||{},protections=data.protections||{};
+  const confusion=protections.confusion||{},rot=protections.rot||{},drift=protections.drift||{};
+  const measured=value.ledger_status==='measured';contextHealthShare=((data.share||{}).text)||'';
+  const net=measured?fmt(value.measured_net_tokens||0):'Not measured';
+  const netClass=measured&&Number(value.measured_net_tokens||0)<0?'hv-rose':'hv-green';
+  const recovery=value.recovery_tax_pct==null?'Not measured':Number(value.recovery_tax_pct).toFixed(1)+'%';
+  const integrity=evidence.integrity_pct==null?'No receipts':Number(evidence.integrity_pct).toFixed(1)+'%';
+  const recoverable=evidence.recoverability_pct==null?'Not measured':Number(evidence.recoverability_pct).toFixed(1)+'%';
+  el.innerHTML='<div class="context-health-head"><div><h2>Context Health</h2><p>Aggregate evidence only. Zero means no event observed—not that a risk was eliminated. Dollar values are modeled; source freshness stays unavailable until directly checked.</p></div><button id="contextShare" class="context-share" onclick="copyContextHealth()" '+(contextHealthShare?'':'disabled')+'>Copy privacy-safe proof</button></div>'+
+    '<div class="context-health-grid">'+
+      '<div class="context-health-card"><label>Measured net tokens</label><strong class="'+netClass+'">'+net+'</strong><small>'+(measured?fmt(value.measured_gross_tokens||0)+' gross − '+fmt(value.measured_reexpanded_tokens||0)+' re-expanded':'Enable the optimization ledger for net accounting')+'</small></div>'+
+      '<div class="context-health-card"><label>Recovery tax</label><strong class="hv-amber">'+recovery+'</strong><small>Re-expanded tokens ÷ measured gross reduction</small></div>'+
+      '<div class="context-health-card"><label>Receipt integrity</label><strong class="hv-blue">'+integrity+'</strong><small>'+fmt(evidence.valid_sessions||0)+' valid / '+fmt(evidence.sessions_sampled||0)+' sampled sessions</small></div>'+
+      '<div class="context-health-card"><label>Omission recoverability</label><strong class="hv-violet">'+recoverable+'</strong><small>'+fmt(evidence.recoverable_omitted_items||0)+' recoverable / '+fmt(evidence.omitted_items||0)+' omitted items</small></div>'+
+    '</div><div class="context-protections">'+
+      '<div class="context-protection"><b>Confusion protection</b><span>'+fmt(confusion.unsupported_claims_blocked||0)+' unsupported claims blocked. '+escHtml(confusion.scope||'')+'</span></div>'+
+      '<div class="context-protection"><b>Rot resilience</b><span>Status: '+escHtml(rot.status||'unavailable')+'. '+escHtml(rot.scope||'')+'</span></div>'+
+      '<div class="context-protection"><b>Drift protection</b><span>Status: '+escHtml(drift.status||'unavailable')+'; source freshness '+escHtml(drift.source_freshness||'unavailable')+'. '+escHtml(drift.scope||'')+'</span></div>'+
+    '</div>';
+}
+async function refreshContextHealth(){
+  const el=document.getElementById('contextHealth');
+  try{const response=await fetch('/api/context/health');if(!response.ok)throw new Error('Context health returned '+response.status);renderContextHealth(await response.json());}
+  catch(error){if(el)el.innerHTML='<div class="context-diagnostic">Context health unavailable: '+escHtml(error.message||error)+'</div>';}
+}
 function renderWitness(d){
   const w=d.witness||{},el=document.getElementById('witness'),b=document.getElementById('wb');
   if(!el||!b)return;
@@ -1239,7 +1280,7 @@ async function refresh(){
     renderErrors([{section:'fetch',type:e.name||'Error',message:e.message||String(e)}]);
   }
 }
-refresh();setInterval(refresh,3000);refreshContextSessions();setInterval(()=>refreshContextSessions(),15000);
+refresh();setInterval(refresh,3000);refreshContextSessions();setInterval(()=>refreshContextSessions(),15000);refreshContextHealth();setInterval(refreshContextHealth,15000);
 </script>
 </body>
 </html>
@@ -1297,6 +1338,8 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self._send_json(200, self._safe_tracker_call("get_confidence"))
         elif path == "/api/context/sessions":
             self._handle_context_sessions(parse_qs(parsed.query))
+        elif path == "/api/context/health":
+            self._handle_context_health()
         elif path.startswith("/api/context/sessions/"):
             self._handle_context_session(path.removeprefix("/api/context/sessions/"))
         elif path == "/health":
@@ -1337,6 +1380,20 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": "context session not found"})
             return
         self._send_json(200, session)
+
+    def _handle_context_health(self) -> None:
+        try:
+            from entroly.context_health import build_context_health
+
+            self._send_json(200, build_context_health())
+        except Exception as error:
+            self._send_json(
+                503,
+                {
+                    "error": "context health is temporarily unavailable",
+                    "type": type(error).__name__,
+                },
+            )
 
     @staticmethod
     def _safe_tracker_call(method: str) -> dict:

--- a/tests/test_context_health.py
+++ b/tests/test_context_health.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+
+from entroly.context_health import build_context_health
+from entroly.optimization_ledger import (
+    OptimizationAdjustment,
+    OptimizationEvent,
+    OptimizationLedger,
+    SavingsTier,
+)
+
+
+class _Index:
+    def list_sessions(self, *, query: str = "", limit: int = 50):
+        assert query == ""
+        assert limit == 100
+        return {
+            "total": 2,
+            "diagnostics": [{"message": "bounded diagnostic"}],
+            "sessions": [
+                {"key": "valid"},
+                {"key": "invalid"},
+            ],
+        }
+
+    def get_session(self, key: str):
+        if key == "valid":
+            return {
+                "integrity": {"valid": True},
+                "receipts": [
+                    {
+                        "selected_tokens": 400,
+                        "omitted_tokens": 600,
+                        "selected": [{"excerpt": "private selected code"}],
+                        "omitted": [
+                            {
+                                "recoverable": True,
+                                "excerpt": "private omitted code",
+                                "source_path": "private.py",
+                            },
+                            {"recoverable": False, "excerpt": "secret"},
+                        ],
+                    }
+                ],
+            }
+        return {
+            "integrity": {"valid": False, "issues": ["tampered-private-id"]},
+            "receipts": [],
+        }
+
+
+def test_context_health_reports_net_evidence_without_user_content(tmp_path):
+    ledger_path = tmp_path / "optimization.sqlite3"
+    ledger = OptimizationLedger(ledger_path)
+    ledger.record(
+        OptimizationEvent(
+            event_id="event-private",
+            feature="compression",
+            tier=SavingsTier.MEASURED,
+            gross_tokens_saved=1_000,
+            gross_micro_usd=5_000,
+            cost_micro_usd=500,
+            session_id="session-private",
+            metadata={"prompt": "do not leak me"},
+        )
+    )
+    ledger.adjust(
+        OptimizationAdjustment(
+            adjustment_id="adjust-private",
+            event_id="event-private",
+            tokens_reexpanded=250,
+            cost_micro_usd=1_000,
+        )
+    )
+
+    report = build_context_health(
+        index=_Index(),
+        ledger_path=ledger_path,
+        value_confidence={
+            "lifetime": {
+                "tokens_saved": 2_000,
+                "cost_saved_usd": 0.012345,
+                "hallucinations_blocked": 3,
+            }
+        },
+    )
+
+    assert report["schema_version"] == "entroly.context-health.v1"
+    assert report["value"]["measured_gross_tokens"] == 1_000
+    assert report["value"]["measured_reexpanded_tokens"] == 250
+    assert report["value"]["measured_net_tokens"] == 750
+    assert report["value"]["measured_net_usd"] == 0.0035
+    assert report["value"]["recovery_tax_pct"] == 25.0
+    assert report["evidence"]["integrity_pct"] == 50.0
+    assert report["evidence"]["recoverability_pct"] == 50.0
+    assert report["protections"]["confusion"]["unsupported_claims_blocked"] == 3
+    assert report["protections"]["drift"]["source_freshness"] == "unavailable"
+    assert report["privacy"]["content_blind"] is True
+    serialized = json.dumps(report, sort_keys=True)
+    for private in (
+        "private selected code",
+        "private omitted code",
+        "private.py",
+        "tampered-private-id",
+        "event-private",
+        "session-private",
+        "do not leak me",
+    ):
+        assert private not in serialized
+
+
+def test_context_health_marks_unobserved_dimensions_honestly(tmp_path):
+    report = build_context_health(
+        index=_IndexWithoutSessions(),
+        ledger_path=tmp_path / "missing.sqlite3",
+        value_confidence={"lifetime": {}},
+    )
+
+    assert report["value"]["ledger_status"] == "unavailable"
+    assert report["value"]["recovery_tax_pct"] is None
+    assert report["evidence"]["integrity_pct"] is None
+    assert report["protections"]["confusion"]["status"] == "no_events_observed"
+    assert report["protections"]["rot"]["status"] == "unavailable"
+    assert report["protections"]["drift"]["status"] == "unavailable"
+    assert "fixed" not in report["share"]["text"].casefold()
+
+
+def test_context_health_preserves_token_negative_recovery_outcomes(tmp_path):
+    ledger_path = tmp_path / "negative.sqlite3"
+    ledger = OptimizationLedger(ledger_path)
+    ledger.record(
+        OptimizationEvent(
+            event_id="negative-event",
+            feature="compression",
+            tier=SavingsTier.MEASURED,
+            gross_tokens_saved=100,
+            gross_micro_usd=100,
+        )
+    )
+    ledger.adjust(
+        OptimizationAdjustment(
+            adjustment_id="negative-adjustment",
+            event_id="negative-event",
+            tokens_reexpanded=150,
+            cost_micro_usd=200,
+        )
+    )
+
+    report = build_context_health(
+        index=_IndexWithoutSessions(),
+        ledger_path=ledger_path,
+        value_confidence={"lifetime": {}},
+    )
+
+    assert report["value"]["measured_net_tokens"] == -50
+    assert report["value"]["measured_net_usd"] == -0.0001
+    assert report["value"]["recovery_tax_pct"] == 150.0
+
+
+class _IndexWithoutSessions:
+    def list_sessions(self, *, query: str = "", limit: int = 50):
+        return {"total": 0, "diagnostics": [], "sessions": []}
+
+    def get_session(self, key: str):
+        raise AssertionError("get_session must not be called without sessions")

--- a/tests/test_dashboard_context_health.py
+++ b/tests/test_dashboard_context_health.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import entroly.context_health as context_health
+import entroly.dashboard as dashboard
+
+
+def test_dashboard_exposes_context_health_panel_and_refresh_loop():
+    assert 'id="contextHealth"' in dashboard.DASHBOARD_HTML
+    assert "function renderContextHealth" in dashboard.DASHBOARD_HTML
+    assert "fetch('/api/context/health')" in dashboard.DASHBOARD_HTML
+    assert "Copy privacy-safe proof" in dashboard.DASHBOARD_HTML
+    assert "Zero means no event observed" in dashboard.DASHBOARD_HTML
+    assert "measured_net_tokens||0)<0?'hv-rose':'hv-green'" in dashboard.DASHBOARD_HTML
+
+
+def test_context_health_endpoint_returns_aggregate_report(monkeypatch):
+    expected = {
+        "schema_version": "entroly.context-health.v1",
+        "privacy": {"content_blind": True},
+    }
+    monkeypatch.setattr(context_health, "build_context_health", lambda: expected)
+    handler = object.__new__(dashboard.DashboardHandler)
+    responses: list[tuple[int, dict]] = []
+    handler._send_json = lambda status, payload: responses.append((status, payload))
+
+    handler._handle_context_health()
+
+    assert responses == [(200, expected)]
+
+
+def test_context_health_endpoint_fails_without_leaking_error_text(monkeypatch):
+    def fail():
+        raise RuntimeError("private path C:/customer/secret.py")
+
+    monkeypatch.setattr(context_health, "build_context_health", fail)
+    handler = object.__new__(dashboard.DashboardHandler)
+    responses: list[tuple[int, dict]] = []
+    handler._send_json = lambda status, payload: responses.append((status, payload))
+
+    handler._handle_context_health()
+
+    assert responses == [
+        (
+            503,
+            {
+                "error": "context health is temporarily unavailable",
+                "type": "RuntimeError",
+            },
+        )
+    ]
+    assert "secret.py" not in str(responses)


### PR DESCRIPTION
## Summary
- add a local, content-blind Context Health API and dashboard panel
- report measured net token savings after re-expansion, recovery tax, receipt integrity, and omission recoverability
- explain the measured scope of confusion, context rot, and context drift protections
- provide privacy-safe aggregate share text without prompts, content, identifiers, paths, or model names

## Trust boundaries
- modeled provider cost avoided is an estimate, not an invoice
- zero blocked claims means no event was observed; it does not claim risk elimination
- source freshness remains explicitly unavailable until measured
- negative net outcomes are retained instead of clamped

## Validation
- 91 focused dashboard, privacy, telemetry, session, and security tests passed
- Ruff passed
- Rust Clippy passed with warnings denied
- Rust library tests: 133 passed, 5 ignored
- browser visual QA completed for the worktree dashboard
- repository-wide Python suite exceeded the 15-minute local command ceiling without reporting a failure; GitHub CI remains the full gate