### PR TITLE
Expand language proof and publish Nemotron Ollama support

### DIFF
--- a/.github/workflows/code-intelligence.yml
+++ b/.github/workflows/code-intelligence.yml
@@ -13,6 +13,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -36,6 +38,15 @@ jobs:
             tests/test_code_intelligence_conformance.py \
             tests/test_universal_code_intelligence.py
 
+      - name: Verify published language-symbol coverage
+        env:
+          ENTROLY_TREE_SITTER_ALLOW_DOWNLOAD: "1"
+          ENTROLY_AIR_GAP: "0"
+        run: |
+          python benchmarks/language_symbol_coverage.py \
+            --baseline-ref 2eeecb8733103fe7234133f48b105f271662b219 \
+            --check
+
       - name: Re-run parser regressions with acquisition disabled
         env:
           ENTROLY_TREE_SITTER_ALLOW_DOWNLOAD: "0"
@@ -53,3 +64,6 @@ jobs:
             tests/test_language_open_registry_contract.py \
             tests/test_code_intelligence_conformance.py \
             tests/test_universal_code_intelligence.py
+          python benchmarks/language_symbol_coverage.py \
+            --baseline-ref 2eeecb8733103fe7234133f48b105f271662b219 \
+            --check

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ AST and Tree-sitter structure, dependency and call graphs, interprocedural flow,
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache-2.0 license"></a>
   <a href="benchmarks/results/receipt_fragment_fidelity_default.json"><img src="https://img.shields.io/badge/Source_spans-5%2C117%2F5%2C117_verified-0A7B83" alt="5,117 of 5,117 native source fragments independently verified"></a>
   <a href="benchmarks/results/receipt_public_integrity.json"><img src="https://img.shields.io/badge/SDK_recovery-13%2F13_exact-blueviolet" alt="13 of 13 public SDK recovery probes exactly matched their source spans"></a>
+  <a href="benchmarks/results/language_symbol_coverage.json"><img src="https://img.shields.io/badge/Symbol_extraction-32%2F37_exact-7C3AED" alt="32 of 37 declaration-bearing language samples passed strict symbol extraction"></a>
   <a href="https://github.com/juyterman1000/entroly"><img src="https://img.shields.io/github/stars/juyterman1000/entroly?style=social" alt="Entroly GitHub stars"></a>
 </p>
 
@@ -104,6 +105,8 @@ Most retrieval systems answer **“which text looks similar?”** Entroly can al
 That combination is why Entroly is more than a context compressor. It is a **code-intelligence control plane for AI agents**: understand the repository, select evidence, verify freshness, preserve provenance, then compress only after the right context has been chosen.
 
 **Evidence, not slogans:** the repository includes a [39-dimension code-intelligence conformance protocol](benchmarks/CODE_INTELLIGENCE_CONFORMANCE.md) covering structural correctness, typed dispatch, call/dependency graphs, value flow, LSP ranges, cache invalidation, architecture reasoning, refactoring safety, stale-source rejection, and tamper evidence. The design and limitations are documented in [Verified Code Context](docs/verified-code-context.md) and [Universal Code Intelligence](docs/research/universal-code-intelligence.md).
+
+**Measured multi-language symbol extraction:** with `tree-sitter-language-pack==1.14.3`, Entroly passes **32/37 declaration-bearing language samples (86.5%)** under a strict contract: valid syntax, complete traversal, the exact expected symbol set, and byte-exact source spans. All **41 mapped languages** were audited; assembly, CSS, HTML, and SCSS are four verified non-declarative samples. Against pre-change `main` (`2eeecb87`), the same harness moves from **20/37 to 32/37**, with 12 newly covered languages and zero losses. The five measured gaps are C3, F#, Groovy, Nim, and OCaml. [Protocol and limitations](docs/benchmarks/language-symbol-coverage.md) · [machine-readable results](benchmarks/results/language_symbol_coverage.json) · reproduce offline after grammar acquisition with `python benchmarks/language_symbol_coverage.py --baseline-ref 2eeecb87 --check`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,19 @@ Runs as a **CLI**, **Python/TypeScript SDK**, **MCP server**, **HTTP proxy**, or
 
 ## Works with your stack
 
+### NVIDIA Nemotron 3.5 Lightning with Ollama
+
+Entroly supports `nemotron-3.5-lightning` through its existing local Ollama discovery and OpenAI-compatible proxy path. This is a model-neutral integration: Entroly manages evidence selection, budgets, recovery handles, Context Receipts, and optional verification around the request; Ollama runs the model.
+
+```bash
+ollama pull nemotron-3.5-lightning
+python -m entroly.models discover ollama --inspect-ollama-context
+# Set ENTROLY_OPENAI_BASE=http://127.0.0.1:11434 in your shell, then:
+entroly proxy
+```
+
+Ollama lists the standard `nemotron-3.5-lightning` tag as a 30B mixture-of-experts model with 3B active parameters and a 1M context window. Its Apple-silicon `30b-mlx` tag is listed separately with a 256K window, so Entroly discovers the installed tag's metadata instead of assuming that every build has the same limit. Local Ollama inference can keep model prompts on the device; agent tools, configured remote providers, and other applications retain their own network and privacy boundaries. [Compatibility, setup, and official sources](docs/nemotron-3-5-lightning-ollama.html).
+
 | Agent / platform | Path | Status |
 |---|---|---|
 | Claude Code | Scoped MCP attachment; API-key proxy | Native |

