### PR TITLE
feat: add live AI Traffic Receipts and executive value

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Run `entroly doctor`. If that doesn't sort it, [open an issue](https://github.co
 - **[Adaptive context](docs/adaptive-context.html)** — bounded self-improving context.
 - **[Verified Code Context](docs/verified-code-context.md)** — parser-backed repository intelligence, typed graphs, architecture, value flow, LSP enrichment, source verification, and refactoring contracts.
 - **[Full benchmark evidence](docs/BENCHMARKS.md)** — every number, protocol, artifact, and caveat.
+- **[Model-triggered recovery holdout](docs/benchmarks/model-triggered-recovery.md)** — frozen recovery protocol, evidence boundary, and reproduction details.
+- **[Context Commit conformance artifact](benchmarks/results/context_commit_conformance.json)** — checked-in conformance evidence for Context Commit contracts.
 - **[Product surface map](docs/product-surface.md)** — CLI, SDK, MCP, proxy, verification, memory, security.
 - **[Architecture & full spec](docs/DETAILS.md)** — Rust modules, compression, provenance, command reference.
 - **[Agent compatibility](docs/agent-compatibility.md)** — every supported client and its exact authentication boundary.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ Runs as a **CLI**, **Python/TypeScript SDK**, **MCP server**, **HTTP proxy**, or
 
 Status describes integration depth, not a savings guarantee — provider-observed savings require requests to actually traverse an Entroly proxy route. Entroly does not claim interception of GitHub-hosted subscription inference on Copilot's native path. Full compatibility matrix: **[docs/agent-compatibility.md](docs/agent-compatibility.md)**.
 
+### NVIDIA Nemotron 3.5 Lightning with Ollama
+
+Entroly supports the Ollama model ID `nemotron-3.5-lightning` through loopback-only local-model discovery and its OpenAI-compatible proxy path. Ollama runs the model; Entroly manages request context, exact recovery handles, Context Receipts, and optional verification. Context capacity is discovered from the installed Ollama tag rather than assumed universally. See [Nemotron 3.5 Lightning with Ollama](docs/nemotron-3-5-lightning-ollama.html).
+
+### Current model support
+
+Entroly's verified model matrix includes GPT-5.6 Sol/Terra/Luna, Gemini 3.6 Flash, Gemini 3.5 Flash-Lite, and runtime-discovered NVIDIA Nemotron 3.5 Lightning through Ollama. A listing means Entroly has a verified public model ID/limit contract or an inspectable local tag; it is not a universal savings claim. Announced or restricted models stay gated until their usable model IDs and limits can be verified. See [current verified model support](docs/model-support.html).
+
 ---
 ## When to use it · when to skip it
 

--- a/docs/traffic-receipts.md
+++ b/docs/traffic-receipts.md
@@ -26,8 +26,8 @@ Entroly context         18,206 tokens
 ──────────────────────────────────
 Tokens avoided          55,234
 
-Evidence retained       100%   (when the context coverage estimator reports it)
-Recoverable             YES    (only when recovery evidence is present)
+Evidence retained       —      (withheld unless request-local evidence exists)
+Recovery evidence       YES    (only when recovery evidence is present)
 Warm prefix protected   14,820 tokens
 Cache hit               YES    (provider-reported cache usage)
 
@@ -40,10 +40,10 @@ Input cost              $...   (provider usage + explicit pricing required)
 Cache benefit           $...   (provider cache usage + explicit pricing required)
 Net measured saving     —      (requires a linked measured counterfactual)
 
-Context risk            LOW
+Context risk            UNKNOWN
 Verification            PASS
 
-Traffic Receipt         ✓
+Receipt integrity       ✓ SHA-256 OK
 ```
 
 The numbers above are an illustrative shape, not bundled benchmark or savings
@@ -57,10 +57,12 @@ Traffic Receipts intentionally distinguish measurement from modeling:
   the provider canonicalization layer.
 - **Tokens avoided** is the difference between the admitted request estimate and
   the final outbound request estimate.
-- **Evidence retained** uses the existing context-coverage estimate when that
-  signal is available; the receipt includes its source label.
-- **Recoverable** becomes true only when per-request recovery evidence is
-  present in the proxy's recovery headers.
+- **Evidence retained** is emitted only when a request-local evidence source is
+  available. Shared mutable proxy `last_*` coverage state is deliberately
+  withheld to prevent cross-request attribution under concurrency.
+- **Recovery evidence** becomes true only when per-request recovery evidence is
+  present in the proxy's recovery headers. It does not claim that exact recovery
+  was available before an intervention.
 - **Warm prefix protected** comes from the existing hash-only
   `PrefixContinuityGuard` intervention for that request.
 - **Cache hit** prefers provider-reported cache-read usage. For streaming calls,
@@ -72,6 +74,18 @@ Traffic Receipts intentionally distinguish measurement from modeling:
   request-correlated measured counterfactual. Modeled token reduction is not
   relabeled as realized invoice savings.
 - **Verification** comes from WITNESS/EICV response evidence when reported.
+- **Receipt integrity** is a SHA-256 canonical-payload consistency check. It is
+  not presented as a cryptographic signature.
+
+## Correlation and recovery ownership
+
+When the client does not provide `X-Request-ID`, Entroly establishes one bounded
+request identifier before the core proxy handles the request. The receipt and
+provider usage accounting therefore observe the same request id.
+
+Recursive exact-recovery attempts contribute to the final outer response but do
+not finalize a separate buyer-visible receipt. Depth zero owns the Traffic
+Receipt lifecycle.
 
 ## Privacy contract
 
@@ -87,8 +101,8 @@ The raw request ID is reduced to a salted correlation digest. The user-agent is
 used only to classify a product label such as `Claude Code` or `Codex` and is not
 stored.
 
-Every receipt has a SHA-256 digest over a canonical JSON payload and is verified
-before it is admitted to the in-memory receipt ledger.
+Every receipt has a SHA-256 digest over a canonical JSON payload and that digest
+is checked before the receipt is admitted to the in-memory ledger.
 
 ## Scope
 

--- a/docs/traffic-receipts.md
+++ b/docs/traffic-receipts.md
@@ -1,0 +1,97 @@
+# Traffic Receipts
+
+Entroly's live proxy exposes a content-blind, per-request **Traffic Receipt** that
+joins the context, cache, routing, provider-usage and verification signals the
+proxy already produces.
+
+Open the live view while the proxy is running:
+
+```text
+http://127.0.0.1:9377/traffic
+```
+
+The bounded JSON surface is:
+
+```text
+GET /traffic-receipts?limit=20
+```
+
+A receipt can show:
+
+```text
+Claude Code request
+
+Original context       73,440 tokens
+Entroly context         18,206 tokens
+──────────────────────────────────
+Tokens avoided          55,234
+
+Evidence retained       100%   (when the context coverage estimator reports it)
+Recoverable             YES    (only when recovery evidence is present)
+Warm prefix protected   14,820 tokens
+Cache hit               YES    (provider-reported cache usage)
+
+Requested model         Sonnet
+Executed model          Sonnet
+Routing decision        STAY
+Reason                   ...
+
+Input cost              $...   (provider usage + explicit pricing required)
+Cache benefit           $...   (provider cache usage + explicit pricing required)
+Net measured saving     —      (requires a linked measured counterfactual)
+
+Context risk            LOW
+Verification            PASS
+
+Traffic Receipt         ✓
+```
+
+The numbers above are an illustrative shape, not bundled benchmark or savings
+claims. The live page itself contains no hard-coded demonstration values.
+
+## Truth contract
+
+Traffic Receipts intentionally distinguish measurement from modeling:
+
+- **Original / Entroly context tokens** are deterministic local estimates from
+  the provider canonicalization layer.
+- **Tokens avoided** is the difference between the admitted request estimate and
+  the final outbound request estimate.
+- **Evidence retained** uses the existing context-coverage estimate when that
+  signal is available; the receipt includes its source label.
+- **Recoverable** becomes true only when per-request recovery evidence is
+  present in the proxy's recovery headers.
+- **Warm prefix protected** comes from the existing hash-only
+  `PrefixContinuityGuard` intervention for that request.
+- **Cache hit** prefers provider-reported cache-read usage. For streaming calls,
+  Entroly can also observe the provider-updated cache lease after the stream
+  completes.
+- **Input cost / cache benefit** require provider-reported usage and an explicit,
+  auditable pricing catalog.
+- **Net measured saving** is deliberately unavailable until Entroly has a
+  request-correlated measured counterfactual. Modeled token reduction is not
+  relabeled as realized invoice savings.
+- **Verification** comes from WITNESS/EICV response evidence when reported.
+
+## Privacy contract
+
+The receipt ledger is bounded and in-memory. Receipts do **not** contain:
+
+- prompt or message content;
+- tool output or code;
+- authorization header values or API keys;
+- the raw request ID;
+- the raw user-agent.
+
+The raw request ID is reduced to a salted correlation digest. The user-agent is
+used only to classify a product label such as `Claude Code` or `Codex` and is not
+stored.
+
+Every receipt has a SHA-256 digest over a canonical JSON payload and is verified
+before it is admitted to the in-memory receipt ledger.
+
+## Scope
+
+Traffic Receipts are an observability/product surface. They do not add a new
+router, retry loop, provider policy, cache engine, optimizer or execution path.
+They observe the existing hardened proxy and expose its evidence in one place.

--- a/docs/traffic-value.md
+++ b/docs/traffic-value.md
@@ -20,11 +20,15 @@ The page is designed to answer three questions immediately:
 
 ## This session
 
-`This session` is an in-process rollup built from the same verified Traffic Receipt stream as the durable dashboard. It is intended for the first-use wow moment: after a handful of requests, a user can immediately see requests optimized, tokens received/sent/avoided, context reduction, estimated value avoided, measured cache benefit when available, warm-cache protection, verification, recovery, and Total AI value protected.
+`This session` is a process-local, in-memory rollup built natively in the same Traffic Value accounting path as the durable dashboard. It consumes the same verified Traffic Receipt stream; there is no session monkey patch, second savings ledger, or second database.
+
+After a handful of requests, a user can immediately see requests optimized, tokens received/sent/avoided, context reduction, estimated value avoided when model pricing is available, measured cache benefit when provider evidence is available, warm-cache protection, verification/recovery evidence, and Total AI value protected when its dollar components are sufficiently evidenced.
 
 The session view is deliberately non-durable and resets when the proxy process restarts. It is **not** added again to All Time, so showing the immediate number cannot double-count durable value.
 
 During the first day of Traffic Value collection, once the current process has observed traffic, `This session` becomes the default view. After that, the durable age-adaptive default below takes over while the session tab remains available.
+
+The dashboard reports **Session duration**, not "working time": it measures wall-clock time since the current proxy process session began and does not pretend to infer human activity.
 
 ## Rolling executive view
 
@@ -36,12 +40,12 @@ The selected durable period can be Today, 7 days, 30 days, 60 days, or 90 days. 
 - tokens avoided and context-reduction percentage;
 - estimated input value avoided;
 - measured cache benefit when provider usage and auditable pricing exist;
-- provider input spend when provider usage and auditable pricing exist;
+- provider input spend observed when provider usage and auditable pricing exist;
 - requests with explicit verification evidence and verification pass rate;
-- recovery invocation and success rates;
+- recovery evidence and final PASS rates;
 - warm-cache tokens protected;
 - observed cache-hit request rate;
-- total AI value protected.
+- total AI value protected when the required dollar evidence is available.
 
 The rolling windows do not reset at calendar week/month boundaries.
 
@@ -77,15 +81,15 @@ All Time persists in the existing `ValueTracker` file across proxy restarts and 
 
 The dashboard intentionally keeps evidence classes visible instead of turning every number into a generic "savings" claim.
 
-**Estimated value avoided** uses the locally observed token difference on a provider-bound request multiplied by the configured input price for the executed model. It is modeled economic value, not an invoice counterfactual.
+**Estimated value avoided** uses the locally observed token difference on a provider-bound request multiplied by the configured input price for the executed model. It is modeled economic value, not an invoice counterfactual. If the executed model has no auditable configured price, the UI shows the dollar value as unavailable rather than pretending that an unknown value is `$0.00`.
 
-**Measured cache benefit** appears only when the Traffic Receipt has provider-reported cache usage plus auditable pricing.
+**Measured cache benefit** appears only when the Traffic Receipt has provider-reported cache usage plus auditable pricing. Missing provider/pricing evidence is displayed as unavailable, not as a measured zero.
 
-**Provider input spend** prices the provider-reported input/cache token categories currently carried by Traffic Receipt v1. It is intentionally not labeled full provider invoice spend because output cost is not yet part of that receipt field.
+**Provider input spend observed** prices the provider-reported input/cache token categories currently carried by Traffic Receipt v1. It is intentionally not labeled full provider invoice spend because output cost is not yet part of that receipt field.
 
-**Total AI value protected** is the sum of avoided-input value and measured cache benefit. The two components remain visible separately so an operator can distinguish modeled optimization value from provider-observed cache economics.
+**Total AI value protected** is the sum of avoided-input value and measured cache benefit when the required evidence for those components is available. The two components remain visible separately so an operator can distinguish modeled optimization value from provider-observed cache economics.
 
-Verification percentages count only explicit PASS/FAIL evidence. Recovery success requires recovery evidence plus a final explicit PASS signal; an attempted recovery is never counted as successful merely because it ran.
+Verification percentages count only explicit PASS/FAIL evidence. Traffic Receipt v1 currently exposes recovery evidence rather than a dedicated recovery-invocation event, so the dashboard labels that evidence conservatively; final PASS is additionally required for the corresponding successful-recovery evidence metric.
 
 Traffic Receipt coverage that is only available through shared mutable proxy state is withheld from per-request receipts rather than risk cross-request attribution. The receipt UI labels observed recovery state as **Recovery evidence**, and its SHA-256 check as **Receipt integrity**, not as a cryptographic signature.
 

--- a/docs/traffic-value.md
+++ b/docs/traffic-value.md
@@ -1,0 +1,34 @@
+# AI Traffic Value
+
+Entroly exposes an executive value view at:
+
+```text
+http://127.0.0.1:9377/traffic-value
+```
+
+The machine-readable surface is:
+
+```text
+GET /traffic-value.json
+```
+
+The view keeps the same durable value counters Entroly already records and shows them as rolling windows:
+
+- Today
+- 7 days
+- 30 days
+- 60 days
+- 90 days
+- All time
+
+`All time` is the persistent cumulative total and survives proxy restarts. The rolling views do not reset at calendar week/month boundaries, so a buyer can compare a stable recent window with the lifetime value Entroly has accumulated.
+
+## Evidence contract
+
+The main dollar number is **estimated provider input value avoided**. It is calculated from provider-bound token reduction observed by Entroly and the configured model input rate. It is intentionally not labelled as provider invoice savings or a measured counterfactual.
+
+Local SDK, MCP, npm, and other reductions remain token-only because Entroly cannot prove that those outputs were sent to a paid provider.
+
+Pricing provenance is displayed with every snapshot, including the active source and `as_of` date.
+
+The dashboard reads the existing persistent `ValueTracker`; it does not create a second savings ledger or double-count Traffic Receipt events.

--- a/docs/traffic-value.md
+++ b/docs/traffic-value.md
@@ -12,23 +12,70 @@ The machine-readable surface is:
 GET /traffic-value.json
 ```
 
-The view keeps the same durable value counters Entroly already records and shows them as rolling windows:
+The page is designed to answer two questions immediately:
 
-- Today
-- 7 days
-- 30 days
-- 60 days
-- 90 days
-- All time
+1. **What did Entroly do to my AI traffic in this period?**
+2. **How much value has Entroly accumulated for me overall?**
 
-`All time` is the persistent cumulative total and survives proxy restarts. The rolling views do not reset at calendar week/month boundaries, so a buyer can compare a stable recent window with the lifetime value Entroly has accumulated.
+## Rolling executive view
+
+The selected period can be Today, 7 days, 30 days, 60 days, or 90 days. The period card can show:
+
+- requests optimized;
+- tokens received by Entroly before its context optimization;
+- tokens sent on the final observed provider-bound request;
+- tokens avoided and context-reduction percentage;
+- estimated input value avoided;
+- measured cache benefit when provider usage and auditable pricing exist;
+- provider input spend when provider usage and auditable pricing exist;
+- requests with explicit verification evidence and verification pass rate;
+- recovery invocation and success rates;
+- warm-cache tokens protected;
+- observed cache-hit request rate;
+- total AI value protected.
+
+The rolling windows do not reset at calendar week/month boundaries.
+
+## Adaptive default
+
+Entroly selects a useful recent window based on how long Traffic Value has actually been collecting receipts:
+
+```text
+< 30 days collecting     -> 7D
+30-59 days collecting    -> 30D
+60-99 days collecting    -> 60D
+100+ days collecting     -> 90D
+```
+
+So an install with 3 days of history opens on 7D, one with 45 days opens on 30D, and one with 100+ days opens on 90D.
+
+## All Time never disappears
+
+The selected rolling period is always accompanied by a separate **ALL TIME** card. It highlights:
+
+```text
+Estimated value avoided
+Measured cache benefit
+Total AI value protected
+Tokens avoided
+Requests optimized
+Warm-cache tokens protected
+```
+
+All Time persists in the existing `ValueTracker` file across proxy restarts and keeps accumulating until the user resets or deletes that telemetry.
 
 ## Evidence contract
 
-The main dollar number is **estimated provider input value avoided**. It is calculated from provider-bound token reduction observed by Entroly and the configured model input rate. It is intentionally not labelled as provider invoice savings or a measured counterfactual.
+The dashboard intentionally keeps evidence classes visible instead of turning every number into a generic "savings" claim.
 
-Local SDK, MCP, npm, and other reductions remain token-only because Entroly cannot prove that those outputs were sent to a paid provider.
+**Estimated value avoided** uses the locally observed token difference on a provider-bound request multiplied by the configured input price for the executed model. It is modeled economic value, not an invoice counterfactual.
 
-Pricing provenance is displayed with every snapshot, including the active source and `as_of` date.
+**Measured cache benefit** appears only when the Traffic Receipt has provider-reported cache usage plus auditable pricing.
 
-The dashboard reads the existing persistent `ValueTracker`; it does not create a second savings ledger or double-count Traffic Receipt events.
+**Provider input spend** prices the provider-reported input/cache token categories currently carried by Traffic Receipt v1. It is intentionally not labeled full provider invoice spend because output cost is not yet part of that receipt field.
+
+**Total AI value protected** is the sum of avoided-input value and measured cache benefit. The two components remain visible separately so an operator can distinguish modeled optimization value from provider-observed cache economics.
+
+Verification percentages count only explicit PASS/FAIL evidence. Recovery success requires recovery evidence plus a final explicit PASS signal; an attempted recovery is never counted as successful merely because it ran.
+
+The dashboard persists only aggregate counters and bounded receipt identifiers in the existing value-tracker file. It does not add prompt, tool-output, code, API-key, or raw user-agent content to the executive rollups.

--- a/docs/traffic-value.md
+++ b/docs/traffic-value.md
@@ -12,14 +12,23 @@ The machine-readable surface is:
 GET /traffic-value.json
 ```
 
-The page is designed to answer two questions immediately:
+The page is designed to answer three questions immediately:
 
-1. **What did Entroly do to my AI traffic in this period?**
-2. **How much value has Entroly accumulated for me overall?**
+1. **Is Entroly helping me in the work session I am in right now?**
+2. **What did Entroly do to my AI traffic in this recent period?**
+3. **How much value has Entroly accumulated for me overall?**
+
+## This session
+
+`This session` is an in-process rollup built from the same verified Traffic Receipt stream as the durable dashboard. It is intended for the first-use wow moment: after a handful of requests, a user can immediately see requests optimized, tokens received/sent/avoided, context reduction, estimated value avoided, measured cache benefit when available, warm-cache protection, verification, recovery, and Total AI value protected.
+
+The session view is deliberately non-durable and resets when the proxy process restarts. It is **not** added again to All Time, so showing the immediate number cannot double-count durable value.
+
+During the first day of Traffic Value collection, once the current process has observed traffic, `This session` becomes the default view. After that, the durable age-adaptive default below takes over while the session tab remains available.
 
 ## Rolling executive view
 
-The selected period can be Today, 7 days, 30 days, 60 days, or 90 days. The period card can show:
+The selected durable period can be Today, 7 days, 30 days, 60 days, or 90 days. The period card can show:
 
 - requests optimized;
 - tokens received by Entroly before its context optimization;
@@ -38,7 +47,7 @@ The rolling windows do not reset at calendar week/month boundaries.
 
 ## Adaptive default
 
-Entroly selects a useful recent window based on how long Traffic Value has actually been collecting receipts:
+After the first day, Entroly selects a useful recent window based on how long Traffic Value has actually been collecting receipts:
 
 ```text
 < 30 days collecting     -> 7D
@@ -47,11 +56,11 @@ Entroly selects a useful recent window based on how long Traffic Value has actua
 100+ days collecting     -> 90D
 ```
 
-So an install with 3 days of history opens on 7D, one with 45 days opens on 30D, and one with 100+ days opens on 90D.
+So an install with 3 days of history opens on 7D, one with 45 days opens on 30D, and one with 100+ days opens on 90D. `This session` remains available in every case.
 
 ## All Time never disappears
 
-The selected rolling period is always accompanied by a separate **ALL TIME** card. It highlights:
+The selected session/recent period is always accompanied by a separate **ALL TIME** card. It highlights:
 
 ```text
 Estimated value avoided
@@ -77,5 +86,7 @@ The dashboard intentionally keeps evidence classes visible instead of turning ev
 **Total AI value protected** is the sum of avoided-input value and measured cache benefit. The two components remain visible separately so an operator can distinguish modeled optimization value from provider-observed cache economics.
 
 Verification percentages count only explicit PASS/FAIL evidence. Recovery success requires recovery evidence plus a final explicit PASS signal; an attempted recovery is never counted as successful merely because it ran.
+
+Traffic Receipt coverage that is only available through shared mutable proxy state is withheld from per-request receipts rather than risk cross-request attribution. The receipt UI labels observed recovery state as **Recovery evidence**, and its SHA-256 check as **Receipt integrity**, not as a cryptographic signature.
 
 The dashboard persists only aggregate counters and bounded receipt identifiers in the existing value-tracker file. It does not add prompt, tool-output, code, API-key, or raw user-agent content to the executive rollups.

--- a/entroly/compression_proxy_live.py
+++ b/entroly/compression_proxy_live.py
@@ -22,7 +22,7 @@ from typing import Any
 # Import order is a security and observability contract:
 #   bounded transport -> final transport -> control-plane audit -> access guard
 #   -> gateway shadow -> routing authority -> routing deployment safety
-#   -> official API execution guard.
+#   -> official API execution guard -> traffic receipt observer.
 from . import proxy as _proxy
 from . import proxy_transport_safe as _proxy_transport_safe  # noqa: F401
 from . import proxy_transport_final as _proxy_transport_final  # noqa: F401
@@ -32,6 +32,7 @@ from . import proxy_gateway_shadow as _proxy_gateway_shadow
 from . import proxy_routing_authority as _proxy_routing_authority
 from . import proxy_routing_official_guard as _proxy_routing_official_guard
 from . import proxy_routing_safety as _proxy_routing_safety
+from . import proxy_traffic_receipt as _proxy_traffic_receipt
 from .compression_proxy import compress_proxy_payload_from_env
 
 _INSTALLED = False
@@ -94,12 +95,14 @@ def _install_gateway_sidecar_factory_seam() -> None:
             )
         _proxy_gateway_shadow._install_route(app)
         _proxy_routing_authority._install_route(app)
+        _proxy_traffic_receipt._install_route(app)
         return app
 
     gateway_inner_factory.__entroly_gateway_shadow_original__ = original
     gateway_inner_factory.__entroly_routing_authority_original__ = original
     gateway_inner_factory.__entroly_routing_safety_original__ = original
     gateway_inner_factory.__entroly_official_routing_guard_original__ = original
+    gateway_inner_factory.__entroly_traffic_receipt_original__ = original
     _proxy_access_security._ORIGINAL_CREATE_PROXY_APP = gateway_inner_factory
     _proxy.create_proxy_app = _proxy_access_security.create_proxy_app
 

--- a/entroly/compression_proxy_live.py
+++ b/entroly/compression_proxy_live.py
@@ -22,8 +22,8 @@ from typing import Any
 # Import order is a security and observability contract:
 #   bounded transport -> final transport -> control-plane audit -> access guard
 #   -> gateway shadow -> routing authority -> routing deployment safety
-#   -> official API execution guard -> traffic receipt observer -> value view
-#   -> immediate session value overlay.
+#   -> official API execution guard -> traffic receipt observer
+#   -> final receipt correctness guard -> value view -> session value overlay.
 from . import proxy as _proxy
 from . import proxy_transport_safe as _proxy_transport_safe  # noqa: F401
 from . import proxy_transport_final as _proxy_transport_final  # noqa: F401
@@ -34,6 +34,7 @@ from . import proxy_routing_authority as _proxy_routing_authority
 from . import proxy_routing_official_guard as _proxy_routing_official_guard
 from . import proxy_routing_safety as _proxy_routing_safety
 from . import proxy_traffic_receipt as _proxy_traffic_receipt
+from . import proxy_traffic_receipt_final as _proxy_traffic_receipt_final  # noqa: F401
 from . import proxy_traffic_value as _proxy_traffic_value
 from . import proxy_traffic_session as _proxy_traffic_session  # noqa: F401
 from .compression_proxy import compress_proxy_payload_from_env

--- a/entroly/compression_proxy_live.py
+++ b/entroly/compression_proxy_live.py
@@ -22,7 +22,7 @@ from typing import Any
 # Import order is a security and observability contract:
 #   bounded transport -> final transport -> control-plane audit -> access guard
 #   -> gateway shadow -> routing authority -> routing deployment safety
-#   -> official API execution guard -> traffic receipt observer.
+#   -> official API execution guard -> traffic receipt observer -> value view.
 from . import proxy as _proxy
 from . import proxy_transport_safe as _proxy_transport_safe  # noqa: F401
 from . import proxy_transport_final as _proxy_transport_final  # noqa: F401
