### PR TITLE
Guard provider cache economics against optimizer interference

### DIFF
--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -132,7 +132,7 @@ Core protections include:
 
 ## Observability and cost
 
-The dashboard and receipts can show source tokens, selected tokens, cache signals, model identity, and modeled cost. Its Context Health panel separately reports measured net tokens after re-expansion, recovery tax, receipt integrity, omission recoverability, and observed unsupported-claim suppressions. The privacy-safe share text contains aggregate counters only. A modeled dollar value depends on the configured price table and is not a provider invoice; unmeasured source freshness remains `unavailable`.
+The dashboard and receipts can show source tokens, selected tokens, cache signals, model identity, and modeled cost. Its Context Health panel separately reports retrieval-adjusted net tokens after re-expansion, provider-observed cache categories, hash-only prefix continuity, recovery tax, receipt integrity, omission recoverability, and observed unsupported-claim suppressions. The privacy-safe share text contains aggregate counters only. Economic net value remains unavailable without a paired baseline; a modeled dollar value depends on the configured price table and is not a provider invoice; unmeasured source freshness remains `unavailable`.
 
 No-provider-call paths still use local CPU, memory, storage, and operator time. Public copy should say “no additional provider call” rather than “free.”
 

--- a/docs/context-control-plane.md
+++ b/docs/context-control-plane.md
@@ -75,11 +75,23 @@ The dashboard is an evidence viewer rather than another chat UI. It provides:
 - receipt and chain-integrity status;
 - bounded evidence excerpts and an omitted-evidence explorer;
 - model, context, output, and cost information when the receipt contains enough data;
-- a content-blind Context Health summary for measured net tokens after
-  re-expansion, recovery tax, receipt integrity, omission recoverability, and
-  observed WITNESS suppressions.
+- a content-blind Context Health summary for retrieval-adjusted net tokens,
+  provider-observed cache categories, hash-only prefix continuity, recovery
+  tax, receipt integrity, omission recoverability, and observed WITNESS
+  suppressions.
 
 Unknown values stay `Unknown`; Entroly does not invent usage or cost. Cost estimates identify their basis and exclude cache discounts, long-context tiers, provider routing, and negotiated pricing.
+
+## Optimizer interference
+
+Context Health separates retrieval-adjusted reduction from provider cache
+economics. The proxy uses a hash-only prefix-continuity guard to detect when an
+optional transform would shorten an append-only agent's reusable prompt prefix.
+For a provider-observed warm cache, the safer baseline wins; required recovery,
+redaction, and emergency context rescue remain authoritative. See
+[`optimizer-interference-guard.md`](optimizer-interference-guard.md).
+Content-blind provider token categories are available process-locally by
+default; durable history and priced accounting remain explicit local opt-ins.
 
 The Context Health share text contains aggregate counters only—never prompts,
 code, paths, queries, model names, receipt identifiers, or pseudonyms. A zero

--- a/docs/optimizer-interference-guard.md
+++ b/docs/optimizer-interference-guard.md
@@ -1,0 +1,69 @@
+# Optimizer interference and provider prompt caches
+
+Reducing the number of tokens in one request is not the same as reducing total
+provider cost. An optimizer can rewrite old conversation history, shorten the
+current request, and still lose money when the rewrite invalidates a discounted
+provider prefix cache.
+
+Entroly separates four quantities:
+
+1. **Gross reduction**: tokens removed from the provider-bound request.
+2. **Recovery tax**: omitted tokens later re-expanded or retrieved.
+3. **Provider cache usage**: cache-read, cache-write, and uncached input tokens
+   reported by the provider.
+4. **Prefix continuity**: a local estimate of how much append-only prefix the
+   upstream agent offered versus how much the optimized request preserved.
+
+The Context Health dashboard calls the first two quantities
+**retrieval-adjusted net tokens**. It does not call them economic net savings.
+Economic attribution requires provider usage, pricing provenance, and a paired
+baseline with the same workload.
+
+## Hash-only continuity measurement
+
+`PrefixContinuityGuard` renders only provider prompt-bearing fields into a
+transient canonical surface. It divides that surface into fixed-size blocks and
+retains SHA-256 digests plus byte counts. Prompt text, code, paths, raw request
+or conversation identifiers, and model names are not retained.
+
+For each conversation transition it compares:
+
+- the common prefix available in consecutive raw agent requests; and
+- the common prefix present in consecutive Entroly outbound requests.
+
+If the outbound prefix is materially shorter, Entroly reports an estimated
+optimizer-interference risk. This is a local estimate, not proof of a provider
+cache miss. Provider usage metadata remains authoritative.
+
+## Automatic guard
+
+The proxy captures the original provider request before optional image or
+history optimization. If emergency session rescue is required, its recoverable
+output becomes the new baseline. Optional image changes, context injection, or
+history pruning are compared with that baseline.
+When the provider has reported a warm cache and the optional candidate would
+materially shorten the reusable prefix, Entroly forwards the safer baseline.
+
+The guard cannot undo:
+
+- outbound redaction;
+- fail-closed safety controls;
+- recovery persistence; or
+- emergency session rescue required to stay inside the context window.
+
+Once session rescue compresses historical evidence, its deterministic frozen
+representation remains byte-stable on later turns.
+
+## Evidence levels
+
+| Dashboard field | Evidence basis |
+|---|---|
+| Retrieval-adjusted net | Optimization ledger events minus measured recovery adjustments |
+| Live request cache-hit rate | Bounded in-memory provider observations |
+| Cached input-token ratio | Content-blind process-local provider totals by default |
+| Priced and durable usage | Opt-in local usage ledger and pricing catalog |
+| Prefix continuity | Local hash-only estimate |
+| Economic net | Unavailable without a paired baseline |
+
+The dashboard does not infer causal savings from a cache correlation and does
+not convert an unavailable price into `$0.00`.

--- a/entroly/context_health.py
+++ b/entroly/context_health.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 
-SCHEMA_VERSION = "entroly.context-health.v1"
+SCHEMA_VERSION = "entroly.context-health.v2"
 
 
 def _nonnegative_int(value: object) -> int:
@@ -120,11 +120,128 @@ def _session_summary(index: Any) -> dict[str, Any]:
     return result
 
 