--- a/benchmarks/language_symbol_coverage.py
+++ b/benchmarks/language_symbol_coverage.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Reproducible symbol-extraction audit for every Entroly-mapped language.
+
+This is a conformance benchmark, not a parser popularity count.  Each case has
+one small, reviewable source sample and an exact expected symbol set.  A case
+passes only when extraction is complete, byte ranges recover the exact source,
+and no extra symbol is invented.  Markup, style, and assembly samples are
+audited separately because they do not contain declarations in Entroly's code
+symbol model.
+
+The optional baseline is loaded from Git without checking it out, so the same
+fixtures and installed grammar pack evaluate both implementations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = ROOT / "benchmarks" / "results" / "language_symbol_coverage.json"
+
+
+@dataclass(frozen=True)
+class Case:
+    language: str
+    path: str
+    source: str
+    expected_symbols: tuple[str, ...]
+    declaration_bearing: bool = True
+
+
+CASES = (
+    Case(
+        "ada",
+        "sample.adb",
+        "procedure Total is\nbegin\n   null;\nend Total;\n",
+        ("Total",),
+    ),
+    Case("asm", "sample.asm", "section .text\n_start:\n    mov rax, 60\n", (), False),
+    Case("bash", "sample.sh", "total() { echo 1; }\n", ("total",)),
+    Case("c", "sample.c", "int total(int x) { return x; }\n", ("total",)),
+    Case("c3", "sample.c3", "fn int total(int x) { return x; }\n", ("total",)),
+    Case(
+        "c_sharp",
+        "sample.cs",
+        "public class Cart { public int Total() { return 1; } }\n",
+        ("Cart", "Total"),
+    ),
+    Case(
+        "cpp",
+        "sample.cpp",
+        "struct Cart { int total() { return 1; } };\n",
+        ("Cart", "total"),
+    ),
+    Case("css", "sample.css", ".cart { color: red; }\n", (), False),
+    Case(
+        "dart",
+        "sample.dart",
+        "int total(int x) { return x; }\nclass Cart { void add() {} }\n",
+        ("Cart", "add", "total"),
+    ),
+    Case(
+        "elixir",
+        "sample.ex",
+        "defmodule Cart do\n  def total(x), do: x\nend\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "erlang", "sample.erl", "total(X) -> X.\nadd() -> total(1).\n", ("add", "total")
+    ),
+    Case("fish", "sample.fish", "function total\n    echo 1\nend\n", ("total",)),
+    Case("fsharp", "sample.fs", "let total x = x + 1\n", ("total",)),
+    Case(
+        "go",
+        "sample.go",
+        "package m\nfunc total() {}\ntype Cart struct{}\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "groovy",
+        "sample.groovy",
+        "class Cart { def total() { 1 } }\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "haskell",
+        "sample.hs",
+        "total :: Int -> Int\ntotal x = x\n\ndata Cart = Empty\n",
+        ("Cart", "total"),
+    ),
+    Case("html", "sample.html", '<main class="cart">hello</main>\n', (), False),
+    Case(
+        "java",
+        "sample.java",
+        "class Cart { int total() { return 1; } }\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "javascript",
+        "sample.js",
+        "function total() {}\nclass Cart {}\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "julia",
+        "sample.jl",
+        "function total(x)\n    x\nend\nstruct Cart\n    x::Int\nend\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "kotlin",
+        "sample.kt",
+        "fun total(price: Int): Int { return price }\nclass Cart {\n    fun add() {}\n    fun clear() {}\n}\n",
+        ("Cart", "add", "clear", "total"),
+    ),
+    Case("lua", "sample.lua", "function total(x) return x end\n", ("total",)),
+    Case("nim", "sample.nim", "proc total(x: int): int = x\n", ("total",)),
+    Case("ocaml", "sample.ml", "let total x = x + 1\n", ("total",)),
+    Case(
+        "php",
+        "sample.php",
+        "<?php function total($x) { return $x; } class Cart {} ?>\n",
+        ("Cart", "total"),
+    ),
+    Case("proto", "sample.proto", "message Cart {\n  string id = 1;\n}\n", ("Cart",)),
+    Case(
+        "python",
+        "sample.py",
+        "def total(x):\n    return x\n\nclass Cart:\n    def add(self):\n        pass\n",
+        ("Cart", "add", "total"),
+    ),
+    Case(
+        "r",
+        "sample.R",
+        "total <- function(x) x + 1\nrunner <- function() total(1)\n",
+        ("runner", "total"),
+    ),
+    Case(
+        "ruby",
+        "sample.rb",
+        "class Cart\n  def total\n    1\n  end\nend\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "rust",
+        "sample.rs",
+        "pub struct Cart { n: u32 }\nimpl Cart { pub fn total(&self) -> u32 { self.n } }\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "scala",
+        "sample.scala",
+        "class Cart { def total: Int = 1 }\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "scss", "sample.scss", "$accent: red;\n.cart { color: $accent; }\n", (), False
+    ),
+    Case(
+        "solidity",
+        "sample.sol",
+        "contract Cart {\n  function total() public {}\n}\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "sql",
+        "sample.sql",
+        "CREATE FUNCTION add_tax(p int) RETURNS int AS $$ SELECT 1 $$ LANGUAGE SQL;\n",
+        ("add_tax",),
+    ),
+    Case(
+        "svelte",
+        "sample.svelte",
+        "<script>\nfunction total() {}\nclass Cart {}\n</script>\n<div/>\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "swift",
+        "sample.swift",
+        "struct Cart { func total() -> Int { 1 } }\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "tsx",
+        "sample.tsx",
+        "export function total(): number { return 1 }\nexport class Cart {}\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "typescript",
+        "sample.ts",
+        "export function total(): number { return 1 }\nexport class Cart {}\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "v",
+        "sample.v",
+        "struct Cart {}\nfn total() int { return 1 }\n",
+        ("Cart", "total"),
+    ),
+    Case(
+        "vue",
+        "sample.vue",
+        "<script>\nfunction total() {}\n</script>\n<template><div/></template>\n",
+        ("total",),
+    ),
+    Case(
+        "zig",
+        "sample.zig",
+        "pub fn total() void {}\nfn add() void {}\n",
+        ("add", "total"),
+    ),
+)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _module_from_source(source: bytes, label: str) -> ModuleType:
+    module_name = f"_entroly_tree_sitter_benchmark_{_sha256(source)[:12]}"
+    spec = importlib.util.spec_from_loader(module_name, loader=None)
+    if spec is None:
+        raise RuntimeError(f"could not create module for {label}")
+    module = importlib.util.module_from_spec(spec)
+    module.__file__ = f"{label}:entroly/tree_sitter_support.py"
+    sys.modules[module_name] = module
+    exec(compile(source, module.__file__, "exec"), module.__dict__)
+    return module
+
+
+def _module_at_ref(ref: str) -> tuple[ModuleType, str]:
+    completed = subprocess.run(
+        ["git", "show", f"{ref}:entroly/tree_sitter_support.py"],
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return _module_from_source(completed.stdout, ref), _sha256(completed.stdout)
+
+
+def _worktree_module() -> tuple[ModuleType, str]:
+    source = (ROOT / "entroly" / "tree_sitter_support.py").read_bytes()
+    return _module_from_source(source, "worktree"), _sha256(source)
+
+
+def _evaluate(module: ModuleType, label: str, source_sha256: str) -> dict[str, Any]:
+    case_languages = {case.language for case in CASES}
+    mapped_languages = set(module.LANGUAGE_BY_SUFFIX.values())
+    if len(case_languages) != len(CASES):
+        raise RuntimeError("benchmark cases contain a duplicate language")
+    if case_languages != mapped_languages:
+        missing = sorted(mapped_languages - case_languages)
+        extra = sorted(case_languages - mapped_languages)
+        raise RuntimeError(f"benchmark/map drift: missing={missing}, extra={extra}")
+    rows: list[dict[str, Any]] = []
+    for case in CASES:
+        report = module.extract_structural_spans_report(case.source, case.path)
+        spans = list(report.items) if report is not None else []
+        symbols = tuple(sorted({str(span.name) for span in spans}))
+        exact_ranges = all(
+            case.source.encode("utf-8")[span.start_byte : span.end_byte].decode("utf-8")
+            == span.source
+            for span in spans
+        )
+        complete = report is not None and bool(report.complete)
+        syntax_valid = module.validate_structural_syntax(case.source, case.path)
+        expected = tuple(sorted(case.expected_symbols))
+        passed = (
+            syntax_valid is True and complete and exact_ranges and symbols == expected
+        )
+        rows.append(
+            {
+                "language": case.language,
+                "path": case.path,
+                "declaration_bearing": case.declaration_bearing,
+                "expected_symbols": list(expected),
+                "observed_symbols": list(symbols),
+                "syntax_valid": syntax_valid,
+                "complete": complete,
+                "byte_exact": exact_ranges,
+                "backend": report.backend if report is not None else "unavailable",
+                "status": (
+                    "covered"
+                    if passed and case.declaration_bearing
+                    else "non_declarative_verified"
+                    if passed
+                    else "gap"
+                ),
+            }
+        )
+    declaration_rows = [row for row in rows if row["declaration_bearing"]]
+    covered = [row for row in declaration_rows if row["status"] == "covered"]
+    non_declarative = [row for row in rows if not row["declaration_bearing"]]
+    non_declarative_verified = [
+        row for row in non_declarative if row["status"] == "non_declarative_verified"
+    ]
+    return {
+        "label": label,
+        "extractor_sha256": source_sha256,
+        "summary": {
+            "mapped_languages_audited": len(rows),
+            "declaration_bearing_languages": len(declaration_rows),
+            "declaration_languages_covered": len(covered),
+            "declaration_coverage_pct": round(
+                100.0 * len(covered) / len(declaration_rows), 1
+            ),
+            "non_declarative_languages": len(non_declarative),
+            "non_declarative_languages_verified": len(non_declarative_verified),
+            "strict_cases_passed": len(covered) + len(non_declarative_verified),
+        },
+        "cases": rows,
+    }
+
+
+def run(baseline_ref: str | None) -> dict[str, Any]:
+    current_module, current_sha = _worktree_module()
+    current = _evaluate(current_module, "worktree", current_sha)
+    result: dict[str, Any] = {
+        "schema": "entroly.language-symbol-coverage.v1",
+        "method": {
+            "case_contract": "exact symbol set, complete traversal, byte-exact spans",
+            "scope": "one representative sample for every language in LANGUAGE_BY_SUFFIX",
+            "economic_or_answer_quality_claim": False,
+            "case_manifest_sha256": _sha256(
+                json.dumps(
+                    [
+                        {
+                            "language": case.language,
+                            "path": case.path,
+                            "source": case.source,
+                            "expected_symbols": case.expected_symbols,
+                            "declaration_bearing": case.declaration_bearing,
+                        }
+                        for case in CASES
+                    ],
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ),
+        },
+        "environment": {
+            "tree_sitter_language_pack": importlib.metadata.version(
+                "tree-sitter-language-pack"
+            ),
+        },
+        "current": current,
+    }
+    if baseline_ref:
+        baseline_module, baseline_sha = _module_at_ref(baseline_ref)
+        baseline = _evaluate(baseline_module, baseline_ref, baseline_sha)
+        current_covered = {
+            row["language"] for row in current["cases"] if row["status"] == "covered"
+        }
+        baseline_covered = {
+            row["language"] for row in baseline["cases"] if row["status"] == "covered"
+        }
+        result["baseline"] = baseline
+        result["comparison"] = {
+            "newly_covered_declaration_languages": sorted(
+                current_covered - baseline_covered
+            ),
+            "lost_declaration_language_coverage": sorted(
+                baseline_covered - current_covered
+            ),
+            "coverage_delta": len(current_covered) - len(baseline_covered),
+        }
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-ref", default=None)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    result = run(args.baseline_ref)
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.check:
+        if (
+            not args.output.exists()
+            or args.output.read_text(encoding="utf-8") != rendered
+        ):
+            print(f"benchmark artifact is stale: {args.output}", file=sys.stderr)
+            return 1
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(json.dumps(result["current"]["summary"], sort_keys=True))
+    if "comparison" in result:
+        print(json.dumps(result["comparison"], sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/language_symbol_coverage.py
+++ b/benchmarks/language_symbol_coverage.py
@@ -29,6 +29,8 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT = ROOT / "benchmarks" / "results" / "language_symbol_coverage.json"
+BENCHMARK_MODULE = "benchmarks/language_symbol_coverage.py"
+IMPLEMENTATION_COMMIT = "4fecb039c579c7d3e7f534d41bef3c0ede2c5d8a"
 
 
 @dataclass(frozen=True)
@@ -228,6 +230,11 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _portable_bytes(path: Path) -> bytes:
+    """Return text bytes independent of checkout newline policy."""
+    return path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
 def _module_from_source(source: bytes, label: str) -> ModuleType:
     module_name = f"_entroly_tree_sitter_benchmark_{_sha256(source)[:12]}"
     spec = importlib.util.spec_from_loader(module_name, loader=None)
@@ -252,7 +259,7 @@ def _module_at_ref(ref: str) -> tuple[ModuleType, str]:
 
 
 def _worktree_module() -> tuple[ModuleType, str]:
-    source = (ROOT / "entroly" / "tree_sitter_support.py").read_bytes()
+    source = _portable_bytes(ROOT / "entroly" / "tree_sitter_support.py")
     return _module_from_source(source, "worktree"), _sha256(source)
 
 
@@ -330,6 +337,32 @@ def run(baseline_ref: str | None) -> dict[str, Any]:
     current = _evaluate(current_module, "worktree", current_sha)
     result: dict[str, Any] = {
         "schema": "entroly.language-symbol-coverage.v1",
+        "headline_eligible": True,
+        "claim_scope": (
+            "Exact symbol extraction for one valid representative sample per "
+            "mapped language under tree-sitter-language-pack 1.14.3"
+        ),
+        "sample_size": {
+            "mapped_languages": 41,
+            "declaration_bearing_languages": 37,
+            "non_declarative_languages": 4,
+        },
+        "benchmark_module": BENCHMARK_MODULE,
+        "harness_sha256": _sha256(_portable_bytes(ROOT / BENCHMARK_MODULE)),
+        "reproduction_command": (
+            "python benchmarks/language_symbol_coverage.py "
+            "--baseline-ref 2eeecb8733103fe7234133f48b105f271662b219 "
+            "--output benchmarks/results/language_symbol_coverage.json --check"
+        ),
+        "implementation": {"commit": IMPLEMENTATION_COMMIT},
+        "limitations": [
+            "One representative sample per language is not complete grammar coverage.",
+            "The benchmark measures declarations, traversal, syntax, and byte spans; "
+            "it does not measure call resolution, data flow, answer quality, or savings.",
+            "Results depend on tree-sitter-language-pack 1.14.3 and must be regenerated "
+            "and reviewed for a different grammar pack.",
+            "C3, F#, Groovy, Nim, and OCaml remain measured declaration gaps.",
+        ],
         "method": {
             "case_contract": "exact symbol set, complete traversal, byte-exact spans",
             "scope": "one representative sample for every language in LANGUAGE_BY_SUFFIX",
@@ -388,6 +421,9 @@ def main() -> int:
     args = parser.parse_args()
     result = run(args.baseline_ref)
     rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    rendered_sha256 = _sha256(rendered.encode("utf-8"))
+    sidecar = args.output.with_suffix(args.output.suffix + ".sha256")
+    sidecar_text = f"{rendered_sha256}  {args.output.name}\n"
     if args.check:
         if (
             not args.output.exists()
@@ -395,9 +431,13 @@ def main() -> int:
         ):
             print(f"benchmark artifact is stale: {args.output}", file=sys.stderr)
             return 1
+        if not sidecar.exists() or sidecar.read_text(encoding="ascii") != sidecar_text:
+            print(f"benchmark checksum is stale: {sidecar}", file=sys.stderr)
+            return 1
     else:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(rendered, encoding="utf-8")
+        sidecar.write_text(sidecar_text, encoding="ascii")
     print(json.dumps(result["current"]["summary"], sort_keys=True))
     if "comparison" in result:
         print(json.dumps(result["comparison"], sort_keys=True))

--- a/benchmarks/results/language_symbol_coverage.json
+++ b/benchmarks/results/language_symbol_coverage.json
@@ -1,0 +1,1408 @@
+{
+  "baseline": {
+    "cases": [
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Total"
+        ],
+        "language": "ada",
+        "observed_symbols": [
+          "Total"
+        ],
+        "path": "sample.adb",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": false,
+        "expected_symbols": [],
+        "language": "asm",
+        "observed_symbols": [],
+        "path": "sample.asm",
+        "status": "non_declarative_verified",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "bash",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.sh",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "c",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.c",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "c3",
+        "observed_symbols": [],
+        "path": "sample.c3",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "Total"
+        ],
+        "language": "c_sharp",
+        "observed_symbols": [
+          "Cart",
+          "Total"
+        ],
+        "path": "sample.cs",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "cpp",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.cpp",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": false,
+        "expected_symbols": [],
+        "language": "css",
+        "observed_symbols": [],
+        "path": "sample.css",
+        "status": "non_declarative_verified",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "add",
+          "total"
+        ],
+        "language": "dart",
+        "observed_symbols": [
+          "Cart"
+        ],
+        "path": "sample.dart",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "elixir",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.ex",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "add",
+          "total"
+        ],
+        "language": "erlang",
+        "observed_symbols": [],
+        "path": "sample.erl",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "fish",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.fish",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "fsharp",
+        "observed_symbols": [],
+        "path": "sample.fs",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "go",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.go",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "groovy",
+        "observed_symbols": [],
+        "path": "sample.groovy",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "haskell",
+        "observed_symbols": [],
+        "path": "sample.hs",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": false,
+        "expected_symbols": [],
+        "language": "html",
+        "observed_symbols": [],
+        "path": "sample.html",
+        "status": "non_declarative_verified",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "java",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.java",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "javascript",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.js",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "julia",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.jl",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "add",
+          "clear",
+          "total"
+        ],
+        "language": "kotlin",
+        "observed_symbols": [
+          "Cart"
+        ],
+        "path": "sample.kt",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "lua",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.lua",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "nim",
+        "observed_symbols": [],
+        "path": "sample.nim",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "ocaml",
+        "observed_symbols": [],
+        "path": "sample.ml",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "php",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.php",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart"
+        ],
+        "language": "proto",
+        "observed_symbols": [],
+        "path": "sample.proto",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "add",
+          "total"
+        ],
+        "language": "python",
+        "observed_symbols": [
+          "Cart",
+          "add",
+          "total"
+        ],
+        "path": "sample.py",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "runner",
+          "total"
+        ],
+        "language": "r",
+        "observed_symbols": [
+          "function"
+        ],
+        "path": "sample.R",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "ruby",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.rb",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "rust",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.rs",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "scala",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.scala",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": false,
+        "expected_symbols": [],
+        "language": "scss",
+        "observed_symbols": [],
+        "path": "sample.scss",
+        "status": "non_declarative_verified",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "solidity",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.sol",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "add_tax"
+        ],
+        "language": "sql",
+        "observed_symbols": [],
+        "path": "sample.sql",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "svelte",
+        "observed_symbols": [],
+        "path": "sample.svelte",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "swift",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.swift",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "tsx",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.tsx",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "typescript",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.ts",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "v",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.v",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "vue",
+        "observed_symbols": [],
+        "path": "sample.vue",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "add",
+          "total"
+        ],
+        "language": "zig",
+        "observed_symbols": [],
+        "path": "sample.zig",
+        "status": "gap",
+        "syntax_valid": true
+      }
+    ],
+    "extractor_sha256": "061775c48ce7c79384dec8f7539f972cb88dae6e94817f880d694131cd389ae0",
+    "label": "2eeecb8733103fe7234133f48b105f271662b219",
+    "summary": {
+      "declaration_bearing_languages": 37,
+      "declaration_coverage_pct": 54.1,
+      "declaration_languages_covered": 20,
+      "mapped_languages_audited": 41,
+      "non_declarative_languages": 4,
+      "non_declarative_languages_verified": 4,
+      "strict_cases_passed": 24
+    }
+  },
+  "comparison": {
+    "coverage_delta": 12,
+    "lost_declaration_language_coverage": [],
+    "newly_covered_declaration_languages": [
+      "dart",
+      "erlang",
+      "go",
+      "haskell",
+      "kotlin",
+      "proto",
+      "r",
+      "solidity",
+      "sql",
+      "svelte",
+      "vue",
+      "zig"
+    ]
+  },
+  "current": {
+    "cases": [
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Total"
+        ],
+        "language": "ada",
+        "observed_symbols": [
+          "Total"
+        ],
+        "path": "sample.adb",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": false,
+        "expected_symbols": [],
+        "language": "asm",
+        "observed_symbols": [],
+        "path": "sample.asm",
+        "status": "non_declarative_verified",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "bash",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.sh",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "c",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.c",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "c3",
+        "observed_symbols": [],
+        "path": "sample.c3",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "Total"
+        ],
+        "language": "c_sharp",
+        "observed_symbols": [
+          "Cart",
+          "Total"
+        ],
+        "path": "sample.cs",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "cpp",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.cpp",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": false,
+        "expected_symbols": [],
+        "language": "css",
+        "observed_symbols": [],
+        "path": "sample.css",
+        "status": "non_declarative_verified",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "add",
+          "total"
+        ],
+        "language": "dart",
+        "observed_symbols": [
+          "Cart",
+          "add",
+          "total"
+        ],
+        "path": "sample.dart",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "elixir",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.ex",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "add",
+          "total"
+        ],
+        "language": "erlang",
+        "observed_symbols": [
+          "add",
+          "total"
+        ],
+        "path": "sample.erl",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "fish",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.fish",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "fsharp",
+        "observed_symbols": [],
+        "path": "sample.fs",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "go",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.go",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "groovy",
+        "observed_symbols": [],
+        "path": "sample.groovy",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "haskell",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.hs",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": false,
+        "expected_symbols": [],
+        "language": "html",
+        "observed_symbols": [],
+        "path": "sample.html",
+        "status": "non_declarative_verified",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "java",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.java",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "javascript",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.js",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "julia",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.jl",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "add",
+          "clear",
+          "total"
+        ],
+        "language": "kotlin",
+        "observed_symbols": [
+          "Cart",
+          "add",
+          "clear",
+          "total"
+        ],
+        "path": "sample.kt",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "lua",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.lua",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "nim",
+        "observed_symbols": [],
+        "path": "sample.nim",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "ocaml",
+        "observed_symbols": [],
+        "path": "sample.ml",
+        "status": "gap",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "php",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.php",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart"
+        ],
+        "language": "proto",
+        "observed_symbols": [
+          "Cart"
+        ],
+        "path": "sample.proto",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "add",
+          "total"
+        ],
+        "language": "python",
+        "observed_symbols": [
+          "Cart",
+          "add",
+          "total"
+        ],
+        "path": "sample.py",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "runner",
+          "total"
+        ],
+        "language": "r",
+        "observed_symbols": [
+          "runner",
+          "total"
+        ],
+        "path": "sample.R",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "ruby",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.rb",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "rust",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.rs",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "scala",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.scala",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": false,
+        "expected_symbols": [],
+        "language": "scss",
+        "observed_symbols": [],
+        "path": "sample.scss",
+        "status": "non_declarative_verified",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "solidity",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.sol",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "add_tax"
+        ],
+        "language": "sql",
+        "observed_symbols": [
+          "add_tax"
+        ],
+        "path": "sample.sql",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "embedded-script",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "svelte",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.svelte",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "swift",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.swift",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "tsx",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.tsx",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "typescript",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.ts",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "language-pack-process",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "Cart",
+          "total"
+        ],
+        "language": "v",
+        "observed_symbols": [
+          "Cart",
+          "total"
+        ],
+        "path": "sample.v",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "embedded-script",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "total"
+        ],
+        "language": "vue",
+        "observed_symbols": [
+          "total"
+        ],
+        "path": "sample.vue",
+        "status": "covered",
+        "syntax_valid": true
+      },
+      {
+        "backend": "tree-sitter-raw",
+        "byte_exact": true,
+        "complete": true,
+        "declaration_bearing": true,
+        "expected_symbols": [
+          "add",
+          "total"
+        ],
+        "language": "zig",
+        "observed_symbols": [
+          "add",
+          "total"
+        ],
+        "path": "sample.zig",
+        "status": "covered",
+        "syntax_valid": true
+      }
+    ],
+    "extractor_sha256": "5c7d38390884d4c45fa4dff7410ce6261748686c6f47529274a72d8b3749c089",
+    "label": "worktree",
+    "summary": {
+      "declaration_bearing_languages": 37,
+      "declaration_coverage_pct": 86.5,
+      "declaration_languages_covered": 32,
+      "mapped_languages_audited": 41,
+      "non_declarative_languages": 4,
+      "non_declarative_languages_verified": 4,
+      "strict_cases_passed": 36
+    }
+  },
+  "environment": {
+    "tree_sitter_language_pack": "1.14.3"
+  },
+  "method": {
+    "case_contract": "exact symbol set, complete traversal, byte-exact spans",
+    "case_manifest_sha256": "7df07e34f77fef3cd3af6fb928358594df82384ce3661297c22233ed325f625d",
+    "economic_or_answer_quality_claim": false,
+    "scope": "one representative sample for every language in LANGUAGE_BY_SUFFIX"
+  },
+  "schema": "entroly.language-symbol-coverage.v1"
+}

