### PR TITLE
fix(proxy): forward __entroly_gateway_shadow_original__ through traffic receipt wrapper

### DIFF
--- a/entroly/proxy_traffic_receipt.py
+++ b/entroly/proxy_traffic_receipt.py
@@ -868,6 +868,13 @@ def install_traffic_receipts() -> None:
             return await _run_traffic_handle_proxy(self, request, original_core)
 
         traffic_core_handle.__entroly_traffic_receipt_original__ = original_core
+        # Forward the gateway-shadow marker so the shadow boundary contract
+        # remains visible after this module wraps _ORIGINAL_HANDLE_PROXY.
+        shadow_original = getattr(
+            original_core, "__entroly_gateway_shadow_original__", None
+        )
+        if shadow_original is not None:
+            traffic_core_handle.__entroly_gateway_shadow_original__ = shadow_original
         _transport._ORIGINAL_HANDLE_PROXY = traffic_core_handle
 
     current_forward = _proxy.PromptCompilerProxy._forward_response


### PR DESCRIPTION
## Problem

CI failing on main (introduced by #310) with:

\\\
FAILED tests/test_proxy_gateway_shadow.py::test_shadow_installs_behind_existing_security_boundaries
AssertionError: assert False
assert hasattr(<function install_traffic_receipts.<locals>.traffic_core_handle ...>, '__entroly_gateway_shadow_original__')
\\\

## Root Cause

\proxy_traffic_receipt.py\ (added in #310) wraps \_transport._ORIGINAL_HANDLE_PROXY\ with \	raffic_core_handle\ but does **not** forward the \__entroly_gateway_shadow_original__\ attribute that \proxy_gateway_shadow.py\ had previously set on it.

The shadow boundary test asserts that attribute is always reachable on \_ORIGINAL_HANDLE_PROXY\ — the traffic receipt wrapper silently broke that contract.

## Fix

7-line addition in \install_traffic_receipts()\: after wrapping, copy \__entroly_gateway_shadow_original__\ from the previous value onto the new wrapper if present. Both layers remain independently introspectable, neither bypasses the other.

## Tests

\\\
tests/test_proxy_gateway_shadow.py           8/8 passed
tests/test_proxy_traffic_receipt.py          19/19 passed (all traffic receipt tests still pass)
\\\

Pre-push: ruff ✅ · clippy ✅ · cargo test 133/133 ✅