### PR TITLE
fix(proxy): forward all boundary-contract markers and preserve bounded stream wrapper

### DIFF
--- a/entroly/proxy_traffic_receipt.py
+++ b/entroly/proxy_traffic_receipt.py
@@ -868,13 +868,15 @@ def install_traffic_receipts() -> None:
             return await _run_traffic_handle_proxy(self, request, original_core)
 
         traffic_core_handle.__entroly_traffic_receipt_original__ = original_core
-        # Forward the gateway-shadow marker so the shadow boundary contract
-        # remains visible after this module wraps _ORIGINAL_HANDLE_PROXY.
-        shadow_original = getattr(
-            original_core, "__entroly_gateway_shadow_original__", None
-        )
-        if shadow_original is not None:
-            traffic_core_handle.__entroly_gateway_shadow_original__ = shadow_original
+        # Forward boundary-contract markers from all prior wrappers so each
+        # module's install test remains introspectable after this one runs.
+        for _marker in (
+            "__entroly_gateway_shadow_original__",
+            "__entroly_routing_authority_original__",
+        ):
+            _val = getattr(original_core, _marker, None)
+            if _val is not None:
+                setattr(traffic_core_handle, _marker, _val)
         _transport._ORIGINAL_HANDLE_PROXY = traffic_core_handle
 
     current_forward = _proxy.PromptCompilerProxy._forward_response
@@ -883,11 +885,18 @@ def install_traffic_receipts() -> None:
         _traffic_forward_response.__entroly_traffic_receipt_original__ = current_forward
         _proxy.PromptCompilerProxy._forward_response = _traffic_forward_response
 
-    current_stream = _proxy.PromptCompilerProxy._stream_response
-    if not hasattr(current_stream, "__entroly_traffic_receipt_original__"):
-        _ORIGINAL_STREAM_RESPONSE = current_stream
-        _traffic_stream_response.__entroly_traffic_receipt_original__ = current_stream
-        _proxy.PromptCompilerProxy._stream_response = _traffic_stream_response
+    # For _stream_response: proxy_transport_final installs _bounded_stream_response
+    # as the class method and calls its own _ORIGINAL_STREAM_RESPONSE module global
+    # at invocation time. Inject traffic observability into that global so the
+    # bounded wrapper stays as the class method (preserving the stream-bounds
+    # contract) while still routing through the traffic receipt layer.
+    from . import proxy_transport_final as _transport_final
+
+    current_stream_inner = _transport_final._ORIGINAL_STREAM_RESPONSE
+    if not hasattr(current_stream_inner, "__entroly_traffic_receipt_original__"):
+        _ORIGINAL_STREAM_RESPONSE = current_stream_inner
+        _traffic_stream_response.__entroly_traffic_receipt_original__ = current_stream_inner
+        _transport_final._ORIGINAL_STREAM_RESPONSE = _traffic_stream_response
 
 
 _current_forward = _proxy.PromptCompilerProxy._forward_response


### PR DESCRIPTION
## Problem

Main CI still red after #312 merged. Two more failures in the same root cause area:

\\\
FAILED tests/test_proxy_routing_authority.py::test_routing_authority_installs_behind_existing_security_boundaries
AssertionError: hasattr(traffic_core_handle, '__entroly_routing_authority_original__') is False

FAILED tests/test_proxy_stream_bounds.py::test_bounded_stream_wrapper_is_active
AssertionError: PromptCompilerProxy._stream_response is _traffic_stream_response, not _bounded_stream_response
\\\

## Root Cause

\proxy_traffic_receipt.py\ (PR #310):

1. **Routing authority marker**: only forwarded \__entroly_gateway_shadow_original__\ (#312) but not \__entroly_routing_authority_original__\, which \proxy_routing_authority\ sets on the same \_ORIGINAL_HANDLE_PROXY\ chain.

2. **Stream wrapper**: replaced \_stream_response\ class method outright with \_traffic_stream_response\, evicting \_bounded_stream_response\ (installed by \proxy_transport_final\). The stream bounds test asserts the class method must be \_bounded_stream_response\.

## Fix (single commit, cherry-picked from #312 branch)

1. **Generalized marker forwarding**: replaced the single shadow-marker copy with a loop over all known boundary markers (\__entroly_gateway_shadow_original__\, \__entroly_routing_authority_original__\).

2. **Stream injection via module global**: instead of replacing the class method, inject traffic observability into \proxy_transport_final._ORIGINAL_STREAM_RESPONSE\ — the global that \_bounded_stream_response\ resolves at call time. \_bounded_stream_response\ stays as the class method; traffic layer runs underneath it.

## Tests

\\\
tests/test_proxy_gateway_shadow.py          8/8  ✅
tests/test_proxy_routing_authority.py       1/1  ✅ (boundary test)
tests/test_proxy_stream_bounds.py           4/4  ✅
tests/test_proxy_traffic_receipt.py         6/6  ✅
tests/test_proxy_traffic_receipt_final.py   4/4  ✅
tests/test_proxy_traffic_session.py         5/5  ✅
tests/test_proxy_traffic_value.py           4/4  ✅
Total: 34 passed ✅
\\\

Pre-push: ruff ✅ · clippy ✅ · cargo test 133/133 ✅