--- a/benchmarks/results/language_symbol_coverage.json
+++ b/benchmarks/results/language_symbol_coverage.json
@@ -675,6 +675,8 @@
       "strict_cases_passed": 24
     }
   },
+  "benchmark_module": "benchmarks/language_symbol_coverage.py",
+  "claim_scope": "Exact symbol extraction for one valid representative sample per mapped language under tree-sitter-language-pack 1.14.3",
   "comparison": {
     "coverage_delta": 12,
     "lost_declaration_language_coverage": [],
@@ -1383,7 +1385,7 @@
         "syntax_valid": true
       }
     ],
-    "extractor_sha256": "5c7d38390884d4c45fa4dff7410ce6261748686c6f47529274a72d8b3749c089",
+    "extractor_sha256": "7ab642179ea4c77c71d502f9abde064a8c5850dd9e7130b53038838c395a5cd2",
     "label": "worktree",
     "summary": {
       "declaration_bearing_languages": 37,
@@ -1398,11 +1400,28 @@
   "environment": {
     "tree_sitter_language_pack": "1.14.3"
   },
+  "harness_sha256": "c8ce2c18c622c2d5be086d9e664e098f6400f8cc3fc4d715eb6d86a6e8138fa6",
+  "headline_eligible": true,
+  "implementation": {
+    "commit": "4fecb039c579c7d3e7f534d41bef3c0ede2c5d8a"
+  },
+  "limitations": [
+    "One representative sample per language is not complete grammar coverage.",
+    "The benchmark measures declarations, traversal, syntax, and byte spans; it does not measure call resolution, data flow, answer quality, or savings.",
+    "Results depend on tree-sitter-language-pack 1.14.3 and must be regenerated and reviewed for a different grammar pack.",
+    "C3, F#, Groovy, Nim, and OCaml remain measured declaration gaps."
+  ],
   "method": {
     "case_contract": "exact symbol set, complete traversal, byte-exact spans",
     "case_manifest_sha256": "7df07e34f77fef3cd3af6fb928358594df82384ce3661297c22233ed325f625d",
     "economic_or_answer_quality_claim": false,
     "scope": "one representative sample for every language in LANGUAGE_BY_SUFFIX"
+  },
+  "reproduction_command": "python benchmarks/language_symbol_coverage.py --baseline-ref 2eeecb8733103fe7234133f48b105f271662b219 --output benchmarks/results/language_symbol_coverage.json --check",
+  "sample_size": {
+    "declaration_bearing_languages": 37,
+    "mapped_languages": 41,
+    "non_declarative_languages": 4
   },
   "schema": "entroly.language-symbol-coverage.v1"
 }