+def _cache_economics(snapshot: Mapping[str, Any] | None) -> dict[str, Any]:
+    snapshot = snapshot if isinstance(snapshot, Mapping) else {}
+    provider_cache = snapshot.get("provider_cache", {})
+    if not isinstance(provider_cache, Mapping):
+        provider_cache = {}
+    accounting = snapshot.get("usage_accounting", {})
+    if not isinstance(accounting, Mapping):
+        accounting = {}
+    usage = accounting.get("ledger", {})
+    if not isinstance(usage, Mapping):
+        usage = {}
+    live_usage = accounting.get("live", {})
+    if not isinstance(live_usage, Mapping):
+        live_usage = {}
+    continuity = snapshot.get("optimizer_interference", {})
+    if not isinstance(continuity, Mapping):
+        continuity = {}
+
+    observed_hits = _nonnegative_int(provider_cache.get("observed_hits"))
+    observed_misses = _nonnegative_int(provider_cache.get("observed_misses"))
+    observed_requests = observed_hits + observed_misses
+    ledger_requests = _nonnegative_int(usage.get("requests"))
+    live_requests = _nonnegative_int(live_usage.get("requests"))
+    token_usage = usage if ledger_requests else live_usage
+    usage_requests = ledger_requests or live_requests
+    unpriced_requests = _nonnegative_int(usage.get("unpriced_requests"))
+    priced_requests = max(0, ledger_requests - unpriced_requests)
+    cache_read = _nonnegative_int(token_usage.get("cache_read_tokens"))
+    cache_write = _nonnegative_int(token_usage.get("cache_write_tokens"))
+    uncached = _nonnegative_int(token_usage.get("uncached_input_tokens"))
+    input_tokens = cache_read + cache_write + uncached
+    comparable = _nonnegative_int(continuity.get("comparable_transitions"))
+    degraded = _nonnegative_int(continuity.get("prefix_degraded"))
+
+    return {
+        "status": (
+            "provider_observed"
+            if observed_requests or usage_requests
+            else "unavailable"
+        ),
+        "provider_observed_requests": observed_requests,
+        "provider_observed_hits": observed_hits,
+        "provider_observed_misses": observed_misses,
+        "provider_observation_window": "bounded_live_proxy",
+        "request_hit_rate_pct": (
+            round(observed_hits * 100.0 / observed_requests, 1)
+            if observed_requests
+            else None
+        ),
+        "usage_ledger_status": (
+            "provider_observed" if ledger_requests else
+            "enabled_no_events" if accounting.get("enabled") else
+            "disabled"
+        ),
+        "provider_usage_status": (
+            "durable_provider_observed" if ledger_requests else
+            "live_provider_observed" if live_requests else
+            "unavailable"
+        ),
+        "provider_usage_requests": usage_requests,
+        "uncached_input_tokens": uncached,
+        "cache_read_tokens": cache_read,
+        "cache_write_tokens": cache_write,
+        "output_tokens": _nonnegative_int(token_usage.get("output_tokens")),
+        "cache_read_token_ratio_pct": (
+            round(cache_read * 100.0 / input_tokens, 1) if input_tokens else None
+        ),
+        "accounted_provider_cost_usd": (
+            round(
+                _nonnegative_int(usage.get("cost_micro_usd")) / 1_000_000.0,
+                6,
+            )
+            if priced_requests else None
+        ),
+        "priced_requests": priced_requests,
+        "unpriced_requests": unpriced_requests,
+        "pricing_basis": (
+            "configured catalog applied to priced provider-reported usage; not an invoice"
+            if priced_requests else
+            "unavailable"
+        ),
+        "prefix_continuity": {
+            "measurement": str(
+                continuity.get("measurement", "local_hash_only_prefix_estimate")
+            ),
+            "content_retained": False,
+            "comparable_transitions": comparable,
+            "prefix_preserved": _nonnegative_int(
+                continuity.get("prefix_preserved")
+            ),
+            "prefix_degraded": degraded,
+            "continuity_rate_pct": (
+                round((comparable - degraded) * 100.0 / comparable, 1)
+                if comparable
+                else None
+            ),
+            "estimated_optimizer_interference_tokens": _nonnegative_int(
+                continuity.get("estimated_optimizer_interference_tokens")
+            ),
+            "guard_interventions": _nonnegative_int(
+                continuity.get("guard_interventions")
+            ),
+            "estimated_prefix_tokens_preserved": _nonnegative_int(
+                continuity.get("estimated_prefix_tokens_preserved")
+            ),
+        },
+        "economic_net_status": "unavailable_without_paired_baseline",
+        "economically_net_positive": None,
+        "scope": (
+            "cache fields and token categories are bounded live provider observations; "
+            "durability and priced totals require the opt-in local usage ledger; "
+            "prefix continuity is a local hash-only estimate; causality requires a paired baseline"
+        ),
+    }
+
+
 def build_context_health(
     *,
     index: Any | None = None,
     ledger_path: str | Path | None = None,
     value_confidence: Mapping[str, Any] | None = None,
+    provider_economics: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a content-blind, locally derived context-health snapshot."""
     if index is None:
@@ -141,6 +258,7 @@ def build_context_health(
     sessions = _session_summary(index)
     path = Path(ledger_path).expanduser() if ledger_path else default_ledger_path()
     ledger, ledger_available = _ledger_summary(path)
+    cache = _cache_economics(provider_economics)
 
     lifetime = value_confidence.get("lifetime", {})
     if not isinstance(lifetime, Mapping):
@@ -174,6 +292,15 @@ def build_context_health(
         )
     if recovery_tax_pct is not None:
         share_parts.append(f"{recovery_tax_pct:.1f}% measured recovery tax")
+    if cache["request_hit_rate_pct"] is not None:
+        share_parts.append(
+            f"{cache['request_hit_rate_pct']:.1f}% live provider-observed request cache hit rate"
+        )
+    guard_interventions = cache["prefix_continuity"]["guard_interventions"]
+    if guard_interventions:
+        share_parts.append(
+            f"{guard_interventions} warm-prefix rewrites prevented"
+        )
     if unsupported_blocked:
         share_parts.append(f"{unsupported_blocked} unsupported claims blocked")
     share_parts.append("local aggregate only; no prompts, code, paths, or queries")
@@ -195,9 +322,14 @@ def build_context_health(
             "measured_gross_tokens": gross,
             "measured_reexpanded_tokens": reexpanded,
             "measured_net_tokens": net,
+            "retrieval_adjusted_net_tokens": net,
+            "retrieval_adjusted_net_label": (
+                "gross reduction minus measured re-expansion; excludes provider cache effects"
+            ),
             "measured_net_usd": round(net_micro_usd / 1_000_000.0, 6),
             "recovery_tax_pct": recovery_tax_pct,
         },
+        "cache_economics": cache,
         "evidence": sessions,
         "protections": {
             "confusion": {
@@ -228,6 +360,8 @@ def build_context_health(
         },
         "limitations": [
             "Provider cost is modeled from configured rates and is not an invoice.",
+            "Retrieval-adjusted net tokens exclude provider cache-write and cache-miss effects.",
+            "Economic net value requires a paired baseline; cache correlation alone is not attribution.",
             "A zero counter means no event was observed, not that the risk was eliminated.",
             "Source freshness and counterfactual answer quality are not inferred.",
             "Receipt aggregates are bounded to the newest 100 locally discoverable sessions.",

--- a/entroly/dashboard.py
+++ b/entroly/dashboard.py
@@ -488,6 +488,91 @@ def _fetch_witness_snapshot() -> dict[str, Any]:
     return {"available": False, "count": 0, "items": [], "feedback": {}}
 
 
+def _fetch_context_economics_snapshot() -> dict[str, Any]:
+    """Fetch only content-blind cache/accounting aggregates from localhost."""
+    import os
+    import urllib.error
+    import urllib.request
+
+    ports = [os.environ.get("ENTROLY_PROXY_PORT", "9377"), "9399"]
+    seen: set[str] = set()
+    for port in ports:
+        if port in seen:
+            continue
+        seen.add(port)
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/stats",
+                timeout=0.25,
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, dict):
+                continue
+            provider_cache = payload.get("provider_cache", {})
+            if not isinstance(provider_cache, dict):
+                provider_cache = {}
+            accounting = payload.get("usage_accounting", {})
+            if not isinstance(accounting, dict):
+                accounting = {}
+            ledger = accounting.get("ledger", {})
+            if not isinstance(ledger, dict):
+                ledger = {}
+            live = accounting.get("live", {})
+            if not isinstance(live, dict):
+                live = {}
+            interference = payload.get("optimizer_interference", {})
+            if not isinstance(interference, dict):
+                interference = {}
+            return {
+                "provider_cache": {
+                    key: provider_cache.get(key)
+                    for key in ("observed_hits", "observed_misses")
+                },
+                "usage_accounting": {
+                    "enabled": accounting.get("enabled") is True,
+                    "live": {
+                        key: live.get(key)
+                        for key in (
+                            "scope",
+                            "requests",
+                            "uncached_input_tokens",
+                            "cache_read_tokens",
+                            "cache_write_tokens",
+                            "output_tokens",
+                        )
+                    },
+                    "ledger": {
+                        key: ledger.get(key)
+                        for key in (
+                            "requests",
+                            "uncached_input_tokens",
+                            "cache_read_tokens",
+                            "cache_write_tokens",
+                            "output_tokens",
+                            "cost_micro_usd",
+                            "unpriced_requests",
+                        )
+                    },
+                },
+                "optimizer_interference": {
+                    key: interference.get(key)
+                    for key in (
+                        "measurement",
+                        "comparable_transitions",
+                        "prefix_preserved",
+                        "prefix_degraded",
+                        "prefix_improved",
+                        "estimated_optimizer_interference_tokens",
+                        "guard_interventions",
+                        "estimated_prefix_tokens_preserved",
+                    )
+                },
+            }
+        except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError):
+            continue
+    return {}
+
+
 # ── HTML Dashboard ────────────────────────────────────────────────────────────
 
 DASHBOARD_HTML = r"""<!DOCTYPE html>
@@ -1077,21 +1162,31 @@ async function copyContextHealth(){
 }
 function renderContextHealth(data){
   const el=document.getElementById('contextHealth');if(!el)return;
-  const value=data.value||{},evidence=data.evidence||{},protections=data.protections||{};
+  const value=data.value||{},evidence=data.evidence||{},protections=data.protections||{},cache=data.cache_economics||{},continuity=cache.prefix_continuity||{};
   const confusion=protections.confusion||{},rot=protections.rot||{},drift=protections.drift||{};
   const measured=value.ledger_status==='measured';contextHealthShare=((data.share||{}).text)||'';
-  const net=measured?fmt(value.measured_net_tokens||0):'Not measured';
-  const netClass=measured&&Number(value.measured_net_tokens||0)<0?'hv-rose':'hv-green';
+  const retrievalNet=measured?fmt(value.retrieval_adjusted_net_tokens||0):'Not measured';
+  const netClass=measured&&Number(value.retrieval_adjusted_net_tokens||0)<0?'hv-rose':'hv-green';
   const recovery=value.recovery_tax_pct==null?'Not measured':Number(value.recovery_tax_pct).toFixed(1)+'%';
   const integrity=evidence.integrity_pct==null?'No receipts':Number(evidence.integrity_pct).toFixed(1)+'%';
   const recoverable=evidence.recoverability_pct==null?'Not measured':Number(evidence.recoverability_pct).toFixed(1)+'%';
-  el.innerHTML='<div class="context-health-head"><div><h2>Context Health</h2><p>Aggregate evidence only. Zero means no event observed—not that a risk was eliminated. Dollar values are modeled; source freshness stays unavailable until directly checked.</p></div><button id="contextShare" class="context-share" onclick="copyContextHealth()" '+(contextHealthShare?'':'disabled')+'>Copy privacy-safe proof</button></div>'+
+  const requestHit=cache.request_hit_rate_pct==null?'Not observed':Number(cache.request_hit_rate_pct).toFixed(1)+'%';
+  const tokenHit=cache.cache_read_token_ratio_pct==null?'Not recorded':Number(cache.cache_read_token_ratio_pct).toFixed(1)+'%';
+  const continuityRate=continuity.continuity_rate_pct==null?'Not measured':Number(continuity.continuity_rate_pct).toFixed(1)+'%';
+  const economicNet=cache.economically_net_positive==null?'Baseline required':(cache.economically_net_positive?'Net positive':'Net negative');
+  const economicClass=cache.economically_net_positive==null?'hv-amber':(cache.economically_net_positive?'hv-green':'hv-rose');
+  el.innerHTML='<div class="context-health-head"><div><h2>Context Health</h2><p>Aggregate evidence only. Retrieval-adjusted savings and provider cache economics are separate. Zero means no event observed, not that a risk was eliminated.</p></div><button id="contextShare" class="context-share" onclick="copyContextHealth()" '+(contextHealthShare?'':'disabled')+'>Copy privacy-safe proof</button></div>'+
     '<div class="context-health-grid">'+
-      '<div class="context-health-card"><label>Measured net tokens</label><strong class="'+netClass+'">'+net+'</strong><small>'+(measured?fmt(value.measured_gross_tokens||0)+' gross − '+fmt(value.measured_reexpanded_tokens||0)+' re-expanded':'Enable the optimization ledger for net accounting')+'</small></div>'+
+      '<div class="context-health-card"><label>Retrieval-adjusted net</label><strong class="'+netClass+'">'+retrievalNet+'</strong><small>'+(measured?fmt(value.measured_gross_tokens||0)+' gross minus '+fmt(value.measured_reexpanded_tokens||0)+' re-expanded; cache effects excluded':'Enable the optimization ledger for recovery accounting')+'</small></div>'+
       '<div class="context-health-card"><label>Recovery tax</label><strong class="hv-amber">'+recovery+'</strong><small>Re-expanded tokens ÷ measured gross reduction</small></div>'+
       '<div class="context-health-card"><label>Receipt integrity</label><strong class="hv-blue">'+integrity+'</strong><small>'+fmt(evidence.valid_sessions||0)+' valid / '+fmt(evidence.sessions_sampled||0)+' sampled sessions</small></div>'+
       '<div class="context-health-card"><label>Omission recoverability</label><strong class="hv-violet">'+recoverable+'</strong><small>'+fmt(evidence.recoverable_omitted_items||0)+' recoverable / '+fmt(evidence.omitted_items||0)+' omitted items</small></div>'+
+      '<div class="context-health-card"><label>Provider request cache hits</label><strong class="hv-blue">'+requestHit+'</strong><small>'+fmt(cache.provider_observed_hits||0)+' hits / '+fmt(cache.provider_observed_requests||0)+' bounded live observations</small></div>'+
+      '<div class="context-health-card"><label>Cached input-token ratio</label><strong class="hv-violet">'+tokenHit+'</strong><small>'+fmt(cache.cache_read_tokens||0)+' cache-read / '+fmt(cache.cache_write_tokens||0)+' cache-write / '+fmt(cache.uncached_input_tokens||0)+' uncached</small></div>'+
+      '<div class="context-health-card"><label>Prefix continuity</label><strong class="hv-green">'+continuityRate+'</strong><small>'+fmt(continuity.prefix_degraded||0)+' degraded transitions / '+fmt(continuity.guard_interventions||0)+' warm-prefix rewrites prevented</small></div>'+
+      '<div class="context-health-card"><label>Economic net</label><strong class="'+economicClass+'">'+economicNet+'</strong><small>Requires a paired baseline; correlation is not savings attribution</small></div>'+
     '</div><div class="context-protections">'+
+      '<div class="context-protection"><b>Optimizer interference guard</b><span>'+fmt(continuity.estimated_prefix_tokens_preserved||0)+' estimated warm-prefix tokens preserved. Hash-only local measurement; no prompt content retained.</span></div>'+
       '<div class="context-protection"><b>Confusion protection</b><span>'+fmt(confusion.unsupported_claims_blocked||0)+' unsupported claims blocked. '+escHtml(confusion.scope||'')+'</span></div>'+
       '<div class="context-protection"><b>Rot resilience</b><span>Status: '+escHtml(rot.status||'unavailable')+'. '+escHtml(rot.scope||'')+'</span></div>'+
       '<div class="context-protection"><b>Drift protection</b><span>Status: '+escHtml(drift.status||'unavailable')+'; source freshness '+escHtml(drift.source_freshness||'unavailable')+'. '+escHtml(drift.scope||'')+'</span></div>'+
@@ -1385,7 +1480,12 @@ class DashboardHandler(BaseHTTPRequestHandler):
         try:
             from entroly.context_health import build_context_health
 
-            self._send_json(200, build_context_health())
+            self._send_json(
+                200,
+                build_context_health(
+                    provider_economics=_fetch_context_economics_snapshot()
+                ),
+            )
         except Exception as error:
             self._send_json(
                 503,

--- a/entroly/prefix_continuity.py
+++ b/entroly/prefix_continuity.py
@@ -1,0 +1,344 @@
+"""Content-blind detection and prevention of optimizer prefix interference.
+
+Provider prompt caches reuse an exact leading token sequence.  A request can
+therefore contain fewer tokens and still cost more when an optimizer rewrites
+old history.  This module compares the prefix an append-only client made
+available with the prefix Entroly actually forwards.
+
+Only fixed-size SHA-256 block digests and byte counts survive an observation.
+Prompt text, code, paths, message bodies, raw request/conversation identifiers,
+and model names are never retained by the tracker or returned by :meth:`stats`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+_PROMPT_FIELDS = (
+    "system",
+    "instructions",
+    "systemInstruction",
+    "tools",
+    "tool_choice",
+    "messages",
+    "input",
+    "contents",
+)
+
+
+def _prompt_surface(body: Mapping[str, Any], provider: str) -> dict[str, Any]:
+    """Return the prompt-only structure consumed by the streaming encoder."""
+    prompt = [
+        (field, body[field])
+        for field in _PROMPT_FIELDS
+        if field in body
+    ]
+    return {"provider": provider.lower().strip(), "prompt": prompt}
+
+
+def _stream_block_digests(
+    surface: Mapping[str, Any],
+    *,
+    block_bytes: int,
+) -> tuple[tuple[str, ...], tuple[int, ...], int]:
+    """Hash canonical JSON in bounded blocks without building a full copy."""
+    encoder = json.JSONEncoder(
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    pending = bytearray()
+    digests: list[str] = []
+    lengths: list[int] = []
+    total = 0
+    for piece in encoder.iterencode(surface):
+        encoded = piece.encode("utf-8")
+        total += len(encoded)
+        offset = 0
+        while offset < len(encoded):
+            take = min(block_bytes - len(pending), len(encoded) - offset)
+            pending.extend(encoded[offset : offset + take])
+            offset += take
+            if len(pending) == block_bytes:
+                digests.append(hashlib.sha256(pending).hexdigest())
+                lengths.append(len(pending))
+                pending.clear()
+    if pending:
+        digests.append(hashlib.sha256(pending).hexdigest())
+        lengths.append(len(pending))
+    return tuple(digests), tuple(lengths), total
+
+
+@dataclass(frozen=True, slots=True)
+class PrefixFingerprint:
+    """Irreversible block identity for one outbound prompt surface."""
+
+    block_digests: tuple[str, ...]
+    block_lengths: tuple[int, ...]
+    total_bytes: int
+
+    @property
+    def estimated_tokens(self) -> int:
+        return (self.total_bytes + 3) // 4
+
+
+def fingerprint_prompt(
+    body: Mapping[str, Any],
+    provider: str,
+    *,
+    block_bytes: int = 256,
+) -> PrefixFingerprint:
+    if block_bytes < 64:
+        raise ValueError("block_bytes must be at least 64")
+    digests, lengths, total = _stream_block_digests(
+        _prompt_surface(body, provider),
+        block_bytes=block_bytes,
+    )
+    return PrefixFingerprint(
+        block_digests=digests,
+        block_lengths=lengths,
+        total_bytes=total,
+    )
+
+
+def common_prefix_bytes(
+    previous: PrefixFingerprint,
+    current: PrefixFingerprint,
+) -> int:
+    """Return a conservative common-prefix byte count at block granularity."""
+    total = 0
+    for previous_digest, current_digest, previous_length, current_length in zip(
+        previous.block_digests,
+        current.block_digests,
+        previous.block_lengths,
+        current.block_lengths,
+    ):
+        if previous_digest != current_digest or previous_length != current_length:
+            break
+        total += previous_length
+    return total
+
+
+@dataclass(frozen=True, slots=True)
+class PrefixGuardDecision:
+    action: str
+    cache_warm: bool
+    baseline_reusable_tokens: int
+    candidate_reusable_tokens: int
+    estimated_tokens_at_risk: int
+
+    @property
+    def preserved_baseline(self) -> bool:
+        return self.action == "preserve_warm_prefix"
+
+
+@dataclass(frozen=True, slots=True)
+class PrefixContinuityObservation:
+    status: str
+    raw_reusable_prefix_tokens: int | None
+    outbound_reusable_prefix_tokens: int | None
+    estimated_optimizer_interference_tokens: int
+
+
+@dataclass(slots=True)
+class _PrefixState:
+    raw: PrefixFingerprint
+    outbound: PrefixFingerprint
+
+
+class PrefixContinuityGuard:
+    """Bounded hash-only continuity tracker with a conservative warm-cache guard."""
+
+    def __init__(
+        self,
+        *,
+        max_conversations: int = 2_000,
+        block_bytes: int = 256,
+        material_loss_tokens: int = 64,
+    ) -> None:
+        if max_conversations < 1:
+            raise ValueError("max_conversations must be positive")
+        if block_bytes < 64:
+            raise ValueError("block_bytes must be at least 64")
+        if material_loss_tokens < 1:
+            raise ValueError("material_loss_tokens must be positive")
+        self.max_conversations = max_conversations
+        self.block_bytes = block_bytes
+        self.material_loss_tokens = material_loss_tokens
+        self._states: OrderedDict[str, _PrefixState] = OrderedDict()
+        self._lock = threading.RLock()
+        self._observations = 0
+        self._cold_starts = 0
+        self._preserved = 0
+        self._degraded = 0
+        self._improved = 0
+        self._interference_tokens = 0
+        self._guard_interventions = 0
+        self._guard_tokens_preserved = 0
+
+    def _fingerprint(
+        self,
+        body: Mapping[str, Any],
+        provider: str,
+    ) -> PrefixFingerprint:
+        return fingerprint_prompt(body, provider, block_bytes=self.block_bytes)
+
+    @staticmethod
+    def _state_key(conversation_id: str) -> str:
+        return hashlib.sha256(conversation_id.encode("utf-8")).hexdigest()
+
+    def choose(
+        self,
+        conversation_id: str,
+        *,
+        provider: str,
+        baseline_body: Mapping[str, Any],
+        candidate_body: Mapping[str, Any],
+        cache_warm: bool,
+    ) -> tuple[dict[str, Any], PrefixGuardDecision]:
+        """Preserve the safer optional-transform candidate for a warm cache.
+
+        ``baseline_body`` must already include required security, recovery, and
+        emergency-rescue mutations.  The guard is intentionally unable to undo
+        those changes; it arbitrates optional transformations only.
+        """
+        baseline = dict(baseline_body)
+        candidate = dict(candidate_body)
+        state_key = self._state_key(conversation_id)
+        with self._lock:
+            previous = self._states.get(state_key)
+            if previous is None:
+                return candidate, PrefixGuardDecision(
+                    action="observe",
+                    cache_warm=cache_warm,
+                    baseline_reusable_tokens=0,
+                    candidate_reusable_tokens=0,
+                    estimated_tokens_at_risk=0,
+                )
+            baseline_common = common_prefix_bytes(
+                previous.outbound,
+                self._fingerprint(baseline, provider),
+            ) // 4
+            candidate_common = common_prefix_bytes(
+                previous.outbound,
+                self._fingerprint(candidate, provider),
+            ) // 4
+            at_risk = max(0, baseline_common - candidate_common)
+            preserve = cache_warm and at_risk >= self.material_loss_tokens
+            if preserve:
+                self._guard_interventions += 1
+                self._guard_tokens_preserved += at_risk
+            return (baseline if preserve else candidate), PrefixGuardDecision(
+                action="preserve_warm_prefix" if preserve else "allow_candidate",
+                cache_warm=cache_warm,
+                baseline_reusable_tokens=baseline_common,
+                candidate_reusable_tokens=candidate_common,
+                estimated_tokens_at_risk=at_risk,
+            )
+
+    def observe(
+        self,
+        conversation_id: str,
+        *,
+        provider: str,
+        raw_body: Mapping[str, Any],
+        outbound_body: Mapping[str, Any],
+    ) -> PrefixContinuityObservation:
+        """Record an outbound request without retaining its prompt content."""
+        raw = self._fingerprint(raw_body, provider)
+        outbound = self._fingerprint(outbound_body, provider)
+        state_key = self._state_key(conversation_id)
+        with self._lock:
+            previous = self._states.get(state_key)
+            self._observations += 1
+            if previous is None:
+                self._cold_starts += 1
+                observation = PrefixContinuityObservation(
+                    status="first_observation",
+                    raw_reusable_prefix_tokens=None,
+                    outbound_reusable_prefix_tokens=None,
+                    estimated_optimizer_interference_tokens=0,
+                )
+            else:
+                raw_common_bytes = common_prefix_bytes(previous.raw, raw)
+                outbound_common_bytes = common_prefix_bytes(
+                    previous.outbound,
+                    outbound,
+                )
+                raw_common = raw_common_bytes // 4
+                outbound_common = outbound_common_bytes // 4
+                raw_disrupted = max(
+                    0,
+                    previous.raw.total_bytes - raw_common_bytes,
+                ) // 4
+                outbound_disrupted = max(
+                    0,
+                    previous.outbound.total_bytes - outbound_common_bytes,
+                ) // 4
+                interference = max(0, outbound_disrupted - raw_disrupted)
+                material = interference >= self.material_loss_tokens
+                if material:
+                    status = "prefix_degraded"
+                    self._degraded += 1
+                    self._interference_tokens += interference
+                elif raw_disrupted > outbound_disrupted + self.material_loss_tokens:
+                    status = "prefix_improved"
+                    self._improved += 1
+                else:
+                    status = "prefix_preserved"
+                    self._preserved += 1
+                observation = PrefixContinuityObservation(
+                    status=status,
+                    raw_reusable_prefix_tokens=raw_common,
+                    outbound_reusable_prefix_tokens=outbound_common,
+                    estimated_optimizer_interference_tokens=(
+                        interference if material else 0
+                    ),
+                )
+            self._states[state_key] = _PrefixState(raw=raw, outbound=outbound)
+            self._states.move_to_end(state_key)
+            while len(self._states) > self.max_conversations:
+                self._states.popitem(last=False)
+            return observation
+
+    def stats(self) -> dict[str, int | float | str | bool]:
+        with self._lock:
+            comparable = self._preserved + self._degraded + self._improved
+            return {
+                "measurement": "local_hash_only_prefix_estimate",
+                "content_retained": False,
+                "identifiers_exposed": False,
+                "observations": self._observations,
+                "cold_starts": self._cold_starts,
+                "comparable_transitions": comparable,
+                "prefix_preserved": self._preserved,
+                "prefix_degraded": self._degraded,
+                "prefix_improved": self._improved,
+                "continuity_rate": (
+                    (self._preserved + self._improved) / comparable
+                    if comparable
+                    else 0.0
+                ),
+                "estimated_optimizer_interference_tokens": self._interference_tokens,
+                "guard_interventions": self._guard_interventions,
+                "estimated_prefix_tokens_preserved": self._guard_tokens_preserved,
+                "block_bytes": self.block_bytes,
+                "material_loss_tokens": self.material_loss_tokens,
+            }
+
+
+__all__ = [
+    "PrefixContinuityGuard",
+    "PrefixContinuityObservation",
+    "PrefixFingerprint",
+    "PrefixGuardDecision",
+    "common_prefix_bytes",
+    "fingerprint_prompt",
+]

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -63,6 +63,7 @@ from .proxy_transform import (
 from .behavioral_waste import BehavioralWasteDetector, observe_canonical_messages
 from .cache_aligner import CacheAligner
 from .cache_routing import CacheAwareRouter, CachePrice, ModelCandidate
+from .prefix_continuity import PrefixContinuityGuard
 from .compression_proxy import compress_proxy_payload
 from .compression_retrieval_store_secure import CompressionRetrievalStore
 from .control_plane import (
@@ -1102,6 +1103,7 @@ class PromptCompilerProxy:
         # Provider-reported cache and spend accounting. A ledger is opt-in;
         # cache observations remain available in-memory for routing decisions.
         self._cache_router = CacheAwareRouter()
+        self._prefix_continuity = PrefixContinuityGuard()
         ledger_path = os.environ.get("ENTROLY_USAGE_LEDGER", "").strip()
         catalog_path = os.environ.get("ENTROLY_PRICING_CATALOG", "").strip()
         self._usage_ledger = UsageLedger(ledger_path) if ledger_path else None
@@ -1114,6 +1116,11 @@ class PromptCompilerProxy:
         self._usage_recorded = 0
         self._usage_unpriced = 0
         self._usage_failures = 0
+        self._live_usage_requests = 0
+        self._live_uncached_input_tokens = 0
+        self._live_cache_read_tokens = 0
+        self._live_cache_write_tokens = 0
+        self._live_output_tokens = 0
         self._trust_usage_headers = (
             os.environ.get("ENTROLY_TRUST_USAGE_HEADERS", "0").lower()
             in {"1", "true", "yes", "on"}
@@ -1620,6 +1627,68 @@ class PromptCompilerProxy:
         }
         return redacted, headers
 
+    def _prefix_cache_is_warm(self, conversation_id: str) -> bool:
+        if not conversation_id:
+            return False
+        lease = self._cache_router.lease_snapshot(conversation_id)
+        return bool(lease is not None and lease.cached_prefix_tokens > 0)
+
+    def _guard_optional_prefix_mutation(
+        self,
+        *,
+        conversation_id: str,
+        provider: str,
+        baseline_body: dict[str, Any],
+        candidate_body: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, str]]:
+        """Protect a provider-observed warm prefix from optional rewrites."""
+        if not conversation_id:
+            return candidate_body, {}
+        try:
+            guarded, decision = self._prefix_continuity.choose(
+                conversation_id,
+                provider=provider,
+                baseline_body=baseline_body,
+                candidate_body=candidate_body,
+                cache_warm=self._prefix_cache_is_warm(conversation_id),
+            )
+        except Exception as exc:
+            logger.debug("Prefix-continuity guard skipped: %s", exc)
+            return candidate_body, {"X-Entroly-Prefix-Guard": "unavailable"}
+        return guarded, {
+            "X-Entroly-Prefix-Guard": decision.action,
+            "X-Entroly-Prefix-Tokens-At-Risk": str(
+                decision.estimated_tokens_at_risk
+            ),
+        }
+
+    def _observe_prefix_continuity(
+        self,
+        *,
+        conversation_id: str,
+        provider: str,
+        raw_body: dict[str, Any],
+        outbound_body: dict[str, Any],
+    ) -> dict[str, str]:
+        if not conversation_id:
+            return {}
+        try:
+            observation = self._prefix_continuity.observe(
+                conversation_id,
+                provider=provider,
+                raw_body=raw_body,
+                outbound_body=outbound_body,
+            )
+        except Exception as exc:
+            logger.debug("Prefix-continuity observation skipped: %s", exc)
+            return {"X-Entroly-Prefix-Continuity": "unavailable"}
+        return {
+            "X-Entroly-Prefix-Continuity": observation.status,
+            "X-Entroly-Prefix-Interference-Tokens": str(
+                observation.estimated_optimizer_interference_tokens
+            ),
+        }
+
     def _usage_dimensions(
         self,
         headers: dict[str, str],
@@ -1895,6 +1964,13 @@ class PromptCompilerProxy:
         if not inserted:
             return
 
+        with self._stats_lock:
+            self._live_usage_requests += 1
+            self._live_uncached_input_tokens += usage.uncached_input_tokens
+            self._live_cache_read_tokens += usage.cache_read_tokens
+            self._live_cache_write_tokens += usage.cache_write_tokens
+            self._live_output_tokens += usage.output_tokens
+
         cached_prefix_tokens = max(
             usage.cache_read_tokens,
             usage.cache_write_tokens,
@@ -2100,6 +2176,12 @@ class PromptCompilerProxy:
         except Exception as e:
             logger.debug("Control-plane planning skipped: %s", e)
 
+        # Start from the original provider request so every optional mutation
+        # (including image optimization) is eligible for warm-prefix review.
+        # Required redaction is applied after the guard, and emergency rescue
+        # replaces this baseline below, so neither can be undone.
+        cache_guard_baseline = control_before
+
         # Embedded vision optimization is explicit opt-in and fail-open.  URL
         # images and unknown shapes are untouched; each decision is summarized
         # without exposing image bytes in headers or logs.
@@ -2226,6 +2308,8 @@ class PromptCompilerProxy:
                     else:
                         body[sequence_key] = rescue.messages
                     session_rescue_result = rescue
+                    if rescue.tokens_saved > 0:
+                        cache_guard_baseline = copy.deepcopy(body)
                     control_headers.update(rescue.headers())
                     self._session_rescue_last = {
                         "action": rescue.action,
@@ -2318,6 +2402,14 @@ class PromptCompilerProxy:
         if self._bypass:
             body, redaction_headers = self._apply_outbound_redaction(body)
             control_headers.update(redaction_headers)
+            control_headers.update(
+                self._observe_prefix_continuity(
+                    conversation_id=conversation_id,
+                    provider=provider,
+                    raw_body=control_before,
+                    outbound_body=body,
+                )
+            )
             with self._stats_lock:
                 self._requests_bypassed += 1
             target_url = self._resolve_target(provider, path)
@@ -2699,6 +2791,14 @@ class PromptCompilerProxy:
             logger.warning("Pipeline error (forwarding unmodified): %s: %s",
                           type(e).__name__, str(e)[:200])
 
+        body, prefix_guard_headers = self._guard_optional_prefix_mutation(
+            conversation_id=conversation_id,
+            provider=provider,
+            baseline_body=cache_guard_baseline,
+            candidate_body=body,
+        )
+        control_headers.update(prefix_guard_headers)
+
         # Await warmup (usually completes during pipeline, essentially free)
         await warmup_task
 
@@ -2883,6 +2983,14 @@ class PromptCompilerProxy:
 
         body, redaction_headers = self._apply_outbound_redaction(body)
         control_headers.update(redaction_headers)
+        control_headers.update(
+            self._observe_prefix_continuity(
+                conversation_id=conversation_id,
+                provider=provider,
+                raw_body=control_before,
+                outbound_body=body,
+            )
+        )
 
         try:
             control_audit = audit_request_transform(
@@ -5755,6 +5863,7 @@ async def _proxy_stats(request: Request) -> JSONResponse:
         "blocked_unpriced": proxy._cache_route_blocked_unpriced,
         "last_decision": proxy._cache_route_last,
     }
+    stats["optimizer_interference"] = proxy._prefix_continuity.stats()
     stats["behavioral_waste"] = {
         "findings": proxy._behavior_findings,
         "failures": proxy._behavior_failures,
@@ -5782,6 +5891,14 @@ async def _proxy_stats(request: Request) -> JSONResponse:
         "recorded": proxy._usage_recorded,
         "unpriced": proxy._usage_unpriced,
         "failures": proxy._usage_failures,
+        "live": {
+            "scope": "process_local_content_blind",
+            "requests": proxy._live_usage_requests,
+            "uncached_input_tokens": proxy._live_uncached_input_tokens,
+            "cache_read_tokens": proxy._live_cache_read_tokens,
+            "cache_write_tokens": proxy._live_cache_write_tokens,
+            "output_tokens": proxy._live_output_tokens,
+        },
     }
     if proxy._usage_ledger is not None:
         try:

--- a/tests/test_context_health.py
+++ b/tests/test_context_health.py
@@ -86,10 +86,11 @@ def test_context_health_reports_net_evidence_without_user_content(tmp_path):
         },
     )
 
-    assert report["schema_version"] == "entroly.context-health.v1"
+    assert report["schema_version"] == "entroly.context-health.v2"
     assert report["value"]["measured_gross_tokens"] == 1_000
     assert report["value"]["measured_reexpanded_tokens"] == 250
     assert report["value"]["measured_net_tokens"] == 750
+    assert report["value"]["retrieval_adjusted_net_tokens"] == 750
     assert report["value"]["measured_net_usd"] == 0.0035
     assert report["value"]["recovery_tax_pct"] == 25.0
     assert report["evidence"]["integrity_pct"] == 50.0
@@ -156,6 +157,101 @@ def test_context_health_preserves_token_negative_recovery_outcomes(tmp_path):
     assert report["value"]["measured_net_tokens"] == -50
     assert report["value"]["measured_net_usd"] == -0.0001
     assert report["value"]["recovery_tax_pct"] == 150.0
+
+
+def test_context_health_separates_provider_cache_economics_from_retrieval_net(
+    tmp_path,
+):
+    report = build_context_health(
+        index=_IndexWithoutSessions(),
+        ledger_path=tmp_path / "missing.sqlite3",
+        value_confidence={"lifetime": {}},
+        provider_economics={
+            "provider_cache": {
+                "observed_hits": 6,
+                "observed_misses": 4,
+                "observed_hit_rate": 0.6,
+            },
+            "usage_accounting": {
+                "enabled": True,
+                "ledger": {
+                    "requests": 10,
+                    "uncached_input_tokens": 4_000,
+                    "cache_read_tokens": 6_000,
+                    "cache_write_tokens": 500,
+                    "output_tokens": 700,
+                    "cost_micro_usd": 12_345,
+                    "unpriced_requests": 0,
+                },
+            },
+            "optimizer_interference": {
+                "measurement": "local_hash_only_prefix_estimate",
+                "comparable_transitions": 9,
+                "prefix_preserved": 7,
+                "prefix_improved": 1,
+                "prefix_degraded": 1,
+                "estimated_optimizer_interference_tokens": 900,
+                "guard_interventions": 2,
+                "estimated_prefix_tokens_preserved": 1_500,
+            },
+        },
+    )
+
+    cache = report["cache_economics"]
+    assert cache["status"] == "provider_observed"
+    assert cache["request_hit_rate_pct"] == 60.0
+    assert cache["cache_read_token_ratio_pct"] == 57.1
+    assert cache["cache_write_tokens"] == 500
+    assert cache["accounted_provider_cost_usd"] == 0.012345
+    assert cache["prefix_continuity"]["continuity_rate_pct"] == 88.9
+    assert cache["prefix_continuity"]["guard_interventions"] == 2
+    assert cache["economically_net_positive"] is None
+    assert cache["economic_net_status"] == "unavailable_without_paired_baseline"
+
+
+def test_context_health_cache_snapshot_cannot_leak_content(tmp_path):
+    private = "PRIVATE_CACHE_PROMPT_SHOULD_NOT_LEAK"
+    report = build_context_health(
+        index=_IndexWithoutSessions(),
+        ledger_path=tmp_path / "missing.sqlite3",
+        value_confidence={"lifetime": {}},
+        provider_economics={
+            "provider_cache": {"observed_hits": 1, "private": private},
+            "usage_accounting": {"ledger": {"requests": 1, "private": private}},
+            "optimizer_interference": {"private": private},
+            "private": private,
+        },
+    )
+
+    assert private not in json.dumps(report, sort_keys=True)
+
+
+def test_context_health_uses_content_blind_live_usage_without_persistence(tmp_path):
+    report = build_context_health(
+        index=_IndexWithoutSessions(),
+        ledger_path=tmp_path / "missing.sqlite3",
+        value_confidence={"lifetime": {}},
+        provider_economics={
+            "usage_accounting": {
+                "enabled": False,
+                "live": {
+                    "scope": "process_local_content_blind",
+                    "requests": 2,
+                    "uncached_input_tokens": 200,
+                    "cache_read_tokens": 800,
+                    "cache_write_tokens": 0,
+                    "output_tokens": 50,
+                },
+            },
+        },
+    )
+
+    cache = report["cache_economics"]
+    assert cache["provider_usage_status"] == "live_provider_observed"
+    assert cache["provider_usage_requests"] == 2
+    assert cache["cache_read_token_ratio_pct"] == 80.0
+    assert cache["accounted_provider_cost_usd"] is None
+    assert cache["pricing_basis"] == "unavailable"
 
 
 class _IndexWithoutSessions:

--- a/tests/test_dashboard_context_health.py
+++ b/tests/test_dashboard_context_health.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import entroly.context_health as context_health
 import entroly.dashboard as dashboard
 
@@ -10,15 +12,30 @@ def test_dashboard_exposes_context_health_panel_and_refresh_loop():
     assert "fetch('/api/context/health')" in dashboard.DASHBOARD_HTML
     assert "Copy privacy-safe proof" in dashboard.DASHBOARD_HTML
     assert "Zero means no event observed" in dashboard.DASHBOARD_HTML
-    assert "measured_net_tokens||0)<0?'hv-rose':'hv-green'" in dashboard.DASHBOARD_HTML
+    assert "retrieval_adjusted_net_tokens||0)<0?'hv-rose':'hv-green'" in dashboard.DASHBOARD_HTML
+    assert "Provider request cache hits" in dashboard.DASHBOARD_HTML
+    assert "Cached input-token ratio" in dashboard.DASHBOARD_HTML
+    assert "Optimizer interference guard" in dashboard.DASHBOARD_HTML
+    assert "Requires a paired baseline" in dashboard.DASHBOARD_HTML
 
 
 def test_context_health_endpoint_returns_aggregate_report(monkeypatch):
     expected = {
-        "schema_version": "entroly.context-health.v1",
+        "schema_version": "entroly.context-health.v2",
         "privacy": {"content_blind": True},
     }
-    monkeypatch.setattr(context_health, "build_context_health", lambda: expected)
+    captured = {}
+
+    def build_context_health(*, provider_economics):
+        captured.update(provider_economics)
+        return expected
+
+    monkeypatch.setattr(context_health, "build_context_health", build_context_health)
+    monkeypatch.setattr(
+        dashboard,
+        "_fetch_context_economics_snapshot",
+        lambda: {"provider_cache": {"observed_hits": 2}},
+    )
     handler = object.__new__(dashboard.DashboardHandler)
     responses: list[tuple[int, dict]] = []
     handler._send_json = lambda status, payload: responses.append((status, payload))
@@ -26,10 +43,11 @@ def test_context_health_endpoint_returns_aggregate_report(monkeypatch):
     handler._handle_context_health()
 
     assert responses == [(200, expected)]
+    assert captured == {"provider_cache": {"observed_hits": 2}}
 
 
 def test_context_health_endpoint_fails_without_leaking_error_text(monkeypatch):
-    def fail():
+    def fail(*, provider_economics):
         raise RuntimeError("private path C:/customer/secret.py")
 
     monkeypatch.setattr(context_health, "build_context_health", fail)
@@ -49,3 +67,58 @@ def test_context_health_endpoint_fails_without_leaking_error_text(monkeypatch):
         )
     ]
     assert "secret.py" not in str(responses)
+
+
+def test_proxy_economics_fetcher_filters_paths_content_and_identifiers(monkeypatch):
+    private = "C:/customer/private-prompt.py"
+    payload = {
+        "provider_cache": {
+            "observed_hits": 3,
+            "observed_misses": 1,
+            "last_decision": {"model": "private-model", "query": private},
+        },
+        "usage_accounting": {
+            "enabled": True,
+            "pricing_catalog": private,
+            "live": {
+                "scope": "process_local_content_blind",
+                "requests": 4,
+                "cache_read_tokens": 300,
+                "private": private,
+            },
+            "ledger": {
+                "requests": 4,
+                "cache_read_tokens": 300,
+                "private": private,
+            },
+        },
+        "optimizer_interference": {
+            "guard_interventions": 2,
+            "private": private,
+        },
+        "last_query": private,
+    }
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return json.dumps(payload).encode("utf-8")
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: Response())
+
+    filtered = dashboard._fetch_context_economics_snapshot()
+
+    assert filtered["provider_cache"] == {
+        "observed_hits": 3,
+        "observed_misses": 1,
+    }
+    assert filtered["usage_accounting"]["ledger"]["requests"] == 4
+    assert filtered["usage_accounting"]["live"]["requests"] == 4
+    assert filtered["optimizer_interference"]["guard_interventions"] == 2
+    assert private not in json.dumps(filtered, sort_keys=True)
+    assert "private-model" not in json.dumps(filtered, sort_keys=True)

--- a/tests/test_prefix_continuity.py
+++ b/tests/test_prefix_continuity.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from entroly.prefix_continuity import PrefixContinuityGuard
+from entroly.proxy_transform import inject_context_live_zone
+
+
+def _body(messages: list[dict]) -> dict:
+    return {
+        "model": "test-model",
+        "messages": [{"role": "system", "content": "stable policy"}, *messages],
+    }
+
+
+def _large_tool(label: str) -> dict:
+    return {
+        "role": "tool",
+        "tool_call_id": "call-1",
+        "content": (label + " factual output\n") * 300,
+    }
+
+
+def test_append_only_history_preserves_prefix() -> None:
+    guard = PrefixContinuityGuard(block_bytes=64, material_loss_tokens=16)
+    first = _body([{"role": "user", "content": "first question"}])
+    guard.observe("conversation", provider="openai", raw_body=first, outbound_body=first)
+
+    second = _body(
+        [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second question"},
+        ]
+    )
+    observation = guard.observe(
+        "conversation",
+        provider="openai",
+        raw_body=second,
+        outbound_body=second,
+    )
+
+    assert observation.status == "prefix_preserved"
+    assert observation.estimated_optimizer_interference_tokens == 0
+
+
+def test_live_zone_suffix_does_not_materially_clobber_append_only_prefix() -> None:
+    guard = PrefixContinuityGuard(block_bytes=64, material_loss_tokens=32)
+    raw_first = _body([{"role": "user", "content": "inspect authentication"}])
+    outbound_first, injected = inject_context_live_zone(
+        raw_first, "relevant source evidence", "openai"
+    )
+    assert injected
+    guard.observe(
+        "conversation",
+        provider="openai",
+        raw_body=raw_first,
+        outbound_body=outbound_first,
+    )
+
+    raw_second = _body(
+        [
+            {"role": "user", "content": "inspect authentication"},
+            {"role": "assistant", "content": "analysis"},
+            {"role": "user", "content": "add a regression test"},
+        ]
+    )
+    outbound_second, injected = inject_context_live_zone(
+        raw_second, "new relevant evidence", "openai"
+    )
+    assert injected
+    observation = guard.observe(
+        "conversation",
+        provider="openai",
+        raw_body=raw_second,
+        outbound_body=outbound_second,
+    )
+
+    assert observation.status == "prefix_preserved"
+    assert observation.estimated_optimizer_interference_tokens == 0
+
+
+def test_rewriting_old_history_is_attributed_to_optimizer_interference() -> None:
+    guard = PrefixContinuityGuard(block_bytes=64, material_loss_tokens=16)
+    first = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            _large_tool("original"),
+            {"role": "assistant", "content": "tests passed"},
+        ]
+    )
+    guard.observe("conversation", provider="openai", raw_body=first, outbound_body=first)
+
+    raw_second = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            _large_tool("original"),
+            {"role": "assistant", "content": "tests passed"},
+            {"role": "user", "content": "continue"},
+        ]
+    )
+    rewritten = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            _large_tool("compressed"),
+            {"role": "assistant", "content": "tests passed"},
+            {"role": "user", "content": "continue"},
+        ]
+    )
+    observation = guard.observe(
+        "conversation",
+        provider="openai",
+        raw_body=raw_second,
+        outbound_body=rewritten,
+    )
+
+    assert observation.status == "prefix_degraded"
+    assert observation.estimated_optimizer_interference_tokens > 100
+
+
+def test_stable_compression_is_not_mislabeled_as_interference() -> None:
+    guard = PrefixContinuityGuard(block_bytes=64, material_loss_tokens=16)
+    raw_first = _body(
+        [{"role": "user", "content": "run tests"}, _large_tool("original")]
+    )
+    optimized_first = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            {"role": "tool", "tool_call_id": "call-1", "content": "31 passed"},
+        ]
+    )
+    guard.observe(
+        "conversation",
+        provider="openai",
+        raw_body=raw_first,
+        outbound_body=optimized_first,
+    )
+    raw_second = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            _large_tool("original"),
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "continue"},
+        ]
+    )
+    optimized_second = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            {"role": "tool", "tool_call_id": "call-1", "content": "31 passed"},
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "continue"},
+        ]
+    )
+
+    observation = guard.observe(
+        "conversation",
+        provider="openai",
+        raw_body=raw_second,
+        outbound_body=optimized_second,
+    )
+
+    assert observation.status == "prefix_preserved"
+    assert observation.estimated_optimizer_interference_tokens == 0
+
+
+def test_warm_cache_guard_preserves_safer_optional_baseline() -> None:
+    guard = PrefixContinuityGuard(block_bytes=64, material_loss_tokens=16)
+    first = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            _large_tool("original"),
+        ]
+    )
+    guard.observe("conversation", provider="openai", raw_body=first, outbound_body=first)
+    baseline = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            _large_tool("original"),
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "continue"},
+        ]
+    )
+    candidate = _body(
+        [
+            {"role": "user", "content": "run tests"},
+            _large_tool("rewritten"),
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "continue"},
+        ]
+    )
+
+    selected, decision = guard.choose(
+        "conversation",
+        provider="openai",
+        baseline_body=baseline,
+        candidate_body=candidate,
+        cache_warm=True,
+    )
+
+    assert decision.preserved_baseline
+    assert decision.estimated_tokens_at_risk > 100
+    assert selected == baseline
+    assert guard.stats()["guard_interventions"] == 1
+
+
+def test_cold_cache_does_not_suppress_optional_candidate() -> None:
+    guard = PrefixContinuityGuard(block_bytes=64, material_loss_tokens=16)
+    first = _body([{"role": "user", "content": "q"}, _large_tool("original")])
+    guard.observe("conversation", provider="openai", raw_body=first, outbound_body=first)
+    candidate = _body([{"role": "user", "content": "q"}, _large_tool("rewritten")])
+
+    selected, decision = guard.choose(
+        "conversation",
+        provider="openai",
+        baseline_body=first,
+        candidate_body=candidate,
+        cache_warm=False,
+    )
+
+    assert not decision.preserved_baseline
+    assert selected == candidate
+
+
+def test_tracker_retains_no_prompt_content_or_raw_identifier() -> None:
+    guard = PrefixContinuityGuard()
+    secret = "PRIVATE_PROMPT_SENTINEL_DO_NOT_RETAIN"
+    conversation_id = "raw-conversation-identifier"
+    body = _body([{"role": "user", "content": secret}])
+
+    guard.observe(
+        conversation_id,
+        provider="openai",
+        raw_body=body,
+        outbound_body=body,
+    )
+
+    retained = repr(guard._states)
+    assert secret not in retained
+    assert conversation_id not in retained
+    assert guard.stats()["content_retained"] is False

--- a/tests/test_proxy_optimizer_interference.py
+++ b/tests/test_proxy_optimizer_interference.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from entroly.proxy import PromptCompilerProxy
+from entroly.proxy_config import ProxyConfig
+from entroly.usage_ledger import TokenUsage
+
+
+def _body(tool_content: str, *, append: bool = False) -> dict:
+    messages = [
+        {"role": "system", "content": "stable policy"},
+        {"role": "user", "content": "run tests"},
+        {"role": "tool", "tool_call_id": "call-1", "content": tool_content},
+    ]
+    if append:
+        messages.extend(
+            [
+                {"role": "assistant", "content": "done"},
+                {"role": "user", "content": "continue"},
+            ]
+        )
+    return {"model": "test-model", "messages": messages}
+
+
+def test_proxy_guard_uses_provider_observation_to_preserve_warm_prefix(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ENTROLY_SESSION_RESCUE", "0")
+    proxy = PromptCompilerProxy(
+        object(),
+        ProxyConfig(enable_conversation_compression=False),
+    )
+    conversation_id = "conversation"
+    original_tool = ("original factual output\n" * 300)
+    rewritten_tool = ("rewritten factual output\n" * 300)
+    first = _body(original_tool)
+    proxy._prefix_continuity.observe(
+        conversation_id,
+        provider="openai",
+        raw_body=first,
+        outbound_body=first,
+    )
+    proxy._cache_router.observe(
+        conversation_id,
+        model="test-model",
+        provider="openai",
+        prefix_hash="observed-provider-prefix",
+        cached_prefix_tokens=1_000,
+        cache_hit=True,
+    )
+    baseline = _body(original_tool, append=True)
+    candidate = _body(rewritten_tool, append=True)
+
+    selected, headers = proxy._guard_optional_prefix_mutation(
+        conversation_id=conversation_id,
+        provider="openai",
+        baseline_body=baseline,
+        candidate_body=candidate,
+    )
+
+    assert selected == baseline
+    assert headers["X-Entroly-Prefix-Guard"] == "preserve_warm_prefix"
+    assert int(headers["X-Entroly-Prefix-Tokens-At-Risk"]) > 100
+
+
+def test_proxy_continuity_headers_expose_only_aggregate_status(monkeypatch) -> None:
+    monkeypatch.setenv("ENTROLY_SESSION_RESCUE", "0")
+    proxy = PromptCompilerProxy(
+        object(),
+        ProxyConfig(enable_conversation_compression=False),
+    )
+    secret = "PRIVATE_PROMPT_MUST_NOT_REACH_HEADERS"
+    body = _body(secret * 100)
+
+    headers = proxy._observe_prefix_continuity(
+        conversation_id="conversation",
+        provider="openai",
+        raw_body=body,
+        outbound_body=body,
+    )
+
+    assert headers["X-Entroly-Prefix-Continuity"] == "first_observation"
+    assert headers["X-Entroly-Prefix-Interference-Tokens"] == "0"
+    assert secret not in repr(headers)
+
+
+def test_proxy_tracks_content_blind_live_provider_usage_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("ENTROLY_USAGE_LEDGER", raising=False)
+    monkeypatch.setenv("ENTROLY_SESSION_RESCUE", "0")
+    proxy = PromptCompilerProxy(object(), ProxyConfig())
+
+    proxy._record_provider_usage(
+        body=_body("tool output"),
+        provider="openai",
+        request_id="request-local-only",
+        usage=TokenUsage(
+            uncached_input_tokens=200,
+            cache_read_tokens=800,
+            cache_write_tokens=25,
+            output_tokens=50,
+        ),
+        streaming=False,
+    )
+
+    assert proxy._usage_ledger is None
+    assert proxy._live_usage_requests == 1
+    assert proxy._live_uncached_input_tokens == 200
+    assert proxy._live_cache_read_tokens == 800
+    assert proxy._live_cache_write_tokens == 25
+    assert proxy._live_output_tokens == 50


### PR DESCRIPTION
## What changed

- add a content-blind, hash-only prefix continuity tracker and warm-cache guard
- preserve the safer provider prefix when an optional image, history, or context mutation would materially disrupt a provider-observed warm cache
- expose process-local provider token categories by default while keeping durable usage and pricing opt-in
- upgrade Context Health to separate retrieval-adjusted reduction, provider cache observations, and economic attribution
- document evidence levels, privacy boundaries, and the paired-baseline requirement

## Why

A request optimizer can reduce the current prompt while increasing total provider cost if it rewrites a previously cached prefix. Token reduction alone is therefore insufficient evidence of economic benefit.

The proxy now treats provider-reported cache state as authoritative and prevents optional rewrites that would destroy a material warm prefix. Required redaction, fail-closed controls, recovery persistence, and emergency session rescue remain non-negotiable and cannot be undone by the guard.

## User impact

Users get automatic protection against optimizer interference plus privacy-safe visibility into request cache hits, cached input-token ratios, prefix continuity, and guard interventions. The dashboard deliberately reports economic net as unavailable until a paired baseline exists.

## Privacy

Only fixed-size SHA-256 block digests, byte counts, and aggregate counters are retained. Prompt text, code, paths, raw request or conversation identifiers, and model names are not retained by the continuity tracker.

## Validation

- `python -m ruff check entroly tests/test_prefix_continuity.py tests/test_proxy_optimizer_interference.py tests/test_context_health.py tests/test_dashboard_context_health.py`
- 242 proxy, cache, session, provider, transport, usage, and continuity tests passed
- 43 focused continuity, Context Health, provider-image, control-plane, and rescue tests passed after the final baseline expansion
- 24 dashboard security tests passed
- 11 dashboard wiring tests passed
- 19 dashboard response-integrity, fallback, compression, and Context Health tests passed
- manual in-app browser QA at desktop width; Context Health empty states and evidence labels rendered correctly