@@ -33,6 +33,7 @@ from . import proxy_routing_authority as _proxy_routing_authority
 from . import proxy_routing_official_guard as _proxy_routing_official_guard
 from . import proxy_routing_safety as _proxy_routing_safety
 from . import proxy_traffic_receipt as _proxy_traffic_receipt
+from . import proxy_traffic_value as _proxy_traffic_value
 from .compression_proxy import compress_proxy_payload_from_env
 
 _INSTALLED = False
@@ -96,6 +97,7 @@ def _install_gateway_sidecar_factory_seam() -> None:
         _proxy_gateway_shadow._install_route(app)
         _proxy_routing_authority._install_route(app)
         _proxy_traffic_receipt._install_route(app)
+        _proxy_traffic_value._install_route(app)
         return app
 
     gateway_inner_factory.__entroly_gateway_shadow_original__ = original
@@ -103,6 +105,7 @@ def _install_gateway_sidecar_factory_seam() -> None:
     gateway_inner_factory.__entroly_routing_safety_original__ = original
     gateway_inner_factory.__entroly_official_routing_guard_original__ = original
     gateway_inner_factory.__entroly_traffic_receipt_original__ = original
+    gateway_inner_factory.__entroly_traffic_value_original__ = original
     _proxy_access_security._ORIGINAL_CREATE_PROXY_APP = gateway_inner_factory
     _proxy.create_proxy_app = _proxy_access_security.create_proxy_app
 

--- a/entroly/compression_proxy_live.py
+++ b/entroly/compression_proxy_live.py
@@ -22,7 +22,8 @@ from typing import Any
 # Import order is a security and observability contract:
 #   bounded transport -> final transport -> control-plane audit -> access guard
 #   -> gateway shadow -> routing authority -> routing deployment safety
-#   -> official API execution guard -> traffic receipt observer -> value view.
+#   -> official API execution guard -> traffic receipt observer -> value view
+#   -> immediate session value overlay.
 from . import proxy as _proxy
 from . import proxy_transport_safe as _proxy_transport_safe  # noqa: F401
 from . import proxy_transport_final as _proxy_transport_final  # noqa: F401
@@ -34,6 +35,7 @@ from . import proxy_routing_official_guard as _proxy_routing_official_guard
 from . import proxy_routing_safety as _proxy_routing_safety
 from . import proxy_traffic_receipt as _proxy_traffic_receipt
 from . import proxy_traffic_value as _proxy_traffic_value
+from . import proxy_traffic_session as _proxy_traffic_session  # noqa: F401
 from .compression_proxy import compress_proxy_payload_from_env
 
 _INSTALLED = False

--- a/entroly/proxy_traffic_receipt.py
+++ b/entroly/proxy_traffic_receipt.py
@@ -1,7 +1,7 @@
 """Live, content-blind AI traffic receipts for the Entroly proxy.
 
 This module turns the proxy's existing context, cache, routing, usage and
-verification signals into one bounded per-request product surface.  It does not
+verification signals into one bounded per-request product surface. It does not
 introduce another router, retry loop, optimizer or pricing model.
 
 The design is deliberately evidence conservative:
@@ -14,7 +14,7 @@ The design is deliberately evidence conservative:
   linked, rather than presenting modeled compression savings as invoice truth;
 * the receipt is SHA-256 self-verifying.
 
-The installer wraps the already-hardened live proxy seams.  The request wrapper
+The installer wraps the already-hardened live proxy seams. The request wrapper
 is placed *inside* the bounded transport admission path, so reading the cached
 request body here cannot bypass the proxy's request-size limit.
 """
@@ -231,15 +231,20 @@ def _money_for_request(
     )
 
 
-def _coverage(proxy: Any) -> tuple[float | None, str]:
+def _coverage_snapshot(proxy: Any) -> tuple[float | None, str, str]:
     raw = getattr(proxy, "_last_coverage", None)
     try:
         value = float(raw)
     except (TypeError, ValueError, OverflowError):
-        return None, "unavailable"
-    if not 0.0 <= value <= 1.0:
-        return None, "unavailable"
-    return round(value * 100.0, 2), "context_coverage_estimate"
+        value = -1.0
+    if 0.0 <= value <= 1.0:
+        percent: float | None = round(value * 100.0, 2)
+        source = "context_coverage_estimate"
+    else:
+        percent = None
+        source = "unavailable"
+    risk = _bounded(getattr(proxy, "_last_coverage_risk", "unknown"), limit=48)
+    return percent, source, (risk.upper() if risk else "UNKNOWN")
 
 
 def _verification(response: Response) -> str:
@@ -256,7 +261,6 @@ def _verification(response: Response) -> str:
 
 
 def _recovery_state(
-    proxy: Any,
     request_headers: Mapping[str, str],
     response: Response,
 ) -> tuple[bool, int]:
@@ -303,12 +307,6 @@ def _routing_decision(
     if requested_model and executed_model and requested_model != executed_model:
         return "SWITCH", "authorized model rewrite"
     return "STAY", "requested model preserved"
-
-
-def _cache_hit_from_usage(usage: TokenUsage | None) -> bool | None:
-    if usage is None:
-        return None
-    return usage.cache_read_tokens > 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -407,6 +405,7 @@ class TrafficReceiptLedger:
 @dataclass(slots=True)
 class _TrafficRequestContext:
     proxy: Any
+    request_id: str
     request_correlation: str
     client: str
     provider: str
@@ -414,10 +413,15 @@ class _TrafficRequestContext:
     headers: Mapping[str, str]
     requested_model: str
     original_context_tokens: int
-    original_body: Mapping[str, Any]
     started_at: float = field(default_factory=time.perf_counter)
+    conversation_id: str = ""
+    cache_hits_before: int = 0
+    cache_misses_before: int = 0
     executed_model: str = ""
     entroly_context_tokens: int = 0
+    evidence_retained_pct: float | None = None
+    evidence_retained_source: str = "unavailable"
+    context_risk: str = "UNKNOWN"
     outbound_headers: dict[str, str] = field(default_factory=dict)
     streaming: bool = False
     completed: bool = False
@@ -440,12 +444,78 @@ def _ledger_for_proxy(proxy: Any) -> TrafficReceiptLedger:
     return ledger
 
 
+def _usage_for_context(
+    context: _TrafficRequestContext,
+    response: Response,
+) -> TokenUsage | None:
+    usage = _provider_usage(response, context.provider)
+    if usage is not None:
+        return usage
+    ledger = getattr(context.proxy, "_usage_ledger", None)
+    if ledger is not None and context.request_id:
+        try:
+            event = ledger.get(context.request_id)
+        except Exception:
+            event = None
+        if event is not None:
+            return event.usage
+    return None
+
+
+def _cache_observation(
+    context: _TrafficRequestContext,
+    usage: TokenUsage | None,
+) -> tuple[bool | None, int]:
+    if usage is not None:
+        return usage.cache_read_tokens > 0, usage.cache_read_tokens
+    if not context.conversation_id:
+        return None, 0
+    router = getattr(context.proxy, "_cache_router", None)
+    if router is None:
+        return None, 0
+    try:
+        lease = router.lease_snapshot(context.conversation_id)
+    except Exception:
+        return None, 0
+    if lease is None:
+        return None, 0
+    if int(lease.hits) > context.cache_hits_before:
+        return True, max(0, int(lease.cached_prefix_tokens))
+    if int(lease.misses) > context.cache_misses_before:
+        return False, 0
+    return None, 0
+
+
+def _capture_outbound_state(
+    context: _TrafficRequestContext,
+    body: Mapping[str, Any],
+    *,
+    extra_headers: Mapping[str, Any] | None,
+    streaming: bool,
+) -> None:
+    context.executed_model = _bounded(
+        str(body.get("model") or context.requested_model), limit=128
+    )
+    context.entroly_context_tokens = _estimate_context_tokens(
+        context.provider,
+        body,
+        headers=context.headers,
+        path=context.path,
+    )
+    context.outbound_headers.update(_lower_headers(extra_headers))
+    context.streaming = streaming
+    (
+        context.evidence_retained_pct,
+        context.evidence_retained_source,
+        context.context_risk,
+    ) = _coverage_snapshot(context.proxy)
+
+
 def _build_receipt(
     context: _TrafficRequestContext,
     response: Response,
 ) -> TrafficReceipt:
-    proxy = context.proxy
-    usage = _provider_usage(response, context.provider)
+    usage = _usage_for_context(context, response)
     executed_model = context.executed_model or context.requested_model
     response_headers = _lower_headers(getattr(response, "headers", {}))
     escalated_to = _bounded(response_headers.get("x-entroly-escalated-to", ""), limit=128)
@@ -453,14 +523,12 @@ def _build_receipt(
         executed_model = escalated_to
 
     input_cost, cache_benefit, money_source = _money_for_request(
-        proxy,
+        context.proxy,
         provider=context.provider,
         model=executed_model,
         usage=usage,
     )
-    evidence_pct, evidence_source = _coverage(proxy)
     recoverable, recovery_receipts = _recovery_state(
-        proxy,
         context.outbound_headers,
         response,
     )
@@ -472,7 +540,7 @@ def _build_receipt(
     )
     optimized = context.entroly_context_tokens or context.original_context_tokens
     tokens_avoided = max(0, context.original_context_tokens - optimized)
-    risk = _bounded(getattr(proxy, "_last_coverage_risk", "unknown"), limit=48)
+    cache_hit, cache_read_tokens = _cache_observation(context, usage)
     unsigned: dict[str, Any] = {
         "schema_version": _SCHEMA_VERSION,
         "receipt_id": f"tr_{uuid.uuid4().hex[:16]}",
@@ -484,23 +552,20 @@ def _build_receipt(
         "original_context_tokens": max(0, context.original_context_tokens),
         "entroly_context_tokens": max(0, optimized),
         "tokens_avoided": tokens_avoided,
-        "evidence_retained_pct": evidence_pct,
-        "evidence_retained_source": evidence_source,
+        "evidence_retained_pct": context.evidence_retained_pct,
+        "evidence_retained_source": context.evidence_retained_source,
         "recoverable": recoverable,
         "recovery_receipts": recovery_receipts,
         "warm_prefix_protected_tokens": protected_tokens,
-        "cache_hit": _cache_hit_from_usage(usage),
-        "cache_read_tokens": 0 if usage is None else usage.cache_read_tokens,
+        "cache_hit": cache_hit,
+        "cache_read_tokens": cache_read_tokens,
         "routing_decision": routing_decision,
         "routing_reason": routing_reason,
         "input_cost_micro_usd": input_cost,
         "cache_benefit_micro_usd": cache_benefit,
-        # Deliberately unavailable until a request-correlated measured
-        # counterfactual exists. Do not relabel modeled token reduction as
-        # realized invoice savings.
         "net_measured_saving_micro_usd": None,
         "money_source": money_source,
-        "context_risk": risk.upper() if risk else "UNKNOWN",
+        "context_risk": context.context_risk,
         "verification": _verification(response),
         "response_status": int(getattr(response, "status_code", 0) or 0) or None,
         "streaming": context.streaming,
@@ -564,8 +629,26 @@ async def _run_traffic_handle_proxy(
         except Exception:
             requested_model = str(body.get("model") or "")
     request_id = headers.get("x-request-id") or uuid.uuid4().hex[:16]
+    conversation_id = ""
+    cache_hits_before = 0
+    cache_misses_before = 0
+    if body:
+        try:
+            conversation_id = proxy._routing_conversation_id(dict(body), provider)
+        except Exception:
+            conversation_id = ""
+    if conversation_id:
+        try:
+            lease = proxy._cache_router.lease_snapshot(conversation_id)
+        except Exception:
+            lease = None
+        if lease is not None:
+            cache_hits_before = int(lease.hits)
+            cache_misses_before = int(lease.misses)
+
     context = _TrafficRequestContext(
         proxy=proxy,
+        request_id=request_id,
         request_correlation=_correlation_digest(request_id),
         client=_classify_client(headers),
         provider=provider,
@@ -577,16 +660,22 @@ async def _run_traffic_handle_proxy(
             if body
             else 0
         ),
-        original_body=body,
+        conversation_id=conversation_id,
+        cache_hits_before=cache_hits_before,
+        cache_misses_before=cache_misses_before,
     )
     _ledger_for_proxy(proxy).register_request()
     token = _CURRENT_CONTEXT.set(context)
     response: Response | None = None
     try:
         response = await original(proxy, request)
-        # Normal non-forwarding paths (policy refusal, malformed request, etc.)
-        # do not pass through _forward_response/_stream_response. Record them.
         if not context.completed and not isinstance(response, StreamingResponse):
+            if context.evidence_retained_source == "unavailable":
+                (
+                    context.evidence_retained_pct,
+                    context.evidence_retained_source,
+                    context.context_risk,
+                ) = _coverage_snapshot(proxy)
             _complete_context(context, response)
         return response
     except Exception:
@@ -606,15 +695,12 @@ async def _traffic_forward_response(
 ) -> Response:
     context = _CURRENT_CONTEXT.get()
     if context is not None:
-        context.executed_model = _bounded(str(body.get("model") or context.requested_model), limit=128)
-        context.entroly_context_tokens = _estimate_context_tokens(
-            context.provider,
+        _capture_outbound_state(
+            context,
             body,
-            headers=context.headers,
-            path=context.path,
+            extra_headers=kwargs.get("extra_headers"),
+            streaming=False,
         )
-        context.outbound_headers.update(_lower_headers(kwargs.get("extra_headers") or {}))
-        context.streaming = False
     response = await _ORIGINAL_FORWARD_RESPONSE(self, url, headers, body, *args, **kwargs)
     if context is not None:
         _complete_context(context, response)
@@ -631,15 +717,12 @@ async def _traffic_stream_response(
 ) -> Response:
     context = _CURRENT_CONTEXT.get()
     if context is not None:
-        context.executed_model = _bounded(str(body.get("model") or context.requested_model), limit=128)
-        context.entroly_context_tokens = _estimate_context_tokens(
-            context.provider,
+        _capture_outbound_state(
+            context,
             body,
-            headers=context.headers,
-            path=context.path,
+            extra_headers=kwargs.get("extra_headers"),
+            streaming=True,
         )
-        context.outbound_headers.update(_lower_headers(kwargs.get("extra_headers") or {}))
-        context.streaming = True
     response = await _ORIGINAL_STREAM_RESPONSE(self, url, headers, body, *args, **kwargs)
     if context is None:
         return response
@@ -800,11 +883,17 @@ def install_traffic_receipts() -> None:
         _proxy.PromptCompilerProxy._stream_response = _traffic_stream_response
 
 
-_ORIGINAL_FORWARD_RESPONSE: Callable[..., Awaitable[Response]] = (
-    _proxy.PromptCompilerProxy._forward_response
+_current_forward = _proxy.PromptCompilerProxy._forward_response
+_current_stream = _proxy.PromptCompilerProxy._stream_response
+_ORIGINAL_FORWARD_RESPONSE: Callable[..., Awaitable[Response]] = getattr(
+    _current_forward,
+    "__entroly_traffic_receipt_original__",
+    _current_forward,
 )
-_ORIGINAL_STREAM_RESPONSE: Callable[..., Awaitable[Response]] = (
-    _proxy.PromptCompilerProxy._stream_response
+_ORIGINAL_STREAM_RESPONSE: Callable[..., Awaitable[Response]] = getattr(
+    _current_stream,
+    "__entroly_traffic_receipt_original__",
+    _current_stream,
 )
 
 install_traffic_receipts()
@@ -813,7 +902,12 @@ install_traffic_receipts()
 __all__ = [
     "TrafficReceipt",
     "TrafficReceiptLedger",
+    "_TRAFFIC_HTML",
+    "_canonical_json",
     "_classify_client",
     "_install_route",
+    "_prefix_protection",
+    "_routing_decision",
+    "_verification",
     "install_traffic_receipts",
 ]

--- a/entroly/proxy_traffic_receipt.py
+++ b/entroly/proxy_traffic_receipt.py
@@ -1,0 +1,819 @@
+"""Live, content-blind AI traffic receipts for the Entroly proxy.
+
+This module turns the proxy's existing context, cache, routing, usage and
+verification signals into one bounded per-request product surface.  It does not
+introduce another router, retry loop, optimizer or pricing model.
+
+The design is deliberately evidence conservative:
+
+* prompt/message content and credentials are never stored in receipts;
+* token counts are deterministic local estimates unless provider usage exists;
+* cache hits come from provider-reported usage (or remain unknown);
+* monetary values require provider usage plus an explicit pricing catalog;
+* "net measured saving" remains unavailable until a measured counterfactual is
+  linked, rather than presenting modeled compression savings as invoice truth;
+* the receipt is SHA-256 self-verifying.
+
+The installer wraps the already-hardened live proxy seams.  The request wrapper
+is placed *inside* the bounded transport admission path, so reading the cached
+request body here cannot bypass the proxy's request-size limit.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import hashlib
+import json
+import os
+import threading
+import time
+import uuid
+from collections import deque
+from dataclasses import asdict, dataclass, field
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, AsyncIterator, Awaitable, Callable, Mapping
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.routing import Route
+
+from . import proxy as _proxy
+from . import proxy_transport_safe as _transport
+from .provider_adapters import canonical_request_from_provider_body
+from .proxy_transform import detect_provider, extract_model
+from .usage_ledger import TokenUsage, parse_provider_usage
+
+_SCHEMA_VERSION = "entroly.traffic-receipt.v1"
+_DEFAULT_MAX_RECORDS = 100
+_MAX_RECORDS_LIMIT = 1_000
+_CORRELATION_SALT = os.urandom(32)
+_CURRENT_CONTEXT: contextvars.ContextVar["_TrafficRequestContext | None"] = (
+    contextvars.ContextVar("entroly_traffic_receipt_context", default=None)
+)
+
+
+def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw = os.environ.get(name)
+    try:
+        parsed = default if raw is None else int(raw)
+    except (TypeError, ValueError, OverflowError):
+        parsed = default
+    return max(minimum, min(parsed, maximum))
+
+
+def _bounded(value: object, *, limit: int = 180) -> str:
+    return (
+        str(value or "")
+        .replace("\r", " ")
+        .replace("\n", " ")
+        .strip()[:limit]
+    )
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+
+def _correlation_digest(value: str) -> str:
+    return hashlib.sha256(
+        _CORRELATION_SALT + value.encode("utf-8", errors="replace")
+    ).hexdigest()[:16]
+
+
+def _safe_int(value: object, default: int = 0) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _lower_headers(headers: Mapping[str, Any] | None) -> dict[str, str]:
+    if not headers:
+        return {}
+    return {str(key).casefold(): str(value) for key, value in headers.items()}
+
+
+def _classify_client(headers: Mapping[str, str]) -> str:
+    """Return a bounded product label without retaining the raw user-agent."""
+    tool = _bounded(headers.get("x-entroly-tool", ""), limit=64)
+    if tool:
+        return tool
+    user_agent = str(headers.get("user-agent", "")).casefold()
+    markers = (
+        ("claude-code", "Claude Code"),
+        ("claude code", "Claude Code"),
+        ("codex", "Codex"),
+        ("cursor", "Cursor"),
+        ("openclaw", "OpenClaw"),
+        ("opencode", "OpenCode"),
+        ("cline", "Cline"),
+        ("continue", "Continue"),
+        ("aider", "Aider"),
+    )
+    for marker, label in markers:
+        if marker in user_agent:
+            return label
+    return "AI client"
+
+
+def _estimate_context_tokens(
+    provider: str,
+    body: Mapping[str, Any],
+    *,
+    headers: Mapping[str, str] | None = None,
+    path: str = "",
+) -> int:
+    """Use the canonical gateway estimator; fall back to bounded JSON bytes."""
+    try:
+        adapter = canonical_request_from_provider_body(
+            provider,
+            body,
+            headers=headers,
+            path=path,
+        )
+        return max(
+            0,
+            int(adapter.prefix_tokens_estimate)
+            + int(adapter.new_input_tokens_estimate),
+        )
+    except Exception:
+        try:
+            encoded = json.dumps(
+                body,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+            return max(1, len(encoded) // 4)
+        except Exception:
+            return 0
+
+
+def _response_json(response: Response) -> Mapping[str, Any] | None:
+    payload = getattr(response, "body", None)
+    if not isinstance(payload, (bytes, bytearray)) or not payload:
+        return None
+    try:
+        decoded = json.loads(bytes(payload))
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+    return decoded if isinstance(decoded, Mapping) else None
+
+
+def _usage_payload_present(payload: Mapping[str, Any]) -> bool:
+    if any(key in payload for key in ("usage", "usage_metadata", "usageMetadata")):
+        return True
+    for key in ("message", "response"):
+        nested = payload.get(key)
+        if isinstance(nested, Mapping) and "usage" in nested:
+            return True
+    return False
+
+
+def _provider_usage(response: Response, provider: str) -> TokenUsage | None:
+    payload = _response_json(response)
+    if payload is None or not _usage_payload_present(payload):
+        return None
+    try:
+        return parse_provider_usage(provider, payload)
+    except Exception:
+        return None
+
+
+def _input_cost_micro_usd(usage: TokenUsage, pricing: Any) -> int:
+    """Price input/cache categories only, using integer microdollars."""
+    raw = (
+        Decimal(usage.uncached_input_tokens) * pricing.input_per_million
+        + Decimal(usage.cache_read_tokens) * pricing.cache_read_per_million
+        + Decimal(usage.cache_write_tokens) * pricing.cache_write_rate
+    )
+    return int(raw.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def _cache_benefit_micro_usd(usage: TokenUsage, pricing: Any) -> int:
+    no_cache = Decimal(usage.cache_read_tokens + usage.cache_write_tokens) * (
+        pricing.input_per_million
+    )
+    actual = (
+        Decimal(usage.cache_read_tokens) * pricing.cache_read_per_million
+        + Decimal(usage.cache_write_tokens) * pricing.cache_write_rate
+    )
+    return max(
+        0,
+        int((no_cache - actual).quantize(Decimal("1"), rounding=ROUND_HALF_UP)),
+    )
+
+
+def _money_for_request(
+    proxy: Any,
+    *,
+    provider: str,
+    model: str,
+    usage: TokenUsage | None,
+) -> tuple[int | None, int | None, str]:
+    if usage is None:
+        return None, None, "provider_usage_unavailable"
+    catalog = getattr(proxy, "_pricing_catalog", None)
+    pricing = catalog.resolve(provider, model) if catalog is not None else None
+    if pricing is None:
+        return None, None, "auditable_pricing_unavailable"
+    return (
+        _input_cost_micro_usd(usage, pricing),
+        _cache_benefit_micro_usd(usage, pricing),
+        _bounded(getattr(pricing, "source", "explicit"), limit=160),
+    )
+
+
+def _coverage(proxy: Any) -> tuple[float | None, str]:
+    raw = getattr(proxy, "_last_coverage", None)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError, OverflowError):
+        return None, "unavailable"
+    if not 0.0 <= value <= 1.0:
+        return None, "unavailable"
+    return round(value * 100.0, 2), "context_coverage_estimate"
+
+
+def _verification(response: Response) -> str:
+    headers = _lower_headers(getattr(response, "headers", {}))
+    witness = headers.get("x-entroly-witness", "").casefold()
+    eicv = headers.get("x-entroly-eicv", "").casefold()
+    if witness == "flagged" or eicv in {"hallucinated", "flagged"}:
+        return "FAIL"
+    if witness == "pass" or eicv == "clean":
+        return "PASS"
+    if witness == "error" or eicv == "error":
+        return "ERROR"
+    return "NOT_REPORTED"
+
+
+def _recovery_state(
+    proxy: Any,
+    request_headers: Mapping[str, str],
+    response: Response,
+) -> tuple[bool, int]:
+    merged = dict(_lower_headers(request_headers))
+    merged.update(_lower_headers(getattr(response, "headers", {})))
+    keys = (
+        "x-entroly-session-recovery-receipts",
+        "x-entroly-recovery-fragments",
+        "x-entroly-recovered-fragments",
+    )
+    receipts = max((_safe_int(merged.get(key)) for key in keys), default=0)
+    recovered = merged.get("x-entroly-recovered", "").casefold() == "true"
+    return bool(receipts > 0 or recovered), receipts
+
+
+def _prefix_protection(
+    request_headers: Mapping[str, str],
+    response: Response,
+) -> int:
+    merged = dict(_lower_headers(request_headers))
+    merged.update(_lower_headers(getattr(response, "headers", {})))
+    if merged.get("x-entroly-prefix-guard", "") != "preserve_warm_prefix":
+        return 0
+    return _safe_int(merged.get("x-entroly-prefix-tokens-at-risk"))
+
+
+def _routing_decision(
+    requested_model: str,
+    executed_model: str,
+    response: Response,
+) -> tuple[str, str]:
+    headers = _lower_headers(getattr(response, "headers", {}))
+    explicit = _bounded(headers.get("x-entroly-routing-decision", ""), limit=64)
+    reason = _bounded(headers.get("x-entroly-routing-reason", ""), limit=180)
+    if explicit:
+        normalized = explicit.upper().replace("_", "-")
+        if normalized in {"EXECUTED", "WOULD-SWITCH", "SWITCH"}:
+            decision = "SWITCH"
+        elif normalized in {"STAY", "DENIED", "NO-PROPOSAL"}:
+            decision = "STAY"
+        else:
+            decision = normalized
+        return decision, reason or "routing authority decision"
+    if requested_model and executed_model and requested_model != executed_model:
+        return "SWITCH", "authorized model rewrite"
+    return "STAY", "requested model preserved"
+
+
+def _cache_hit_from_usage(usage: TokenUsage | None) -> bool | None:
+    if usage is None:
+        return None
+    return usage.cache_read_tokens > 0
+
+
+@dataclass(frozen=True, slots=True)
+class TrafficReceipt:
+    schema_version: str
+    receipt_id: str
+    request_correlation: str
+    client: str
+    provider: str
+    requested_model: str
+    executed_model: str
+    original_context_tokens: int
+    entroly_context_tokens: int
+    tokens_avoided: int
+    evidence_retained_pct: float | None
+    evidence_retained_source: str
+    recoverable: bool
+    recovery_receipts: int
+    warm_prefix_protected_tokens: int
+    cache_hit: bool | None
+    cache_read_tokens: int
+    routing_decision: str
+    routing_reason: str
+    input_cost_micro_usd: int | None
+    cache_benefit_micro_usd: int | None
+    net_measured_saving_micro_usd: int | None
+    money_source: str
+    context_risk: str
+    verification: str
+    response_status: int | None
+    streaming: bool
+    latency_ms: float
+    observed_at: float
+    receipt_digest: str
+
+    def payload(self) -> dict[str, Any]:
+        value = asdict(self)
+        value.pop("receipt_digest", None)
+        return value
+
+    def verify(self) -> bool:
+        return (
+            hashlib.sha256(_canonical_json(self.payload())).hexdigest()
+            == self.receipt_digest
+        )
+
+
+class TrafficReceiptLedger:
+    """Bounded in-memory receipt ledger containing no prompt or credentials."""
+
+    def __init__(self, *, max_records: int = _DEFAULT_MAX_RECORDS) -> None:
+        self.max_records = max(1, min(int(max_records), _MAX_RECORDS_LIMIT))
+        self._records: deque[TrafficReceipt] = deque(maxlen=self.max_records)
+        self._lock = threading.RLock()
+        self._requests = 0
+        self._completed = 0
+        self._failures = 0
+
+    def register_request(self) -> None:
+        with self._lock:
+            self._requests += 1
+
+    def fail(self) -> None:
+        with self._lock:
+            self._failures += 1
+
+    def append(self, receipt: TrafficReceipt) -> None:
+        if not receipt.verify():
+            raise ValueError("traffic receipt digest verification failed")
+        with self._lock:
+            self._records.append(receipt)
+            self._completed += 1
+
+    def snapshot(self, *, limit: int | None = None) -> dict[str, Any]:
+        with self._lock:
+            records = list(self._records)
+            requested = self.max_records if limit is None else max(1, int(limit))
+            selected = records[-min(requested, self.max_records) :]
+            return {
+                "schema_version": _SCHEMA_VERSION,
+                "records_contain_prompt_content": False,
+                "records_contain_credentials": False,
+                "money_policy": (
+                    "provider usage + explicit pricing only; net measured saving "
+                    "requires a linked measured counterfactual"
+                ),
+                "requests": self._requests,
+                "completed": self._completed,
+                "failures": self._failures,
+                "max_records": self.max_records,
+                "latest": asdict(records[-1]) if records else None,
+                "recent": [asdict(record) for record in reversed(selected)],
+            }
+
+
+@dataclass(slots=True)
+class _TrafficRequestContext:
+    proxy: Any
+    request_correlation: str
+    client: str
+    provider: str
+    path: str
+    headers: Mapping[str, str]
+    requested_model: str
+    original_context_tokens: int
+    original_body: Mapping[str, Any]
+    started_at: float = field(default_factory=time.perf_counter)
+    executed_model: str = ""
+    entroly_context_tokens: int = 0
+    outbound_headers: dict[str, str] = field(default_factory=dict)
+    streaming: bool = False
+    completed: bool = False
+    lock: threading.RLock = field(default_factory=threading.RLock)
+
+
+def _ledger_for_proxy(proxy: Any) -> TrafficReceiptLedger:
+    ledger = getattr(proxy, "_traffic_receipt_ledger", None)
+    if isinstance(ledger, TrafficReceiptLedger):
+        return ledger
+    ledger = TrafficReceiptLedger(
+        max_records=_env_int(
+            "ENTROLY_TRAFFIC_RECEIPT_MAX_RECORDS",
+            _DEFAULT_MAX_RECORDS,
+            minimum=1,
+            maximum=_MAX_RECORDS_LIMIT,
+        )
+    )
+    proxy._traffic_receipt_ledger = ledger
+    return ledger
+
+
+def _build_receipt(
+    context: _TrafficRequestContext,
+    response: Response,
+) -> TrafficReceipt:
+    proxy = context.proxy
+    usage = _provider_usage(response, context.provider)
+    executed_model = context.executed_model or context.requested_model
+    response_headers = _lower_headers(getattr(response, "headers", {}))
+    escalated_to = _bounded(response_headers.get("x-entroly-escalated-to", ""), limit=128)
+    if escalated_to:
+        executed_model = escalated_to
+
+    input_cost, cache_benefit, money_source = _money_for_request(
+        proxy,
+        provider=context.provider,
+        model=executed_model,
+        usage=usage,
+    )
+    evidence_pct, evidence_source = _coverage(proxy)
+    recoverable, recovery_receipts = _recovery_state(
+        proxy,
+        context.outbound_headers,
+        response,
+    )
+    protected_tokens = _prefix_protection(context.outbound_headers, response)
+    routing_decision, routing_reason = _routing_decision(
+        context.requested_model,
+        executed_model,
+        response,
+    )
+    optimized = context.entroly_context_tokens or context.original_context_tokens
+    tokens_avoided = max(0, context.original_context_tokens - optimized)
+    risk = _bounded(getattr(proxy, "_last_coverage_risk", "unknown"), limit=48)
+    unsigned: dict[str, Any] = {
+        "schema_version": _SCHEMA_VERSION,
+        "receipt_id": f"tr_{uuid.uuid4().hex[:16]}",
+        "request_correlation": context.request_correlation,
+        "client": context.client,
+        "provider": _bounded(context.provider, limit=48),
+        "requested_model": _bounded(context.requested_model, limit=128),
+        "executed_model": _bounded(executed_model, limit=128),
+        "original_context_tokens": max(0, context.original_context_tokens),
+        "entroly_context_tokens": max(0, optimized),
+        "tokens_avoided": tokens_avoided,
+        "evidence_retained_pct": evidence_pct,
+        "evidence_retained_source": evidence_source,
+        "recoverable": recoverable,
+        "recovery_receipts": recovery_receipts,
+        "warm_prefix_protected_tokens": protected_tokens,
+        "cache_hit": _cache_hit_from_usage(usage),
+        "cache_read_tokens": 0 if usage is None else usage.cache_read_tokens,
+        "routing_decision": routing_decision,
+        "routing_reason": routing_reason,
+        "input_cost_micro_usd": input_cost,
+        "cache_benefit_micro_usd": cache_benefit,
+        # Deliberately unavailable until a request-correlated measured
+        # counterfactual exists. Do not relabel modeled token reduction as
+        # realized invoice savings.
+        "net_measured_saving_micro_usd": None,
+        "money_source": money_source,
+        "context_risk": risk.upper() if risk else "UNKNOWN",
+        "verification": _verification(response),
+        "response_status": int(getattr(response, "status_code", 0) or 0) or None,
+        "streaming": context.streaming,
+        "latency_ms": round((time.perf_counter() - context.started_at) * 1000.0, 3),
+        "observed_at": time.time(),
+    }
+    digest = hashlib.sha256(_canonical_json(unsigned)).hexdigest()
+    return TrafficReceipt(receipt_digest=digest, **unsigned)
+
+
+def _complete_context(context: _TrafficRequestContext, response: Response) -> None:
+    with context.lock:
+        if context.completed:
+            return
+        context.completed = True
+    try:
+        receipt = _build_receipt(context, response)
+        _ledger_for_proxy(context.proxy).append(receipt)
+    except Exception:
+        _ledger_for_proxy(context.proxy).fail()
+        _proxy.logger.warning("Traffic receipt finalization failed", exc_info=True)
+
+
+async def _finalizing_iterator(
+    iterator: AsyncIterator[bytes | str],
+    *,
+    context: _TrafficRequestContext,
+    response: Response,
+) -> AsyncIterator[bytes | str]:
+    try:
+        async for chunk in iterator:
+            yield chunk
+    finally:
+        _complete_context(context, response)
+
+
+async def _run_traffic_handle_proxy(
+    proxy: Any,
+    request: Request,
+    original: Callable[[Any, Request], Awaitable[Response]],
+) -> Response:
+    """Start a receipt after bounded transport has admitted the request body."""
+    body: Mapping[str, Any] = {}
+    try:
+        decoded = json.loads(await request.body())
+        if isinstance(decoded, Mapping):
+            body = decoded
+    except Exception:
+        body = {}
+
+    headers = {str(key).casefold(): str(value) for key, value in request.headers.items()}
+    path = request.url.path
+    try:
+        provider = detect_provider(path, dict(headers), dict(body))
+    except Exception:
+        provider = "unknown"
+    requested_model = ""
+    if body:
+        try:
+            requested_model = extract_model(dict(body), path) or str(body.get("model") or "")
+        except Exception:
+            requested_model = str(body.get("model") or "")
+    request_id = headers.get("x-request-id") or uuid.uuid4().hex[:16]
+    context = _TrafficRequestContext(
+        proxy=proxy,
+        request_correlation=_correlation_digest(request_id),
+        client=_classify_client(headers),
+        provider=provider,
+        path=path,
+        headers=headers,
+        requested_model=_bounded(requested_model, limit=128),
+        original_context_tokens=(
+            _estimate_context_tokens(provider, body, headers=headers, path=path)
+            if body
+            else 0
+        ),
+        original_body=body,
+    )
+    _ledger_for_proxy(proxy).register_request()
+    token = _CURRENT_CONTEXT.set(context)
+    response: Response | None = None
+    try:
+        response = await original(proxy, request)
+        # Normal non-forwarding paths (policy refusal, malformed request, etc.)
+        # do not pass through _forward_response/_stream_response. Record them.
+        if not context.completed and not isinstance(response, StreamingResponse):
+            _complete_context(context, response)
+        return response
+    except Exception:
+        _ledger_for_proxy(proxy).fail()
+        raise
+    finally:
+        _CURRENT_CONTEXT.reset(token)
+
+
+async def _traffic_forward_response(
+    self: Any,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Response:
+    context = _CURRENT_CONTEXT.get()
+    if context is not None:
+        context.executed_model = _bounded(str(body.get("model") or context.requested_model), limit=128)
+        context.entroly_context_tokens = _estimate_context_tokens(
+            context.provider,
+            body,
+            headers=context.headers,
+            path=context.path,
+        )
+        context.outbound_headers.update(_lower_headers(kwargs.get("extra_headers") or {}))
+        context.streaming = False
+    response = await _ORIGINAL_FORWARD_RESPONSE(self, url, headers, body, *args, **kwargs)
+    if context is not None:
+        _complete_context(context, response)
+    return response
+
+
+async def _traffic_stream_response(
+    self: Any,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Response:
+    context = _CURRENT_CONTEXT.get()
+    if context is not None:
+        context.executed_model = _bounded(str(body.get("model") or context.requested_model), limit=128)
+        context.entroly_context_tokens = _estimate_context_tokens(
+            context.provider,
+            body,
+            headers=context.headers,
+            path=context.path,
+        )
+        context.outbound_headers.update(_lower_headers(kwargs.get("extra_headers") or {}))
+        context.streaming = True
+    response = await _ORIGINAL_STREAM_RESPONSE(self, url, headers, body, *args, **kwargs)
+    if context is None:
+        return response
+    if isinstance(response, StreamingResponse):
+        response.body_iterator = _finalizing_iterator(
+            response.body_iterator,
+            context=context,
+            response=response,
+        )
+    else:
+        _complete_context(context, response)
+    return response
+
+
+_TRAFFIC_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Entroly Traffic Receipt</title>
+<style>
+:root{color-scheme:dark;--bg:#07090d;--card:#0d1118;--line:#202938;--text:#edf2f7;--dim:#8b98aa;--good:#5ee6a8;--blue:#79b8ff;--warn:#ffd166;--bad:#ff7b8b}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 50% -20%,#172036 0,transparent 42%),var(--bg);font:14px/1.45 Inter,ui-sans-serif,system-ui;color:var(--text)}
+main{max-width:900px;margin:0 auto;padding:32px 20px 64px}.top{display:flex;align-items:end;justify-content:space-between;margin-bottom:18px}.eyebrow{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--good);font-weight:800}.title{font-size:28px;font-weight:850;letter-spacing:-.03em}.live{font-size:12px;color:var(--dim)}
+.card{background:linear-gradient(180deg,rgba(18,24,34,.96),rgba(11,15,22,.96));border:1px solid var(--line);border-radius:18px;box-shadow:0 24px 80px rgba(0,0,0,.35);overflow:hidden}.cardhead{display:flex;justify-content:space-between;align-items:center;padding:18px 22px;border-bottom:1px solid var(--line)}.client{font-size:17px;font-weight:800}.receipt{font:11px ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--dim)}
+.rows{padding:12px 22px 18px}.row{display:grid;grid-template-columns:minmax(220px,1fr) auto;gap:24px;align-items:center;padding:9px 0}.row.sep{border-top:1px solid var(--line);margin-top:8px;padding-top:16px}.label{color:var(--dim)}.value{font:700 14px ui-monospace,SFMono-Regular,Menlo,monospace;text-align:right}.big{font-size:17px}.good{color:var(--good)}.blue{color:var(--blue)}.warn{color:var(--warn)}.bad{color:var(--bad)}.muted{color:var(--dim)}
+.reason{font-family:Inter,ui-sans-serif,system-ui;font-size:12px;max-width:430px}.foot{display:flex;justify-content:space-between;gap:20px;padding:13px 22px;border-top:1px solid var(--line);color:var(--dim);font-size:11px}.empty{padding:44px 22px;text-align:center;color:var(--dim)}
+.note{margin-top:14px;padding:12px 15px;border:1px solid var(--line);border-radius:12px;color:var(--dim);font-size:12px}.note b{color:var(--text)}
+@media(max-width:620px){.row{grid-template-columns:1fr}.value{text-align:left}.top{align-items:start;gap:10px;flex-direction:column}.foot{flex-direction:column}}
+</style>
+</head>
+<body><main>
+<div class="top"><div><div class="eyebrow">AI Traffic Assurance</div><div class="title">Traffic Receipt</div></div><div class="live" id="status">waiting for live traffic…</div></div>
+<div class="card" id="card"><div class="empty">Send an AI request through Entroly to generate a receipt.</div></div>
+<div class="note"><b>Truth policy:</b> monetary values appear only when provider-reported usage and an explicit pricing catalog are available. Net measured saving stays blank until a request-correlated measured counterfactual exists.</div>
+</main>
+<script>
+const fmt=n=>Number(n||0).toLocaleString();
+const usd=m=>m==null?'—':'$'+(Number(m)/1e6).toFixed(6).replace(/0+$/,'').replace(/\.$/,'');
+const yn=v=>v===true?'YES':v===false?'NO':'—';
+const hit=v=>v===true?'YES':v===false?'NO':'—';
+const cls=(v,good)=>v===good?'good':v==='FAIL'||v==='ERROR'?'bad':'muted';
+function render(r){
+ if(!r){document.getElementById('card').innerHTML='<div class="empty">Send an AI request through Entroly to generate a receipt.</div>';return;}
+ const evidence=r.evidence_retained_pct==null?'—':Number(r.evidence_retained_pct).toFixed(1)+'%';
+ const decision=r.routing_decision||'—', verify=r.verification||'NOT_REPORTED';
+ document.getElementById('card').innerHTML=`
+ <div class="cardhead"><div class="client">${esc(r.client||'AI client')} request</div><div class="receipt">${esc(r.receipt_id||'')}</div></div>
+ <div class="rows">
+  <div class="row"><div class="label">Original context</div><div class="value big">${fmt(r.original_context_tokens)} tokens</div></div>
+  <div class="row"><div class="label">Entroly context</div><div class="value big blue">${fmt(r.entroly_context_tokens)} tokens</div></div>
+  <div class="row sep"><div class="label">Tokens avoided</div><div class="value big good">${fmt(r.tokens_avoided)}</div></div>
+  <div class="row sep"><div class="label">Evidence retained <span class="muted">(${esc(r.evidence_retained_source||'unavailable')})</span></div><div class="value">${evidence}</div></div>
+  <div class="row"><div class="label">Recoverable</div><div class="value ${r.recoverable?'good':'muted'}">${yn(r.recoverable)}</div></div>
+  <div class="row"><div class="label">Warm prefix protected</div><div class="value">${fmt(r.warm_prefix_protected_tokens)} tokens</div></div>
+  <div class="row"><div class="label">Cache hit</div><div class="value ${r.cache_hit===true?'good':'muted'}">${hit(r.cache_hit)}</div></div>
+  <div class="row sep"><div class="label">Requested model</div><div class="value">${esc(r.requested_model||'—')}</div></div>
+  <div class="row"><div class="label">Executed model</div><div class="value">${esc(r.executed_model||'—')}</div></div>
+  <div class="row"><div class="label">Routing decision</div><div class="value ${decision==='STAY'?'good':'blue'}">${esc(decision)}</div></div>
+  <div class="row"><div class="label">Reason</div><div class="value reason">${esc(r.routing_reason||'—')}</div></div>
+  <div class="row sep"><div class="label">Input cost</div><div class="value">${usd(r.input_cost_micro_usd)}</div></div>
+  <div class="row"><div class="label">Cache benefit</div><div class="value good">${usd(r.cache_benefit_micro_usd)}</div></div>
+  <div class="row"><div class="label">Net measured saving</div><div class="value">${usd(r.net_measured_saving_micro_usd)}</div></div>
+  <div class="row sep"><div class="label">Context risk</div><div class="value ${r.context_risk==='LOW'?'good':r.context_risk==='HIGH'?'bad':'warn'}">${esc(r.context_risk||'UNKNOWN')}</div></div>
+  <div class="row"><div class="label">Verification</div><div class="value ${cls(verify,'PASS')}">${esc(verify)}</div></div>
+  <div class="row"><div class="label">Traffic Receipt</div><div class="value good">✓ VERIFIED</div></div>
+ </div>
+ <div class="foot"><span>${esc(r.provider||'unknown')} · ${r.streaming?'streaming':'buffered'} · ${Number(r.latency_ms||0).toFixed(1)} ms</span><span>digest ${esc((r.receipt_digest||'').slice(0,16))}…</span></div>`;
+ document.getElementById('status').textContent='live · '+new Date((r.observed_at||0)*1000).toLocaleTimeString();
+}
+function esc(v){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));}
+async function refresh(){try{const x=await fetch('/traffic-receipts?limit=1',{cache:'no-store'});if(!x.ok)throw Error(x.status);const d=await x.json();render(d.latest);}catch(e){document.getElementById('status').textContent='receipt API unavailable';}}
+refresh();setInterval(refresh,2000);
+</script></body></html>"""
+
+
+async def _traffic_receipts_endpoint(request: Request) -> Response:
+    proxy = request.app.state.proxy
+    raw_limit = request.query_params.get("limit", "20")
+    try:
+        limit = max(1, min(int(raw_limit), _MAX_RECORDS_LIMIT))
+    except (TypeError, ValueError, OverflowError):
+        limit = 20
+    return JSONResponse(
+        _ledger_for_proxy(proxy).snapshot(limit=limit),
+        headers={
+            "Cache-Control": "no-store, max-age=0",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+async def _traffic_page_endpoint(_request: Request) -> Response:
+    return Response(
+        _TRAFFIC_HTML,
+        media_type="text/html",
+        headers={
+            "Cache-Control": "no-store, max-age=0",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "no-referrer",
+            "Content-Security-Policy": (
+                "default-src 'none'; style-src 'unsafe-inline'; "
+                "script-src 'unsafe-inline'; connect-src 'self'; "
+                "img-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+            ),
+        },
+    )
+
+
+def _install_route(app: Any) -> None:
+    routes = getattr(getattr(app, "router", None), "routes", None)
+    if not isinstance(routes, list):
+        return
+    existing = {getattr(route, "path", None) for route in routes}
+    page = _proxy._sidecar_guard(_traffic_page_endpoint)
+    api = _proxy._sidecar_guard(_traffic_receipts_endpoint)
+    if "/traffic" not in existing:
+        routes.insert(
+            0,
+            Route("/traffic", endpoint=page, methods=["GET"], name="traffic-receipt-page"),
+        )
+    if "/traffic-receipts" not in existing:
+        routes.insert(
+            0,
+            Route(
+                "/traffic-receipts",
+                endpoint=api,
+                methods=["GET"],
+                name="traffic-receipts",
+            ),
+        )
+
+
+def install_traffic_receipts() -> None:
+    """Install request/forwarding observers without changing execution policy."""
+    global _ORIGINAL_FORWARD_RESPONSE, _ORIGINAL_STREAM_RESPONSE
+
+    current_core = _transport._ORIGINAL_HANDLE_PROXY
+    if not hasattr(current_core, "__entroly_traffic_receipt_original__"):
+        original_core = current_core
+
+        async def traffic_core_handle(self: Any, request: Request) -> Response:
+            return await _run_traffic_handle_proxy(self, request, original_core)
+
+        traffic_core_handle.__entroly_traffic_receipt_original__ = original_core
+        _transport._ORIGINAL_HANDLE_PROXY = traffic_core_handle
+
+    current_forward = _proxy.PromptCompilerProxy._forward_response
+    if not hasattr(current_forward, "__entroly_traffic_receipt_original__"):
+        _ORIGINAL_FORWARD_RESPONSE = current_forward
+        _traffic_forward_response.__entroly_traffic_receipt_original__ = current_forward
+        _proxy.PromptCompilerProxy._forward_response = _traffic_forward_response
+
+    current_stream = _proxy.PromptCompilerProxy._stream_response
+    if not hasattr(current_stream, "__entroly_traffic_receipt_original__"):
+        _ORIGINAL_STREAM_RESPONSE = current_stream
+        _traffic_stream_response.__entroly_traffic_receipt_original__ = current_stream
+        _proxy.PromptCompilerProxy._stream_response = _traffic_stream_response
+
+
+_ORIGINAL_FORWARD_RESPONSE: Callable[..., Awaitable[Response]] = (
+    _proxy.PromptCompilerProxy._forward_response
+)
+_ORIGINAL_STREAM_RESPONSE: Callable[..., Awaitable[Response]] = (
+    _proxy.PromptCompilerProxy._stream_response
+)
+
+install_traffic_receipts()
+
+
+__all__ = [
+    "TrafficReceipt",
+    "TrafficReceiptLedger",
+    "_classify_client",
+    "_install_route",
+    "install_traffic_receipts",
+]

--- a/entroly/proxy_traffic_receipt_final.py
+++ b/entroly/proxy_traffic_receipt_final.py
@@ -1,0 +1,139 @@
+"""Final correctness guard for live Traffic Receipts.
+
+Traffic Receipts are buyer-visible evidence, so attribution must fail closed.
+This module is intentionally narrow and installs after ``proxy_traffic_receipt``:
+
+* establishes one request id at admission when the client did not provide one,
+  so the receipt and provider usage ledger correlate on the same id;
+* keeps recursive exact-recovery attempts from finalizing the outer receipt;
+* withholds shared proxy coverage state until a request-local coverage source is
+  wired, preventing concurrent requests from borrowing each other's evidence;
+* tightens the UI wording so SHA-256 payload integrity is not presented as a
+  cryptographic signature and recovery evidence is not mislabeled as recovery
+  availability.
+
+It does not change routing, compression, retry, provider, or recovery policy.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Awaitable, Callable
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+from . import proxy as _proxy
+from . import proxy_traffic_receipt as _receipt
+
+
+def _ensure_request_id(request: Request) -> str:
+    """Ensure downstream proxy and receipt code observe the same request id."""
+    scope = request.scope
+    raw_headers = list(scope.get("headers") or [])
+    for key, value in raw_headers:
+        if bytes(key).lower() == b"x-request-id":
+            try:
+                return bytes(value).decode("latin-1")
+            except Exception:
+                return ""
+
+    request_id = uuid.uuid4().hex[:16]
+    raw_headers.append((b"x-request-id", request_id.encode("ascii")))
+    scope["headers"] = raw_headers
+    # Starlette caches Headers on first access. Invalidate only that derived
+    # view; body admission/cache state is untouched.
+    if hasattr(request, "_headers"):
+        try:
+            delattr(request, "_headers")
+        except Exception:
+            pass
+    return request_id
+
+
+def _nested_recovery_depth(args: tuple[Any, ...], kwargs: dict[str, Any]) -> int:
+    """Extract PromptCompilerProxy._forward_response recovery_depth safely."""
+    raw = kwargs.get("recovery_depth")
+    if raw is None and len(args) >= 6:
+        # Positional fields after body are:
+        # selected_frag_ids, witness_context, provider, recoverable_fragments,
+        # request_id, recovery_depth, ...
+        raw = args[5]
+    try:
+        return max(0, int(raw or 0))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _request_local_coverage_unavailable(_proxy_instance: Any) -> tuple[None, str, str]:
+    """Do not publish shared mutable coverage as per-request evidence."""
+    return None, "withheld_shared_state", "UNKNOWN"
+
+
+def _tighten_receipt_html() -> None:
+    html = _receipt._TRAFFIC_HTML
+    html = html.replace(
+        '<div class="label">Recoverable</div>',
+        '<div class="label">Recovery evidence</div>',
+    )
+    html = html.replace(
+        '<div class="label">Traffic Receipt</div><div class="value good">✓ VERIFIED</div>',
+        '<div class="label">Receipt integrity</div><div class="value good">✓ SHA-256 OK</div>',
+    )
+    _receipt._TRAFFIC_HTML = html
+
+
+def install_receipt_final_guard() -> None:
+    """Install attribution/correlation guards exactly once."""
+    current_run = _receipt._run_traffic_handle_proxy
+    if not hasattr(current_run, "__entroly_receipt_final_original__"):
+        original_run = current_run
+
+        async def run_with_request_id(
+            proxy: Any,
+            request: Request,
+            original: Callable[[Any, Request], Awaitable[Response]],
+        ) -> Response:
+            _ensure_request_id(request)
+            return await original_run(proxy, request, original)
+
+        run_with_request_id.__entroly_receipt_final_original__ = original_run
+        _receipt._run_traffic_handle_proxy = run_with_request_id
+
+    current_forward = _proxy.PromptCompilerProxy._forward_response
+    if not hasattr(current_forward, "__entroly_receipt_final_original__"):
+        receipt_forward = current_forward
+        core_forward = _receipt._ORIGINAL_FORWARD_RESPONSE
+
+        async def depth_safe_forward(
+            self: Any,
+            url: str,
+            headers: dict[str, str],
+            body: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> Response:
+            if _nested_recovery_depth(args, kwargs) > 0:
+                # Nested exact-recovery attempts contribute to the final outer
+                # response but must never own/finalize the request receipt.
+                return await core_forward(self, url, headers, body, *args, **kwargs)
+            return await receipt_forward(self, url, headers, body, *args, **kwargs)
+
+        depth_safe_forward.__entroly_receipt_final_original__ = receipt_forward
+        _proxy.PromptCompilerProxy._forward_response = depth_safe_forward
+
+    # The current proxy exposes coverage through shared mutable last-* fields.
+    # Until the optimizer supplies a ContextVar/request-local value, publishing
+    # that as request evidence is worse than showing it as unavailable.
+    _receipt._coverage_snapshot = _request_local_coverage_unavailable
+    _tighten_receipt_html()
+
+
+install_receipt_final_guard()
+
+
+__all__ = [
+    "_ensure_request_id",
+    "_nested_recovery_depth",
+    "install_receipt_final_guard",
+]

--- a/entroly/proxy_traffic_session.py
+++ b/entroly/proxy_traffic_session.py
@@ -1,61 +1,20 @@
-"""Immediate in-process Traffic Value for fresh Entroly users.
+"""Compatibility seams for process-local AI Traffic Value.
 
-The durable executive dashboard already keeps Today / 7D / 30D / 60D / 90D
-and All Time rollups in ``ValueTracker``. This module adds a deliberately
-non-durable **This session** view on top of the same Traffic Receipt stream so a
-user can see value after a few requests instead of waiting for a longer window.
-
-No second savings ledger or database is introduced. The session accumulator is
-bounded, content-blind, process-local, and resets when the proxy process
-restarts. Durable accounting remains owned by :mod:`entroly.proxy_traffic_value`.
+``This session`` is now implemented natively by :mod:`entroly.proxy_traffic_value`.
+This module intentionally performs no monkey patching. It remains as a small
+compatibility surface for integrations/tests that imported the earlier session
+module while all accounting and snapshot ownership stays in one place.
 """
 
 from __future__ import annotations
 
-import threading
-import time
-from collections import deque
 from typing import Any
 
 from . import proxy_traffic_value as _value
 
-_MAX_SESSION_SEEN = 2048
-_SESSION_LOCK = threading.RLock()
-_SESSION_STARTED_AT = time.time()
-_SESSION_METRICS: dict[str, Any] = _value._empty_metrics()
-_SESSION_SEEN: deque[str] = deque()
-_SESSION_SEEN_SET: set[str] = set()
-
-_ORIGINAL_RECORD = _value.record_traffic_value_receipt
-_ORIGINAL_SNAPSHOT = _value.build_traffic_value_snapshot
-
-
-def _remember_receipt(receipt_id: str) -> bool:
-    """Return True only once per bounded in-process receipt id."""
-    if not receipt_id:
-        return False
-    with _SESSION_LOCK:
-        if receipt_id in _SESSION_SEEN_SET:
-            return False
-        if len(_SESSION_SEEN) >= _MAX_SESSION_SEEN:
-            old = _SESSION_SEEN.popleft()
-            _SESSION_SEEN_SET.discard(old)
-        _SESSION_SEEN.append(receipt_id)
-        _SESSION_SEEN_SET.add(receipt_id)
-        return True
-
 
 def _record_session_receipt(receipt: Any) -> bool:
-    """Accumulate one verified Traffic Receipt into this process session."""
-    if not getattr(receipt, "verify", lambda: False)():
-        return False
-    receipt_id = str(getattr(receipt, "receipt_id", "") or "")
-    if not _remember_receipt(receipt_id):
-        return False
-    delta = _value._receipt_delta(receipt)
-    with _SESSION_LOCK:
-        _value._accumulate(_SESSION_METRICS, delta)
-    return True
+    return _value._record_session_receipt(receipt)
 
 
 def _record_with_session(
@@ -63,29 +22,11 @@ def _record_with_session(
     *,
     tracker: Any | None = None,
 ) -> bool:
-    # Session value should remain useful even if durable telemetry is temporarily
-    # unavailable. Idempotency is enforced independently by the bounded receipt
-    # id set above; durable idempotency remains owned by ValueTracker.
-    _record_session_receipt(receipt)
-    return _ORIGINAL_RECORD(receipt, tracker=tracker)
+    return _value.record_traffic_value_receipt(receipt, tracker=tracker)
 
 
 def _session_rollup(*, now: float | None = None) -> dict[str, Any]:
-    now_ts = time.time() if now is None else float(now)
-    with _SESSION_LOCK:
-        result: dict[str, Any] = {
-            "key": "session",
-            "label": "This session",
-            **_value._empty_metrics(),
-        }
-        _value._accumulate(result, _SESSION_METRICS)
-    result["session_started_at"] = _SESSION_STARTED_AT
-    result["session_elapsed_seconds"] = max(0, int(now_ts - _SESSION_STARTED_AT))
-    result["window_start"] = time.strftime(
-        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(_SESSION_STARTED_AT)
-    )
-    result["window_end"] = "now"
-    return _value._finalize_metrics(result)
+    return _value._session_rollup(now=now)
 
 
 def _snapshot_with_session(
@@ -94,54 +35,23 @@ def _snapshot_with_session(
     today: Any | None = None,
     now: float | None = None,
 ) -> dict[str, Any]:
-    snapshot = _ORIGINAL_SNAPSHOT(tracker, today=today, now=now)
-    session = _session_rollup(now=now)
-
-    windows = dict(snapshot.get("windows", {}))
-    windows["session"] = session
-    snapshot["windows"] = windows
-
-    order = [str(key) for key in snapshot.get("window_order", [])]
-    snapshot["window_order"] = ["session", *[key for key in order if key != "session"]]
-    snapshot["session_started_at"] = _SESSION_STARTED_AT
-    snapshot["session_elapsed_seconds"] = session["session_elapsed_seconds"]
-
-    # Immediate proof matters most during the first day. After that, retain the
-    # age-adaptive durable default while keeping This session one click away.
-    if session["requests_observed"] > 0 and int(snapshot.get("installed_days", 0) or 0) == 0:
-        snapshot["default_window"] = "session"
-
-    truth = dict(snapshot.get("truth", {}))
-    truth["session"] = (
-        "This session is an in-process rollup of verified Traffic Receipts. "
-        "It resets on proxy restart and is not added again to All Time."
-    )
-    snapshot["truth"] = truth
-    return snapshot
+    return _value.build_traffic_value_snapshot(tracker, today=today, now=now)
 
 
 def _reset_session_state_for_tests(*, started_at: float | None = None) -> None:
-    global _SESSION_STARTED_AT, _SESSION_METRICS
-    with _SESSION_LOCK:
-        _SESSION_STARTED_AT = time.time() if started_at is None else float(started_at)
-        _SESSION_METRICS = _value._empty_metrics()
-        _SESSION_SEEN.clear()
-        _SESSION_SEEN_SET.clear()
+    _value._reset_session_state_for_tests(started_at=started_at)
 
 
 def install_session_value() -> None:
-    """Patch the existing value module's public seams exactly once."""
-    if _value.record_traffic_value_receipt is not _record_with_session:
-        _value.record_traffic_value_receipt = _record_with_session
-    if _value.build_traffic_value_snapshot is not _snapshot_with_session:
-        _value.build_traffic_value_snapshot = _snapshot_with_session
-
-
-install_session_value()
+    """Compatibility no-op: session value is already native in the value module."""
+    return None
 
 
 __all__ = [
+    "_record_session_receipt",
+    "_record_with_session",
     "_reset_session_state_for_tests",
     "_session_rollup",
+    "_snapshot_with_session",
     "install_session_value",
 ]

--- a/entroly/proxy_traffic_session.py
+++ b/entroly/proxy_traffic_session.py
@@ -1,0 +1,147 @@
+"""Immediate in-process Traffic Value for fresh Entroly users.
+
+The durable executive dashboard already keeps Today / 7D / 30D / 60D / 90D
+and All Time rollups in ``ValueTracker``. This module adds a deliberately
+non-durable **This session** view on top of the same Traffic Receipt stream so a
+user can see value after a few requests instead of waiting for a longer window.
+
+No second savings ledger or database is introduced. The session accumulator is
+bounded, content-blind, process-local, and resets when the proxy process
+restarts. Durable accounting remains owned by :mod:`entroly.proxy_traffic_value`.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from typing import Any
+
+from . import proxy_traffic_value as _value
+
+_MAX_SESSION_SEEN = 2048
+_SESSION_LOCK = threading.RLock()
+_SESSION_STARTED_AT = time.time()
+_SESSION_METRICS: dict[str, Any] = _value._empty_metrics()
+_SESSION_SEEN: deque[str] = deque()
+_SESSION_SEEN_SET: set[str] = set()
+
+_ORIGINAL_RECORD = _value.record_traffic_value_receipt
+_ORIGINAL_SNAPSHOT = _value.build_traffic_value_snapshot
+
+
+def _remember_receipt(receipt_id: str) -> bool:
+    """Return True only once per bounded in-process receipt id."""
+    if not receipt_id:
+        return False
+    with _SESSION_LOCK:
+        if receipt_id in _SESSION_SEEN_SET:
+            return False
+        if len(_SESSION_SEEN) >= _MAX_SESSION_SEEN:
+            old = _SESSION_SEEN.popleft()
+            _SESSION_SEEN_SET.discard(old)
+        _SESSION_SEEN.append(receipt_id)
+        _SESSION_SEEN_SET.add(receipt_id)
+        return True
+
+
+def _record_session_receipt(receipt: Any) -> bool:
+    """Accumulate one verified Traffic Receipt into this process session."""
+    if not getattr(receipt, "verify", lambda: False)():
+        return False
+    receipt_id = str(getattr(receipt, "receipt_id", "") or "")
+    if not _remember_receipt(receipt_id):
+        return False
+    delta = _value._receipt_delta(receipt)
+    with _SESSION_LOCK:
+        _value._accumulate(_SESSION_METRICS, delta)
+    return True
+
+
+def _record_with_session(
+    receipt: Any,
+    *,
+    tracker: Any | None = None,
+) -> bool:
+    # Session value should remain useful even if durable telemetry is temporarily
+    # unavailable. Idempotency is enforced independently by the bounded receipt
+    # id set above; durable idempotency remains owned by ValueTracker.
+    _record_session_receipt(receipt)
+    return _ORIGINAL_RECORD(receipt, tracker=tracker)
+
+
+def _session_rollup(*, now: float | None = None) -> dict[str, Any]:
+    now_ts = time.time() if now is None else float(now)
+    with _SESSION_LOCK:
+        result: dict[str, Any] = {
+            "key": "session",
+            "label": "This session",
+            **_value._empty_metrics(),
+        }
+        _value._accumulate(result, _SESSION_METRICS)
+    result["session_started_at"] = _SESSION_STARTED_AT
+    result["session_elapsed_seconds"] = max(0, int(now_ts - _SESSION_STARTED_AT))
+    result["window_start"] = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(_SESSION_STARTED_AT)
+    )
+    result["window_end"] = "now"
+    return _value._finalize_metrics(result)
+
+
+def _snapshot_with_session(
+    tracker: Any | None = None,
+    *,
+    today: Any | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    snapshot = _ORIGINAL_SNAPSHOT(tracker, today=today, now=now)
+    session = _session_rollup(now=now)
+
+    windows = dict(snapshot.get("windows", {}))
+    windows["session"] = session
+    snapshot["windows"] = windows
+
+    order = [str(key) for key in snapshot.get("window_order", [])]
+    snapshot["window_order"] = ["session", *[key for key in order if key != "session"]]
+    snapshot["session_started_at"] = _SESSION_STARTED_AT
+    snapshot["session_elapsed_seconds"] = session["session_elapsed_seconds"]
+
+    # Immediate proof matters most during the first day. After that, retain the
+    # age-adaptive durable default while keeping This session one click away.
+    if session["requests_observed"] > 0 and int(snapshot.get("installed_days", 0) or 0) == 0:
+        snapshot["default_window"] = "session"
+
+    truth = dict(snapshot.get("truth", {}))
+    truth["session"] = (
+        "This session is an in-process rollup of verified Traffic Receipts. "
+        "It resets on proxy restart and is not added again to All Time."
+    )
+    snapshot["truth"] = truth
+    return snapshot
+
+
+def _reset_session_state_for_tests(*, started_at: float | None = None) -> None:
+    global _SESSION_STARTED_AT, _SESSION_METRICS
+    with _SESSION_LOCK:
+        _SESSION_STARTED_AT = time.time() if started_at is None else float(started_at)
+        _SESSION_METRICS = _value._empty_metrics()
+        _SESSION_SEEN.clear()
+        _SESSION_SEEN_SET.clear()
+
+
+def install_session_value() -> None:
+    """Patch the existing value module's public seams exactly once."""
+    if _value.record_traffic_value_receipt is not _record_with_session:
+        _value.record_traffic_value_receipt = _record_with_session
+    if _value.build_traffic_value_snapshot is not _snapshot_with_session:
+        _value.build_traffic_value_snapshot = _snapshot_with_session
+
+
+install_session_value()
+
+
+__all__ = [
+    "_reset_session_state_for_tests",
+    "_session_rollup",
+    "install_session_value",
+]

--- a/entroly/proxy_traffic_value.py
+++ b/entroly/proxy_traffic_value.py
@@ -1,0 +1,298 @@
+"""Rolling executive value dashboard for Entroly AI traffic.
+
+This module exposes durable, evidence-classified value accumulated by the
+existing :mod:`entroly.value_tracker`. It deliberately does not create a second
+accounting system. Provider-bound token reductions are shown with modeled input
+value using Entroly's auditable pricing provenance; local-only reductions remain
+token-only.
+
+The dashboard uses rolling windows (today, 7d, 30d, 60d, 90d) plus lifetime so
+value compounds visibly without resetting at arbitrary calendar boundaries.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import time
+from typing import Any, Mapping
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from . import proxy as _proxy
+from .value_tracker import get_tracker, pricing_provenance
+
+_SCHEMA_VERSION = "entroly.traffic-value.v1"
+
+
+def _nonnegative_int(value: object) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _nonnegative_float(value: object) -> float:
+    try:
+        parsed = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    if parsed < 0.0 or parsed != parsed or parsed in {float("inf"), float("-inf")}:
+        return 0.0
+    return parsed
+
+
+def _empty_rollup(*, key: str, label: str) -> dict[str, Any]:
+    return {
+        "key": key,
+        "label": label,
+        "provider_tokens_avoided": 0,
+        "estimated_input_value_avoided_usd": 0.0,
+        "provider_requests_observed": 0,
+        "provider_requests_optimized": 0,
+        "provider_unpriced_tokens": 0,
+        "provider_unpriced_requests": 0,
+        "local_tokens_reduced": 0,
+        "local_operations": 0,
+    }
+
+
+def _accumulate(target: dict[str, Any], row: Mapping[str, Any]) -> None:
+    target["provider_tokens_avoided"] += _nonnegative_int(
+        row.get("provider_tokens_saved")
+    )
+    target["estimated_input_value_avoided_usd"] = round(
+        float(target["estimated_input_value_avoided_usd"])
+        + _nonnegative_float(row.get("provider_cost_avoided_usd")),
+        6,
+    )
+    target["provider_requests_observed"] += _nonnegative_int(
+        row.get("provider_requests")
+    )
+    target["provider_requests_optimized"] += _nonnegative_int(
+        row.get("provider_requests_optimized")
+    )
+    target["provider_unpriced_tokens"] += _nonnegative_int(
+        row.get("provider_unpriced_tokens")
+    )
+    target["provider_unpriced_requests"] += _nonnegative_int(
+        row.get("provider_unpriced_requests")
+    )
+    target["local_tokens_reduced"] += _nonnegative_int(
+        row.get("local_tokens_reduced")
+    )
+    target["local_operations"] += _nonnegative_int(row.get("local_operations"))
+
+
+def _rolling_window(
+    rows: list[Mapping[str, Any]],
+    *,
+    days: int,
+    key: str,
+    label: str,
+    today: _dt.date,
+) -> dict[str, Any]:
+    result = _empty_rollup(key=key, label=label)
+    cutoff = today - _dt.timedelta(days=max(1, days) - 1)
+    for row in rows:
+        try:
+            day = _dt.date.fromisoformat(str(row.get("date") or ""))
+        except (TypeError, ValueError):
+            continue
+        if cutoff <= day <= today:
+            _accumulate(result, row)
+    result["window_start"] = cutoff.isoformat()
+    result["window_end"] = today.isoformat()
+    return result
+
+
+def _lifetime_rollup(lifetime: Mapping[str, Any]) -> dict[str, Any]:
+    result = _empty_rollup(key="lifetime", label="All time")
+    result.update(
+        {
+            "provider_tokens_avoided": _nonnegative_int(
+                lifetime.get("provider_tokens_saved")
+            ),
+            "estimated_input_value_avoided_usd": round(
+                _nonnegative_float(lifetime.get("provider_cost_avoided_usd")), 6
+            ),
+            "provider_requests_observed": _nonnegative_int(
+                lifetime.get("provider_requests")
+            ),
+            "provider_requests_optimized": _nonnegative_int(
+                lifetime.get("provider_requests_optimized")
+            ),
+            "provider_unpriced_tokens": _nonnegative_int(
+                lifetime.get("provider_unpriced_tokens")
+            ),
+            "provider_unpriced_requests": _nonnegative_int(
+                lifetime.get("provider_unpriced_requests")
+            ),
+            "local_tokens_reduced": _nonnegative_int(
+                lifetime.get("local_tokens_reduced")
+            ),
+            "local_operations": _nonnegative_int(
+                lifetime.get("local_operations")
+            ),
+        }
+    )
+    return result
+
+
+def build_traffic_value_snapshot(
+    tracker: Any | None = None,
+    *,
+    today: _dt.date | None = None,
+) -> dict[str, Any]:
+    """Build rolling provider-value windows from the durable ValueTracker.
+
+    ``estimated_input_value_avoided_usd`` is intentionally evidence-labelled:
+    it is observed provider-bound token reduction multiplied by the configured
+    input rate, not an invoice claim. Local SDK/MCP/npm reductions never enter
+    that dollar number.
+    """
+
+    value_tracker = tracker or get_tracker()
+    try:
+        value_tracker.reload_if_changed()
+    except Exception:
+        pass
+    current_day = today or _dt.datetime.now(_dt.timezone.utc).date()
+    daily = list(value_tracker.get_daily(90))
+    lifetime = value_tracker.get_lifetime()
+    windows = [
+        _rolling_window(daily, days=1, key="today", label="Today", today=current_day),
+        _rolling_window(daily, days=7, key="7d", label="7 days", today=current_day),
+        _rolling_window(daily, days=30, key="30d", label="30 days", today=current_day),
+        _rolling_window(daily, days=60, key="60d", label="60 days", today=current_day),
+        _rolling_window(daily, days=90, key="90d", label="90 days", today=current_day),
+        _lifetime_rollup(lifetime),
+    ]
+    pricing = pricing_provenance()
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "generated_at_unix": round(time.time(), 3),
+        "default_window": "lifetime",
+        "windows": {window["key"]: window for window in windows},
+        "window_order": [window["key"] for window in windows],
+        "pricing": pricing,
+        "truth": {
+            "provider_tokens": (
+                "Observed provider-bound token reduction recorded by Entroly."
+            ),
+            "estimated_usd": (
+                "Observed provider-bound token reduction multiplied by the "
+                "configured model input rate. This is modeled value avoided, "
+                "not a provider invoice or counterfactual billing measurement."
+            ),
+            "local_tokens": (
+                "Local SDK/MCP/npm token reductions are shown separately and "
+                "never converted to dollars without provider-bound evidence."
+            ),
+            "lifetime": (
+                "Lifetime counters persist across proxy restarts and keep "
+                "accumulating until the user deletes or resets local telemetry."
+            ),
+        },
+    }
+
+
+_TRAFFIC_VALUE_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Entroly AI Traffic Value</title>
+<style>
+:root{color-scheme:dark;--bg:#07090d;--card:#0d1118;--line:#202938;--text:#edf2f7;--dim:#8b98aa;--good:#5ee6a8;--blue:#79b8ff;--warn:#ffd166}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 50% -20%,#172036 0,transparent 42%),var(--bg);font:14px/1.45 Inter,ui-sans-serif,system-ui;color:var(--text)}
+main{max-width:980px;margin:0 auto;padding:32px 20px 64px}.eyebrow{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--good);font-weight:800}.title{font-size:30px;font-weight:850;letter-spacing:-.035em;margin-top:4px}.sub{color:var(--dim);margin-top:4px}
+.tabs{display:flex;gap:8px;flex-wrap:wrap;margin:22px 0 16px}.tab{border:1px solid var(--line);background:#0b1018;color:var(--dim);padding:8px 12px;border-radius:999px;cursor:pointer;font:700 12px Inter,system-ui}.tab.active{color:var(--text);border-color:#3b506d;background:#152033}
+.hero{background:linear-gradient(180deg,rgba(18,24,34,.97),rgba(11,15,22,.97));border:1px solid var(--line);border-radius:20px;padding:24px;box-shadow:0 24px 80px rgba(0,0,0,.35)}.period{font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.12em;font-weight:800}.money{font-size:52px;font-weight:900;letter-spacing:-.055em;margin-top:8px;color:var(--good)}.moneylabel{font-size:13px;color:var(--dim)}
+.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:20px}.metric{border:1px solid var(--line);border-radius:14px;padding:16px;background:rgba(8,12,18,.6)}.mval{font:800 22px ui-monospace,SFMono-Regular,Menlo,monospace}.mlabel{color:var(--dim);font-size:12px;margin-top:5px}.blue{color:var(--blue)}.good{color:var(--good)}.warn{color:var(--warn)}
+.note{margin-top:14px;padding:13px 15px;border:1px solid var(--line);border-radius:12px;color:var(--dim);font-size:12px}.note b{color:var(--text)}.meta{display:flex;justify-content:space-between;gap:18px;margin-top:14px;color:var(--dim);font-size:11px}
+@media(max-width:720px){.grid{grid-template-columns:1fr}.money{font-size:42px}.meta{flex-direction:column}}
+</style>
+</head>
+<body><main>
+<div class="eyebrow">AI Traffic Assurance</div><div class="title">Value that keeps adding up</div><div class="sub">Provider-bound token reduction and its evidence-labelled economic value.</div>
+<div class="tabs" id="tabs"></div>
+<div class="hero" id="hero"><div class="period">Loading…</div></div>
+<div class="note"><b>Truth policy:</b> the dollar hero is estimated input value avoided from observed provider-bound token reduction and configured model pricing. It is not presented as invoice-verified savings. Local-only token reduction is kept separate.</div>
+</main>
+<script>
+const fmt=n=>Number(n||0).toLocaleString();
+const usd=v=>'$'+Number(v||0).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
+const esc=v=>String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+let DATA=null,ACTIVE='lifetime';
+function render(){if(!DATA)return;const w=DATA.windows[ACTIVE]||DATA.windows.lifetime;const p=DATA.pricing||{};document.querySelectorAll('.tab').forEach(b=>b.classList.toggle('active',b.dataset.key===ACTIVE));document.getElementById('hero').innerHTML=`
+<div class="period">${esc(w.label)}</div><div class="money">${usd(w.estimated_input_value_avoided_usd)}</div><div class="moneylabel">estimated provider input value avoided</div>
+<div class="grid"><div class="metric"><div class="mval good">${fmt(w.provider_tokens_avoided)}</div><div class="mlabel">provider-bound tokens avoided</div></div><div class="metric"><div class="mval blue">${fmt(w.provider_requests_optimized)}</div><div class="mlabel">requests optimized</div></div><div class="metric"><div class="mval">${fmt(w.local_tokens_reduced)}</div><div class="mlabel">local-only tokens reduced · no $ claim</div></div></div>
+<div class="meta"><span>pricing ${esc(p.as_of||'unknown')} · ${esc(p.source||'unknown')}</span><span>${w.window_start?esc(w.window_start)+' → '+esc(w.window_end):'persistent lifetime total'}</span></div>`;}
+async function load(){try{const r=await fetch('/traffic-value.json',{cache:'no-store'});if(!r.ok)throw Error(r.status);DATA=await r.json();ACTIVE=DATA.default_window||'lifetime';const tabs=document.getElementById('tabs');tabs.innerHTML='';for(const key of DATA.window_order||[]){const b=document.createElement('button');b.className='tab';b.dataset.key=key;b.textContent=DATA.windows[key].label;b.onclick=()=>{ACTIVE=key;render()};tabs.appendChild(b)}render()}catch(e){document.getElementById('hero').innerHTML='<div class="period">Value API unavailable</div>';}}
+load();setInterval(load,10000);
+</script></body></html>"""
+
+
+async def _traffic_value_json(_request: Request) -> Response:
+    return JSONResponse(
+        build_traffic_value_snapshot(),
+        headers={
+            "Cache-Control": "no-store, max-age=0",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+async def _traffic_value_page(_request: Request) -> Response:
+    return Response(
+        _TRAFFIC_VALUE_HTML,
+        media_type="text/html",
+        headers={
+            "Cache-Control": "no-store, max-age=0",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "no-referrer",
+            "Content-Security-Policy": (
+                "default-src 'none'; style-src 'unsafe-inline'; "
+                "script-src 'unsafe-inline'; connect-src 'self'; "
+                "img-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+            ),
+        },
+    )
+
+
+def _install_route(app: Any) -> None:
+    routes = getattr(getattr(app, "router", None), "routes", None)
+    if not isinstance(routes, list):
+        return
+    existing = {getattr(route, "path", None) for route in routes}
+    page = _proxy._sidecar_guard(_traffic_value_page)
+    api = _proxy._sidecar_guard(_traffic_value_json)
+    if "/traffic-value" not in existing:
+        routes.insert(
+            0,
+            Route(
+                "/traffic-value",
+                endpoint=page,
+                methods=["GET"],
+                name="traffic-value-page",
+            ),
+        )
+    if "/traffic-value.json" not in existing:
+        routes.insert(
+            0,
+            Route(
+                "/traffic-value.json",
+                endpoint=api,
+                methods=["GET"],
+                name="traffic-value-json",
+            ),
+        )
+
+
+__all__ = [
+    "_TRAFFIC_VALUE_HTML",
+    "_install_route",
+    "build_traffic_value_snapshot",
+]

--- a/entroly/proxy_traffic_value.py
+++ b/entroly/proxy_traffic_value.py
@@ -1,27 +1,24 @@
 """Executive AI Traffic Value dashboard for Entroly.
 
-This module turns Traffic Receipts into durable executive rollups inside the
-existing ValueTracker file. It does not create a second accounting database.
+Traffic Receipts feed two views through one accounting path:
 
-The surface is deliberately evidence-classified:
-- token reduction and context reduction come from locally observed pre/post
-  request estimates;
-- estimated value avoided comes from observed avoided tokens and an explicit
-  model price in Entroly's pricing table;
-- cache benefit and provider input spend are shown only when the Traffic Receipt
-  has provider usage plus auditable pricing;
-- verification/recovery percentages are derived from request-level evidence;
-- lifetime totals keep accumulating across proxy restarts.
+* ``This session`` is an in-process, content-blind rollup for immediate proof.
+  It resets when the proxy process restarts.
+* Today / 7D / 30D / 60D / 90D / All Time are durable rollups stored in the
+  existing ValueTracker file.
 
-Rolling windows are Today / 7D / 30D / 60D / 90D. The selected default adapts
-to how long Traffic Value has actually been collecting data, while All Time is
-always visible beside the selected period.
+No second savings database is introduced. Dollar fields keep their evidence
+class visible: avoided-token value is modeled from Entroly's configured model
+price, while cache benefit and provider input spend require provider-observed
+usage carried by the Traffic Receipt.
 """
 
 from __future__ import annotations
 
 import datetime as _dt
+import threading
 import time
+from collections import deque
 from typing import Any, Mapping
 
 from starlette.requests import Request
@@ -37,10 +34,11 @@ from .value_tracker import (
     pricing_provenance,
 )
 
-_SCHEMA_VERSION = "entroly.traffic-value.v2"
+_SCHEMA_VERSION = "entroly.traffic-value.v3"
 _TRAFFIC_KEY = "traffic_assurance"
 _MAX_DAILY = 90
 _MAX_SEEN_RECEIPTS = 2048
+_MAX_SESSION_SEEN = 2048
 
 _COUNTER_FIELDS = (
     "requests_observed",
@@ -55,6 +53,8 @@ _COUNTER_FIELDS = (
     "warm_cache_protected_tokens",
     "cache_observed",
     "cache_hits",
+    "estimated_priced_requests",
+    "cache_benefit_priced_requests",
     "provider_priced_requests",
 )
 _MONEY_FIELDS = (
@@ -62,6 +62,12 @@ _MONEY_FIELDS = (
     "measured_cache_benefit_usd",
     "provider_input_spend_usd",
 )
+
+_SESSION_LOCK = threading.RLock()
+_SESSION_STARTED_AT = time.time()
+_SESSION_METRICS: dict[str, Any] = {}
+_SESSION_SEEN: deque[str] = deque()
+_SESSION_SEEN_SET: set[str] = set()
 
 
 def _nonnegative_int(value: object) -> int:
@@ -86,6 +92,10 @@ def _empty_metrics() -> dict[str, int | float]:
         **{field: 0 for field in _COUNTER_FIELDS},
         **{field: 0.0 for field in _MONEY_FIELDS},
     }
+
+
+# Initialize after _empty_metrics exists.
+_SESSION_METRICS = _empty_metrics()
 
 
 def _ensure_metrics(row: dict[str, Any]) -> dict[str, Any]:
@@ -150,27 +160,34 @@ def _receipt_day(receipt: Any) -> str:
     return _dt.datetime.fromtimestamp(ts, tz=_dt.timezone.utc).date().isoformat()
 
 
-def _estimated_value_for_receipt(receipt: Any) -> float:
-    model = str(getattr(receipt, "executed_model", "") or "")
-    tokens = _nonnegative_int(getattr(receipt, "tokens_avoided", 0))
-    if not tokens or not _has_priced_model(model):
-        return 0.0
-    return round(max(0.0, float(estimate_cost(tokens, model, kind="input"))), 6)
-
-
 def _receipt_delta(receipt: Any) -> dict[str, int | float]:
     original = _nonnegative_int(getattr(receipt, "original_context_tokens", 0))
     sent = _nonnegative_int(getattr(receipt, "entroly_context_tokens", 0))
     avoided = _nonnegative_int(getattr(receipt, "tokens_avoided", 0))
+    model = str(getattr(receipt, "executed_model", "") or "")
+    model_priced = bool(model and _has_priced_model(model))
     verification = str(getattr(receipt, "verification", "") or "").upper()
+
     recovery_receipts = _nonnegative_int(getattr(receipt, "recovery_receipts", 0))
     recovery_invoked = recovery_receipts > 0
-    # A recovery is counted successful only when the final surfaced response has
-    # explicit PASS evidence. This avoids equating "attempted" with "succeeded".
+    # Receipt v1 currently exposes recovery evidence, not a dedicated invocation
+    # event. Keep this conservative and require explicit final PASS for success.
     recovery_succeeded = recovery_invoked and verification == "PASS"
+
     cache_hit = getattr(receipt, "cache_hit", None)
     input_cost_micro = getattr(receipt, "input_cost_micro_usd", None)
     cache_benefit_micro = getattr(receipt, "cache_benefit_micro_usd", None)
+
+    estimated_value = 0.0
+    if avoided and model_priced:
+        try:
+            estimated_value = round(
+                max(0.0, float(estimate_cost(avoided, model, kind="input"))),
+                6,
+            )
+        except Exception:
+            model_priced = False
+            estimated_value = 0.0
 
     return {
         "requests_observed": 1,
@@ -178,19 +195,20 @@ def _receipt_delta(receipt: Any) -> dict[str, int | float]:
         "tokens_received": original,
         "tokens_sent": sent,
         "tokens_avoided": avoided,
-        "estimated_value_avoided_usd": _estimated_value_for_receipt(receipt),
+        "estimated_value_avoided_usd": estimated_value,
         "measured_cache_benefit_usd": (
             round(_nonnegative_int(cache_benefit_micro) / 1_000_000.0, 6)
             if cache_benefit_micro is not None
             else 0.0
         ),
-        # Current Traffic Receipt v1 prices provider input/cache categories only.
-        # The UI labels this precisely as provider input spend, not full invoice.
+        # Traffic Receipt v1 prices provider input/cache categories only.
         "provider_input_spend_usd": (
             round(_nonnegative_int(input_cost_micro) / 1_000_000.0, 6)
             if input_cost_micro is not None
             else 0.0
         ),
+        "estimated_priced_requests": int(model_priced),
+        "cache_benefit_priced_requests": int(cache_benefit_micro is not None),
         "provider_priced_requests": int(input_cost_micro is not None),
         "verified_requests": int(verification in {"PASS", "FAIL"}),
         "verification_passed": int(verification == "PASS"),
@@ -204,26 +222,110 @@ def _receipt_delta(receipt: Any) -> dict[str, int | float]:
     }
 
 
+def _record_session_receipt(receipt: Any) -> bool:
+    """Accumulate one verified receipt into the current proxy process session."""
+    if not getattr(receipt, "verify", lambda: False)():
+        return False
+    receipt_id = str(getattr(receipt, "receipt_id", "") or "")
+    if not receipt_id:
+        return False
+    delta = _receipt_delta(receipt)
+
+    with _SESSION_LOCK:
+        if receipt_id in _SESSION_SEEN_SET:
+            return False
+        if len(_SESSION_SEEN) >= _MAX_SESSION_SEEN:
+            old = _SESSION_SEEN.popleft()
+            _SESSION_SEEN_SET.discard(old)
+        _SESSION_SEEN.append(receipt_id)
+        _SESSION_SEEN_SET.add(receipt_id)
+        _accumulate(_SESSION_METRICS, delta)
+    return True
+
+
+def _session_status(row: Mapping[str, Any]) -> tuple[str, str]:
+    requests = _nonnegative_int(row.get("requests_observed"))
+    if requests == 0:
+        return (
+            "waiting",
+            "Send traffic through Entroly to see immediate value proof here.",
+        )
+    if (
+        _nonnegative_int(row.get("tokens_avoided")) > 0
+        or _nonnegative_int(row.get("warm_cache_protected_tokens")) > 0
+        or _nonnegative_float(row.get("measured_cache_benefit_usd")) > 0
+    ):
+        return (
+            "measurable",
+            "Entroly is creating measurable value in this session.",
+        )
+    return (
+        "no_measurable_value",
+        "Traffic is flowing; no measurable context reduction or cache benefit "
+        "in this session yet.",
+    )
+
+
+def _session_rollup(*, now: float | None = None) -> dict[str, Any]:
+    now_ts = time.time() if now is None else float(now)
+    with _SESSION_LOCK:
+        started_at = _SESSION_STARTED_AT
+        result: dict[str, Any] = {
+            "key": "session",
+            "label": "This session",
+            **_empty_metrics(),
+        }
+        _accumulate(result, _SESSION_METRICS)
+
+    result["session_started_at"] = started_at
+    result["session_elapsed_seconds"] = max(0, int(now_ts - started_at))
+    result["window_start"] = _dt.datetime.fromtimestamp(
+        started_at, tz=_dt.timezone.utc
+    ).isoformat().replace("+00:00", "Z")
+    result["window_end"] = "now"
+    result["durability"] = "process-local"
+    result["reset_event"] = "proxy process restart"
+    status, message = _session_status(result)
+    result["session_status"] = status
+    result["session_status_message"] = message
+    return _finalize_metrics(result)
+
+
+def _reset_session_state_for_tests(*, started_at: float | None = None) -> None:
+    """Reset process-local session state. Internal test seam only."""
+    global _SESSION_STARTED_AT, _SESSION_METRICS
+    with _SESSION_LOCK:
+        _SESSION_STARTED_AT = time.time() if started_at is None else float(started_at)
+        _SESSION_METRICS = _empty_metrics()
+        _SESSION_SEEN.clear()
+        _SESSION_SEEN_SET.clear()
+
+
 def record_traffic_value_receipt(
     receipt: Any,
     *,
     tracker: Any | None = None,
 ) -> bool:
-    """Persist one Traffic Receipt into the existing ValueTracker data file.
+    """Record one Traffic Receipt into session and durable executive rollups.
 
-    The bounded ``seen_receipts`` list makes recent retries/idempotent replays
-    harmless without retaining request content or an unbounded identifier set.
+    Session aggregation is deliberately independent of durable persistence so a
+    temporary telemetry-file problem does not erase immediate operator feedback.
+    The return value retains the historical contract: ``True`` means the durable
+    rollup accepted and persisted the receipt.
     """
-
     if not getattr(receipt, "verify", lambda: False)():
         return False
-    value_tracker = tracker or get_tracker()
+
     receipt_id = str(getattr(receipt, "receipt_id", "") or "")
     if not receipt_id:
         return False
+
+    value_tracker = tracker or get_tracker()
     day = _receipt_day(receipt)
     delta = _receipt_delta(receipt)
-    observed_at = _nonnegative_float(getattr(receipt, "observed_at", 0.0)) or time.time()
+    observed_at = (
+        _nonnegative_float(getattr(receipt, "observed_at", 0.0)) or time.time()
+    )
 
     try:
         with value_tracker._mutation():  # same process+file lock as ValueTracker
@@ -252,13 +354,18 @@ def record_traffic_value_receipt(
             _accumulate(lifetime, delta)
             _accumulate(day_row, delta)
 
-            # Keep exactly the rolling-history horizon needed by this view.
             for old_day in sorted(daily)[:-_MAX_DAILY]:
                 daily.pop(old_day, None)
 
             value_tracker._save()
+
+        # Only live receipts accepted by the durable idempotency gate enter the
+        # process session. If persistence itself is unavailable, the exception
+        # path below still preserves immediate process-local proof.
+        _record_session_receipt(receipt)
         return True
     except Exception as exc:
+        _record_session_receipt(receipt)
         _proxy.logger.debug("Traffic value persistence skipped: %s", exc, exc_info=True)
         return False
 
@@ -304,11 +411,6 @@ def _lifetime_rollup(state: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _default_window(age_days: int) -> str:
-    # Product rule:
-    # 3 days installed  -> 7D
-    # 45 days installed -> 30D
-    # 60-99 days        -> 60D
-    # 100+ days         -> 90D
     if age_days < 30:
         return "7d"
     if age_days < 60:
@@ -334,12 +436,15 @@ def build_traffic_value_snapshot(
     current_day = today or _dt.datetime.fromtimestamp(
         now_ts, tz=_dt.timezone.utc
     ).date()
+
     state = _traffic_state(value_tracker)
     daily = state.get("daily", {})
     if not isinstance(daily, Mapping):
         daily = {}
 
+    session = _session_rollup(now=now_ts)
     windows = [
+        session,
         _rolling_window(daily, days=1, key="today", label="Today", today=current_day),
         _rolling_window(daily, days=7, key="7d", label="7 days", today=current_day),
         _rolling_window(daily, days=30, key="30d", label="30 days", today=current_day),
@@ -349,25 +454,30 @@ def build_traffic_value_snapshot(
     ]
 
     started_at = _nonnegative_float(state.get("started_at"))
-    age_days = (
-        max(0, int((now_ts - started_at) // 86400))
-        if started_at
-        else 0
-    )
+    age_days = max(0, int((now_ts - started_at) // 86400)) if started_at else 0
     default_window = _default_window(age_days)
-    pricing = pricing_provenance()
+    if session["requests_observed"] > 0 and age_days == 0:
+        default_window = "session"
 
     return {
         "schema_version": _SCHEMA_VERSION,
         "generated_at_unix": round(now_ts, 3),
         "collection_started_at": started_at or None,
+        # Kept for backward API compatibility. This is days collecting Traffic Value.
         "installed_days": age_days,
         "default_window": default_window,
         "always_show_lifetime": True,
+        "session_started_at": session["session_started_at"],
+        "session_elapsed_seconds": session["session_elapsed_seconds"],
         "windows": {window["key"]: window for window in windows},
         "window_order": [window["key"] for window in windows],
-        "pricing": pricing,
+        "pricing": pricing_provenance(),
         "truth": {
+            "session": (
+                "This session is a process-local rollup of verified Traffic "
+                "Receipts. It resets on proxy restart and is not added again to "
+                "All Time."
+            ),
             "tokens_received_sent": (
                 "Local deterministic pre/post context estimates for provider-bound "
                 "requests observed by Traffic Receipts."
@@ -389,13 +499,13 @@ def build_traffic_value_snapshot(
                 "NOT_REPORTED and ERROR do not inflate the percentage."
             ),
             "recovery": (
-                "Recovery invoked requires recovery evidence; recovery succeeded "
-                "requires final explicit PASS verification."
+                "Recovery invoked currently follows receipt recovery evidence; "
+                "recovery succeeded additionally requires final explicit PASS "
+                "verification."
             ),
             "total_ai_value": (
                 "Estimated value on tokens not sent plus measured cache benefit on "
-                "tokens that were sent. These are displayed as separate evidence "
-                "classes and summed as Total AI value protected."
+                "tokens that were sent. The components keep separate evidence labels."
             ),
             "lifetime": (
                 "All Time persists in the existing ValueTracker file across proxy "
@@ -417,18 +527,19 @@ _TRAFFIC_VALUE_HTML = r"""<!doctype html>
 main{max-width:1080px;margin:0 auto;padding:32px 20px 64px}.eyebrow{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--good);font-weight:800}.title{font-size:32px;font-weight:900;letter-spacing:-.04em;margin-top:4px}.sub{color:var(--dim);margin-top:5px}
 .tabs{display:flex;gap:8px;flex-wrap:wrap;margin:22px 0 16px}.tab{border:1px solid var(--line);background:#0b1018;color:var(--dim);padding:8px 12px;border-radius:999px;cursor:pointer;font:750 12px Inter,system-ui}.tab.active{color:var(--text);border-color:#3b506d;background:#152033}
 .card{background:linear-gradient(180deg,rgba(18,24,34,.97),rgba(11,15,22,.97));border:1px solid var(--line);border-radius:20px;padding:24px;box-shadow:0 24px 80px rgba(0,0,0,.32)}.period{font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.12em;font-weight:850}
+.sessionstatus{display:flex;justify-content:space-between;gap:16px;margin-top:14px;padding:12px 14px;border:1px solid var(--line);border-radius:12px;background:rgba(8,12,18,.6)}.sessionstatus.measurable b{color:var(--good)}.sessionstatus.waiting b{color:var(--blue)}.sessionstatus.no_measurable_value b{color:var(--warn)}.sessionstatus span{color:var(--dim);font-size:12px}
 .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:16px}.metric{border:1px solid var(--line);border-radius:14px;padding:15px;background:rgba(8,12,18,.58)}.mval{font:800 21px ui-monospace,SFMono-Regular,Menlo,monospace}.mlabel{color:var(--dim);font-size:12px;margin-top:5px}
 .moneygrid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:16px}.moneybox{border:1px solid var(--line);border-radius:15px;padding:17px;background:rgba(8,12,18,.7)}.money{font-size:30px;font-weight:900;letter-spacing:-.04em}.moneylabel{color:var(--dim);font-size:12px;margin-top:4px}
 .alltime{margin-top:18px;border-color:#30435e}.alltitle{display:flex;justify-content:space-between;gap:20px;align-items:center}.badge{font-size:11px;color:var(--dim);border:1px solid var(--line);padding:5px 9px;border-radius:999px}
 .good{color:var(--good)}.blue{color:var(--blue)}.warn{color:var(--warn)}.bad{color:var(--bad)}.dim{color:var(--dim)}
 .note{margin-top:14px;padding:13px 15px;border:1px solid var(--line);border-radius:12px;color:var(--dim);font-size:12px}.note b{color:var(--text)}.meta{display:flex;justify-content:space-between;gap:18px;margin-top:14px;color:var(--dim);font-size:11px}
-@media(max-width:760px){.grid,.moneygrid{grid-template-columns:1fr}.alltitle,.meta{align-items:flex-start;flex-direction:column}}
+@media(max-width:760px){.grid,.moneygrid{grid-template-columns:1fr}.alltitle,.meta,.sessionstatus{align-items:flex-start;flex-direction:column}}
 </style>
 </head>
 <body><main>
 <div class="eyebrow">AI Traffic Assurance</div>
 <div class="title">AI Traffic Value</div>
-<div class="sub">The value Entroly has created and protected across your AI traffic.</div>
+<div class="sub">Immediate session proof, recent operating value, and durable All Time impact.</div>
 <div class="tabs" id="tabs"></div>
 <div class="card" id="period"><div class="period">Loading live value…</div></div>
 <div class="card alltime" id="lifetime"><div class="period">Loading All Time…</div></div>
@@ -439,44 +550,54 @@ const fmt=n=>Number(n||0).toLocaleString();
 const compact=n=>{n=Number(n||0);if(Math.abs(n)>=1e9)return(n/1e9).toFixed(n>=1e10?1:2).replace(/\.0+$/,'')+'B';if(Math.abs(n)>=1e6)return(n/1e6).toFixed(n>=1e7?1:2).replace(/\.0+$/,'')+'M';if(Math.abs(n)>=1e3)return(n/1e3).toFixed(n>=1e4?1:2).replace(/\.0+$/,'')+'K';return fmt(n)};
 const usd=v=>'$'+Number(v||0).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
 const pct=v=>v==null?'—':Number(v).toFixed(1)+'%';
+const duration=s=>{s=Math.max(0,Number(s||0));const h=Math.floor(s/3600),m=Math.floor((s%3600)/60);return h?`${h}h ${m}m`:`${m}m`};
 const esc=v=>String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 let DATA=null,ACTIVE=null,USER_SELECTED=false;
 function moneyBox(value,label,cls='good'){return `<div class="moneybox"><div class="money ${cls}">${usd(value)}</div><div class="moneylabel">${esc(label)}</div></div>`}
+function moneyMaybe(value,label,available,cls='good'){return `<div class="moneybox"><div class="money ${available?cls:'dim'}">${available?usd(value):'—'}</div><div class="moneylabel">${esc(label)}${available?'':' · not measured'}</div></div>`}
 function metric(value,label,cls=''){return `<div class="metric"><div class="mval ${cls}">${value}</div><div class="mlabel">${esc(label)}</div></div>`}
 function renderWindow(w){
- const measured=w.provider_priced_requests>0;
+ const estimateAvailable=w.estimated_priced_requests>0;
+ const cacheBenefitAvailable=w.cache_benefit_priced_requests>0;
+ const spendAvailable=w.provider_priced_requests>0;
+ const totalAvailable=(Number(w.tokens_avoided||0)===0||estimateAvailable)&&(Number(w.cache_hits||0)===0||cacheBenefitAvailable);
+ const sessionBanner=w.key==='session'?`<div class="sessionstatus ${esc(w.session_status)}"><b>${esc(w.session_status_message)}</b><span>Session duration ${duration(w.session_elapsed_seconds)} · resets on proxy restart</span></div>`:'';
  document.getElementById('period').innerHTML=`
  <div class="period">AI TRAFFIC VALUE — ${esc(w.label).toUpperCase()}</div>
+ ${sessionBanner}
  <div class="grid">
   ${metric(fmt(w.requests_optimized),'Requests optimized','blue')}
-  ${metric(compact(w.tokens_received)+' tokens','Tokens received')}
-  ${metric(compact(w.tokens_sent)+' tokens','Tokens sent')}
+  ${metric(compact(w.tokens_received)+' tokens','Tokens received by Entroly')}
+  ${metric(compact(w.tokens_sent)+' tokens','Tokens sent to provider')}
   ${metric(compact(w.tokens_avoided)+' tokens','Tokens avoided','good')}
   ${metric(pct(w.context_reduction_pct),'Context reduction','good')}
   ${metric(compact(w.warm_cache_protected_tokens)+' tokens','Warm cache protected','blue')}
  </div>
  <div class="moneygrid">
-  ${moneyBox(w.estimated_value_avoided_usd,'Estimated value avoided')}
-  ${moneyBox(w.measured_cache_benefit_usd,'Measured cache benefit',measured?'good':'dim')}
-  ${moneyBox(w.provider_input_spend_usd,'Provider input spend',measured?'':'dim')}
+  ${moneyMaybe(w.estimated_value_avoided_usd,'Estimated value avoided',estimateAvailable)}
+  ${moneyMaybe(w.measured_cache_benefit_usd,'Measured cache benefit',cacheBenefitAvailable)}
+  ${moneyMaybe(w.provider_input_spend_usd,'Provider input spend observed',spendAvailable,'')}
  </div>
  <div class="grid">
   ${metric(pct(w.requests_verified_pct),'Requests verified')}
-  ${metric(pct(w.recovery_invoked_pct),'Recovery invoked')}
-  ${metric(pct(w.recovery_succeeded_pct),'Recovery succeeded')}
+  ${metric(pct(w.recovery_invoked_pct),'Recovery evidence observed')}
+  ${metric(pct(w.recovery_succeeded_pct),'Recovery evidence + PASS')}
   ${metric(pct(w.verification_pass_pct),'Verification pass rate')}
   ${metric(pct(w.cache_hit_request_pct),'Cache-hit requests')}
-  ${metric(usd(w.total_ai_value_protected_usd),'Total AI value protected','good')}
+  ${metric(totalAvailable?usd(w.total_ai_value_protected_usd):'—','Total AI value protected',totalAvailable?'good':'dim')}
  </div>
- <div class="meta"><span>${w.window_start?esc(w.window_start)+' → '+esc(w.window_end):''}</span><span>${measured?'provider-priced traffic observed':'measured provider $ appears when usage + pricing exist'}</span></div>`;
+ <div class="meta"><span>${w.key==='session'?'Process-local session':(w.window_start?esc(w.window_start)+' → '+esc(w.window_end):'')}</span><span>${spendAvailable?'provider-priced input usage observed':'provider $ appears when usage + pricing exist'}</span></div>`;
 }
 function renderLifetime(w){
+ const estimateAvailable=w.estimated_priced_requests>0;
+ const cacheBenefitAvailable=w.cache_benefit_priced_requests>0;
+ const totalAvailable=(Number(w.tokens_avoided||0)===0||estimateAvailable)&&(Number(w.cache_hits||0)===0||cacheBenefitAvailable);
  document.getElementById('lifetime').innerHTML=`
  <div class="alltitle"><div><div class="period">ALL TIME</div><div class="dim">Keeps accumulating across proxy restarts.</div></div><div class="badge">${fmt(DATA.installed_days||0)} days collecting Traffic Value</div></div>
  <div class="moneygrid">
-  ${moneyBox(w.estimated_value_avoided_usd,'Estimated value avoided')}
-  ${moneyBox(w.measured_cache_benefit_usd,'Measured cache benefit','blue')}
-  ${moneyBox(w.total_ai_value_protected_usd,'Total AI value protected','good')}
+  ${moneyMaybe(w.estimated_value_avoided_usd,'Estimated value avoided',estimateAvailable)}
+  ${moneyMaybe(w.measured_cache_benefit_usd,'Measured cache benefit',cacheBenefitAvailable,'blue')}
+  ${moneyMaybe(w.total_ai_value_protected_usd,'Total AI value protected',totalAvailable)}
  </div>
  <div class="grid">
   ${metric(compact(w.tokens_avoided),'Tokens avoided')}
@@ -494,7 +615,7 @@ function render(){
 async function load(){
  try{
   const r=await fetch('/traffic-value.json',{cache:'no-store'});if(!r.ok)throw Error(r.status);
-  const next=await r.json();DATA=next;
+  DATA=await r.json();
   if(!USER_SELECTED)ACTIVE=DATA.default_window||'7d';
   const tabs=document.getElementById('tabs');tabs.innerHTML='';
   for(const key of DATA.window_order||[]){
@@ -568,7 +689,7 @@ def _install_route(app: Any) -> None:
 
 
 def _install_receipt_bridge() -> None:
-    """Persist every admitted Traffic Receipt into the existing ValueTracker."""
+    """Persist each admitted Traffic Receipt through the single value recorder."""
     current = _traffic_receipt.TrafficReceiptLedger.append
     if hasattr(current, "__entroly_traffic_value_original__"):
         return
@@ -589,6 +710,8 @@ __all__ = [
     "_TRAFFIC_VALUE_HTML",
     "_default_window",
     "_install_route",
+    "_reset_session_state_for_tests",
+    "_session_rollup",
     "build_traffic_value_snapshot",
     "record_traffic_value_receipt",
 ]

--- a/entroly/proxy_traffic_value.py
+++ b/entroly/proxy_traffic_value.py
@@ -1,13 +1,21 @@
-"""Rolling executive value dashboard for Entroly AI traffic.
+"""Executive AI Traffic Value dashboard for Entroly.
 
-This module exposes durable, evidence-classified value accumulated by the
-existing :mod:`entroly.value_tracker`. It deliberately does not create a second
-accounting system. Provider-bound token reductions are shown with modeled input
-value using Entroly's auditable pricing provenance; local-only reductions remain
-token-only.
+This module turns Traffic Receipts into durable executive rollups inside the
+existing ValueTracker file. It does not create a second accounting database.
 
-The dashboard uses rolling windows (today, 7d, 30d, 60d, 90d) plus lifetime so
-value compounds visibly without resetting at arbitrary calendar boundaries.
+The surface is deliberately evidence-classified:
+- token reduction and context reduction come from locally observed pre/post
+  request estimates;
+- estimated value avoided comes from observed avoided tokens and an explicit
+  model price in Entroly's pricing table;
+- cache benefit and provider input spend are shown only when the Traffic Receipt
+  has provider usage plus auditable pricing;
+- verification/recovery percentages are derived from request-level evidence;
+- lifetime totals keep accumulating across proxy restarts.
+
+Rolling windows are Today / 7D / 30D / 60D / 90D. The selected default adapts
+to how long Traffic Value has actually been collecting data, while All Time is
+always visible beside the selected period.
 """
 
 from __future__ import annotations
@@ -21,9 +29,39 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from . import proxy as _proxy
-from .value_tracker import get_tracker, pricing_provenance
+from . import proxy_traffic_receipt as _traffic_receipt
+from .value_tracker import (
+    _has_priced_model,
+    estimate_cost,
+    get_tracker,
+    pricing_provenance,
+)
 
-_SCHEMA_VERSION = "entroly.traffic-value.v1"
+_SCHEMA_VERSION = "entroly.traffic-value.v2"
+_TRAFFIC_KEY = "traffic_assurance"
+_MAX_DAILY = 90
+_MAX_SEEN_RECEIPTS = 2048
+
+_COUNTER_FIELDS = (
+    "requests_observed",
+    "requests_optimized",
+    "tokens_received",
+    "tokens_sent",
+    "tokens_avoided",
+    "verified_requests",
+    "verification_passed",
+    "recovery_invoked",
+    "recovery_succeeded",
+    "warm_cache_protected_tokens",
+    "cache_observed",
+    "cache_hits",
+    "provider_priced_requests",
+)
+_MONEY_FIELDS = (
+    "estimated_value_avoided_usd",
+    "measured_cache_benefit_usd",
+    "provider_input_spend_usd",
+)
 
 
 def _nonnegative_int(value: object) -> int:
@@ -43,156 +81,325 @@ def _nonnegative_float(value: object) -> float:
     return parsed
 
 
-def _empty_rollup(*, key: str, label: str) -> dict[str, Any]:
+def _empty_metrics() -> dict[str, int | float]:
     return {
-        "key": key,
-        "label": label,
-        "provider_tokens_avoided": 0,
-        "estimated_input_value_avoided_usd": 0.0,
-        "provider_requests_observed": 0,
-        "provider_requests_optimized": 0,
-        "provider_unpriced_tokens": 0,
-        "provider_unpriced_requests": 0,
-        "local_tokens_reduced": 0,
-        "local_operations": 0,
+        **{field: 0 for field in _COUNTER_FIELDS},
+        **{field: 0.0 for field in _MONEY_FIELDS},
     }
 
 
+def _ensure_metrics(row: dict[str, Any]) -> dict[str, Any]:
+    defaults = _empty_metrics()
+    for key, value in defaults.items():
+        row.setdefault(key, value)
+    return row
+
+
 def _accumulate(target: dict[str, Any], row: Mapping[str, Any]) -> None:
-    target["provider_tokens_avoided"] += _nonnegative_int(
-        row.get("provider_tokens_saved")
+    for field in _COUNTER_FIELDS:
+        target[field] = _nonnegative_int(target.get(field)) + _nonnegative_int(
+            row.get(field)
+        )
+    for field in _MONEY_FIELDS:
+        target[field] = round(
+            _nonnegative_float(target.get(field))
+            + _nonnegative_float(row.get(field)),
+            6,
+        )
+
+
+def _finalize_metrics(row: dict[str, Any]) -> dict[str, Any]:
+    received = _nonnegative_int(row.get("tokens_received"))
+    avoided = _nonnegative_int(row.get("tokens_avoided"))
+    requests = _nonnegative_int(row.get("requests_observed"))
+    verified = _nonnegative_int(row.get("verified_requests"))
+    passed = _nonnegative_int(row.get("verification_passed"))
+    recovery_invoked = _nonnegative_int(row.get("recovery_invoked"))
+    recovery_succeeded = _nonnegative_int(row.get("recovery_succeeded"))
+    cache_observed = _nonnegative_int(row.get("cache_observed"))
+    cache_hits = _nonnegative_int(row.get("cache_hits"))
+
+    row["context_reduction_pct"] = round(100.0 * avoided / max(1, received), 2)
+    row["requests_verified_pct"] = round(100.0 * verified / max(1, requests), 2)
+    row["verification_pass_pct"] = (
+        round(100.0 * passed / verified, 2) if verified else None
     )
-    target["estimated_input_value_avoided_usd"] = round(
-        float(target["estimated_input_value_avoided_usd"])
-        + _nonnegative_float(row.get("provider_cost_avoided_usd")),
+    row["recovery_invoked_pct"] = round(
+        100.0 * recovery_invoked / max(1, requests), 2
+    )
+    row["recovery_succeeded_pct"] = (
+        round(100.0 * recovery_succeeded / recovery_invoked, 2)
+        if recovery_invoked
+        else None
+    )
+    row["cache_hit_request_pct"] = (
+        round(100.0 * cache_hits / cache_observed, 2)
+        if cache_observed
+        else None
+    )
+    row["total_ai_value_protected_usd"] = round(
+        _nonnegative_float(row.get("estimated_value_avoided_usd"))
+        + _nonnegative_float(row.get("measured_cache_benefit_usd")),
         6,
     )
-    target["provider_requests_observed"] += _nonnegative_int(
-        row.get("provider_requests")
-    )
-    target["provider_requests_optimized"] += _nonnegative_int(
-        row.get("provider_requests_optimized")
-    )
-    target["provider_unpriced_tokens"] += _nonnegative_int(
-        row.get("provider_unpriced_tokens")
-    )
-    target["provider_unpriced_requests"] += _nonnegative_int(
-        row.get("provider_unpriced_requests")
-    )
-    target["local_tokens_reduced"] += _nonnegative_int(
-        row.get("local_tokens_reduced")
-    )
-    target["local_operations"] += _nonnegative_int(row.get("local_operations"))
+    return row
+
+
+def _receipt_day(receipt: Any) -> str:
+    ts = _nonnegative_float(getattr(receipt, "observed_at", 0.0)) or time.time()
+    return _dt.datetime.fromtimestamp(ts, tz=_dt.timezone.utc).date().isoformat()
+
+
+def _estimated_value_for_receipt(receipt: Any) -> float:
+    model = str(getattr(receipt, "executed_model", "") or "")
+    tokens = _nonnegative_int(getattr(receipt, "tokens_avoided", 0))
+    if not tokens or not _has_priced_model(model):
+        return 0.0
+    return round(max(0.0, float(estimate_cost(tokens, model, kind="input"))), 6)
+
+
+def _receipt_delta(receipt: Any) -> dict[str, int | float]:
+    original = _nonnegative_int(getattr(receipt, "original_context_tokens", 0))
+    sent = _nonnegative_int(getattr(receipt, "entroly_context_tokens", 0))
+    avoided = _nonnegative_int(getattr(receipt, "tokens_avoided", 0))
+    verification = str(getattr(receipt, "verification", "") or "").upper()
+    recovery_receipts = _nonnegative_int(getattr(receipt, "recovery_receipts", 0))
+    recovery_invoked = recovery_receipts > 0
+    # A recovery is counted successful only when the final surfaced response has
+    # explicit PASS evidence. This avoids equating "attempted" with "succeeded".
+    recovery_succeeded = recovery_invoked and verification == "PASS"
+    cache_hit = getattr(receipt, "cache_hit", None)
+    input_cost_micro = getattr(receipt, "input_cost_micro_usd", None)
+    cache_benefit_micro = getattr(receipt, "cache_benefit_micro_usd", None)
+
+    return {
+        "requests_observed": 1,
+        "requests_optimized": int(avoided > 0),
+        "tokens_received": original,
+        "tokens_sent": sent,
+        "tokens_avoided": avoided,
+        "estimated_value_avoided_usd": _estimated_value_for_receipt(receipt),
+        "measured_cache_benefit_usd": (
+            round(_nonnegative_int(cache_benefit_micro) / 1_000_000.0, 6)
+            if cache_benefit_micro is not None
+            else 0.0
+        ),
+        # Current Traffic Receipt v1 prices provider input/cache categories only.
+        # The UI labels this precisely as provider input spend, not full invoice.
+        "provider_input_spend_usd": (
+            round(_nonnegative_int(input_cost_micro) / 1_000_000.0, 6)
+            if input_cost_micro is not None
+            else 0.0
+        ),
+        "provider_priced_requests": int(input_cost_micro is not None),
+        "verified_requests": int(verification in {"PASS", "FAIL"}),
+        "verification_passed": int(verification == "PASS"),
+        "recovery_invoked": int(recovery_invoked),
+        "recovery_succeeded": int(recovery_succeeded),
+        "warm_cache_protected_tokens": _nonnegative_int(
+            getattr(receipt, "warm_prefix_protected_tokens", 0)
+        ),
+        "cache_observed": int(cache_hit is not None),
+        "cache_hits": int(cache_hit is True),
+    }
+
+
+def record_traffic_value_receipt(
+    receipt: Any,
+    *,
+    tracker: Any | None = None,
+) -> bool:
+    """Persist one Traffic Receipt into the existing ValueTracker data file.
+
+    The bounded ``seen_receipts`` list makes recent retries/idempotent replays
+    harmless without retaining request content or an unbounded identifier set.
+    """
+
+    if not getattr(receipt, "verify", lambda: False)():
+        return False
+    value_tracker = tracker or get_tracker()
+    receipt_id = str(getattr(receipt, "receipt_id", "") or "")
+    if not receipt_id:
+        return False
+    day = _receipt_day(receipt)
+    delta = _receipt_delta(receipt)
+    observed_at = _nonnegative_float(getattr(receipt, "observed_at", 0.0)) or time.time()
+
+    try:
+        with value_tracker._mutation():  # same process+file lock as ValueTracker
+            root = value_tracker._data.setdefault(
+                _TRAFFIC_KEY,
+                {
+                    "started_at": observed_at,
+                    "lifetime": _empty_metrics(),
+                    "daily": {},
+                    "seen_receipts": [],
+                },
+            )
+            started = _nonnegative_float(root.get("started_at"))
+            if not started or observed_at < started:
+                root["started_at"] = observed_at
+
+            seen = [str(x) for x in root.get("seen_receipts", []) if x]
+            if receipt_id in seen:
+                return False
+            seen.append(receipt_id)
+            root["seen_receipts"] = seen[-_MAX_SEEN_RECEIPTS:]
+
+            lifetime = _ensure_metrics(root.setdefault("lifetime", {}))
+            daily = root.setdefault("daily", {})
+            day_row = _ensure_metrics(daily.setdefault(day, {}))
+            _accumulate(lifetime, delta)
+            _accumulate(day_row, delta)
+
+            # Keep exactly the rolling-history horizon needed by this view.
+            for old_day in sorted(daily)[:-_MAX_DAILY]:
+                daily.pop(old_day, None)
+
+            value_tracker._save()
+        return True
+    except Exception as exc:
+        _proxy.logger.debug("Traffic value persistence skipped: %s", exc, exc_info=True)
+        return False
+
+
+def _traffic_state(tracker: Any) -> Mapping[str, Any]:
+    data = getattr(tracker, "_data", {})
+    state = data.get(_TRAFFIC_KEY, {}) if isinstance(data, Mapping) else {}
+    return state if isinstance(state, Mapping) else {}
 
 
 def _rolling_window(
-    rows: list[Mapping[str, Any]],
+    rows: Mapping[str, Mapping[str, Any]],
     *,
     days: int,
     key: str,
     label: str,
     today: _dt.date,
 ) -> dict[str, Any]:
-    result = _empty_rollup(key=key, label=label)
+    result: dict[str, Any] = {"key": key, "label": label, **_empty_metrics()}
     cutoff = today - _dt.timedelta(days=max(1, days) - 1)
-    for row in rows:
+    for raw_day, row in rows.items():
         try:
-            day = _dt.date.fromisoformat(str(row.get("date") or ""))
+            day = _dt.date.fromisoformat(str(raw_day))
         except (TypeError, ValueError):
             continue
-        if cutoff <= day <= today:
+        if cutoff <= day <= today and isinstance(row, Mapping):
             _accumulate(result, row)
     result["window_start"] = cutoff.isoformat()
     result["window_end"] = today.isoformat()
-    return result
+    return _finalize_metrics(result)
 
 
-def _lifetime_rollup(lifetime: Mapping[str, Any]) -> dict[str, Any]:
-    result = _empty_rollup(key="lifetime", label="All time")
-    result.update(
-        {
-            "provider_tokens_avoided": _nonnegative_int(
-                lifetime.get("provider_tokens_saved")
-            ),
-            "estimated_input_value_avoided_usd": round(
-                _nonnegative_float(lifetime.get("provider_cost_avoided_usd")), 6
-            ),
-            "provider_requests_observed": _nonnegative_int(
-                lifetime.get("provider_requests")
-            ),
-            "provider_requests_optimized": _nonnegative_int(
-                lifetime.get("provider_requests_optimized")
-            ),
-            "provider_unpriced_tokens": _nonnegative_int(
-                lifetime.get("provider_unpriced_tokens")
-            ),
-            "provider_unpriced_requests": _nonnegative_int(
-                lifetime.get("provider_unpriced_requests")
-            ),
-            "local_tokens_reduced": _nonnegative_int(
-                lifetime.get("local_tokens_reduced")
-            ),
-            "local_operations": _nonnegative_int(
-                lifetime.get("local_operations")
-            ),
-        }
-    )
-    return result
+def _lifetime_rollup(state: Mapping[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "key": "lifetime",
+        "label": "All time",
+        **_empty_metrics(),
+    }
+    lifetime = state.get("lifetime", {})
+    if isinstance(lifetime, Mapping):
+        _accumulate(result, lifetime)
+    return _finalize_metrics(result)
+
+
+def _default_window(age_days: int) -> str:
+    # Product rule:
+    # 3 days installed  -> 7D
+    # 45 days installed -> 30D
+    # 60-99 days        -> 60D
+    # 100+ days         -> 90D
+    if age_days < 30:
+        return "7d"
+    if age_days < 60:
+        return "30d"
+    if age_days < 100:
+        return "60d"
+    return "90d"
 
 
 def build_traffic_value_snapshot(
     tracker: Any | None = None,
     *,
     today: _dt.date | None = None,
+    now: float | None = None,
 ) -> dict[str, Any]:
-    """Build rolling provider-value windows from the durable ValueTracker.
-
-    ``estimated_input_value_avoided_usd`` is intentionally evidence-labelled:
-    it is observed provider-bound token reduction multiplied by the configured
-    input rate, not an invoice claim. Local SDK/MCP/npm reductions never enter
-    that dollar number.
-    """
-
     value_tracker = tracker or get_tracker()
     try:
         value_tracker.reload_if_changed()
     except Exception:
         pass
-    current_day = today or _dt.datetime.now(_dt.timezone.utc).date()
-    daily = list(value_tracker.get_daily(90))
-    lifetime = value_tracker.get_lifetime()
+
+    now_ts = time.time() if now is None else float(now)
+    current_day = today or _dt.datetime.fromtimestamp(
+        now_ts, tz=_dt.timezone.utc
+    ).date()
+    state = _traffic_state(value_tracker)
+    daily = state.get("daily", {})
+    if not isinstance(daily, Mapping):
+        daily = {}
+
     windows = [
         _rolling_window(daily, days=1, key="today", label="Today", today=current_day),
         _rolling_window(daily, days=7, key="7d", label="7 days", today=current_day),
         _rolling_window(daily, days=30, key="30d", label="30 days", today=current_day),
         _rolling_window(daily, days=60, key="60d", label="60 days", today=current_day),
         _rolling_window(daily, days=90, key="90d", label="90 days", today=current_day),
-        _lifetime_rollup(lifetime),
+        _lifetime_rollup(state),
     ]
+
+    started_at = _nonnegative_float(state.get("started_at"))
+    age_days = (
+        max(0, int((now_ts - started_at) // 86400))
+        if started_at
+        else 0
+    )
+    default_window = _default_window(age_days)
     pricing = pricing_provenance()
+
     return {
         "schema_version": _SCHEMA_VERSION,
-        "generated_at_unix": round(time.time(), 3),
-        "default_window": "lifetime",
+        "generated_at_unix": round(now_ts, 3),
+        "collection_started_at": started_at or None,
+        "installed_days": age_days,
+        "default_window": default_window,
+        "always_show_lifetime": True,
         "windows": {window["key"]: window for window in windows},
         "window_order": [window["key"] for window in windows],
         "pricing": pricing,
         "truth": {
-            "provider_tokens": (
-                "Observed provider-bound token reduction recorded by Entroly."
+            "tokens_received_sent": (
+                "Local deterministic pre/post context estimates for provider-bound "
+                "requests observed by Traffic Receipts."
             ),
-            "estimated_usd": (
-                "Observed provider-bound token reduction multiplied by the "
-                "configured model input rate. This is modeled value avoided, "
-                "not a provider invoice or counterfactual billing measurement."
+            "estimated_value": (
+                "Observed avoided input tokens multiplied by the configured model "
+                "input rate. It is modeled value avoided, not invoice savings."
             ),
-            "local_tokens": (
-                "Local SDK/MCP/npm token reductions are shown separately and "
-                "never converted to dollars without provider-bound evidence."
+            "measured_cache_benefit": (
+                "Shown only when provider usage and auditable pricing were present "
+                "on the Traffic Receipt."
+            ),
+            "provider_input_spend": (
+                "Provider-reported input/cache token categories priced with the "
+                "auditable catalog. It is not labeled full provider invoice spend."
+            ),
+            "verification": (
+                "Requests verified counts only explicit PASS/FAIL evidence. "
+                "NOT_REPORTED and ERROR do not inflate the percentage."
+            ),
+            "recovery": (
+                "Recovery invoked requires recovery evidence; recovery succeeded "
+                "requires final explicit PASS verification."
+            ),
+            "total_ai_value": (
+                "Estimated value on tokens not sent plus measured cache benefit on "
+                "tokens that were sent. These are displayed as separate evidence "
+                "classes and summed as Total AI value protected."
             ),
             "lifetime": (
-                "Lifetime counters persist across proxy restarts and keep "
-                "accumulating until the user deletes or resets local telemetry."
+                "All Time persists in the existing ValueTracker file across proxy "
+                "restarts and accumulates until telemetry is reset/deleted."
             ),
         },
     }
@@ -205,32 +412,101 @@ _TRAFFIC_VALUE_HTML = r"""<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Entroly AI Traffic Value</title>
 <style>
-:root{color-scheme:dark;--bg:#07090d;--card:#0d1118;--line:#202938;--text:#edf2f7;--dim:#8b98aa;--good:#5ee6a8;--blue:#79b8ff;--warn:#ffd166}
+:root{color-scheme:dark;--bg:#07090d;--card:#0d1118;--line:#202938;--text:#edf2f7;--dim:#8b98aa;--good:#5ee6a8;--blue:#79b8ff;--warn:#ffd166;--bad:#ff7b8b}
 *{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 50% -20%,#172036 0,transparent 42%),var(--bg);font:14px/1.45 Inter,ui-sans-serif,system-ui;color:var(--text)}
-main{max-width:980px;margin:0 auto;padding:32px 20px 64px}.eyebrow{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--good);font-weight:800}.title{font-size:30px;font-weight:850;letter-spacing:-.035em;margin-top:4px}.sub{color:var(--dim);margin-top:4px}
-.tabs{display:flex;gap:8px;flex-wrap:wrap;margin:22px 0 16px}.tab{border:1px solid var(--line);background:#0b1018;color:var(--dim);padding:8px 12px;border-radius:999px;cursor:pointer;font:700 12px Inter,system-ui}.tab.active{color:var(--text);border-color:#3b506d;background:#152033}
-.hero{background:linear-gradient(180deg,rgba(18,24,34,.97),rgba(11,15,22,.97));border:1px solid var(--line);border-radius:20px;padding:24px;box-shadow:0 24px 80px rgba(0,0,0,.35)}.period{font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.12em;font-weight:800}.money{font-size:52px;font-weight:900;letter-spacing:-.055em;margin-top:8px;color:var(--good)}.moneylabel{font-size:13px;color:var(--dim)}
-.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:20px}.metric{border:1px solid var(--line);border-radius:14px;padding:16px;background:rgba(8,12,18,.6)}.mval{font:800 22px ui-monospace,SFMono-Regular,Menlo,monospace}.mlabel{color:var(--dim);font-size:12px;margin-top:5px}.blue{color:var(--blue)}.good{color:var(--good)}.warn{color:var(--warn)}
+main{max-width:1080px;margin:0 auto;padding:32px 20px 64px}.eyebrow{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--good);font-weight:800}.title{font-size:32px;font-weight:900;letter-spacing:-.04em;margin-top:4px}.sub{color:var(--dim);margin-top:5px}
+.tabs{display:flex;gap:8px;flex-wrap:wrap;margin:22px 0 16px}.tab{border:1px solid var(--line);background:#0b1018;color:var(--dim);padding:8px 12px;border-radius:999px;cursor:pointer;font:750 12px Inter,system-ui}.tab.active{color:var(--text);border-color:#3b506d;background:#152033}
+.card{background:linear-gradient(180deg,rgba(18,24,34,.97),rgba(11,15,22,.97));border:1px solid var(--line);border-radius:20px;padding:24px;box-shadow:0 24px 80px rgba(0,0,0,.32)}.period{font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.12em;font-weight:850}
+.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:16px}.metric{border:1px solid var(--line);border-radius:14px;padding:15px;background:rgba(8,12,18,.58)}.mval{font:800 21px ui-monospace,SFMono-Regular,Menlo,monospace}.mlabel{color:var(--dim);font-size:12px;margin-top:5px}
+.moneygrid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:16px}.moneybox{border:1px solid var(--line);border-radius:15px;padding:17px;background:rgba(8,12,18,.7)}.money{font-size:30px;font-weight:900;letter-spacing:-.04em}.moneylabel{color:var(--dim);font-size:12px;margin-top:4px}
+.alltime{margin-top:18px;border-color:#30435e}.alltitle{display:flex;justify-content:space-between;gap:20px;align-items:center}.badge{font-size:11px;color:var(--dim);border:1px solid var(--line);padding:5px 9px;border-radius:999px}
+.good{color:var(--good)}.blue{color:var(--blue)}.warn{color:var(--warn)}.bad{color:var(--bad)}.dim{color:var(--dim)}
 .note{margin-top:14px;padding:13px 15px;border:1px solid var(--line);border-radius:12px;color:var(--dim);font-size:12px}.note b{color:var(--text)}.meta{display:flex;justify-content:space-between;gap:18px;margin-top:14px;color:var(--dim);font-size:11px}
-@media(max-width:720px){.grid{grid-template-columns:1fr}.money{font-size:42px}.meta{flex-direction:column}}
+@media(max-width:760px){.grid,.moneygrid{grid-template-columns:1fr}.alltitle,.meta{align-items:flex-start;flex-direction:column}}
 </style>
 </head>
 <body><main>
-<div class="eyebrow">AI Traffic Assurance</div><div class="title">Value that keeps adding up</div><div class="sub">Provider-bound token reduction and its evidence-labelled economic value.</div>
+<div class="eyebrow">AI Traffic Assurance</div>
+<div class="title">AI Traffic Value</div>
+<div class="sub">The value Entroly has created and protected across your AI traffic.</div>
 <div class="tabs" id="tabs"></div>
-<div class="hero" id="hero"><div class="period">Loading…</div></div>
-<div class="note"><b>Truth policy:</b> the dollar hero is estimated input value avoided from observed provider-bound token reduction and configured model pricing. It is not presented as invoice-verified savings. Local-only token reduction is kept separate.</div>
+<div class="card" id="period"><div class="period">Loading live value…</div></div>
+<div class="card alltime" id="lifetime"><div class="period">Loading All Time…</div></div>
+<div class="note"><b>Evidence policy:</b> avoided-token dollars are estimates from observed token reduction and configured model prices. Cache benefit is measured only when provider usage is available. Provider input spend is not presented as a full invoice.</div>
 </main>
 <script>
 const fmt=n=>Number(n||0).toLocaleString();
+const compact=n=>{n=Number(n||0);if(Math.abs(n)>=1e9)return(n/1e9).toFixed(n>=1e10?1:2).replace(/\.0+$/,'')+'B';if(Math.abs(n)>=1e6)return(n/1e6).toFixed(n>=1e7?1:2).replace(/\.0+$/,'')+'M';if(Math.abs(n)>=1e3)return(n/1e3).toFixed(n>=1e4?1:2).replace(/\.0+$/,'')+'K';return fmt(n)};
 const usd=v=>'$'+Number(v||0).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
+const pct=v=>v==null?'—':Number(v).toFixed(1)+'%';
 const esc=v=>String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-let DATA=null,ACTIVE='lifetime';
-function render(){if(!DATA)return;const w=DATA.windows[ACTIVE]||DATA.windows.lifetime;const p=DATA.pricing||{};document.querySelectorAll('.tab').forEach(b=>b.classList.toggle('active',b.dataset.key===ACTIVE));document.getElementById('hero').innerHTML=`
-<div class="period">${esc(w.label)}</div><div class="money">${usd(w.estimated_input_value_avoided_usd)}</div><div class="moneylabel">estimated provider input value avoided</div>
-<div class="grid"><div class="metric"><div class="mval good">${fmt(w.provider_tokens_avoided)}</div><div class="mlabel">provider-bound tokens avoided</div></div><div class="metric"><div class="mval blue">${fmt(w.provider_requests_optimized)}</div><div class="mlabel">requests optimized</div></div><div class="metric"><div class="mval">${fmt(w.local_tokens_reduced)}</div><div class="mlabel">local-only tokens reduced · no $ claim</div></div></div>
-<div class="meta"><span>pricing ${esc(p.as_of||'unknown')} · ${esc(p.source||'unknown')}</span><span>${w.window_start?esc(w.window_start)+' → '+esc(w.window_end):'persistent lifetime total'}</span></div>`;}
-async function load(){try{const r=await fetch('/traffic-value.json',{cache:'no-store'});if(!r.ok)throw Error(r.status);DATA=await r.json();ACTIVE=DATA.default_window||'lifetime';const tabs=document.getElementById('tabs');tabs.innerHTML='';for(const key of DATA.window_order||[]){const b=document.createElement('button');b.className='tab';b.dataset.key=key;b.textContent=DATA.windows[key].label;b.onclick=()=>{ACTIVE=key;render()};tabs.appendChild(b)}render()}catch(e){document.getElementById('hero').innerHTML='<div class="period">Value API unavailable</div>';}}
+let DATA=null,ACTIVE=null,USER_SELECTED=false;
+function moneyBox(value,label,cls='good'){return `<div class="moneybox"><div class="money ${cls}">${usd(value)}</div><div class="moneylabel">${esc(label)}</div></div>`}
+function metric(value,label,cls=''){return `<div class="metric"><div class="mval ${cls}">${value}</div><div class="mlabel">${esc(label)}</div></div>`}
+function renderWindow(w){
+ const measured=w.provider_priced_requests>0;
+ document.getElementById('period').innerHTML=`
+ <div class="period">AI TRAFFIC VALUE — ${esc(w.label).toUpperCase()}</div>
+ <div class="grid">
+  ${metric(fmt(w.requests_optimized),'Requests optimized','blue')}
+  ${metric(compact(w.tokens_received)+' tokens','Tokens received')}
+  ${metric(compact(w.tokens_sent)+' tokens','Tokens sent')}
+  ${metric(compact(w.tokens_avoided)+' tokens','Tokens avoided','good')}
+  ${metric(pct(w.context_reduction_pct),'Context reduction','good')}
+  ${metric(compact(w.warm_cache_protected_tokens)+' tokens','Warm cache protected','blue')}
+ </div>
+ <div class="moneygrid">
+  ${moneyBox(w.estimated_value_avoided_usd,'Estimated value avoided')}
+  ${moneyBox(w.measured_cache_benefit_usd,'Measured cache benefit',measured?'good':'dim')}
+  ${moneyBox(w.provider_input_spend_usd,'Provider input spend',measured?'':'dim')}
+ </div>
+ <div class="grid">
+  ${metric(pct(w.requests_verified_pct),'Requests verified')}
+  ${metric(pct(w.recovery_invoked_pct),'Recovery invoked')}
+  ${metric(pct(w.recovery_succeeded_pct),'Recovery succeeded')}
+  ${metric(pct(w.verification_pass_pct),'Verification pass rate')}
+  ${metric(pct(w.cache_hit_request_pct),'Cache-hit requests')}
+  ${metric(usd(w.total_ai_value_protected_usd),'Total AI value protected','good')}
+ </div>
+ <div class="meta"><span>${w.window_start?esc(w.window_start)+' → '+esc(w.window_end):''}</span><span>${measured?'provider-priced traffic observed':'measured provider $ appears when usage + pricing exist'}</span></div>`;
+}
+function renderLifetime(w){
+ document.getElementById('lifetime').innerHTML=`
+ <div class="alltitle"><div><div class="period">ALL TIME</div><div class="dim">Keeps accumulating across proxy restarts.</div></div><div class="badge">${fmt(DATA.installed_days||0)} days collecting Traffic Value</div></div>
+ <div class="moneygrid">
+  ${moneyBox(w.estimated_value_avoided_usd,'Estimated value avoided')}
+  ${moneyBox(w.measured_cache_benefit_usd,'Measured cache benefit','blue')}
+  ${moneyBox(w.total_ai_value_protected_usd,'Total AI value protected','good')}
+ </div>
+ <div class="grid">
+  ${metric(compact(w.tokens_avoided),'Tokens avoided')}
+  ${metric(fmt(w.requests_optimized),'Requests optimized')}
+  ${metric(compact(w.warm_cache_protected_tokens),'Warm-cache tokens protected')}
+ </div>`;
+}
+function render(){
+ if(!DATA)return;
+ if(!ACTIVE)ACTIVE=DATA.default_window||'7d';
+ document.querySelectorAll('.tab').forEach(b=>b.classList.toggle('active',b.dataset.key===ACTIVE));
+ renderWindow(DATA.windows[ACTIVE]||DATA.windows['7d']);
+ renderLifetime(DATA.windows.lifetime);
+}
+async function load(){
+ try{
+  const r=await fetch('/traffic-value.json',{cache:'no-store'});if(!r.ok)throw Error(r.status);
+  const next=await r.json();DATA=next;
+  if(!USER_SELECTED)ACTIVE=DATA.default_window||'7d';
+  const tabs=document.getElementById('tabs');tabs.innerHTML='';
+  for(const key of DATA.window_order||[]){
+   if(key==='lifetime')continue;
+   const b=document.createElement('button');b.className='tab';b.dataset.key=key;b.textContent=DATA.windows[key].label;
+   b.onclick=()=>{USER_SELECTED=true;ACTIVE=key;render()};tabs.appendChild(b);
+  }
+  render();
+ }catch(e){
+  document.getElementById('period').innerHTML='<div class="period">Traffic Value API unavailable</div>';
+ }
+}
 load();setInterval(load,10000);
 </script></body></html>"""
 
@@ -291,8 +567,28 @@ def _install_route(app: Any) -> None:
         )
 
 
+def _install_receipt_bridge() -> None:
+    """Persist every admitted Traffic Receipt into the existing ValueTracker."""
+    current = _traffic_receipt.TrafficReceiptLedger.append
+    if hasattr(current, "__entroly_traffic_value_original__"):
+        return
+    original = current
+
+    def append_with_value(self: Any, receipt: Any) -> None:
+        original(self, receipt)
+        record_traffic_value_receipt(receipt)
+
+    append_with_value.__entroly_traffic_value_original__ = original
+    _traffic_receipt.TrafficReceiptLedger.append = append_with_value
+
+
+_install_receipt_bridge()
+
+
 __all__ = [
     "_TRAFFIC_VALUE_HTML",
+    "_default_window",
     "_install_route",
     "build_traffic_value_snapshot",
+    "record_traffic_value_receipt",
 ]

--- a/tests/test_proxy_traffic_receipt.py
+++ b/tests/test_proxy_traffic_receipt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from dataclasses import asdict
 
 from starlette.responses import Response
 
@@ -71,7 +72,9 @@ def test_traffic_receipt_verifies_and_ledger_is_content_blind() -> None:
 
 def test_traffic_receipt_rejects_bad_digest() -> None:
     receipt = _receipt()
-    broken = TrafficReceipt(**{**receipt.__dict__, "receipt_digest": "0" * 64})
+    broken_payload = asdict(receipt)
+    broken_payload["receipt_digest"] = "0" * 64
+    broken = TrafficReceipt(**broken_payload)
     ledger = TrafficReceiptLedger()
     try:
         ledger.append(broken)

--- a/tests/test_proxy_traffic_receipt.py
+++ b/tests/test_proxy_traffic_receipt.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import hashlib
+
+from starlette.responses import Response
+
+from entroly.proxy_traffic_receipt import (
+    TrafficReceipt,
+    TrafficReceiptLedger,
+    _TRAFFIC_HTML,
+    _canonical_json,
+    _classify_client,
+    _prefix_protection,
+    _routing_decision,
+    _verification,
+)
+
+
+def _receipt(**overrides) -> TrafficReceipt:
+    payload = {
+        "schema_version": "entroly.traffic-receipt.v1",
+        "receipt_id": "tr_test",
+        "request_correlation": "deadbeefdeadbeef",
+        "client": "Claude Code",
+        "provider": "anthropic",
+        "requested_model": "claude-test",
+        "executed_model": "claude-test",
+        "original_context_tokens": 73440,
+        "entroly_context_tokens": 18206,
+        "tokens_avoided": 55234,
+        "evidence_retained_pct": 100.0,
+        "evidence_retained_source": "context_coverage_estimate",
+        "recoverable": True,
+        "recovery_receipts": 4,
+        "warm_prefix_protected_tokens": 14820,
+        "cache_hit": True,
+        "cache_read_tokens": 14820,
+        "routing_decision": "STAY",
+        "routing_reason": "requested model preserved",
+        "input_cost_micro_usd": 1200,
+        "cache_benefit_micro_usd": 400,
+        "net_measured_saving_micro_usd": None,
+        "money_source": "operator-catalog",
+        "context_risk": "LOW",
+        "verification": "PASS",
+        "response_status": 200,
+        "streaming": True,
+        "latency_ms": 123.4,
+        "observed_at": 1_700_000_000.0,
+    }
+    payload.update(overrides)
+    digest = hashlib.sha256(_canonical_json(payload)).hexdigest()
+    return TrafficReceipt(receipt_digest=digest, **payload)
+
+
+def test_traffic_receipt_verifies_and_ledger_is_content_blind() -> None:
+    secret = "sk-secret-prompt-must-never-appear"
+    receipt = _receipt(routing_reason="warm cache economics")
+    assert receipt.verify()
+
+    ledger = TrafficReceiptLedger(max_records=2)
+    ledger.register_request()
+    ledger.append(receipt)
+    snapshot = ledger.snapshot()
+
+    assert snapshot["records_contain_prompt_content"] is False
+    assert snapshot["records_contain_credentials"] is False
+    assert snapshot["latest"]["receipt_digest"] == receipt.receipt_digest
+    assert secret not in repr(snapshot)
+
+
+def test_traffic_receipt_rejects_bad_digest() -> None:
+    receipt = _receipt()
+    broken = TrafficReceipt(**{**receipt.__dict__, "receipt_digest": "0" * 64})
+    ledger = TrafficReceiptLedger()
+    try:
+        ledger.append(broken)
+    except ValueError as exc:
+        assert "digest" in str(exc)
+    else:
+        raise AssertionError("tampered receipt should be rejected")
+
+
+def test_claude_code_client_detection_does_not_store_user_agent() -> None:
+    headers = {"user-agent": "claude-code/9.9.9 secret-user-agent-detail"}
+    assert _classify_client(headers) == "Claude Code"
+
+
+def test_prefix_protection_uses_per_request_headers() -> None:
+    response = Response(status_code=200)
+    headers = {
+        "x-entroly-prefix-guard": "preserve_warm_prefix",
+        "x-entroly-prefix-tokens-at-risk": "14820",
+    }
+    assert _prefix_protection(headers, response) == 14820
+
+
+def test_routing_and_verification_use_execution_evidence() -> None:
+    response = Response(
+        status_code=200,
+        headers={
+            "X-Entroly-Routing-Decision": "denied",
+            "X-Entroly-Routing-Reason": "warm cache economics",
+            "X-Entroly-Witness": "pass",
+        },
+    )
+    decision, reason = _routing_decision("sonnet", "sonnet", response)
+    assert decision == "STAY"
+    assert reason == "warm cache economics"
+    assert _verification(response) == "PASS"
+
+
+def test_traffic_page_contains_no_hardcoded_demo_numbers_or_fake_savings() -> None:
+    # The product surface must render live receipt values, not the PM mockup.
+    assert "73,440" not in _TRAFFIC_HTML
+    assert "18,206" not in _TRAFFIC_HTML
+    assert "55,234" not in _TRAFFIC_HTML
+    assert "Net measured saving" in _TRAFFIC_HTML
+    assert "measured counterfactual" in _TRAFFIC_HTML

--- a/tests/test_proxy_traffic_receipt_final.py
+++ b/tests/test_proxy_traffic_receipt_final.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from starlette.requests import Request
+
+from entroly.proxy_traffic_receipt_final import (
+    _ensure_request_id,
+    _nested_recovery_depth,
+    _request_local_coverage_unavailable,
+)
+
+
+def _request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/v1/messages",
+            "raw_path": b"/v1/messages",
+            "query_string": b"",
+            "headers": list(headers or []),
+            "client": ("127.0.0.1", 12345),
+            "server": ("127.0.0.1", 9377),
+        }
+    )
+
+
+def test_request_id_is_injected_once_and_visible_to_starlette_headers() -> None:
+    request = _request()
+    first = _ensure_request_id(request)
+    second = _ensure_request_id(request)
+
+    assert first
+    assert second == first
+    assert request.headers["x-request-id"] == first
+    ids = [value for key, value in request.scope["headers"] if key.lower() == b"x-request-id"]
+    assert len(ids) == 1
+
+
+def test_existing_request_id_is_preserved() -> None:
+    request = _request([(b"x-request-id", b"client-owned-id")])
+    assert _ensure_request_id(request) == "client-owned-id"
+    assert request.headers["x-request-id"] == "client-owned-id"
+
+
+def test_nested_recovery_depth_supports_keyword_and_positional_calls() -> None:
+    assert _nested_recovery_depth((), {}) == 0
+    assert _nested_recovery_depth((), {"recovery_depth": 1}) == 1
+    assert _nested_recovery_depth((None, "", "openai", None, "req", 2), {}) == 2
+
+
+def test_shared_coverage_is_withheld_from_per_request_receipts() -> None:
+    pct, source, risk = _request_local_coverage_unavailable(object())
+    assert pct is None
+    assert source == "withheld_shared_state"
+    assert risk == "UNKNOWN"

--- a/tests/test_proxy_traffic_session.py
+++ b/tests/test_proxy_traffic_session.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import entroly.proxy_traffic_session as session
+
+
+def _receipt(receipt_id: str = "tr_session") -> SimpleNamespace:
+    return SimpleNamespace(
+        receipt_id=receipt_id,
+        verify=lambda: True,
+        original_context_tokens=1000,
+        entroly_context_tokens=400,
+        tokens_avoided=600,
+        executed_model="unknown-test-model",
+        verification="PASS",
+        recovery_receipts=0,
+        cache_hit=True,
+        input_cost_micro_usd=2000,
+        cache_benefit_micro_usd=500,
+        warm_prefix_protected_tokens=120,
+    )
+
+
+def _base_snapshot(installed_days: int) -> dict:
+    return {
+        "schema_version": "entroly.traffic-value.v2",
+        "installed_days": installed_days,
+        "default_window": "7d",
+        "windows": {
+            "today": {"key": "today", "label": "Today"},
+            "7d": {"key": "7d", "label": "7 days"},
+            "lifetime": {"key": "lifetime", "label": "All time"},
+        },
+        "window_order": ["today", "7d", "lifetime"],
+        "truth": {},
+    }
+
+
+def test_session_value_is_immediate_and_idempotent(monkeypatch) -> None:
+    session._reset_session_state_for_tests(started_at=1000.0)
+    monkeypatch.setattr(session, "_ORIGINAL_RECORD", lambda receipt, tracker=None: True)
+
+    assert session._record_with_session(_receipt()) is True
+    assert session._record_with_session(_receipt()) is True  # durable layer may accept; session must not double count
+
+    rollup = session._session_rollup(now=1600.0)
+    assert rollup["requests_observed"] == 1
+    assert rollup["requests_optimized"] == 1
+    assert rollup["tokens_received"] == 1000
+    assert rollup["tokens_sent"] == 400
+    assert rollup["tokens_avoided"] == 600
+    assert rollup["context_reduction_pct"] == 60.0
+    assert rollup["warm_cache_protected_tokens"] == 120
+    assert rollup["cache_hit_request_pct"] == 100.0
+    assert rollup["session_elapsed_seconds"] == 600
+
+
+def test_first_day_defaults_to_session_but_all_time_stays_visible(monkeypatch) -> None:
+    session._reset_session_state_for_tests(started_at=1000.0)
+    session._record_session_receipt(_receipt("tr_fresh"))
+    monkeypatch.setattr(
+        session,
+        "_ORIGINAL_SNAPSHOT",
+        lambda tracker=None, today=None, now=None: _base_snapshot(installed_days=0),
+    )
+
+    snapshot = session._snapshot_with_session(now=1600.0)
+    assert snapshot["default_window"] == "session"
+    assert snapshot["window_order"][0] == "session"
+    assert snapshot["windows"]["session"]["tokens_avoided"] == 600
+    assert "lifetime" in snapshot["windows"]
+    assert "resets on proxy restart" in snapshot["truth"]["session"]
+
+
+def test_older_install_keeps_age_adaptive_default_with_session_available(monkeypatch) -> None:
+    session._reset_session_state_for_tests(started_at=1000.0)
+    session._record_session_receipt(_receipt("tr_old"))
+    monkeypatch.setattr(
+        session,
+        "_ORIGINAL_SNAPSHOT",
+        lambda tracker=None, today=None, now=None: _base_snapshot(installed_days=3),
+    )
+
+    snapshot = session._snapshot_with_session(now=1600.0)
+    assert snapshot["default_window"] == "7d"
+    assert snapshot["window_order"][0] == "session"
+    assert snapshot["windows"]["session"]["requests_optimized"] == 1

--- a/tests/test_proxy_traffic_session.py
+++ b/tests/test_proxy_traffic_session.py
@@ -1,13 +1,49 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 
-import entroly.proxy_traffic_session as session
+import pytest
+
+import entroly.proxy_traffic_session as session_compat
+import entroly.proxy_traffic_value as value
 
 
-def _receipt(receipt_id: str = "tr_session") -> SimpleNamespace:
+class _FakeTracker:
+    def __init__(self, *, started_at: float = 0.0):
+        self._data = {
+            "version": 4,
+            "traffic_assurance": {
+                "started_at": started_at,
+                "lifetime": value._empty_metrics(),
+                "daily": {},
+                "seen_receipts": [],
+            },
+        }
+        self.saved = 0
+
+    def reload_if_changed(self) -> bool:
+        return False
+
+    @contextmanager
+    def _mutation(self):
+        yield
+
+    def _save(self) -> None:
+        self.saved += 1
+
+
+@pytest.fixture(autouse=True)
+def _clean_session():
+    value._reset_session_state_for_tests(started_at=1000.0)
+    yield
+    value._reset_session_state_for_tests()
+
+
+def _receipt(receipt_id: str = "tr_session", *, observed_at: float = 1500.0):
     return SimpleNamespace(
         receipt_id=receipt_id,
+        observed_at=observed_at,
         verify=lambda: True,
         original_context_tokens=1000,
         entroly_context_tokens=400,
@@ -22,29 +58,14 @@ def _receipt(receipt_id: str = "tr_session") -> SimpleNamespace:
     )
 
 
-def _base_snapshot(installed_days: int) -> dict:
-    return {
-        "schema_version": "entroly.traffic-value.v2",
-        "installed_days": installed_days,
-        "default_window": "7d",
-        "windows": {
-            "today": {"key": "today", "label": "Today"},
-            "7d": {"key": "7d", "label": "7 days"},
-            "lifetime": {"key": "lifetime", "label": "All time"},
-        },
-        "window_order": ["today", "7d", "lifetime"],
-        "truth": {},
-    }
+def test_session_value_is_native_immediate_and_idempotent(monkeypatch) -> None:
+    monkeypatch.setattr(value, "_has_priced_model", lambda _model: False)
+    tracker = _FakeTracker()
 
+    assert value.record_traffic_value_receipt(_receipt(), tracker=tracker) is True
+    assert value.record_traffic_value_receipt(_receipt(), tracker=tracker) is False
 
-def test_session_value_is_immediate_and_idempotent(monkeypatch) -> None:
-    session._reset_session_state_for_tests(started_at=1000.0)
-    monkeypatch.setattr(session, "_ORIGINAL_RECORD", lambda receipt, tracker=None: True)
-
-    assert session._record_with_session(_receipt()) is True
-    assert session._record_with_session(_receipt()) is True  # durable layer may accept; session must not double count
-
-    rollup = session._session_rollup(now=1600.0)
+    rollup = value._session_rollup(now=1600.0)
     assert rollup["requests_observed"] == 1
     assert rollup["requests_optimized"] == 1
     assert rollup["tokens_received"] == 1000
@@ -54,18 +75,19 @@ def test_session_value_is_immediate_and_idempotent(monkeypatch) -> None:
     assert rollup["warm_cache_protected_tokens"] == 120
     assert rollup["cache_hit_request_pct"] == 100.0
     assert rollup["session_elapsed_seconds"] == 600
+    assert rollup["session_status"] == "measurable"
+    assert "measurable value" in rollup["session_status_message"]
 
 
 def test_first_day_defaults_to_session_but_all_time_stays_visible(monkeypatch) -> None:
-    session._reset_session_state_for_tests(started_at=1000.0)
-    session._record_session_receipt(_receipt("tr_fresh"))
-    monkeypatch.setattr(
-        session,
-        "_ORIGINAL_SNAPSHOT",
-        lambda tracker=None, today=None, now=None: _base_snapshot(installed_days=0),
+    monkeypatch.setattr(value, "pricing_provenance", lambda: {"source": "test"})
+    tracker = _FakeTracker(started_at=1500.0)
+    assert value.record_traffic_value_receipt(
+        _receipt("tr_fresh", observed_at=1500.0),
+        tracker=tracker,
     )
 
-    snapshot = session._snapshot_with_session(now=1600.0)
+    snapshot = value.build_traffic_value_snapshot(tracker, now=1600.0)
     assert snapshot["default_window"] == "session"
     assert snapshot["window_order"][0] == "session"
     assert snapshot["windows"]["session"]["tokens_avoided"] == 600
@@ -73,16 +95,36 @@ def test_first_day_defaults_to_session_but_all_time_stays_visible(monkeypatch) -
     assert "resets on proxy restart" in snapshot["truth"]["session"]
 
 
-def test_older_install_keeps_age_adaptive_default_with_session_available(monkeypatch) -> None:
-    session._reset_session_state_for_tests(started_at=1000.0)
-    session._record_session_receipt(_receipt("tr_old"))
-    monkeypatch.setattr(
-        session,
-        "_ORIGINAL_SNAPSHOT",
-        lambda tracker=None, today=None, now=None: _base_snapshot(installed_days=3),
+def test_mature_install_keeps_age_adaptive_default_with_session_available(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(value, "pricing_provenance", lambda: {"source": "test"})
+    now = 10_000_000.0
+    tracker = _FakeTracker(started_at=now - 45 * 86400)
+    assert value.record_traffic_value_receipt(
+        _receipt("tr_old", observed_at=now),
+        tracker=tracker,
     )
 
-    snapshot = session._snapshot_with_session(now=1600.0)
-    assert snapshot["default_window"] == "7d"
+    snapshot = value.build_traffic_value_snapshot(tracker, now=now)
+    assert snapshot["default_window"] == "30d"
     assert snapshot["window_order"][0] == "session"
     assert snapshot["windows"]["session"]["requests_optimized"] == 1
+
+
+def test_session_reports_waiting_without_claiming_value() -> None:
+    rollup = value._session_rollup(now=1600.0)
+    assert rollup["requests_observed"] == 0
+    assert rollup["session_status"] == "waiting"
+    assert "Send traffic through Entroly" in rollup["session_status_message"]
+
+
+def test_compatibility_module_does_not_monkeypatch_value_ownership() -> None:
+    record_before = value.record_traffic_value_receipt
+    snapshot_before = value.build_traffic_value_snapshot
+
+    assert session_compat.install_session_value() is None
+
+    assert value.record_traffic_value_receipt is record_before
+    assert value.build_traffic_value_snapshot is snapshot_before
+    assert session_compat._session_rollup(now=1600.0)["key"] == "session"

--- a/tests/test_proxy_traffic_value.py
+++ b/tests/test_proxy_traffic_value.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from entroly.proxy_traffic_value import (
+    _TRAFFIC_VALUE_HTML,
+    build_traffic_value_snapshot,
+)
+
+
+class _FakeTracker:
+    def reload_if_changed(self) -> bool:
+        return False
+
+    def get_daily(self, last_n: int = 90):
+        assert last_n == 90
+        return [
+            {
+                "date": "2026-08-12",
+                "provider_tokens_saved": 100,
+                "provider_cost_avoided_usd": 1.25,
+                "provider_requests": 2,
+                "provider_requests_optimized": 2,
+                "provider_unpriced_tokens": 0,
+                "provider_unpriced_requests": 0,
+                "local_tokens_reduced": 50,
+                "local_operations": 1,
+            },
+            {
+                "date": "2026-08-06",
+                "provider_tokens_saved": 300,
+                "provider_cost_avoided_usd": 3.75,
+                "provider_requests": 3,
+                "provider_requests_optimized": 3,
+                "provider_unpriced_tokens": 25,
+                "provider_unpriced_requests": 1,
+                "local_tokens_reduced": 70,
+                "local_operations": 2,
+            },
+            {
+                "date": "2026-07-14",
+                "provider_tokens_saved": 700,
+                "provider_cost_avoided_usd": 7.00,
+                "provider_requests": 4,
+                "provider_requests_optimized": 4,
+                "provider_unpriced_tokens": 0,
+                "provider_unpriced_requests": 0,
+                "local_tokens_reduced": 90,
+                "local_operations": 3,
+            },
+            {
+                "date": "2026-06-14",
+                "provider_tokens_saved": 900,
+                "provider_cost_avoided_usd": 9.00,
+                "provider_requests": 5,
+                "provider_requests_optimized": 5,
+                "provider_unpriced_tokens": 0,
+                "provider_unpriced_requests": 0,
+                "local_tokens_reduced": 110,
+                "local_operations": 4,
+            },
+            {
+                "date": "2026-05-14",
+                "provider_tokens_saved": 1100,
+                "provider_cost_avoided_usd": 11.00,
+                "provider_requests": 6,
+                "provider_requests_optimized": 6,
+                "provider_unpriced_tokens": 0,
+                "provider_unpriced_requests": 0,
+                "local_tokens_reduced": 130,
+                "local_operations": 5,
+            },
+        ]
+
+    def get_lifetime(self):
+        return {
+            "provider_tokens_saved": 9999,
+            "provider_cost_avoided_usd": 123.456,
+            "provider_requests": 42,
+            "provider_requests_optimized": 40,
+            "provider_unpriced_tokens": 25,
+            "provider_unpriced_requests": 1,
+            "local_tokens_reduced": 777,
+            "local_operations": 12,
+        }
+
+
+def test_traffic_value_has_rolling_windows_and_lifetime(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "entroly.proxy_traffic_value.pricing_provenance",
+        lambda: {"as_of": "2026-08", "source": "test-catalog"},
+    )
+    snapshot = build_traffic_value_snapshot(
+        _FakeTracker(),
+        today=dt.date(2026, 8, 12),
+    )
+
+    assert snapshot["window_order"] == ["today", "7d", "30d", "60d", "90d", "lifetime"]
+    assert snapshot["default_window"] == "lifetime"
+    assert snapshot["windows"]["today"]["provider_tokens_avoided"] == 100
+    assert snapshot["windows"]["7d"]["provider_tokens_avoided"] == 400
+    assert snapshot["windows"]["30d"]["provider_tokens_avoided"] == 1100
+    assert snapshot["windows"]["60d"]["provider_tokens_avoided"] == 2000
+    assert snapshot["windows"]["90d"]["provider_tokens_avoided"] == 3100
+    assert snapshot["windows"]["lifetime"]["provider_tokens_avoided"] == 9999
+    assert snapshot["windows"]["lifetime"]["estimated_input_value_avoided_usd"] == 123.456
+    assert snapshot["pricing"]["source"] == "test-catalog"
+
+
+def test_traffic_value_does_not_mix_local_tokens_into_dollar_value(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "entroly.proxy_traffic_value.pricing_provenance",
+        lambda: {"as_of": "2026-08", "source": "test-catalog"},
+    )
+    snapshot = build_traffic_value_snapshot(
+        _FakeTracker(),
+        today=dt.date(2026, 8, 12),
+    )
+    today = snapshot["windows"]["today"]
+    assert today["estimated_input_value_avoided_usd"] == 1.25
+    assert today["local_tokens_reduced"] == 50
+    assert "not a provider invoice" in snapshot["truth"]["estimated_usd"]
+
+
+def test_traffic_value_ui_has_no_hardcoded_demo_savings() -> None:
+    assert "73,440" not in _TRAFFIC_VALUE_HTML
+    assert "$4,812" not in _TRAFFIC_VALUE_HTML
+    assert "Today" not in _TRAFFIC_VALUE_HTML  # labels come from the live API
+    assert "estimated provider input value avoided" in _TRAFFIC_VALUE_HTML
+    assert "not presented as invoice-verified savings" in _TRAFFIC_VALUE_HTML

--- a/tests/test_proxy_traffic_value.py
+++ b/tests/test_proxy_traffic_value.py
@@ -1,130 +1,269 @@
 from __future__ import annotations
 
 import datetime as dt
+from contextlib import contextmanager
+from types import SimpleNamespace
 
 from entroly.proxy_traffic_value import (
     _TRAFFIC_VALUE_HTML,
+    _default_window,
     build_traffic_value_snapshot,
+    record_traffic_value_receipt,
 )
 
 
+def _metrics(**overrides):
+    row = {
+        "requests_observed": 0,
+        "requests_optimized": 0,
+        "tokens_received": 0,
+        "tokens_sent": 0,
+        "tokens_avoided": 0,
+        "estimated_value_avoided_usd": 0.0,
+        "measured_cache_benefit_usd": 0.0,
+        "provider_input_spend_usd": 0.0,
+        "verified_requests": 0,
+        "verification_passed": 0,
+        "recovery_invoked": 0,
+        "recovery_succeeded": 0,
+        "warm_cache_protected_tokens": 0,
+        "cache_observed": 0,
+        "cache_hits": 0,
+        "provider_priced_requests": 0,
+    }
+    row.update(overrides)
+    return row
+
+
 class _FakeTracker:
+    def __init__(self, state: dict | None = None):
+        self._data = {
+            "version": 4,
+            "traffic_assurance": state
+            or {
+                "started_at": 0.0,
+                "lifetime": _metrics(),
+                "daily": {},
+                "seen_receipts": [],
+            },
+        }
+        self.saved = 0
+
     def reload_if_changed(self) -> bool:
         return False
 
-    def get_daily(self, last_n: int = 90):
-        assert last_n == 90
-        return [
-            {
-                "date": "2026-08-12",
-                "provider_tokens_saved": 100,
-                "provider_cost_avoided_usd": 1.25,
-                "provider_requests": 2,
-                "provider_requests_optimized": 2,
-                "provider_unpriced_tokens": 0,
-                "provider_unpriced_requests": 0,
-                "local_tokens_reduced": 50,
-                "local_operations": 1,
-            },
-            {
-                "date": "2026-08-06",
-                "provider_tokens_saved": 300,
-                "provider_cost_avoided_usd": 3.75,
-                "provider_requests": 3,
-                "provider_requests_optimized": 3,
-                "provider_unpriced_tokens": 25,
-                "provider_unpriced_requests": 1,
-                "local_tokens_reduced": 70,
-                "local_operations": 2,
-            },
-            {
-                "date": "2026-07-14",
-                "provider_tokens_saved": 700,
-                "provider_cost_avoided_usd": 7.00,
-                "provider_requests": 4,
-                "provider_requests_optimized": 4,
-                "provider_unpriced_tokens": 0,
-                "provider_unpriced_requests": 0,
-                "local_tokens_reduced": 90,
-                "local_operations": 3,
-            },
-            {
-                "date": "2026-06-14",
-                "provider_tokens_saved": 900,
-                "provider_cost_avoided_usd": 9.00,
-                "provider_requests": 5,
-                "provider_requests_optimized": 5,
-                "provider_unpriced_tokens": 0,
-                "provider_unpriced_requests": 0,
-                "local_tokens_reduced": 110,
-                "local_operations": 4,
-            },
-            {
-                "date": "2026-05-14",
-                "provider_tokens_saved": 1100,
-                "provider_cost_avoided_usd": 11.00,
-                "provider_requests": 6,
-                "provider_requests_optimized": 6,
-                "provider_unpriced_tokens": 0,
-                "provider_unpriced_requests": 0,
-                "local_tokens_reduced": 130,
-                "local_operations": 5,
-            },
-        ]
+    @contextmanager
+    def _mutation(self):
+        yield
 
-    def get_lifetime(self):
-        return {
-            "provider_tokens_saved": 9999,
-            "provider_cost_avoided_usd": 123.456,
-            "provider_requests": 42,
-            "provider_requests_optimized": 40,
-            "provider_unpriced_tokens": 25,
-            "provider_unpriced_requests": 1,
-            "local_tokens_reduced": 777,
-            "local_operations": 12,
-        }
+    def _save(self) -> None:
+        self.saved += 1
 
 
-def test_traffic_value_has_rolling_windows_and_lifetime(monkeypatch) -> None:
+def _utc_ts(day: dt.date) -> float:
+    return dt.datetime.combine(
+        day,
+        dt.time(12, 0),
+        tzinfo=dt.timezone.utc,
+    ).timestamp()
+
+
+def test_default_window_adapts_to_collection_age() -> None:
+    assert _default_window(3) == "7d"
+    assert _default_window(29) == "7d"
+    assert _default_window(45) == "30d"
+    assert _default_window(70) == "60d"
+    assert _default_window(100) == "90d"
+    assert _default_window(365) == "90d"
+
+
+def test_traffic_value_rolls_up_full_30_day_executive_surface(monkeypatch) -> None:
+    today = dt.date(2026, 8, 12)
+    now = _utc_ts(today)
+    state = {
+        "started_at": now - 45 * 86400,
+        "lifetime": _metrics(
+            requests_observed=500,
+            requests_optimized=420,
+            tokens_received=2_000_000,
+            tokens_sent=700_000,
+            tokens_avoided=1_300_000,
+            estimated_value_avoided_usd=420.0,
+            measured_cache_benefit_usd=80.0,
+            provider_input_spend_usd=210.0,
+            verified_requests=490,
+            verification_passed=485,
+            recovery_invoked=20,
+            recovery_succeeded=19,
+            warm_cache_protected_tokens=300_000,
+            cache_observed=400,
+            cache_hits=320,
+            provider_priced_requests=400,
+        ),
+        "daily": {
+            "2026-08-12": _metrics(
+                requests_observed=100,
+                requests_optimized=90,
+                tokens_received=1_000,
+                tokens_sent=400,
+                tokens_avoided=600,
+                estimated_value_avoided_usd=6.0,
+                measured_cache_benefit_usd=2.0,
+                provider_input_spend_usd=3.0,
+                verified_requests=99,
+                verification_passed=98,
+                recovery_invoked=10,
+                recovery_succeeded=9,
+                warm_cache_protected_tokens=200,
+                cache_observed=80,
+                cache_hits=60,
+                provider_priced_requests=80,
+            ),
+            "2026-07-20": _metrics(
+                requests_observed=50,
+                requests_optimized=40,
+                tokens_received=500,
+                tokens_sent=200,
+                tokens_avoided=300,
+                estimated_value_avoided_usd=3.0,
+                measured_cache_benefit_usd=1.0,
+                provider_input_spend_usd=1.5,
+                verified_requests=49,
+                verification_passed=48,
+                recovery_invoked=5,
+                recovery_succeeded=5,
+                warm_cache_protected_tokens=100,
+                cache_observed=40,
+                cache_hits=30,
+                provider_priced_requests=40,
+            ),
+            # Outside the rolling 30-day window.
+            "2026-07-01": _metrics(
+                requests_observed=999,
+                requests_optimized=999,
+                tokens_received=9_999,
+                tokens_sent=1,
+                tokens_avoided=9_998,
+                estimated_value_avoided_usd=999.0,
+            ),
+        },
+        "seen_receipts": [],
+    }
+    tracker = _FakeTracker(state)
     monkeypatch.setattr(
         "entroly.proxy_traffic_value.pricing_provenance",
         lambda: {"as_of": "2026-08", "source": "test-catalog"},
     )
-    snapshot = build_traffic_value_snapshot(
-        _FakeTracker(),
-        today=dt.date(2026, 8, 12),
-    )
 
-    assert snapshot["window_order"] == ["today", "7d", "30d", "60d", "90d", "lifetime"]
-    assert snapshot["default_window"] == "lifetime"
-    assert snapshot["windows"]["today"]["provider_tokens_avoided"] == 100
-    assert snapshot["windows"]["7d"]["provider_tokens_avoided"] == 400
-    assert snapshot["windows"]["30d"]["provider_tokens_avoided"] == 1100
-    assert snapshot["windows"]["60d"]["provider_tokens_avoided"] == 2000
-    assert snapshot["windows"]["90d"]["provider_tokens_avoided"] == 3100
-    assert snapshot["windows"]["lifetime"]["provider_tokens_avoided"] == 9999
-    assert snapshot["windows"]["lifetime"]["estimated_input_value_avoided_usd"] == 123.456
+    snapshot = build_traffic_value_snapshot(
+        tracker,
+        today=today,
+        now=now,
+    )
+    thirty = snapshot["windows"]["30d"]
+
+    assert snapshot["default_window"] == "30d"
+    assert snapshot["always_show_lifetime"] is True
+    assert snapshot["window_order"] == [
+        "today",
+        "7d",
+        "30d",
+        "60d",
+        "90d",
+        "lifetime",
+    ]
+    assert thirty["requests_optimized"] == 130
+    assert thirty["tokens_received"] == 1500
+    assert thirty["tokens_sent"] == 600
+    assert thirty["tokens_avoided"] == 900
+    assert thirty["context_reduction_pct"] == 60.0
+    assert thirty["estimated_value_avoided_usd"] == 9.0
+    assert thirty["measured_cache_benefit_usd"] == 3.0
+    assert thirty["provider_input_spend_usd"] == 4.5
+    assert thirty["requests_verified_pct"] == 98.67
+    assert thirty["recovery_invoked_pct"] == 10.0
+    assert thirty["recovery_succeeded_pct"] == 93.33
+    assert thirty["warm_cache_protected_tokens"] == 300
+    assert thirty["cache_hit_request_pct"] == 75.0
+    assert thirty["total_ai_value_protected_usd"] == 12.0
+
+    lifetime = snapshot["windows"]["lifetime"]
+    assert lifetime["estimated_value_avoided_usd"] == 420.0
+    assert lifetime["measured_cache_benefit_usd"] == 80.0
+    assert lifetime["total_ai_value_protected_usd"] == 500.0
     assert snapshot["pricing"]["source"] == "test-catalog"
 
 
-def test_traffic_value_does_not_mix_local_tokens_into_dollar_value(monkeypatch) -> None:
+def test_receipt_persistence_is_idempotent_and_evidence_classified(monkeypatch) -> None:
+    tracker = _FakeTracker()
     monkeypatch.setattr(
-        "entroly.proxy_traffic_value.pricing_provenance",
-        lambda: {"as_of": "2026-08", "source": "test-catalog"},
+        "entroly.proxy_traffic_value._has_priced_model",
+        lambda _model: True,
     )
-    snapshot = build_traffic_value_snapshot(
-        _FakeTracker(),
-        today=dt.date(2026, 8, 12),
+    monkeypatch.setattr(
+        "entroly.proxy_traffic_value.estimate_cost",
+        lambda tokens, model, kind="input": 2.5 if tokens == 600 else 0.0,
     )
-    today = snapshot["windows"]["today"]
-    assert today["estimated_input_value_avoided_usd"] == 1.25
-    assert today["local_tokens_reduced"] == 50
-    assert "not a provider invoice" in snapshot["truth"]["estimated_usd"]
+
+    receipt = SimpleNamespace(
+        receipt_id="tr_same",
+        observed_at=_utc_ts(dt.date(2026, 8, 12)),
+        executed_model="claude-test",
+        original_context_tokens=1000,
+        entroly_context_tokens=400,
+        tokens_avoided=600,
+        verification="PASS",
+        recovery_receipts=2,
+        warm_prefix_protected_tokens=250,
+        cache_hit=True,
+        input_cost_micro_usd=1_250_000,
+        cache_benefit_micro_usd=300_000,
+        verify=lambda: True,
+    )
+
+    assert record_traffic_value_receipt(receipt, tracker=tracker) is True
+    assert record_traffic_value_receipt(receipt, tracker=tracker) is False
+
+    state = tracker._data["traffic_assurance"]
+    lifetime = state["lifetime"]
+    assert lifetime["requests_observed"] == 1
+    assert lifetime["requests_optimized"] == 1
+    assert lifetime["tokens_received"] == 1000
+    assert lifetime["tokens_sent"] == 400
+    assert lifetime["tokens_avoided"] == 600
+    assert lifetime["estimated_value_avoided_usd"] == 2.5
+    assert lifetime["measured_cache_benefit_usd"] == 0.3
+    assert lifetime["provider_input_spend_usd"] == 1.25
+    assert lifetime["verified_requests"] == 1
+    assert lifetime["verification_passed"] == 1
+    assert lifetime["recovery_invoked"] == 1
+    assert lifetime["recovery_succeeded"] == 1
+    assert lifetime["warm_cache_protected_tokens"] == 250
+    assert lifetime["cache_observed"] == 1
+    assert lifetime["cache_hits"] == 1
+    assert state["seen_receipts"] == ["tr_same"]
+    assert tracker.saved == 1
 
 
-def test_traffic_value_ui_has_no_hardcoded_demo_savings() -> None:
-    assert "73,440" not in _TRAFFIC_VALUE_HTML
-    assert "$4,812" not in _TRAFFIC_VALUE_HTML
-    assert "Today" not in _TRAFFIC_VALUE_HTML  # labels come from the live API
-    assert "estimated provider input value avoided" in _TRAFFIC_VALUE_HTML
-    assert "not presented as invoice-verified savings" in _TRAFFIC_VALUE_HTML
+def test_traffic_value_ui_has_requested_exec_metrics_without_fake_values() -> None:
+    # Product surface renders live API values, never the illustrative PM mockup.
+    for fake in ("84,291", "2.41B", "$4,812", "$11,487", "$14,705"):
+        assert fake not in _TRAFFIC_VALUE_HTML
+
+    for label in (
+        "Requests optimized",
+        "Tokens received",
+        "Tokens sent",
+        "Tokens avoided",
+        "Context reduction",
+        "Estimated value avoided",
+        "Measured cache benefit",
+        "Provider input spend",
+        "Requests verified",
+        "Recovery invoked",
+        "Recovery succeeded",
+        "Warm cache protected",
+        "Total AI value protected",
+        "ALL TIME",
+    ):
+        assert label in _TRAFFIC_VALUE_HTML

--- a/tests/test_proxy_traffic_value.py
+++ b/tests/test_proxy_traffic_value.py
@@ -4,9 +4,12 @@ import datetime as dt
 from contextlib import contextmanager
 from types import SimpleNamespace
 
+import pytest
+
 from entroly.proxy_traffic_value import (
     _TRAFFIC_VALUE_HTML,
     _default_window,
+    _reset_session_state_for_tests,
     build_traffic_value_snapshot,
     record_traffic_value_receipt,
 )
@@ -29,6 +32,8 @@ def _metrics(**overrides):
         "warm_cache_protected_tokens": 0,
         "cache_observed": 0,
         "cache_hits": 0,
+        "estimated_priced_requests": 0,
+        "cache_benefit_priced_requests": 0,
         "provider_priced_requests": 0,
     }
     row.update(overrides)
@@ -58,6 +63,13 @@ class _FakeTracker:
 
     def _save(self) -> None:
         self.saved += 1
+
+
+@pytest.fixture(autouse=True)
+def _clean_process_session():
+    _reset_session_state_for_tests()
+    yield
+    _reset_session_state_for_tests()
 
 
 def _utc_ts(day: dt.date) -> float:
@@ -98,6 +110,8 @@ def test_traffic_value_rolls_up_full_30_day_executive_surface(monkeypatch) -> No
             warm_cache_protected_tokens=300_000,
             cache_observed=400,
             cache_hits=320,
+            estimated_priced_requests=420,
+            cache_benefit_priced_requests=400,
             provider_priced_requests=400,
         ),
         "daily": {
@@ -117,6 +131,8 @@ def test_traffic_value_rolls_up_full_30_day_executive_surface(monkeypatch) -> No
                 warm_cache_protected_tokens=200,
                 cache_observed=80,
                 cache_hits=60,
+                estimated_priced_requests=90,
+                cache_benefit_priced_requests=80,
                 provider_priced_requests=80,
             ),
             "2026-07-20": _metrics(
@@ -135,9 +151,10 @@ def test_traffic_value_rolls_up_full_30_day_executive_surface(monkeypatch) -> No
                 warm_cache_protected_tokens=100,
                 cache_observed=40,
                 cache_hits=30,
+                estimated_priced_requests=40,
+                cache_benefit_priced_requests=40,
                 provider_priced_requests=40,
             ),
-            # Outside the rolling 30-day window.
             "2026-07-01": _metrics(
                 requests_observed=999,
                 requests_optimized=999,
@@ -155,16 +172,13 @@ def test_traffic_value_rolls_up_full_30_day_executive_surface(monkeypatch) -> No
         lambda: {"as_of": "2026-08", "source": "test-catalog"},
     )
 
-    snapshot = build_traffic_value_snapshot(
-        tracker,
-        today=today,
-        now=now,
-    )
+    snapshot = build_traffic_value_snapshot(tracker, today=today, now=now)
     thirty = snapshot["windows"]["30d"]
 
     assert snapshot["default_window"] == "30d"
     assert snapshot["always_show_lifetime"] is True
     assert snapshot["window_order"] == [
+        "session",
         "today",
         "7d",
         "30d",
@@ -172,6 +186,7 @@ def test_traffic_value_rolls_up_full_30_day_executive_surface(monkeypatch) -> No
         "90d",
         "lifetime",
     ]
+    assert snapshot["windows"]["session"]["requests_observed"] == 0
     assert thirty["requests_optimized"] == 130
     assert thirty["tokens_received"] == 1500
     assert thirty["tokens_sent"] == 600
@@ -194,7 +209,9 @@ def test_traffic_value_rolls_up_full_30_day_executive_surface(monkeypatch) -> No
     assert snapshot["pricing"]["source"] == "test-catalog"
 
 
-def test_receipt_persistence_is_idempotent_and_evidence_classified(monkeypatch) -> None:
+def test_receipt_persistence_and_session_are_idempotent_and_evidence_classified(
+    monkeypatch,
+) -> None:
     tracker = _FakeTracker()
     monkeypatch.setattr(
         "entroly.proxy_traffic_value._has_priced_model",
@@ -234,6 +251,9 @@ def test_receipt_persistence_is_idempotent_and_evidence_classified(monkeypatch) 
     assert lifetime["estimated_value_avoided_usd"] == 2.5
     assert lifetime["measured_cache_benefit_usd"] == 0.3
     assert lifetime["provider_input_spend_usd"] == 1.25
+    assert lifetime["estimated_priced_requests"] == 1
+    assert lifetime["cache_benefit_priced_requests"] == 1
+    assert lifetime["provider_priced_requests"] == 1
     assert lifetime["verified_requests"] == 1
     assert lifetime["verification_passed"] == 1
     assert lifetime["recovery_invoked"] == 1
@@ -244,26 +264,31 @@ def test_receipt_persistence_is_idempotent_and_evidence_classified(monkeypatch) 
     assert state["seen_receipts"] == ["tr_same"]
     assert tracker.saved == 1
 
+    session = build_traffic_value_snapshot(tracker)["windows"]["session"]
+    assert session["requests_observed"] == 1
+    assert session["tokens_avoided"] == 600
 
-def test_traffic_value_ui_has_requested_exec_metrics_without_fake_values() -> None:
-    # Product surface renders live API values, never the illustrative PM mockup.
+
+def test_traffic_value_ui_has_immediate_proof_without_fake_or_fake_zero_values() -> None:
     for fake in ("84,291", "2.41B", "$4,812", "$11,487", "$14,705"):
         assert fake not in _TRAFFIC_VALUE_HTML
 
     for label in (
         "Requests optimized",
-        "Tokens received",
-        "Tokens sent",
+        "Tokens received by Entroly",
+        "Tokens sent to provider",
         "Tokens avoided",
         "Context reduction",
         "Estimated value avoided",
         "Measured cache benefit",
-        "Provider input spend",
+        "Provider input spend observed",
         "Requests verified",
-        "Recovery invoked",
-        "Recovery succeeded",
+        "Recovery evidence observed",
         "Warm cache protected",
         "Total AI value protected",
         "ALL TIME",
+        "Session duration",
+        "resets on proxy restart",
+        "not measured",
     ):
         assert label in _TRAFFIC_VALUE_HTML


### PR DESCRIPTION
## Why

Turn Entroly's existing context, cache, routing, provider-usage, recovery and verification intelligence into buyer-visible proof at three time scales: **per request**, **this session**, and **durable executive value**.

## Product surfaces

### `/traffic` + `/traffic-receipts`
Per-request, content-blind evidence for:
- original vs final outbound context and tokens avoided
- requested vs executed model and routing decision
- provider-observed cache state and warm-prefix protection
- input/cache economics when provider usage + auditable pricing exist
- verification/recovery evidence
- privacy-bounded SHA-256 receipt integrity

### `/traffic-value` + `/traffic-value.json`
Executive value for **This session / Today / 7D / 30D / 60D / 90D**, with **ALL TIME always visible**:
- requests optimized
- tokens received / sent / avoided
- context reduction %
- estimated input value avoided
- measured cache benefit
- provider input spend when measurable
- requests verified / verification pass rate
- recovery invoked / recovery succeeded
- warm-cache tokens protected and cache-hit rate
- Total AI value protected

`This session` is process-local and intentionally resets on proxy restart. It gives a fresh user immediate proof after a handful of requests and is not added a second time to All Time. During the first day of collection, active session traffic becomes the default view. After that, the durable default adapts to collection age: <30d -> 7D, 30-59d -> 30D, 60-99d -> 60D, 100+d -> 90D.

Durable Traffic Value persists inside the existing `ValueTracker` file and accumulates across proxy restarts. It does not create a second savings database.

## Evidence / truth contract

- **Estimated value avoided** = locally observed avoided input tokens × configured executed-model input price. This is modeled economic value, not invoice-counterfactual savings.
- **Measured cache benefit** appears only with provider usage + auditable pricing.
- **Provider input spend** is deliberately not labeled full provider spend because Traffic Receipt v1 currently prices input/cache categories, not complete output-inclusive invoices.
- **Total AI value protected** keeps estimated avoided-input value and measured cache benefit visible as separate evidence classes before summing them.
- Verification percentages count only explicit PASS/FAIL evidence.
- Recovery success requires recovery evidence plus a final explicit PASS signal.
- Shared mutable proxy coverage is withheld from per-request receipts until a request-local source exists; wrong attribution is worse than an unavailable field.
- Receipt UI says **Recovery evidence** rather than claiming recovery availability, and **Receipt integrity / SHA-256 OK** rather than implying a cryptographic signature.
- Illustrative PM numbers are never hard-coded into the live UI.

## Correctness hardening

The earlier audit blockers are addressed by a final receipt guard:
- one request id is established at admission when the client did not provide one, so receipt/provider-usage correlation uses the same id;
- recursive exact-recovery calls no longer own/finalize the outer Traffic Receipt;
- shared `last_*` coverage state is withheld instead of being exposed as request-local evidence;
- recovery/integrity wording is narrowed to what the implementation can actually prove.

## Privacy

Receipts/rollups contain no prompt, tool-output, code, credentials, raw API keys or raw user-agent strings. Request identifiers are reduced to bounded receipt/correlation identifiers; executive rollups persist aggregate counters only.

## Architecture

No new router, retry loop, cache engine or optimizer. These surfaces observe the existing hardened proxy and reuse `ValueTracker`, provider usage accounting, cache continuity, routing authority and WITNESS/EICV evidence.

## Merge gate

Merge only when the exact current head is green in required CI and GitHub reports the PR mergeable.

Docs: `docs/traffic-receipts.md`, `docs/traffic-value.md`.