--- a/benchmarks/results/language_symbol_coverage.json.sha256
+++ b/benchmarks/results/language_symbol_coverage.json.sha256
@@ -1,0 +1,1 @@
+ca2ce750b84ffefeeadac79fd5ef49cce86227c0ff20f4a7ef448c1a718f1e39  language_symbol_coverage.json

--- a/docs/benchmarks/language-symbol-coverage.md
+++ b/docs/benchmarks/language-symbol-coverage.md
@@ -1,0 +1,76 @@
+# Language symbol extraction coverage
+
+Entroly audits every language in its path-to-language map with one small,
+reviewable source sample. This benchmark measures a narrow but important
+contract: can the parser-backed extractor return the exact declarations in the
+sample without inventing a parameter, return type, keyword, or body identifier?
+
+## Measured result
+
+Environment: `tree-sitter-language-pack==1.14.3`.
+
+| Measure | Pre-change `main` (`2eeecb87`) | Current result |
+|---|---:|---:|
+| Mapped languages audited | 41 | 41 |
+| Declaration-bearing samples | 37 | 37 |
+| Exact declaration samples | 20 | **32** |
+| Declaration coverage | 54.1% | **86.5%** |
+| Verified non-declarative samples | 4/4 | **4/4** |
+| Lost declaration coverage | — | **0** |
+
+The 12 newly conforming language samples are Dart, Erlang, Go, Haskell,
+Kotlin, Protobuf, R, Solidity, SQL, Svelte, Vue, and Zig.
+
+- **Exact declaration samples (32):** Ada, Bash, C, C#, C++, Dart, Elixir,
+  Erlang, Fish, Go, Haskell, Java, JavaScript, Julia, Kotlin, Lua, PHP,
+  Protobuf, Python, R, Ruby, Rust, Scala, Solidity, SQL, Svelte, Swift, TSX,
+  TypeScript, V, Vue, and Zig.
+- **Measured declaration gaps (5):** C3, F#, Groovy, Nim, and OCaml.
+- **Verified non-declarative samples (4):** assembly, CSS, HTML, and SCSS. These
+  are audited for zero invented code declarations and are not placed in the
+  37-language declaration denominator.
+
+## Pass contract
+
+A language sample passes only when all four conditions hold:
+
+1. Tree-sitter reports valid syntax for the sample.
+2. The bounded traversal completes.
+3. The observed symbol set exactly equals the expected set; subset matching is
+   not enough.
+4. Every reported byte range decodes to the exact source stored on the span.
+
+The exact-set rule caught a Dart false positive during this work: a generic
+`function_body` heuristic emitted the returned identifier `x` as a declaration.
+The public result was generated only after that defect was fixed and protected
+by a regression test.
+
+## Reproduce
+
+From a full repository checkout:
+
+```bash
+python -m pip install "tree-sitter-language-pack==1.14.3"
+python benchmarks/language_symbol_coverage.py \
+  --baseline-ref 2eeecb8733103fe7234133f48b105f271662b219 \
+  --check
+```
+
+The runner loads the baseline extractor directly from Git, so baseline and
+current code use the same cases and installed grammar pack. CI runs the check
+once with explicit grammar acquisition and again in air-gap mode. The checked-in
+[JSON artifact](../../benchmarks/results/language_symbol_coverage.json) records
+the case-manifest hash, extractor hashes, exact observed symbols, parser backend,
+syntax status, traversal completeness, and byte-fidelity outcome.
+
+## Limitations
+
+- One representative sample per language is conformance evidence, not proof of
+  complete grammar coverage.
+- This benchmark measures declaration extraction, not call resolution, data
+  flow, build semantics, answer quality, latency, or token savings.
+- Coverage depends on the recorded optional parser-pack version. A later grammar
+  release must regenerate and review the artifact rather than silently inheriting
+  these numbers.
+- The five gaps remain visible. They are not counted as supported and are not
+  filled with regex-generated symbols.

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <meta name="description"
     content="Open-source Context OS for AI agents: auditable context engineering, recoverable compression, memory, receipts, verification, and MCP integrations.">
   <meta name="keywords"
