### PR TITLE
fix(ci): restore proxy wrapper contracts and public trust links

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ Run `entroly doctor`. If that doesn't sort it, [open an issue](https://github.co
 - **[Adaptive context](docs/adaptive-context.html)** — bounded self-improving context.
 - **[Verified Code Context](docs/verified-code-context.md)** — parser-backed repository intelligence, typed graphs, architecture, value flow, LSP enrichment, source verification, and refactoring contracts.
 - **[Full benchmark evidence](docs/BENCHMARKS.md)** — every number, protocol, artifact, and caveat.
+- **[Model-triggered recovery holdout](docs/benchmarks/model-triggered-recovery.md)** — frozen recovery protocol, evidence boundary, and reproduction details.
+- **[Context Commit conformance artifact](benchmarks/results/context_commit_conformance.json)** — checked-in conformance evidence for Context Commit contracts.
 - **[Product surface map](docs/product-surface.md)** — CLI, SDK, MCP, proxy, verification, memory, security.
 - **[Architecture & full spec](docs/DETAILS.md)** — Rust modules, compression, provenance, command reference.
 - **[Agent compatibility](docs/agent-compatibility.md)** — every supported client and its exact authentication boundary.

--- a/entroly/proxy_traffic_receipt.py
+++ b/entroly/proxy_traffic_receipt.py
@@ -868,6 +868,13 @@ def install_traffic_receipts() -> None:
             return await _run_traffic_handle_proxy(self, request, original_core)
 
         traffic_core_handle.__entroly_traffic_receipt_original__ = original_core
+        # Forward the gateway-shadow marker so the shadow boundary contract
+        # remains visible after this module wraps _ORIGINAL_HANDLE_PROXY.
+        shadow_original = getattr(
+            original_core, "__entroly_gateway_shadow_original__", None
+        )
+        if shadow_original is not None:
+            traffic_core_handle.__entroly_gateway_shadow_original__ = shadow_original
         _transport._ORIGINAL_HANDLE_PROXY = traffic_core_handle
 
     current_forward = _proxy.PromptCompilerProxy._forward_response

--- a/entroly/proxy_traffic_receipt.py
+++ b/entroly/proxy_traffic_receipt.py
@@ -868,13 +868,15 @@ def install_traffic_receipts() -> None:
             return await _run_traffic_handle_proxy(self, request, original_core)
 
         traffic_core_handle.__entroly_traffic_receipt_original__ = original_core
-        # Forward the gateway-shadow marker so the shadow boundary contract
-        # remains visible after this module wraps _ORIGINAL_HANDLE_PROXY.
-        shadow_original = getattr(
-            original_core, "__entroly_gateway_shadow_original__", None
-        )
-        if shadow_original is not None:
-            traffic_core_handle.__entroly_gateway_shadow_original__ = shadow_original
+        # Forward boundary-contract markers from all prior wrappers so each
+        # module's install test remains introspectable after this one runs.
+        for _marker in (
+            "__entroly_gateway_shadow_original__",
+            "__entroly_routing_authority_original__",
+        ):
+            _val = getattr(original_core, _marker, None)
+            if _val is not None:
+                setattr(traffic_core_handle, _marker, _val)
         _transport._ORIGINAL_HANDLE_PROXY = traffic_core_handle
 
     current_forward = _proxy.PromptCompilerProxy._forward_response
@@ -883,11 +885,18 @@ def install_traffic_receipts() -> None:
         _traffic_forward_response.__entroly_traffic_receipt_original__ = current_forward
         _proxy.PromptCompilerProxy._forward_response = _traffic_forward_response
 
-    current_stream = _proxy.PromptCompilerProxy._stream_response
-    if not hasattr(current_stream, "__entroly_traffic_receipt_original__"):
-        _ORIGINAL_STREAM_RESPONSE = current_stream
-        _traffic_stream_response.__entroly_traffic_receipt_original__ = current_stream
-        _proxy.PromptCompilerProxy._stream_response = _traffic_stream_response
+    # For _stream_response: proxy_transport_final installs _bounded_stream_response
+    # as the class method and calls its own _ORIGINAL_STREAM_RESPONSE module global
+    # at invocation time. Inject traffic observability into that global so the
+    # bounded wrapper stays as the class method (preserving the stream-bounds
+    # contract) while still routing through the traffic receipt layer.
+    from . import proxy_transport_final as _transport_final
+
+    current_stream_inner = _transport_final._ORIGINAL_STREAM_RESPONSE
+    if not hasattr(current_stream_inner, "__entroly_traffic_receipt_original__"):
+        _ORIGINAL_STREAM_RESPONSE = current_stream_inner
+        _traffic_stream_response.__entroly_traffic_receipt_original__ = current_stream_inner
+        _transport_final._ORIGINAL_STREAM_RESPONSE = _traffic_stream_response
 
 
 _current_forward = _proxy.PromptCompilerProxy._forward_response


### PR DESCRIPTION
## Why main is red

The Traffic Receipt installer introduced two Python proxy-composition regressions and the traffic-dashboard merge dropped two canonical README trust links.

## Fix

- preserve the gateway-shadow and routing-authority boundary markers through the Traffic Receipt wrapper;
- keep `proxy_transport_final._bounded_stream_response` as the outer `_stream_response` security boundary, injecting Traffic Receipt observability beneath it;
- restore the canonical model-triggered-recovery and Context Commit conformance links in README.

## Scope

Exact diff against current main: 2 files, README + proxy Traffic Receipt installer. No Rust code changed. Traffic Receipt correlation, nested recovery ownership, and fail-closed shared-coverage withholding remain intact.

Merge only after required checks for the exact head SHA are green.