-    content="context engineering, AI agents, AI coding agents, context compression, context optimization, context management, context window, token optimization, MCP server, Model Context Protocol, Claude Code, Codex, OpenClaw, GitHub Copilot, Cursor, hallucination detection">
+    content="context engineering, AI agents, AI coding agents, context compression, context optimization, context management, context window, token optimization, MCP server, Model Context Protocol, Claude Code, Codex, OpenClaw, NVIDIA Nemotron 3.5 Lightning, Ollama local AI, GitHub Copilot, Cursor, hallucination detection">
   <meta property="og:title" content="Entroly — The Open-Source Context OS for AI Agents">
   <meta property="og:description"
     content="Select the right evidence, compress context recoverably, inspect omissions and receipts, then verify the answer locally.">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -34,6 +34,7 @@ Weak fit: short prompts, tiny repositories, fixed-price subscriptions where the 
 - **What is exact recovery?** Entroly issues content-addressed `ccr:<24-hex>` handles. `entroly_retrieve` performs a hash-only lookup and returns the complete stored original; it does not accept a query or silently substitute a newer source revision.
 - **Does Entroly guarantee lower cost or better answers?** No universal guarantee is claimed. Entroly provides workload-specific measurements, provider-bound evidence where observable, receipts, recovery, and verification.
 - **Does Entroly support GPT-5.6 Sol, Terra, and Luna?** Yes. The bundled registry recognizes `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, including their published context window, output limit, reasoning levels, and list-price metadata. The usable route still depends on the selected proxy, API, agent, or local integration.
+- **Does Entroly support NVIDIA Nemotron 3.5 Lightning?** Yes, through Entroly's loopback-only Ollama model discovery and OpenAI-compatible proxy path. Use the Ollama model ID `nemotron-3.5-lightning`. Entroly discovers the installed tag's context metadata rather than assuming the standard 1M and Apple-silicon MLX 256K variants are interchangeable. Canonical page: https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html
 - **Can Entroly reduce GPT-5.6 API costs?** Entroly can reduce avoidable provider-bound input tokens before a supported request reaches Sol, Terra, or Luna. Actual dollar impact depends on selected evidence, model tier, prompt caching, output usage, and workload.
 - **Can nontechnical users use Entroly?** Today's product requires a small one-time setup through a supported proxy, wrapper, plugin, SDK, or MCP path. A no-terminal desktop product called Entroly Simple Mode is specified but not yet shipped.
 
@@ -50,6 +51,7 @@ Weak fit: short prompts, tiny repositories, fixed-price subscriptions where the 
 
 ## Current Model Support
 
+- [Entroly for NVIDIA Nemotron 3.5 Lightning on Ollama](https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html): Local model discovery, OpenAI-compatible proxy setup, tag-specific context limits, privacy boundaries, and official sources.
 - [Entroly for GPT-5.6 Sol, Terra, and Luna](https://juyterman1000.github.io/entroly/docs/gpt-5-6-sol-terra-luna.html): Verified model IDs, 1.05M-token context windows, 128K output limits, reasoning modes, pricing provenance, and Entroly integration guidance.
 - **GPT-5.6 Sol:** `gpt-5.6-sol`; the unsuffixed `gpt-5.6` alias resolves to Sol. Use for frontier capability.
 - **GPT-5.6 Terra:** `gpt-5.6-terra`. Use to balance intelligence and cost.

--- a/docs/nemotron-3-5-lightning-ollama.html
+++ b/docs/nemotron-3-5-lightning-ollama.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Entroly Support for NVIDIA Nemotron 3.5 Lightning on Ollama</title>
+  <meta name="description" content="Use NVIDIA Nemotron 3.5 Lightning locally through Ollama with Entroly context selection, exact recovery, Context Receipts, verification, and tag-aware context limits.">
+  <meta name="keywords" content="NVIDIA Nemotron 3.5 Lightning, Ollama, local AI agent, 1M context window, context compression, Context Assurance, Entroly">
+  <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">
+  <link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html">
+  <meta property="og:site_name" content="Entroly">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Entroly for NVIDIA Nemotron 3.5 Lightning on Ollama">
+  <meta property="og:description" content="Local, recoverable Context Assurance for long-running agents using Nemotron 3.5 Lightning through Ollama.">
+  <meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html">
+  <meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+  <meta name="twitter:card" content="summary">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SoftwareApplication",
+        "name": "Entroly",
+        "applicationCategory": "DeveloperApplication",
+        "applicationSubCategory": "Local AI Agent Context Assurance",
+        "operatingSystem": "Windows, macOS, Linux",
+        "url": "https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html",
+        "codeRepository": "https://github.com/juyterman1000/entroly",
+        "downloadUrl": "https://pypi.org/project/entroly/",
+        "license": "https://opensource.org/licenses/Apache-2.0",
+        "description": "Local-first context selection, recoverable compression, Context Receipts, and verification for AI agents, including NVIDIA Nemotron 3.5 Lightning served by Ollama."
+      },
+      {
+        "@type": "TechArticle",
+        "headline": "Entroly support for NVIDIA Nemotron 3.5 Lightning on Ollama",
+        "description": "How Entroly discovers and manages context for the local Ollama model nemotron-3.5-lightning.",
+        "url": "https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html",
+        "dateModified": "2026-08-11",
+        "author": {"@type": "Organization", "name": "Entroly", "url": "https://github.com/juyterman1000/entroly"}
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Does Entroly support NVIDIA Nemotron 3.5 Lightning?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Yes. Entroly supports nemotron-3.5-lightning through loopback-only Ollama model discovery and its OpenAI-compatible proxy path. Ollama runs the model; Entroly manages the request context, receipts, recovery, and optional verification."}
+          },
+          {
+            "@type": "Question",
+            "name": "Does Nemotron 3.5 Lightning keep data on my device?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Model prompts can remain on the device when both Ollama and Entroly are configured locally. Agent tools, remote providers, and other applications keep their own network and privacy boundaries, so local inference does not prove the entire agent workflow is offline."}
+          },
+          {
+            "@type": "Question",
+            "name": "What context window does Nemotron 3.5 Lightning use in Ollama?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Ollama lists the standard latest and 30b tags with a 1M context window and the Apple-silicon 30b-mlx tag with a 256K context window. Entroly can inspect the locally installed tag rather than assuming one limit for every build."}
+          }
+        ]
+      }
+    ]
+  }
+  </script>
+  <style>:root{color-scheme:dark;--bg:#07090c;--panel:#11161a;--text:#f7faf8;--muted:#a8b3ac;--green:#76b900;--line:#2b3430}*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 50% 0,#182316,var(--bg) 38%);color:var(--text);font:17px/1.7 system-ui,sans-serif}main{max-width:940px;margin:auto;padding:54px 24px 90px}a{color:#b8e986}h1{font-size:clamp(2.5rem,6vw,4.5rem);line-height:1.04;letter-spacing:-.045em}.lead{font-size:1.2rem;color:#d4ddd7}.answer,.note{background:rgba(17,22,26,.94);border:1px solid var(--line);border-radius:16px;padding:24px;margin:28px 0}.answer{border-color:#547f20}table{width:100%;border-collapse:collapse;background:var(--panel)}th,td{border:1px solid var(--line);padding:14px;text-align:left;vertical-align:top}pre{background:#020302;border:1px solid var(--line);border-radius:14px;padding:20px;overflow:auto}code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}footer{margin-top:64px;border-top:1px solid var(--line);padding-top:24px;color:var(--muted)}</style>
+</head>
+<body><main>
+  <nav><a href="index.html">Entroly</a> / Nemotron 3.5 Lightning on Ollama</nav>
+  <h1>NVIDIA Nemotron 3.5 Lightning context management with Entroly and Ollama</h1>
+  <p class="lead">Run the model locally with Ollama while Entroly selects evidence under a budget, keeps omitted originals recoverable, emits Context Receipts, and optionally checks the response against supplied evidence.</p>
+
+  <div class="answer"><strong>Direct answer:</strong> Entroly supports the Ollama model ID <code>nemotron-3.5-lightning</code> through its existing local-model discovery and OpenAI-compatible proxy path. This is real model-neutral compatibility, not a claim that Entroly modifies NVIDIA's model or Ollama runtime.</div>
+
+  <h2>Verified model and integration boundary</h2>
+  <table><thead><tr><th>Surface</th><th>Verified behavior</th></tr></thead><tbody>
+    <tr><td>Ollama model</td><td><code>nemotron-3.5-lightning</code>; Ollama describes it as a 30B mixture-of-experts model with 3B active parameters and tool support.</td></tr>
+    <tr><td>Context</td><td>Ollama lists <code>latest</code>/<code>30b</code> at 1M and <code>30b-mlx</code> at 256K. Entroly can inspect the local tag's reported context length.</td></tr>
+    <tr><td>Entroly path</td><td>Loopback-only Ollama discovery plus an OpenAI-compatible upstream at <code>http://127.0.0.1:11434</code>.</td></tr>
+    <tr><td>Privacy</td><td>Entroly sends no analytics by default. Local Ollama inference can keep prompts on-device; tool calls and separately configured services may still use the network.</td></tr>
+  </tbody></table>
+
+  <h2>Setup</h2>
+  <pre>ollama pull nemotron-3.5-lightning
+pip install -U entroly
+python -m entroly.models discover ollama --inspect-ollama-context
+
+# Configure this environment variable in your shell:
+ENTROLY_OPENAI_BASE=http://127.0.0.1:11434
+entroly proxy</pre>
+  <p>Point an OpenAI-compatible client at Entroly's local endpoint, normally <code>http://127.0.0.1:9377/v1</code>, and select <code>nemotron-3.5-lightning</code>. Client-specific environment-variable syntax differs across PowerShell, Command Prompt, Bash, and application settings.</p>
+
+  <h2>Why context control still matters with a long window</h2>
+  <p>A large advertised window is capacity, not a requirement to resend every file, log, conversation, and retrieval result. Entroly can select answer-relevant evidence, preserve exact omitted content through local recovery handles, keep stable prefix bytes cache-friendly, and record the decision without claiming that fewer tokens automatically produce a better answer.</p>
+
+  <div class="note"><strong>Limitations:</strong> context capacity depends on the installed Ollama tag, runtime settings, memory, and hardware. Entroly does not guarantee that a machine can load or serve the maximum advertised window, that every agent tool remains offline, or that context reduction improves every workload.</div>
+
+  <h2>Official sources</h2>
+  <ul>
+    <li><a href="https://ollama.com/library/nemotron-3.5-lightning">Ollama model page and tags</a></li>
+    <li><a href="https://www.nvidia.com/en-us/ai-data-science/foundation-models/nemotron/">NVIDIA Nemotron foundation-model page</a></li>
+    <li><a href="context-engineering.html">Entroly context engineering</a></li>
+    <li><a href="https://github.com/juyterman1000/entroly/blob/main/PRIVACY.md">Entroly privacy contract</a></li>
+  </ul>
+  <footer><a href="https://github.com/juyterman1000/entroly">GitHub</a> · <a href="https://pypi.org/project/entroly/">PyPI</a> · Apache-2.0</footer>
+</main></body></html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -18,4 +18,5 @@
   <url><loc>https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html</loc><lastmod>2026-07-25</lastmod></url>
   <url><loc>https://juyterman1000.github.io/entroly/docs/discord.html</loc><lastmod>2026-07-25</lastmod></url>
   <url><loc>https://juyterman1000.github.io/entroly/docs/gpt-5-6-sol-terra-luna.html</loc><lastmod>2026-07-26</lastmod></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html</loc><lastmod>2026-08-11</lastmod><changefreq>weekly</changefreq><priority>0.90</priority></url>
 </urlset>

--- a/entroly/tree_sitter_support.py
+++ b/entroly/tree_sitter_support.py
@@ -57,6 +57,20 @@ _DECLARATION_HINTS = frozenset({
     "macro", "procedure", "subroutine", "routine", "type_alias",
 })
 
+# Grammars whose declaration nodes the generic heuristic cannot match, keyed by
+# language so the names cannot leak across grammars. These were read from the
+# real parse trees, not guessed: Haskell names a definition `function` (bare,
+# with a `name` field), Perl a sub `subroutine_declaration_statement` (ends in
+# `_statement`, so the suffix rule skips it). Both carry a `name` field, so the
+# existing name/kind extraction handles them unchanged. The names are
+# deliberately NOT added to the global set: JavaScript and TypeScript both emit
+# a bare `function` node for function expressions, and matching those globally
+# would invent named declarations from anonymous expressions.
+_LANGUAGE_DECLARATION_TYPES: dict[str, frozenset[str]] = {
+    "haskell": frozenset({"function", "data_type"}),
+    "perl": frozenset({"subroutine_declaration_statement"}),
+}
+
 _KIND_HINTS = (
     ("method", "method"), ("function", "function"), ("constructor", "constructor"),
     ("class", "class"), ("struct", "struct"), ("enum", "enum"),
@@ -257,6 +271,14 @@ def _first_identifier(node: Any) -> Any | None:
     stack = [node]
     while stack:
         current = stack.pop()
+        # Error-recovery subtrees hold fragments in the wrong place: a dense
+        # one-line `class W{ fun run(){} }` mis-parses, and descending into the
+        # ERROR node returns an inner function name as the class name. Skipping
+        # them keeps resolution on the real, well-formed structure.
+        if str(getattr(current, "type", "")) == "ERROR" or bool(
+            getattr(current, "is_error", False)
+        ):
+            continue
         if getattr(current, "type", "") in {
             "identifier", "type_identifier", "field_identifier", "property_identifier",
             "constant", "operator_name", "name",
@@ -266,7 +288,34 @@ def _first_identifier(node: Any) -> Any | None:
     return None
 
 
-def _name_node(node: Any) -> Any | None:
+# Grammars that name a declaration with a bare positional child and expose no
+# `name` field for it. The value is the child node type that holds the name, and
+# only a DIRECT child is taken: Kotlin's `function_declaration` lists
+# `simple_identifier` (the name), `function_value_parameters`, `user_type` (the
+# return type) and `function_body` as siblings with no fields, so the generic
+# `_first_identifier` descends into the return type and returns `Int` for
+# `fun helper(): Int`, and finds nothing for a body-less nested `fun run()`.
+# Taking the first direct `simple_identifier` returns the real name and cannot
+# reach a parameter (nested in function_value_parameters) or a return type
+# (nested in user_type). A class uses `type_identifier`, not `simple_identifier`,
+# so this does not fire for it and the existing resolution still applies.
+_LANGUAGE_NAME_CHILD_TYPE: dict[str, str] = {
+    "kotlin": "simple_identifier",
+}
+
+# Grammars whose pack structure processing returns partial declarations (a named
+# class but null-named functions, no method descent), where the name-resolving
+# tree walk is more complete. Add a language only after verifying the walk does
+# strictly better for it, since the walk's own per-grammar coverage varies.
+_PACK_STRUCTURE_UNRELIABLE: frozenset[str] = frozenset({"kotlin"})
+
+
+def _name_node(node: Any, language: str = "") -> Any | None:
+    preferred = _LANGUAGE_NAME_CHILD_TYPE.get(language) if language else None
+    if preferred:
+        for child in getattr(node, "children", ()):
+            if str(getattr(child, "type", "")) == preferred:
+                return child
     field = getattr(node, "child_by_field_name", None)
     if callable(field):
         named = field("name")
@@ -289,7 +338,24 @@ def _kind(node_type: str) -> str:
     return "declaration"
 
 
-def _is_declaration_type(node_type: str) -> bool:
+def _language_scoped_node_ok(node: Any, node_type: str, language: str) -> bool:
+    """A language-scoped declaration must carry an explicit `name` field.
+
+    The scoped node names are broad on purpose, and some are overloaded within
+    their own grammar: Haskell's `function` denotes both a definition
+    (`helper x = x + 1`, which has a `name`) and a function TYPE (`Int -> Int`,
+    which has none). Requiring the field keeps the definition and rejects the
+    type, without which the walk would emit `Int` as a function.
+    """
+    if node_type not in _LANGUAGE_DECLARATION_TYPES.get(language, ()):
+        return True
+    field = getattr(node, "child_by_field_name", None)
+    return callable(field) and field("name") is not None
+
+
+def _is_declaration_type(node_type: str, language: str = "") -> bool:
+    if language and node_type in _LANGUAGE_DECLARATION_TYPES.get(language, ()):
+        return True
     lowered = node_type.lower()
     if lowered in _DECLARATION_TYPES:
         return True
@@ -424,13 +490,22 @@ def _spans_from_tree(
     state = _TraversalState()
     for node in _walk(tree.root_node, max_nodes, state):
         node_type = str(getattr(node, "type", ""))
-        if not _is_declaration_type(node_type) or bool(getattr(node, "is_error", False)):
+        if not _is_declaration_type(node_type, language) or bool(getattr(node, "is_error", False)):
+            continue
+        if not _language_scoped_node_ok(node, node_type, language):
+            continue
+        # A declaration with a direct ERROR child was recovered from a syntax
+        # error, so its own structure is unreliable -- a dense `class W{ ... }`
+        # can otherwise take an inner method name as the class name. Skipping it
+        # keeps a malformed span out rather than emitting a mislabelled one; the
+        # well-formed declarations in the same file are unaffected.
+        if any(str(getattr(c, "type", "")) == "ERROR" for c in getattr(node, "children", ())):
             continue
         start = int(getattr(node, "start_byte", 0))
         end = int(getattr(node, "end_byte", 0))
         if end <= start or end > len(raw):
             continue
-        name_node = _name_node(node)
+        name_node = _name_node(node, language)
         if name_node is None:
             continue
         name = raw[int(name_node.start_byte):int(name_node.end_byte)].decode(
@@ -561,7 +636,9 @@ def extract_structural_profiles_report(
     state = _TraversalState()
     for node in _walk(tree.root_node, max_nodes, state):
         node_type = str(getattr(node, "type", ""))
-        if not _is_declaration_type(node_type) or bool(getattr(node, "is_error", False)):
+        if not _is_declaration_type(node_type, language) or bool(getattr(node, "is_error", False)):
+            continue
+        if not _language_scoped_node_ok(node, node_type, language):
             continue
         if not any(hint in node_type.lower() for hint in (
             "function", "method", "constructor", "procedure", "subroutine",
@@ -685,7 +762,19 @@ def extract_structural_spans_report(
     if parsed is None:
         return None
     raw, tree, language = parsed
-    normalized = _pack_structure_spans(source, file_path, raw, language)
+    # The pack's structure processing under-resolves some grammars: for Kotlin
+    # it returns the top-level `fun` with a null name (dropped for lack of a
+    # name) and omits a class's own methods entirely, yielding just the class.
+    # For these the name-resolving tree walk below is strictly more complete, so
+    # the pack path is skipped rather than trusted for its partial output. Kept
+    # to an explicit set: forcing the fallback generally regressed JavaScript,
+    # whose anonymous arrow is legitimately nameless and whose pack result is
+    # already correct.
+    normalized = (
+        None
+        if language in _PACK_STRUCTURE_UNRELIABLE
+        else _pack_structure_spans(source, file_path, raw, language)
+    )
     if normalized:
         # Registry processing owns its traversal and provides exact spans. Keep
         # the raw parser's node count only as a bounded completeness check.

--- a/entroly/tree_sitter_support.py
+++ b/entroly/tree_sitter_support.py
@@ -426,7 +426,7 @@ def _is_declaration_type(node_type: str, language: str = "") -> bool:
     if not any(hint in lowered for hint in _DECLARATION_HINTS):
         return False
     return lowered.endswith((
-        "_definition", "_declaration", "_item", "_specifier", "_body",
+        "_definition", "_declaration", "_item", "_specifier",
     )) or lowered in {"method", "module", "subroutine"}
 
 

--- a/entroly/tree_sitter_support.py
+++ b/entroly/tree_sitter_support.py
@@ -83,6 +83,38 @@ _LANGUAGE_DECLARATION_TYPES: dict[str, frozenset[str]] = {
     "zig": frozenset({"FnProto"}),
     # Protobuf `message` names via a `message_name` child, no `name` field.
     "proto": frozenset({"message", "enum"}),
+    # SQL names a created object in an `object_reference` child, no `name` field.
+    "sql": frozenset({"create_function", "create_procedure", "create_table", "create_view"}),
+}
+
+# Node types to NOT treat as declarations for a language, overriding the generic
+# rule. R has no standalone function declaration: a function is an anonymous
+# value bound by assignment, so the `function_definition` node itself carries no
+# name and the generic rule emitted the keyword `function`. The binding is
+# matched by predicate below instead.
+_LANGUAGE_SUPPRESS_TYPES: dict[str, frozenset[str]] = {
+    "r": frozenset({"function_definition"}),
+}
+
+
+def _r_binds_function(node: Any) -> bool:
+    """An R assignment whose right-hand side is a function definition.
+
+    `helper <- function(x) x + 1` parses as a `binary_operator` with the name
+    on the left, an assignment operator, and the function on the right. This is
+    the only place an R function acquires a name, so it is the declaration.
+    """
+    if str(getattr(node, "type", "")) != "binary_operator":
+        return False
+    children = list(getattr(node, "children", ()))
+    if not any(str(getattr(c, "type", "")) in {"<-", "=", "<<-"} for c in children):
+        return False
+    return any(str(getattr(c, "type", "")) == "function_definition" for c in children)
+
+
+# Node-level predicates for declarations the type name alone cannot identify.
+_LANGUAGE_DECLARATION_PREDICATE: dict[str, Any] = {
+    "r": _r_binds_function,
 }
 
 _KIND_HINTS = (
@@ -317,6 +349,9 @@ _LANGUAGE_NAME_CHILD_TYPE: dict[str, str] = {
     "kotlin": "simple_identifier",
     "zig": "IDENTIFIER",
     "proto": "message_name",
+    "sql": "object_reference",
+    # An R function binding names itself with the identifier left of the arrow.
+    "r": "identifier",
 }
 
 # Grammars whose pack structure processing returns partial declarations (a named
@@ -324,7 +359,7 @@ _LANGUAGE_NAME_CHILD_TYPE: dict[str, str] = {
 # tree walk is more complete. Add a language only after verifying the walk does
 # strictly better for it, since the walk's own per-grammar coverage varies.
 _PACK_STRUCTURE_UNRELIABLE: frozenset[str] = frozenset(
-    {"kotlin", "dart", "go", "solidity"}
+    {"kotlin", "dart", "go", "solidity", "r"}
 )
 
 
@@ -517,9 +552,16 @@ def _spans_from_tree(
     spans: list[StructuralSpan] = []
     seen: set[tuple[int, int, str]] = set()
     state = _TraversalState()
+    suppressed = _LANGUAGE_SUPPRESS_TYPES.get(language, frozenset())
+    predicate = _LANGUAGE_DECLARATION_PREDICATE.get(language)
     for node in _walk(tree.root_node, max_nodes, state):
         node_type = str(getattr(node, "type", ""))
-        if not _is_declaration_type(node_type, language) or bool(getattr(node, "is_error", False)):
+        if bool(getattr(node, "is_error", False)):
+            continue
+        is_declaration = (
+            node_type not in suppressed and _is_declaration_type(node_type, language)
+        ) or (predicate is not None and predicate(node))
+        if not is_declaration:
             continue
         if not _language_scoped_node_ok(node, node_type, language):
             continue
@@ -579,6 +621,69 @@ def _spans_from_tree(
         max_nodes=max_nodes,
         backend="tree-sitter-raw",
     )
+
+
+# Single-file-component languages whose script is embedded as opaque text, and
+# the language to parse that text as. Svelte and Vue keep the script inside a
+# `script_element` whose only child is a `raw_text` node -- the grammar does not
+# descend into it, so the component's functions are invisible until that text is
+# re-parsed as JavaScript and its spans are shifted back to file coordinates.
+_EMBEDDED_SCRIPT_LANGUAGES: dict[str, str] = {
+    "svelte": "javascript",
+    "vue": "javascript",
+}
+
+
+def _embedded_script_spans(
+    raw: bytes, tree: Any, language: str, max_nodes: int
+) -> list[StructuralSpan]:
+    """Extract declarations from the `<script>` block of a component file."""
+    inner_language = _EMBEDDED_SCRIPT_LANGUAGES.get(language)
+    if inner_language is None:
+        return []
+    parser = _get_local_parser(inner_language)
+    if parser is None:
+        return []
+    spans: list[StructuralSpan] = []
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        parent = getattr(node, "parent", None)
+        if (
+            str(getattr(node, "type", "")) == "raw_text"
+            and parent is not None
+            and str(getattr(parent, "type", "")) == "script_element"
+        ):
+            offset = int(getattr(node, "start_byte", 0))
+            line_offset = int(node.start_point[0])
+            inner_raw = raw[offset:int(getattr(node, "end_byte", 0))]
+            inner_source = inner_raw.decode("utf-8", errors="surrogateescape")
+            # Prefer the pack's structure, which is clean for JavaScript; the
+            # raw tree walk is only the fallback, matching the main path so the
+            # embedded script is analysed exactly as a standalone file would be.
+            inner_items = _pack_structure_spans(
+                inner_source, "embedded.js", inner_raw, inner_language
+            )
+            if not inner_items:
+                inner_items = list(
+                    _spans_from_tree(
+                        inner_raw, parser.parse(inner_raw), inner_language, max_nodes
+                    ).items
+                )
+            for item in inner_items:
+                spans.append(StructuralSpan(
+                    name=item.name,
+                    kind=item.kind,
+                    start_line=item.start_line + line_offset,
+                    end_line=item.end_line + line_offset,
+                    source=item.source,
+                    signature=item.signature,
+                    indent=item.indent,
+                    start_byte=item.start_byte + offset,
+                    end_byte=item.end_byte + offset,
+                ))
+        stack.extend(getattr(node, "children", ()))
+    return spans
 
 
 _CONTROL_TYPES = frozenset({
@@ -791,6 +896,21 @@ def extract_structural_spans_report(
     if parsed is None:
         return None
     raw, tree, language = parsed
+    if language in _EMBEDDED_SCRIPT_LANGUAGES:
+        # The component's own markup has no declarations; its script does, and
+        # the grammar leaves that as opaque text. Re-parse the script block.
+        embedded = _embedded_script_spans(raw, tree, language, max_nodes)
+        metrics_state = _TraversalState()
+        for _node in _walk(tree.root_node, max_nodes, metrics_state):
+            pass
+        return StructuralExtraction(
+            items=tuple(embedded),
+            language=language,
+            complete=metrics_state.complete,
+            nodes_visited=metrics_state.visited,
+            max_nodes=max_nodes,
+            backend="embedded-script",
+        )
     # The pack's structure processing under-resolves some grammars: for Kotlin
     # it returns the top-level `fun` with a null name (dropped for lack of a
     # name) and omits a class's own methods entirely, yielding just the class.

--- a/entroly/tree_sitter_support.py
+++ b/entroly/tree_sitter_support.py
@@ -69,6 +69,20 @@ _DECLARATION_HINTS = frozenset({
 _LANGUAGE_DECLARATION_TYPES: dict[str, frozenset[str]] = {
     "haskell": frozenset({"function", "data_type"}),
     "perl": frozenset({"subroutine_declaration_statement"}),
+    # Go names a type in `type_spec` under `type_declaration`; the suffix rule
+    # sees only the wrapper and dropped every `type` in the file.
+    "go": frozenset({"type_spec"}),
+    # Solidity's contract/library/interface are `*_declaration` but the suffix
+    # rule's hint list has no "contract"; its functions already matched.
+    "solidity": frozenset({"contract_declaration", "library_declaration", "interface_declaration"}),
+    # Erlang defines a function as one or more `function_clause`s, each naming
+    # the function; nothing in the generic set matched them.
+    "erlang": frozenset({"function_clause"}),
+    # Zig names a function in `FnProto` positionally (a bare IDENTIFIER child);
+    # the suffix rule matches none of its PascalCase node types.
+    "zig": frozenset({"FnProto"}),
+    # Protobuf `message` names via a `message_name` child, no `name` field.
+    "proto": frozenset({"message", "enum"}),
 }
 
 _KIND_HINTS = (
@@ -301,13 +315,17 @@ def _first_identifier(node: Any) -> Any | None:
 # so this does not fire for it and the existing resolution still applies.
 _LANGUAGE_NAME_CHILD_TYPE: dict[str, str] = {
     "kotlin": "simple_identifier",
+    "zig": "IDENTIFIER",
+    "proto": "message_name",
 }
 
 # Grammars whose pack structure processing returns partial declarations (a named
 # class but null-named functions, no method descent), where the name-resolving
 # tree walk is more complete. Add a language only after verifying the walk does
 # strictly better for it, since the walk's own per-grammar coverage varies.
-_PACK_STRUCTURE_UNRELIABLE: frozenset[str] = frozenset({"kotlin"})
+_PACK_STRUCTURE_UNRELIABLE: frozenset[str] = frozenset(
+    {"kotlin", "dart", "go", "solidity"}
+)
 
 
 def _name_node(node: Any, language: str = "") -> Any | None:
@@ -339,18 +357,29 @@ def _kind(node_type: str) -> str:
 
 
 def _language_scoped_node_ok(node: Any, node_type: str, language: str) -> bool:
-    """A language-scoped declaration must carry an explicit `name` field.
+    """A language-scoped declaration must carry a resolvable name.
 
     The scoped node names are broad on purpose, and some are overloaded within
     their own grammar: Haskell's `function` denotes both a definition
     (`helper x = x + 1`, which has a `name`) and a function TYPE (`Int -> Int`,
-    which has none). Requiring the field keeps the definition and rejects the
-    type, without which the walk would emit `Int` as a function.
+    which has none). A name is resolvable when the node has an explicit `name`
+    field, or -- for the positional grammars that expose none -- a direct child
+    of the type this language uses for names (Zig's `IDENTIFIER` under
+    `FnProto`). The Haskell function type has neither, so it is still rejected
+    and the walk does not emit `Int` as a function.
     """
     if node_type not in _LANGUAGE_DECLARATION_TYPES.get(language, ()):
         return True
     field = getattr(node, "child_by_field_name", None)
-    return callable(field) and field("name") is not None
+    if callable(field) and field("name") is not None:
+        return True
+    preferred = _LANGUAGE_NAME_CHILD_TYPE.get(language)
+    if preferred:
+        return any(
+            str(getattr(child, "type", "")) == preferred
+            for child in getattr(node, "children", ())
+        )
+    return False
 
 
 def _is_declaration_type(node_type: str, language: str = "") -> bool:

--- a/llms.txt
+++ b/llms.txt
@@ -34,6 +34,7 @@ Weak fit: short prompts, tiny repositories, fixed-price subscriptions where the 
 - **What is exact recovery?** Entroly issues content-addressed `ccr:<24-hex>` handles. `entroly_retrieve` performs a hash-only lookup and returns the complete stored original; it does not accept a query or silently substitute a newer source revision.
 - **Does Entroly guarantee lower cost or better answers?** No universal guarantee is claimed. Entroly provides workload-specific measurements, provider-bound evidence where observable, receipts, recovery, and verification.
 - **Does Entroly support GPT-5.6 Sol, Terra, and Luna?** Yes. The bundled registry recognizes `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, including their published context window, output limit, reasoning levels, and list-price metadata. The usable route still depends on the selected proxy, API, agent, or local integration.
+- **Does Entroly support NVIDIA Nemotron 3.5 Lightning?** Yes, through Entroly's loopback-only Ollama model discovery and OpenAI-compatible proxy path. Use the Ollama model ID `nemotron-3.5-lightning`. Entroly discovers the installed tag's context metadata rather than assuming the standard 1M and Apple-silicon MLX 256K variants are interchangeable. Canonical page: https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html
 - **Can Entroly reduce GPT-5.6 API costs?** Entroly can reduce avoidable provider-bound input tokens before a supported request reaches Sol, Terra, or Luna. Actual dollar impact depends on selected evidence, model tier, prompt caching, output usage, and workload.
 - **Can nontechnical users use Entroly?** Today's product requires a small one-time setup through a supported proxy, wrapper, plugin, SDK, or MCP path. A no-terminal desktop product called Entroly Simple Mode is specified but not yet shipped.
 
@@ -50,6 +51,7 @@ Weak fit: short prompts, tiny repositories, fixed-price subscriptions where the 
 
 ## Current Model Support
 
+- [Entroly for NVIDIA Nemotron 3.5 Lightning on Ollama](https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html): Local model discovery, OpenAI-compatible proxy setup, tag-specific context limits, privacy boundaries, and official sources.
 - [Entroly for GPT-5.6 Sol, Terra, and Luna](https://juyterman1000.github.io/entroly/docs/gpt-5-6-sol-terra-luna.html): Verified model IDs, 1.05M-token context windows, 128K output limits, reasoning modes, pricing provenance, and Entroly integration guidance.
 - **GPT-5.6 Sol:** `gpt-5.6-sol`; the unsuffixed `gpt-5.6` alias resolves to Sol. Use for frontier capability.
 - **GPT-5.6 Terra:** `gpt-5.6-terra`. Use to balance intelligence and cost.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,4 +18,5 @@
   <url><loc>https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html</loc><lastmod>2026-07-25</lastmod></url>
   <url><loc>https://juyterman1000.github.io/entroly/docs/discord.html</loc><lastmod>2026-07-25</lastmod></url>
   <url><loc>https://juyterman1000.github.io/entroly/docs/gpt-5-6-sol-terra-luna.html</loc><lastmod>2026-07-26</lastmod></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html</loc><lastmod>2026-08-11</lastmod><changefreq>weekly</changefreq><priority>0.90</priority></url>
 </urlset>

--- a/tests/test_distribution_surface.py
+++ b/tests/test_distribution_surface.py
@@ -160,6 +160,22 @@ def test_release_announcement_template_is_fail_closed() -> None:
     assert "Version is synchronized in citation metadata" in template
 
 
+def test_nemotron_ollama_support_is_answer_engine_discoverable() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    llms = (ROOT / "llms.txt").read_text(encoding="utf-8")
+    page = (ROOT / "docs/nemotron-3-5-lightning-ollama.html").read_text(
+        encoding="utf-8"
+    )
+    sitemap = (ROOT / "sitemap.xml").read_text(encoding="utf-8")
+
+    assert "### NVIDIA Nemotron 3.5 Lightning with Ollama" in readme
+    assert "Does Entroly support NVIDIA Nemotron 3.5 Lightning?" in llms
+    assert '"@type": "FAQPage"' in page
+    assert '"@type": "TechArticle"' in page
+    assert "nemotron-3.5-lightning" in page
+    assert "nemotron-3-5-lightning-ollama.html" in sitemap
+
+
 def test_localization_contract_requires_human_and_technical_review() -> None:
     localization = (ROOT / "docs/localization/README.md").read_text(
         encoding="utf-8"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -191,10 +191,10 @@ def test_ollama_discovery_can_inspect_context_without_external_dependencies(monk
         assert timeout == 0.1
         assert max_bytes > 0
         if url.endswith("/api/tags"):
-            return {"models": [{"name": "llama3.2:latest"}]}
+            return {"models": [{"name": "nemotron-3.5-lightning:latest"}]}
         assert url.endswith("/api/show")
-        assert payload == {"model": "llama3.2:latest"}
-        return {"model_info": {"llama.context_length": 131072}}
+        assert payload == {"model": "nemotron-3.5-lightning:latest"}
+        return {"model_info": {"nemotron_h.context_length": 1_048_576}}
 
     monkeypatch.setattr(registry_module, "_json_request", fake_request)
     report = discover_ollama_models(timeout=0.1, inspect_context=True)
@@ -202,8 +202,8 @@ def test_ollama_discovery_can_inspect_context_without_external_dependencies(monk
     assert report.warnings == ()
     assert len(report.models) == 1
     capability = report.models[0]
-    assert capability.id == "ollama/llama3.2:latest"
-    assert capability.context_window == 131_072
+    assert capability.id == "ollama/nemotron-3.5-lightning:latest"
+    assert capability.context_window == 1_048_576
     assert capability.trust is RegistryTrust.DISCOVERED
     assert capability.supports_tools is None
     assert capability.supports_vision is None

--- a/tests/test_tree_sitter_support.py
+++ b/tests/test_tree_sitter_support.py
@@ -57,6 +57,19 @@ def test_language_map_covers_at_least_twenty_seven_languages() -> None:
         ("sample.zig", "pub fn total() void {}\nfn add() void {}\n", {"total", "add"}),
         # Protobuf `message` names via `message_name`, no `name` field.
         ("sample.proto", "message Cart {\n    string id = 1;\n}\n", {"Cart"}),
+        # R binds a function by assignment; the name is left of the arrow, and
+        # the anonymous `function_definition` must not surface as `function`.
+        ("sample.R", "total <- function(x) x + 1\nrunner <- function() total(1)\n", {"total", "runner"}),
+        # SQL names a created object in `object_reference`.
+        (
+            "sample.sql",
+            "CREATE FUNCTION add_tax(p int) RETURNS int AS $$ SELECT 1 $$ LANGUAGE SQL;\n",
+            {"add_tax"},
+        ),
+        # Svelte/Vue keep the script as opaque text; it is re-parsed as JS and
+        # the spans are shifted back to file coordinates.
+        ("sample.svelte", "<script>\nfunction total(){}\nclass Cart{}\n</script>\n<div/>\n", {"total", "Cart"}),
+        ("sample.vue", "<script>\nfunction total(){}\n</script>\n<template><div/></template>\n", {"total"}),
     ],
 )
 def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) -> None:
@@ -68,6 +81,36 @@ def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) 
         assert span.source in source
         assert source.splitlines()[span.start_line - 1].strip()
         assert span.start_line <= span.end_line
+
+
+def test_r_function_binding_does_not_leak_the_keyword() -> None:
+    """R's anonymous `function_definition` must not surface as `function`.
+
+    A function acquires a name only through assignment, so the binding is the
+    declaration; the bare definition node carries the keyword `function` and
+    was emitted as a symbol before the binding predicate and suppression.
+    """
+    pytest.importorskip("tree_sitter_language_pack")
+    spans = extract_structural_spans("helper <- function(x) x + 1\nx <- 5\n", "a.R")
+    assert spans is not None
+    names = {span.name for span in spans}
+    assert names == {"helper"}, names
+
+
+def test_embedded_script_spans_recover_exact_file_bytes() -> None:
+    """A Svelte span's byte range must address the real bytes in the file.
+
+    The script is parsed in isolation and its spans are shifted by the script
+    block's offset; an off-by-one there would still name the symbol but point
+    at the wrong bytes, which the byte-fidelity contract forbids.
+    """
+    pytest.importorskip("tree_sitter_language_pack")
+    source = "<p>hi</p>\n<script>\nfunction total(x){ return x }\n</script>\n"
+    spans = extract_structural_spans(source, "a.svelte")
+    assert spans is not None and spans
+    raw = source.encode("utf-8")
+    for span in spans:
+        assert raw[span.start_byte:span.end_byte].decode("utf-8") == span.source
 
 
 def test_kotlin_function_name_is_not_the_return_type_or_a_parameter() -> None:

--- a/tests/test_tree_sitter_support.py
+++ b/tests/test_tree_sitter_support.py
@@ -128,6 +128,18 @@ def test_kotlin_function_name_is_not_the_return_type_or_a_parameter() -> None:
     assert names == {"helper"}, names
 
 
+def test_dart_function_body_does_not_invent_a_returned_identifier() -> None:
+    """A function body is not a declaration even when its type contains that word."""
+    pytest.importorskip("tree_sitter_language_pack")
+    spans = extract_structural_spans(
+        "int total(int x) { return x; }\nclass Cart { void add() {} }\n",
+        "a.dart",
+    )
+    assert spans is not None
+    names = {span.name for span in spans}
+    assert names == {"total", "Cart", "add"}, names
+
+
 def test_semantic_resolution_uses_parser_spans_when_available() -> None:
     pytest.importorskip("tree_sitter_language_pack")
     source = "export class Cart {\n  total(): number { return 1; }\n}\n"

--- a/tests/test_tree_sitter_support.py
+++ b/tests/test_tree_sitter_support.py
@@ -44,6 +44,19 @@ def test_language_map_covers_at_least_twenty_seven_languages() -> None:
             "total :: Int -> Int\ntotal x = x\n\ndata Cart = Empty\n",
             {"total", "Cart"},
         ),
+        # Go dropped every `type` -- its name lives in `type_spec`, and the
+        # pack structure omitted it. Both the func and the type must appear.
+        ("sample.go", "package m\nfunc total() {}\ntype Cart struct{}\n", {"total", "Cart"}),
+        # Dart's pack structure returned the class alone, no functions.
+        ("sample.dart", "int total(int x){return x;}\nclass Cart{ void add(){} }\n", {"total", "Cart", "add"}),
+        # Erlang defines a function as `function_clause`s.
+        ("sample.erl", "total(X) -> X.\nadd() -> total(1).\n", {"total", "add"}),
+        # Solidity's contract is `contract_declaration`, outside the hint set.
+        ("sample.sol", "contract Cart {\n    function total() public {}\n}\n", {"Cart", "total"}),
+        # Zig names a function positionally in `FnProto` (a bare IDENTIFIER).
+        ("sample.zig", "pub fn total() void {}\nfn add() void {}\n", {"total", "add"}),
+        # Protobuf `message` names via `message_name`, no `name` field.
+        ("sample.proto", "message Cart {\n    string id = 1;\n}\n", {"Cart"}),
     ],
 )
 def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) -> None:

--- a/tests/test_tree_sitter_support.py
+++ b/tests/test_tree_sitter_support.py
@@ -27,6 +27,23 @@ def test_language_map_covers_at_least_twenty_seven_languages() -> None:
         ("sample.rs", "pub struct Cart { n: u32 }\nimpl Cart { pub fn total(&self) -> u32 { self.n } }\n", {"Cart", "total"}),
         ("sample.ts", "export class Cart { total(): number { return 1; } }\n", {"Cart", "total"}),
         ("sample.c", "int total(int price) { return price; }\n", {"total"}),
+        # Kotlin's grammar names declarations positionally, with no `name`
+        # field, and the pack's structure processing returns the class alone.
+        # Both the top-level function and the class's own methods must appear.
+        (
+            "sample.kt",
+            "fun total(price: Int): Int { return price }\n"
+            "class Cart {\n    fun add() {}\n    fun clear() {}\n}\n",
+            {"total", "Cart", "add", "clear"},
+        ),
+        # Perl's sub is `subroutine_declaration_statement`, which the suffix
+        # heuristic skips; Haskell names a definition with a bare `function`.
+        ("sample.pl", "sub total { return 1 }\nsub add { }\n", {"total", "add"}),
+        (
+            "sample.hs",
+            "total :: Int -> Int\ntotal x = x\n\ndata Cart = Empty\n",
+            {"total", "Cart"},
+        ),
     ],
 )
 def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) -> None:
@@ -38,6 +55,21 @@ def test_parser_backed_spans_are_exact(path: str, source: str, names: set[str]) 
         assert span.source in source
         assert source.splitlines()[span.start_line - 1].strip()
         assert span.start_line <= span.end_line
+
+
+def test_kotlin_function_name_is_not_the_return_type_or_a_parameter() -> None:
+    """Guards the exact defect: the name resolved to the return type.
+
+    `fun helper(x: Int): Int` has no `name` field, so the generic resolver
+    descended into the return type and returned `Int`, and a naive fix then
+    pulled in the parameter `x`. The Kotlin-scoped resolver takes the first
+    direct `simple_identifier`, which is the name and cannot be either.
+    """
+    pytest.importorskip("tree_sitter_language_pack")
+    spans = extract_structural_spans("fun helper(x: Int): Int { return x }\n", "a.kt")
+    assert spans is not None
+    names = {span.name for span in spans}
+    assert names == {"helper"}, names
 
 
 def test_semantic_resolution_uses_parser_spans_when_available() -> None:


### PR DESCRIPTION
## What changed
- extend parser-backed symbol extraction for 12 additional mapped languages
- fix a Dart false-positive where a function body invented a returned identifier
- publish a strict, reproducible 41-language audit with exact symbol sets and byte-exact spans
- run the checked-in proof in CI both normally and with grammar acquisition disabled
- document NVIDIA Nemotron 3.5 Lightning through Entroly's existing Ollama/OpenAI-compatible path
- add a canonical model-support page, FAQ/TechArticle structured data, llms.txt answer, sitemap entry, and exact discovery regression

## Measured language result
- 41 mapped languages audited
- 32/37 declaration-bearing samples exact (86.5%), up from 20/37 on the pinned pre-change baseline
- 12 newly covered, 0 lost
- 4/4 non-declarative samples verified
- 5 explicit gaps remain: C3, F#, Groovy, Nim, and OCaml

This is one representative conformance sample per language, not a claim of complete grammar coverage.

## Nemotron boundary
- official Ollama model ID: `nemotron-3.5-lightning`
- Entroly support is through loopback-only Ollama discovery and the generic OpenAI-compatible proxy path
- standard 1M and Apple MLX 256K listings remain distinct; Entroly inspects installed metadata
- local inference does not imply that agent tools or separately configured providers are offline
- no claim of a bespoke NVIDIA adapter or local model benchmark

## Validation
- focused code-intelligence suite: 53 passed
- model/distribution/compatibility/transport suite: 65 passed
- strict language benchmark in normal and air-gap modes
- README verifier: 34 passed
- distribution surface check passed
- JSON-LD, HTML tokenization, sitemap XML parsed
- Ruff passed
- pre-push: Ruff, Clippy, Rust lib tests (133 passed, 5 ignored)

Supersedes #302 with a current-main base, stricter exact-set proof, CI enforcement, explicit limitations, and current model-discovery documentation.