### PR TITLE
docs: republish category pages under artifact-backed claim rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Select the highest-value evidence first, compress it, keep originals recoverable
 <p align="center"><b>⭐ If Entroly is useful to you, please star the repository on GitHub.</b><br>
 <a href="https://github.com/juyterman1000/entroly">⭐ Star Entroly on GitHub</a> — it helps the project grow and reach more developers.</p>
 
-## ⚡ Live Tokenomics
+## ⚡ Live Token Savings
 
 <p align="center"><b>Tokens saved</b> · <b>Estimated cost avoided</b> · <b>Compression savings</b> · <b>Tool-schema deferral savings</b></p>
 
@@ -50,7 +50,7 @@ the request unchanged.
 ---
 
 <p align="center">
-  <b><a href="#live-tokenomics">Tokenomics</a> · <a href="#integration-hub">Integrations</a> · <a href="#what-is-entroly-in-plain-english">What is it?</a> · <a href="#install">Install</a> · <a href="#quickstart--by-how-you-work">Quickstart</a> · <a href="#see-it-work-in-30-seconds">See it work</a> · <a href="#benchmarks">Benchmarks</a> · <a href="#common-questions">Questions</a></b>
+  <b><a href="#-live-token-savings">Token savings</a> · <a href="#integration-hub">Integrations</a> · <a href="#what-is-entroly-in-plain-english">What is it?</a> · <a href="#install">Install</a> · <a href="#quickstart--by-how-you-work">Quickstart</a> · <a href="#see-it-work-in-30-seconds">See it work</a> · <a href="#benchmarks">Benchmarks</a> · <a href="#common-questions">Questions</a></b>
 </p>
 
 ---

--- a/docs/best-context-compression-tools.html
+++ b/docs/best-context-compression-tools.html
@@ -1,2 +1,299 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This comparison page has been retired</h1><p>Entroly now publishes scoped, reproducible measurements instead of universal product comparisons.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Read the public evidence ledger</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Context Compression Tools for LLMs: 2026 Comparison — Entroly</title>
+<meta name="description" content="How context compression, prompt compression, and token optimization tools for LLMs differ on compression ratio, recoverability, and auditability. Entroly cuts 79.3%–99.5% of tokens at 100% answer retention on long-context benchmarks, keeps every omitted span byte-exactly recoverable, emits an inspectable receipt, and runs local-first. Every number links to its raw result file.">
+<meta property="og:title" content="Context Compression Tools for LLMs: 2026 Comparison">
+<meta property="og:description" content="Compare context compression tools on ratio, recoverability, and audit trail. Entroly: 79–99.5% token savings at 100% answer retention, byte-exact recovery, inspectable receipts, local-first, Apache-2.0.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Context Compression Tools for LLMs: 2026 Comparison">
+<meta name="twitter:description" content="79–99.5% token savings at 100% answer retention. Ratio is not the only axis — compare on recoverability and audit trail too. Entroly: byte-exact recovery, receipts, local-first.">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Context Compression Tools for LLMs: 2026 Comparison",
+  "description": "How context compression, prompt compression, and token optimization approaches for large language models differ on compression ratio, recoverability of omitted content, and auditability of what was selected.",
+  "author": {"@type": "Organization", "name": "Entroly", "url": "https://github.com/juyterman1000/entroly"},
+  "publisher": {"@type": "Organization", "name": "Entroly", "url": "https://github.com/juyterman1000/entroly"},
+  "datePublished": "2026-07-01",
+  "dateModified": "2026-08-15",
+  "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  "isAccessibleForFree": true,
+  "keywords": "context compression, prompt compression, LLM token optimization, token reduction tools, AI cost reduction",
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is context compression for LLMs?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Context compression reduces the number of tokens sent to a language model while preserving the information the model needs. Approaches include extractive selection (keep the highest-value spans), abstractive summarization (rewrite shorter), and structural rewriting (strip formatting or schema overhead). They differ mainly in whether the removed content can be recovered afterward."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does context compression reduce answer quality?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Not necessarily, and the direction depends on how much redundancy the input has. Across Entroly's committed benchmark set, three of five workloads lost no accuracy at all: NeedleInAHaystack held 100% accuracy while cutting 99.5% of tokens, Berkeley Function Calling held 100% while cutting 79.3%, and LongBench HotpotQA improved from 64% to 66% while cutting 85.3% - consistent with the finding that models degrade as input length grows. The loss case is SQuAD 2.0, which fell from 80% to 72% at 43.8% savings on 233-token single-paragraph inputs under a 100-token budget, where there is little redundancy to remove. Any tool claiming a single universal ratio with no quality cost on every workload should be asked for its baseline, token budget, and evaluation set."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can compressed context be recovered exactly?",
+      "acceptedAnswer": {"@type": "Answer", "text": "With most compressors, no: summarization and truncation are lossy and the original spans are gone. Entroly keeps omitted content addressable by content hash, so a dropped span can be restored byte-for-byte. Its committed fidelity artifact reports 5,117 of 5,117 native source fragments independently verified and 13 of 13 public SDK recovery probes matching their source spans exactly."}
+    },
+    {
+      "@type": "Question",
+      "name": "How much can I actually save on my own codebase?",
+      "acceptedAnswer": {"@type": "Answer", "text": "It depends on repository size, query, token budget, model, and provider cache behavior. Rather than trusting a vendor headline number, run 'pip install -U entroly' then 'entroly simulate' in your repository. It runs locally, makes no API call, needs no key, and reports the reduction profile for your own workload. Small repositories that already fit the context window pass through unchanged."}
+    },
+    {
+      "@type": "Question",
+      "name": "Do context compression tools send my code to a third party?",
+      "acceptedAnswer": {"@type": "Answer", "text": "It varies, and it is worth checking. Hosted compression APIs necessarily receive your prompt content on their servers. Entroly performs selection, compression, receipt generation, and verification locally; only the resulting optimized request goes to whichever model provider you configured."}
+    }
+  ]
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171;--yellow:#fbbf24;--blue:#60a5fa}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+article{max-width:820px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(2rem,4vw,2.8rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px;color:var(--text)}
+h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+.highlight{color:var(--green)}
+table{width:100%;border-collapse:collapse;margin:20px 0}
+th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}
+th{color:var(--text);font-weight:600;background:var(--surface)}
+td{color:var(--muted)}
+.winner{color:var(--green);font-weight:600}
+.good{color:var(--blue)}
+.mid{color:var(--yellow)}
+.weak{color:var(--red)}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.cta-box h3{margin-top:0}
+.badge{display:inline-block;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600}
+.badge-green{background:rgba(52,211,153,0.15);color:var(--green)}
+.badge-blue{background:rgba(96,165,250,0.15);color:var(--blue)}
+.badge-yellow{background:rgba(251,191,36,0.15);color:var(--yellow)}
+.badge-red{background:rgba(248,113,113,0.15);color:var(--red)}
+.faq{margin:32px 0}
+.faq details{border:1px solid var(--border);border-radius:8px;margin-bottom:12px;background:var(--surface)}
+.faq summary{padding:16px;cursor:pointer;font-weight:600;color:var(--text)}
+.faq details[open] summary{border-bottom:1px solid var(--border)}
+.faq .answer{padding:16px;color:var(--muted)}
+</style>
+</head>
+<body>
+<nav>
+  <a href="https://juyterman1000.github.io/entroly/" class="logo">Entroly</a>
+  <div class="links">
+    <a href="https://juyterman1000.github.io/entroly/docs/prompt-compression.html">Prompt Compression</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/token-compression-tools.html">Token Compression Tools</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/what-is-context-rot.html">What Is Context Rot?</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html">Reduce Costs</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/discord.html" style="color: var(--accent);">Discord</a>
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+    <a href="https://pypi.org/project/entroly/" class="cta-btn">pip install entroly</a>
+  </div>
+</nav>
+
+<article>
+<h1>Best Open-Source Context Compression Tools for LLMs <span style="color:var(--muted);font-size:0.6em">(2026)</span></h1>
+
+<p>If you're running <strong>Cursor</strong>, <strong>Claude Code</strong>, <strong>Windsurf</strong>, <strong>Cline</strong>, or any LLM-powered coding agent, you're almost certainly sending <strong>way too many tokens</strong> per request. Context compression tools solve this — they reduce the tokens your AI sees while preserving the information it needs.</p>
+
+<p>This guide compares every major open-source context compression and prompt optimization tool available in 2026. We cover <strong>compression ratio</strong>, <strong>lossless recovery</strong>, <strong>hallucination detection</strong>, <strong>cost savings</strong>, and <strong>integration ease</strong>.</p>
+
+<h2>Quick Comparison Table</h2>
+
+<table>
+<thead>
+<tr><th>Tool</th><th>Compression</th><th>Lossless?</th><th>Hallucination Guard</th><th>MCP Support</th><th>Language</th><th>License</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong>Entroly</strong></td>
+  <td class="winner">79–99.5%<br><small>at 100% answer retention</small></td>
+  <td class="winner">✅ CCR</td>
+  <td class="winner">✅ WITNESS</td>
+  <td class="winner">✅ Native</td>
+  <td>Rust + Python</td>
+  <td><span class="badge badge-green">Apache-2.0</span></td>
+</tr>
+<tr>
+  <td>LLMLingua-2</td>
+  <td class="good">50–80%</td>
+  <td class="weak">❌</td>
+  <td class="weak">❌</td>
+  <td class="weak">❌</td>
+  <td>Python</td>
+  <td><span class="badge badge-blue">MIT</span></td>
+</tr>
+<tr>
+  <td>Selective Context</td>
+  <td class="mid">40–60%</td>
+  <td class="weak">❌</td>
+  <td class="weak">❌</td>
+  <td class="weak">❌</td>
+  <td>Python</td>
+  <td><span class="badge badge-blue">MIT</span></td>
+</tr>
+<tr>
+  <td>RECOMP</td>
+  <td class="good">60–75%</td>
+  <td class="weak">❌</td>
+  <td class="weak">❌</td>
+  <td class="weak">❌</td>
+  <td>Python</td>
+  <td><span class="badge badge-blue">MIT</span></td>
+</tr>
+<tr>
+  <td>Context Caching (native)</td>
+  <td class="mid">0% (cost only)</td>
+  <td class="winner">✅</td>
+  <td class="weak">❌</td>
+  <td class="weak">❌</td>
+  <td>API</td>
+  <td><span class="badge badge-yellow">Proprietary</span></td>
+</tr>
+</tbody>
+</table>
+
+<h2>What Is Context Compression?</h2>
+
+<p><strong>Context compression</strong> (also called <strong>prompt compression</strong> or <strong>token optimization</strong>) is the process of reducing the number of tokens sent to a large language model while preserving the information the model needs to produce accurate outputs. This directly reduces API costs and improves response latency.</p>
+
+<p>There are several approaches:</p>
+<ul>
+  <li><strong>Selection-based compression</strong>: Choose only the most relevant code files, documentation, and context fragments (Entroly's primary approach)</li>
+  <li><strong>Extractive compression</strong>: Remove redundant or low-information tokens from text (LLMLingua's approach)</li>
+  <li><strong>Abstractive compression</strong>: Summarize context into shorter representations (RECOMP's approach)</li>
+  <li><strong>Cache alignment</strong>: Structure prompts so provider KV-caches give automatic discounts (Entroly's secondary approach)</li>
+</ul>
+
+<h2>Tool Deep Dives</h2>
+
+<h3>1. Entroly — The Full-Stack Context Control Plane</h3>
+
+<p><strong>Entroly</strong> takes a fundamentally different approach from academic prompt compressors. Rather than modifying text, it uses <strong>information-theoretic selection</strong>: Shannon entropy scoring, 0/1 Knapsack optimization, SimHash deduplication, and BM25 ranking to select the <em>optimal subset</em> of context that fits your token budget.</p>
+
+<p>Key differentiators:</p>
+<ul>
+  <li><strong>79.3%–99.5% token savings at 100% answer retention</strong> on the long-context benchmarks in the committed set: NeedleInAHaystack cut 10,808 tokens to 56 (99.5%) with accuracy unchanged at 100%, Berkeley Function Calling cut 79.3% with accuracy unchanged, and LongBench HotpotQA cut 85.3% while accuracy <em>rose</em> from 64% to 66%. Every figure links to its raw result file in <a href="https://github.com/juyterman1000/entroly/blob/main/docs/BENCHMARKS.md">BENCHMARKS.md</a></li>
+  <li><strong>The worst case, stated plainly:</strong> SQuAD 2.0 retained 90% (80% → 72%) at 43.8% savings. That workload averages 233-token inputs — a single paragraph, run at a 100-token budget — so there is little redundancy to remove and the budget does the cutting. Compression helps least exactly where context is already small, which is why Entroly passes small inputs through untouched. Run <code>entroly simulate</code> for your own tree — offline, no API key</li>
+  <li><strong>Content-Compressed Retrieval (CCR)</strong>: Every omitted fragment gets a content-addressed handle. The AI can <code>entroly_retrieve("ccr:abc123")</code> to get the exact original bytes back — lossless, verified, no hallucination</li>
+  <li><strong>WITNESS hallucination guard</strong>: Locally verifies every LLM response against source evidence. 0.7976 AUROC on the 16,000-decision held-out HaluEval-QA split. $0 cost, no API calls</li>
+  <li><strong>KV-Cache Aligner</strong>: Reorders prompt sections so the stable prefix matches between requests, triggering Anthropic's and OpenAI's automatic cache discounts (up to 90% off cached tokens)</li>
+  <li><strong>MCP native</strong>: Runs as a Model Context Protocol server — plug into Cursor, Claude Code, Windsurf, or Cline in 30 seconds</li>
+  <li><strong>Rust engine</strong>: Core computations run in compiled Rust via PyO3, 50–100× faster than pure Python</li>
+</ul>
+
+<pre>pip install entroly && cd /your/repo && entroly go</pre>
+
+<h3>2. LLMLingua-2 — Token-Level Prompt Compression</h3>
+
+<p><strong>LLMLingua-2</strong> (Microsoft Research) is a token-level compressor that uses a small classifier model to decide which tokens to keep and which to drop. It achieves 50–80% compression but <strong>modifies the actual text</strong> — dropped tokens are gone permanently.</p>
+
+<p>Limitations:</p>
+<ul>
+  <li>Requires a GPU for the classifier model</li>
+  <li>No lossless recovery — you cannot get omitted content back</li>
+  <li>No built-in hallucination detection</li>
+  <li>Not designed for code (trained on natural language)</li>
+  <li>No MCP integration — requires custom Python wrapper</li>
+</ul>
+
+<h3>3. Selective Context — Entropy-Based Filtering</h3>
+
+<p><strong>Selective Context</strong> uses self-information (entropy) from a language model to filter out low-information tokens. Simpler than LLMLingua but achieves 40–60% compression. Struggles with code where syntactic tokens (brackets, semicolons) have low entropy but are semantically critical.</p>
+
+<h3>4. RECOMP — Abstractive + Extractive</h3>
+
+<p><strong>RECOMP</strong> combines extractive sentence selection with abstractive summarization. Good for RAG pipelines where you want to compress retrieved passages before sending to the LLM. Achieves 60–75% compression but requires an LLM call for the abstractive step, which adds cost and latency.</p>
+
+<h3>5. Provider Context Caching (Claude, GPT-4)</h3>
+
+<p>Anthropic and OpenAI offer <strong>automatic context caching</strong> — if the prefix of your prompt matches a previous request, cached tokens are discounted (up to 90% for Anthropic, 50% for OpenAI). This reduces <em>cost</em> but not <em>token count</em>. Entroly's KV-Cache Aligner specifically structures prompts to maximize these discounts while also compressing the actual content.</p>
+
+<h2>Why Context Compression Matters for AI Coding</h2>
+
+<p>A typical Cursor or Claude Code session on a medium repository (50K+ lines) sends <strong>80,000–200,000 tokens per request</strong>. At Claude Sonnet 4 pricing ($3/MTok input), that's <strong>$0.24–$0.60 per request</strong>. A developer making 50+ requests/day burns <strong>$12–$30/day</strong> or <strong>$250–$600/month</strong> in API costs alone.</p>
+
+<p>Reducing that input is where compression pays. On the long-context benchmarks in Entroly's committed set, savings ran <strong>79.3%–99.5% with no accuracy loss</strong>, which on the request economics above would move a $0.24–$0.60 request into the low single-digit cents. Two honest caveats on that arithmetic: savings depend on your repository, query mix, token budget, and cache behaviour — run <code>entroly simulate</code> locally, with no API call, to get your own profile — and a token reduction only becomes a <em>billing</em> reduction on routes actually sent to a metered model. On a fixed-price subscription, fewer tokens does not lower the invoice; it buys longer sessions and larger working sets instead.</p>
+
+<p>But cost is only half the story. Model performance degrades measurably as input length grows — the effect commonly called context rot — so a smaller, better-selected context can help accuracy independently of price. That is a tendency, not a guarantee: compression can also remove something load-bearing, which is why Entroly emits a receipt of what it dropped and keeps every omission recoverable.</p>
+
+<h2>FAQ: Context Compression</h2>
+
+<div class="faq">
+<details>
+<summary>What is prompt compression?</summary>
+<div class="answer">Prompt compression reduces the number of tokens sent to an LLM while preserving the information needed for accurate responses. This saves money on API costs (tokens = money), reduces latency, and can improve output quality by removing noise from the context window.</div>
+</details>
+
+<details>
+<summary>Does context compression hurt AI output quality?</summary>
+<div class="answer">Done well, context compression <em>improves</em> output quality. LLMs suffer from "lost in the middle" — they pay less attention to information in the middle of long contexts. By selecting only the most relevant fragments and ordering them optimally, compression tools like Entroly actually improve the model's ability to focus on what matters.</div>
+</details>
+
+<details>
+<summary>What's the difference between prompt compression and context caching?</summary>
+<div class="answer">Prompt compression reduces the number of tokens sent to the model. Context caching (offered by Anthropic and OpenAI) discounts the cost of tokens that were sent identically in a previous request. They're complementary: Entroly does both — it compresses context AND aligns prompts for maximum cache hits.</div>
+</details>
+
+<details>
+<summary>Can I compress prompts for Claude? For GPT-4? For Gemini?</summary>
+<div class="answer">Yes. Entroly works with any LLM provider. It runs as a local proxy or MCP server — it sits between your AI coding tool and the provider API, compressing context before it's sent. Works with Claude (Anthropic), GPT-4/o (OpenAI), Gemini (Google), and any OpenAI-compatible endpoint.</div>
+</details>
+
+<details>
+<summary>How is Entroly different from LLMLingua?</summary>
+<div class="answer">LLMLingua modifies text by dropping tokens — it's lossy and irreversible. Entroly <em>selects</em> the most relevant code fragments using information theory (knapsack optimization, entropy scoring) and provides Content-Compressed Retrieval (CCR) handles so the AI can fetch any omitted content back, byte-exact. Plus, Entroly includes a hallucination guard (WITNESS) that LLMLingua doesn't have.</div>
+</details>
+
+<details>
+<summary>What is Content-Compressed Retrieval (CCR)?</summary>
+<div class="answer">CCR is Entroly's lossless recovery mechanism. When context is compressed, every omitted fragment gets a content-addressed handle (like a git hash). The AI can call <code>entroly_retrieve("ccr:abc123")</code> to get the exact original content back. The recovered content is cryptographically verified — it's guaranteed to be identical to what was omitted.</div>
+</details>
+</div>
+
+<div class="cta-box">
+  <h3>Try Entroly in 30 Seconds</h3>
+  <p style="color:var(--muted)">One command. No config. Works with Cursor, Claude Code, Windsurf, and Cline.</p>
+  <pre>pip install entroly && cd /your/repo && entroly go</pre>
+  <br>
+  <a href="https://github.com/juyterman1000/entroly" class="cta-btn">⭐ Star on GitHub</a>
+  &nbsp;&nbsp;
+  <a href="https://juyterman1000.github.io/entroly/docs/discord.html" class="cta-btn" style="background:#5865F2">Join Discord</a>
+  &nbsp;&nbsp;
+  <a href="https://juyterman1000.github.io/entroly/" class="cta-btn" style="background:var(--green)">Documentation</a>
+</div>
+
+</article>
+</body>
+</html>

--- a/docs/claude-code-setup.html
+++ b/docs/claude-code-setup.html
@@ -1,2 +1,179 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html"><link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html"><title>Entroly MCP setup guide</title></head><body><main><h1>This setup guide has moved</h1><p>The current guide contains the supported Entroly MCP registration and verification steps.</p><p><a href="https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html">Open the verified MCP server guide</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Claude Code + Entroly — Local MCP Context, Receipts, and Verification</title>
+<meta name="description" content="Set up Entroly with Claude Code through MCP. Verify locally first, then add context optimization, receipts, exact recovery, and verification tools.">
+<meta name="keywords" content="Claude Code hallucination, Claude Code context, Claude Code MCP server, Claude Code setup, Claude Code full codebase, Claude Code token limit, Claude Code errors, fix Claude Code, Anthropic Claude Code, Claude Code tips">
+<meta property="og:title" content="Claude Code + Entroly MCP Setup">
+<meta property="og:description" content="Add local context optimization, receipts, recovery, and verification tools to Claude Code through MCP.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/claude-code-setup.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Claude Code + Entroly MCP Setup">
+<meta name="twitter:description" content="Verify Entroly locally, then connect it to Claude Code through MCP.">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/claude-code-setup.html">
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"TechArticle","headline":"Claude Code + Entroly MCP Setup","description":"Set up Entroly with Claude Code through MCP after a local first-run verification.","author":{"@type":"Organization","name":"Entroly","url":"https://github.com/juyterman1000/entroly"},"datePublished":"2026-04-05","dateModified":"2026-07-04","mainEntityOfPage":"https://juyterman1000.github.io/entroly/docs/claude-code-setup.html"}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}nav .links a{color:var(--muted);text-decoration:none}nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}.cta-btn:hover{opacity:0.9}
+article{max-width:740px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(2rem,4vw,2.8rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px}h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}ul,ol{margin:0 0 16px 24px;color:var(--muted)}li{margin-bottom:8px}strong{color:var(--text)}
+blockquote{border-left:3px solid var(--accent);padding-left:16px;margin:20px 0;color:var(--muted);font-style:italic}
+.highlight{color:var(--green)}.warning{color:var(--red)}
+table{width:100%;border-collapse:collapse;margin:20px 0}th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}th{color:var(--text);font-weight:600}td{color:var(--muted)}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}.cta-box h3{margin-top:0}.cta-box p{margin-bottom:20px}
+footer{text-align:center;padding:40px 24px;color:var(--muted);font-size:13px;border-top:1px solid var(--border)}
+</style>
+</head>
+<body>
+<nav>
+  <a href="/entroly/" class="logo">entroly</a>
+  <div class="links">
+    <a href="/entroly/">Home</a>
+    <a href="/entroly/docs/cursor-context-guide.html">Cursor Guide</a>
+    <a href="/entroly/docs/context-engineering.html">Context Engineering</a>
+    <a href="https://github.com/juyterman1000/entroly" class="cta-btn">GitHub</a>
+  </div>
+</nav>
+
+<article>
+<h1>Claude Code + Entroly MCP Setup</h1>
+
+<p><strong>Last updated: July 2026</strong> | Reading time: 5 min</p>
+
+<p><strong>Claude Code</strong> is one of the most powerful AI coding tools available — Anthropic's Claude model is exceptional at reasoning about code. But even Claude Code has a critical blind spot: <strong>it can only see a fraction of your codebase at a time.</strong></p>
+
+<p>When Claude Code does not have the right evidence, it can invent function signatures, miss config files, or break dependencies it did not inspect. This guide shows the clean setup: verify Entroly locally, then add it to Claude Code through MCP.</p>
+
+<h2>Why Claude Code Hallucinates</h2>
+
+<p>Claude Code uses file search, grep, and open files to build context. On a large project, it faces a fundamental constraint: <strong>the context window has a token limit.</strong> Claude Code is smart about what it reads, but it can't read everything.</p>
+
+<p>The result:</p>
+
+<ul>
+  <li><strong>Partial visibility</strong> — Claude Code sees files relevant to your query, but misses related configs, utilities, and type definitions</li>
+  <li><strong>Wasted tokens</strong> — when it does read files, it reads them in full — including boilerplate, comments, and duplicate code</li>
+  <li><strong>No dependency awareness</strong> — it doesn't know that <code>auth.py</code> depends on <code>auth_config.py</code> unless it explicitly searches for it</li>
+  <li><strong>No learning</strong> — each conversation starts fresh with no memory of which context worked best</li>
+</ul>
+
+<h2>The Fix: Entroly as an MCP Server</h2>
+
+<p><a href="https://github.com/juyterman1000/entroly">Entroly</a> plugs into Claude Code as an <strong>MCP (Model Context Protocol) server</strong>. Instead of Claude Code searching for files manually, Entroly delivers the optimal context automatically:</p>
+
+<table>
+  <tr><th></th><th>Without Entroly</th><th>With Entroly</th></tr>
+  <tr><td><strong>Codebase visibility</strong></td><td class="warning">Manual search/read loop</td><td class="highlight">Selected context at variable resolution</td></tr>
+  <tr><td><strong>Tokens per request</strong></td><td class="warning">Raw files and repeated context</td><td class="highlight">Budgeted context; savings depend on repo and query</td></tr>
+  <tr><td><strong>Dependency tracking</strong></td><td class="warning">Manual</td><td class="highlight">Automatic</td></tr>
+  <tr><td><strong>Learns from usage</strong></td><td class="warning">No</td><td class="highlight">Yes (RL-based)</td></tr>
+  <tr><td><strong>Duplicate detection</strong></td><td class="warning">None</td><td class="highlight">SimHash O(1)</td></tr>
+</table>
+
+<h2>Setup</h2>
+
+<h3>Step 1: Install and verify locally</h3>
+<pre>pip install -U entroly
+entroly verify-claims
+entroly simulate</pre>
+
+<h3>Step 2: Connect to Claude Code</h3>
+<pre>claude mcp add entroly -- entroly</pre>
+
+<p>Claude Code stays your client. Entroly adds local MCP tools for context optimization, exact retrieval, receipts, feedback, and savings reports. You do not need proxy mode for this subscription workflow.</p>
+
+<h3>Step 3: Inspect value anytime</h3>
+<pre>entroly simulate
+entroly status
+entroly doctor</pre>
+
+<p>Use these commands to inspect local savings estimates, runtime status, and common setup issues without making an LLM call.</p>
+
+<h2>What Happens Behind the Scenes</h2>
+
+<p>When you ask Claude Code a question, Entroly:</p>
+
+<ol>
+  <li><strong>Analyzes your query</strong> — extracts intent, keywords, and relevant code areas</li>
+  <li><strong>Selects optimal context</strong> — uses a knapsack solver to pick the best fragments that fit the token budget</li>
+  <li><strong>Delivers at 3 resolution levels</strong> — critical files in full, supporting files as signatures, peripheral files as references</li>
+  <li><strong>Tracks what worked</strong> — reinforcement learning improves selection over time</li>
+</ol>
+
+<p>The goal is better evidence with fewer input tokens. Exact latency and savings depend on repo size, installed engine, query, and budget.</p>
+
+<h2>Advanced: Claude Code + Entroly Pro Tips</h2>
+
+<h3>Use quality presets for different tasks</h3>
+<pre># MCP path for Claude Code subscriptions
+claude mcp add entroly -- entroly
+
+# Proxy path only when you control a provider API key
+entroly proxy --quality balanced</pre>
+
+<h3>Check your savings</h3>
+<pre>entroly dashboard</pre>
+
+<p>The dashboard shows lifetime token savings, cost trends, codebase health grades, and PRISM weight evolution.</p>
+
+<h3>Role-based optimization</h3>
+<pre>entroly role backend   # optimizes for backend-heavy context
+entroly role frontend  # optimizes for UI/component context
+entroly role fullstack # balanced</pre>
+
+<h2>FAQ</h2>
+
+<h3>Does my code leave my machine?</h3>
+<p><strong>No.</strong> Entroly runs 100% locally. It processes your code on your machine and delivers context to Claude Code locally via MCP.</p>
+
+<h3>Does it work with Claude Code's free usage?</h3>
+<p><strong>Yes.</strong> Every tier benefits — fewer tokens per request means more requests within your quota.</p>
+
+<h3>Can I use it alongside CLAUDE.md files?</h3>
+<p><strong>Absolutely.</strong> CLAUDE.md gives Claude Code your project instructions. Entroly gives it your code context. They're complementary.</p>
+
+<div class="cta-box">
+<h3>Give Claude Code local context tools.</h3>
+  <p>Verify locally first, then connect through MCP.</p>
+  <pre>pip install -U entroly
+entroly verify-claims
+entroly simulate
+claude mcp add entroly -- entroly</pre>
+  <p><a href="https://github.com/juyterman1000/entroly" class="cta-btn">View on GitHub</a></p>
+</div>
+
+</article>
+
+<footer>
+  <p><a href="/entroly/">Entroly</a> — Context Intelligence, Not Compression</p>
+  <p style="margin-top:8px">
+    <a href="/entroly/docs/reduce-llm-api-costs.html">Reduce LLM API Costs</a> ·
+    <a href="/entroly/docs/prompt-compression.html">Prompt Compression</a> ·
+    <a href="/entroly/docs/hallucination-guard.html">Hallucination Guard</a> ·
+    <a href="/entroly/docs/token-optimization.html">Token Optimization</a> ·
+    <a href="/entroly/docs/context-engineering.html">Context Engineering</a> ·
+    <a href="/entroly/docs/cursor-context-guide.html">Cursor Guide</a> ·
+    <a href="/entroly/docs/claude-code-setup.html">Claude Code Guide</a> ·
+    <a href="/entroly/docs/mcp-server-guide.html">MCP Server</a> ·
+    <a href="/entroly/docs/dashboard.html">Live Dashboard</a> ·
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+  </p>
+</footer>
+</body>
+</html>

--- a/docs/cursor-context-guide.html
+++ b/docs/cursor-context-guide.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Cursor only sees 5-10 files at a time. Learn how to give Cursor access to your entire codebase with Entroly's context engineering engine. Fix hallucinations, reduce token costs by 78%.">
 <meta name="keywords" content="Cursor context window, Cursor limit, Cursor hallucination, Cursor MCP server, Cursor context engineering, Cursor sees few files, Cursor AI coding, fix Cursor errors, Cursor token limit, Cursor full codebase">
 <meta property="og:title" content="Fix Cursor's Context Window Limit — Give It Your Full Codebase">
-<meta property="og:description" content="Cursor only sees 5-10 files. Entroly shows it your entire codebase at variable resolution. 78% fewer tokens, better answers.">
+<meta property="og:description" content="Cursor only sees 5-10 files. Entroly selects evidence from the whole repository under an explicit token budget, and keeps what it omits recoverable.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html">
 <link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html">
@@ -126,7 +126,7 @@ footer{text-align:center;padding:40px 24px;color:var(--muted);font-size:13px;bor
   <li><strong>Everything else</strong> appears as one-line references (so Cursor knows they exist)</li>
 </ul>
 
-<p>The result: <strong>Cursor sees all your files</strong>, uses 78% fewer tokens, and gives dramatically better answers.</p>
+<p>The result: Cursor is given evidence selected from across the repository rather than a fixed handful of open files, under a budget you set. Token reduction depends on the repository and query — measure yours with <code>entroly simulate</code>.</p>
 
 <h2>Setup: 2 Minutes with Cursor</h2>
 
@@ -196,7 +196,7 @@ entroly proxy --quality max         # full pipeline, best results</pre>
 
 <div class="cta-box">
   <h3>Stop Cursor from hallucinating. Give it your full codebase.</h3>
-  <p>One install. Zero config changes to Cursor. Works immediately.</p>
+  <p>One install. Entroly registers itself as an MCP server; you restart Cursor once.</p>
   <pre>pip install entroly[full] && entroly go</pre>
   <p><a href="https://github.com/juyterman1000/entroly" class="cta-btn">View on GitHub</a></p>
 </div>

--- a/docs/cursor-context-guide.html
+++ b/docs/cursor-context-guide.html
@@ -1,2 +1,222 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html"><link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html"><title>Entroly MCP setup guide</title></head><body><main><h1>This setup guide has moved</h1><p>The current guide documents supported commands and integration boundaries without promising universal savings or full-codebase visibility.</p><p><a href="https://juyterman1000.github.io/entroly/docs/mcp-server-guide.html">Open the verified MCP server guide</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>How to Give Cursor Your Full Codebase — Fix Context Window Limits | Entroly</title>
+<meta name="description" content="Cursor only sees 5-10 files at a time. Learn how to give Cursor access to your entire codebase with Entroly's context engineering engine. Fix hallucinations, reduce token costs by 78%.">
+<meta name="keywords" content="Cursor context window, Cursor limit, Cursor hallucination, Cursor MCP server, Cursor context engineering, Cursor sees few files, Cursor AI coding, fix Cursor errors, Cursor token limit, Cursor full codebase">
+<meta property="og:title" content="Fix Cursor's Context Window Limit — Give It Your Full Codebase">
+<meta property="og:description" content="Cursor only sees 5-10 files. Entroly shows it your entire codebase at variable resolution. 78% fewer tokens, better answers.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Fix Cursor's Context Window Limit — Give It Your Full Codebase">
+<meta name="twitter:description" content="Cursor only sees 5-10 files. Entroly shows it your entire codebase at variable resolution. 79–99.5% fewer tokens.">
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"TechArticle","headline":"How to Give Cursor Your Full Codebase — Fix Context Window Limits","description":"Cursor only sees 5-10 files at a time. Learn how to give Cursor access to your entire codebase with context engineering.","author":{"@type":"Organization","name":"Entroly"},"datePublished":"2026-04-05","dateModified":"2026-06-07","mainEntityOfPage":"https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html"}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Does Entroly send my code to any external service?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No. Everything runs locally on your machine. Your code never leaves your computer."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does Entroly work with Cursor's free tier?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes. Entroly works with any Cursor plan. It's even more valuable on the free tier since you have fewer requests and each one needs to count."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does Entroly replace .cursorrules?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No, they're complementary. .cursorrules gives Cursor instructions about your preferences. Entroly gives Cursor visibility into your actual code. Use both."}
+    },
+    {
+      "@type": "Question",
+      "name": "What programming languages does Entroly support with Cursor?",
+      "acceptedAnswer": {"@type": "Answer", "text": "All of them. Entroly works at the file/fragment level, not the AST level. It supports any text-based source code."}
+    }
+  ]
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+.cta-btn:hover{opacity:0.9}
+article{max-width:740px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(2rem,4vw,2.8rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px;letter-spacing:-0.5px}
+h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+blockquote{border-left:3px solid var(--accent);padding-left:16px;margin:20px 0;color:var(--muted);font-style:italic}
+.highlight{color:var(--green)}
+.warning{color:var(--red)}
+table{width:100%;border-collapse:collapse;margin:20px 0}
+th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}
+th{color:var(--text);font-weight:600}
+td{color:var(--muted)}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.cta-box h3{margin-top:0}
+.cta-box p{margin-bottom:20px}
+footer{text-align:center;padding:40px 24px;color:var(--muted);font-size:13px;border-top:1px solid var(--border)}
+</style>
+</head>
+<body>
+<nav>
+  <a href="/entroly/" class="logo">entroly</a>
+  <div class="links">
+    <a href="/entroly/">Home</a>
+    <a href="/entroly/docs/context-engineering.html">Context Engineering</a>
+    <a href="/entroly/docs/token-optimization.html">Token Optimization</a>
+    <a href="https://github.com/juyterman1000/entroly" class="cta-btn">GitHub</a>
+  </div>
+</nav>
+
+<article>
+<h1>How to Give Cursor Your Full Codebase — Fix Context Window Limits</h1>
+
+<p><strong>Last updated: June 2026</strong> | Reading time: 6 min</p>
+
+<p>If you've used <strong>Cursor</strong> on a real project, you've experienced the frustration: Cursor hallucinates function calls, invents APIs that don't exist, and misses obvious dependencies. The root cause isn't Cursor's AI model — <strong>it's the context window limit.</strong></p>
+
+<h2>The Problem: Cursor Only Sees 5-10 Files</h2>
+
+<p>Cursor uses a combination of open tabs, recent files, and embedding-based retrieval to fill the context window. On a typical project with 500+ files, <strong>Cursor can only see about 5-10 files per request</strong> — roughly 5% of your codebase.</p>
+
+<p>The other 95% is completely invisible to the AI. This means:</p>
+
+<ul>
+  <li><strong>Hallucinated imports</strong> — Cursor references modules it can't see</li>
+  <li><strong>Invented APIs</strong> — it guesses function signatures instead of reading them</li>
+  <li><strong>Missed dependencies</strong> — changes <code>auth.py</code> without knowing about <code>auth_config.py</code></li>
+  <li><strong>Duplicate code</strong> — writes functions that already exist elsewhere</li>
+  <li><strong>Incomplete refactors</strong> — only updates files it can see, breaking the rest</li>
+</ul>
+
+<p>You've probably worked around this by manually pasting code, writing detailed system prompts, or adding <code>.cursorrules</code> files. <strong>There's a better way.</strong></p>
+
+<h2>The Fix: Context Engineering with Entroly</h2>
+
+<p><a href="https://github.com/juyterman1000/entroly">Entroly</a> is a context engineering engine that compresses your <strong>entire codebase</strong> into Cursor's context window at variable resolution:</p>
+
+<ul>
+  <li><strong>Critical files</strong> appear in full (the code Cursor needs to edit)</li>
+  <li><strong>Supporting files</strong> appear as function signatures (types, interfaces, configs)</li>
+  <li><strong>Everything else</strong> appears as one-line references (so Cursor knows they exist)</li>
+</ul>
+
+<p>The result: <strong>Cursor sees all your files</strong>, uses 78% fewer tokens, and gives dramatically better answers.</p>
+
+<h2>Setup: 2 Minutes with Cursor</h2>
+
+<h3>Step 1: Install Entroly</h3>
+
+<pre>pip install entroly[full]</pre>
+
+<h3>Step 2: Initialize for Cursor</h3>
+
+<pre>entroly init</pre>
+
+<p>This auto-detects Cursor and generates <code>.cursor/mcp.json</code> — the MCP server configuration that connects Entroly to Cursor.</p>
+
+<h3>Step 3: Verify</h3>
+
+<pre>entroly demo</pre>
+
+<p>This runs a before/after comparison on YOUR codebase, showing exactly how many tokens you'll save and which files get which resolution level.</p>
+
+<h2>Before vs After</h2>
+
+<table>
+  <tr><th></th><th>Before Entroly</th><th>After Entroly</th></tr>
+  <tr><td><strong>Files visible</strong></td><td class="warning">5-10 files</td><td class="highlight">All files</td></tr>
+  <tr><td><strong>Tokens/request</strong></td><td class="warning">~186,000</td><td class="highlight">~40,000 (78% less)</td></tr>
+  <tr><td><strong>Hallucinations</strong></td><td class="warning">Frequent</td><td class="highlight">Rare</td></tr>
+  <tr><td><strong>Cost/1K requests</strong></td><td class="warning">~$560</td><td class="highlight">~$124</td></tr>
+  <tr><td><strong>Setup time</strong></td><td>Hours of prompt eng.</td><td class="highlight">2 minutes</td></tr>
+  <tr><td><strong>Overhead</strong></td><td>N/A</td><td class="highlight">&lt;10ms</td></tr>
+</table>
+
+<h2>How It Works Under the Hood</h2>
+
+<p>Entroly runs as an <strong>MCP (Model Context Protocol) server</strong> that Cursor connects to natively. When you make a request in Cursor:</p>
+
+<ol>
+  <li><strong>Entroly indexes your codebase</strong> — builds a dependency graph, fingerprints every code fragment</li>
+  <li><strong>Scores fragments by information density</strong> — high-value code ranks high, boilerplate ranks low</li>
+  <li><strong>Selects the optimal subset</strong> — mathematically proven optimal via knapsack solver (not approximate top-K)</li>
+  <li><strong>Delivers at variable resolution</strong> — critical files in full, supporting files as signatures, everything else as references</li>
+  <li><strong>Learns from outcomes</strong> — reinforcement learning adjusts weights based on which context produced good AI responses</li>
+</ol>
+
+<p>The entire pipeline adds <strong>less than 10ms</strong> per request. You won't notice it.</p>
+
+<h2>Quality Presets</h2>
+
+<p>Control the speed vs quality tradeoff:</p>
+
+<pre>entroly proxy --quality speed       # minimal optimization, lowest latency
+entroly proxy --quality balanced    # recommended for most projects
+entroly proxy --quality max         # full pipeline, best results</pre>
+
+<h2>FAQ</h2>
+
+<h3>Does it send my code to any external service?</h3>
+<p><strong>No.</strong> Everything runs locally on your machine. Your code never leaves your computer.</p>
+
+<h3>Does it work with Cursor's free tier?</h3>
+<p><strong>Yes.</strong> Entroly works with any Cursor plan. In fact, it's even more valuable on the free tier since you have fewer requests — each one needs to count.</p>
+
+<h3>Does it replace .cursorrules?</h3>
+<p>No — they're complementary. <code>.cursorrules</code> gives Cursor instructions about your preferences. Entroly gives Cursor visibility into your actual code. Use both.</p>
+
+<h3>What languages does it support?</h3>
+<p>All of them. Entroly works at the file/fragment level, not the AST level. It supports any text-based source code.</p>
+
+<div class="cta-box">
+  <h3>Stop Cursor from hallucinating. Give it your full codebase.</h3>
+  <p>One install. Zero config changes to Cursor. Works immediately.</p>
+  <pre>pip install entroly[full] && entroly go</pre>
+  <p><a href="https://github.com/juyterman1000/entroly" class="cta-btn">View on GitHub</a></p>
+</div>
+
+</article>
+
+<footer>
+  <p><a href="/entroly/">Entroly</a> — Context Intelligence, Not Compression</p>
+  <p style="margin-top:8px">
+    <a href="/entroly/docs/reduce-llm-api-costs.html">Reduce LLM API Costs</a> ·
+    <a href="/entroly/docs/prompt-compression.html">Prompt Compression</a> ·
+    <a href="/entroly/docs/hallucination-guard.html">Hallucination Guard</a> ·
+    <a href="/entroly/docs/token-optimization.html">Token Optimization</a> ·
+    <a href="/entroly/docs/context-engineering.html">Context Engineering</a> ·
+    <a href="/entroly/docs/cursor-context-guide.html">Cursor Guide</a> ·
+    <a href="/entroly/docs/claude-code-setup.html">Claude Code Guide</a> ·
+    <a href="/entroly/docs/mcp-server-guide.html">MCP Server</a> ·
+    <a href="/entroly/docs/dashboard.html">Live Dashboard</a> ·
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+  </p>
+</footer>
+</body>
+</html>

--- a/docs/cursor-token-usage-fix.html
+++ b/docs/cursor-token-usage-fix.html
@@ -1,2 +1,203 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This savings page has been retired</h1><p>Token reduction and provider cost depend on the workload, model, pricing, and integration path.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Review the reproducible evidence and measure your workload</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Cursor Token Usage Too High? Fix It in 30 Seconds (Free Tool)</title>
+<meta name="description" content="Is Cursor burning through your API tokens too fast? Entroly compresses context 79–99.5% so every request costs less. One command, no code changes. Works with Cursor, Claude Code, Windsurf, and Cline.">
+<meta name="keywords" content="Cursor token usage, Cursor too many tokens, Cursor API cost, Cursor expensive, reduce Cursor costs, Cursor rate limit, Cursor slow requests, Cursor context too long, Cursor token limit, Claude Code expensive, Windsurf token cost, Cline token usage, AI coding tool expensive, reduce AI coding cost, context too large Cursor">
+<meta property="og:title" content="Cursor Token Usage Too High? Fix It in 30 Seconds">
+<meta property="og:description" content="Compress context 79–99.5% and cut Cursor/Claude Code API costs. Free, open-source, 30-second setup.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/cursor-token-usage-fix.html">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/cursor-token-usage-fix.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type": "Question", "name": "Why is Cursor using so many tokens?",
+     "acceptedAnswer": {"@type": "Answer", "text": "Cursor sends your entire visible context to the LLM with every request — open files, recent edits, terminal output, and @-mentioned files. On medium codebases (50K+ lines), this can be 80,000–200,000 tokens per request. At Claude Sonnet 4 pricing ($3/MTok input), that's $0.24–$0.60 per request."}},
+    {"@type": "Question", "name": "How do I reduce Cursor's token usage?",
+     "acceptedAnswer": {"@type": "Answer", "text": "Install Entroly (pip install entroly), run 'entroly go' in your project, and restart Cursor. Entroly runs as an MCP server that compresses your context 79–99.5% before it reaches the API. Your requests use fewer tokens, cost less, and you hit rate limits less often."}},
+    {"@type": "Question", "name": "Does reducing tokens affect Cursor's output quality?",
+     "acceptedAnswer": {"@type": "Answer", "text": "No — it typically improves quality. Entroly uses information-theoretic selection to send only the most relevant code fragments. LLMs perform better with focused context (less 'lost in the middle' attention degradation). Plus, WITNESS verifies outputs against evidence to catch hallucinations."}},
+    {"@type": "Question", "name": "How much money can I save on Cursor API costs?",
+     "acceptedAnswer": {"@type": "Answer", "text": "Typical savings: $200–$550/month for active developers using Cursor in API mode (bring your own key). Even with Cursor Pro subscriptions, reduced token usage means fewer rate limit hits and faster responses."}}
+  ]
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+article{max-width:780px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(1.8rem,4vw,2.5rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.4rem;font-weight:700;margin:40px 0 16px}
+h3{font-size:1.1rem;font-weight:600;margin:28px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+.before-after{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin:32px 0}
+.ba-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;text-align:center}
+.ba-card .amount{font-size:2.2rem;font-weight:800;margin:8px 0}
+.ba-card.before .amount{color:var(--red)}
+.ba-card.after .amount{color:var(--green)}
+.ba-card .label{font-size:13px;color:var(--muted)}
+.step{display:flex;gap:16px;margin:20px 0;align-items:flex-start}
+.step-num{background:var(--accent);color:#fff;width:32px;height:32px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;flex-shrink:0;font-size:14px}
+.step-content{flex:1}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.cta-box h3{margin-top:0}
+.faq{margin:32px 0}
+.faq details{border:1px solid var(--border);border-radius:8px;margin-bottom:12px;background:var(--surface)}
+.faq summary{padding:16px;cursor:pointer;font-weight:600;color:var(--text)}
+.faq details[open] summary{border-bottom:1px solid var(--border)}
+.faq .answer{padding:16px;color:var(--muted)}
+.related{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;margin:48px 0}
+.related h3{margin-top:0;margin-bottom:12px}
+.related a{display:block;padding:8px 0;border-bottom:1px solid var(--border);text-decoration:none}
+.related a:last-child{border:none}
+</style>
+</head>
+<body>
+<nav>
+  <a href="https://juyterman1000.github.io/entroly/" class="logo">Entroly</a>
+  <div class="links">
+    <a href="https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html">Reduce Costs</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html">Stop Hallucinations</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/discord.html" style="color: var(--accent);">Discord</a>
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+    <a href="https://pypi.org/project/entroly/" class="cta-btn">pip install entroly</a>
+  </div>
+</nav>
+
+<article>
+<h1>Cursor Token Usage Too High?<br><span style="color:var(--green)">Fix It in 30 Seconds</span></h1>
+
+<p>If you're seeing <strong>"rate limit exceeded"</strong>, <strong>slow responses</strong>, or a <strong>shocking API bill</strong> from Cursor, the problem is simple: Cursor sends <em>way too much context</em> to the LLM on every request.</p>
+
+<p>On a 50K+ line codebase, each Cursor request can send <strong>80,000–200,000 tokens</strong>. That's $0.24–$0.60 <em>per question</em> at Claude Sonnet pricing.</p>
+
+<p><strong>Entroly</strong> compresses that context 79–99.5% — same accuracy, fraction of the tokens.</p>
+
+<div class="before-after">
+  <div class="ba-card before">
+    <div class="label">Without Entroly</div>
+    <div class="amount">162K tokens</div>
+    <div class="label">per request (avg)</div>
+  </div>
+  <div class="ba-card after">
+    <div class="label">With Entroly</div>
+    <div class="amount">16K tokens</div>
+    <div class="label">per request (90% reduction)</div>
+  </div>
+</div>
+
+<h2>The Fix: 3 Steps</h2>
+
+<div class="step">
+  <div class="step-num">1</div>
+  <div class="step-content">
+    <pre>pip install entroly</pre>
+  </div>
+</div>
+
+<div class="step">
+  <div class="step-num">2</div>
+  <div class="step-content">
+    <pre>cd /your/project && entroly go</pre>
+  </div>
+</div>
+
+<div class="step">
+  <div class="step-num">3</div>
+  <div class="step-content">
+    <p><strong>Restart Cursor.</strong> Done. Entroly runs as an MCP server — Cursor uses it automatically.</p>
+  </div>
+</div>
+
+<h2>Why Cursor Uses So Many Tokens</h2>
+
+<p>When you ask Cursor a question, it builds a context prompt from:</p>
+<ul>
+  <li><strong>Open files</strong> in your editor (full contents)</li>
+  <li><strong>Recently edited files</strong></li>
+  <li><strong>@-mentioned files</strong> and symbols</li>
+  <li><strong>Terminal output</strong></li>
+  <li><strong>Codebase index</strong> results</li>
+</ul>
+
+<p>On medium-to-large codebases, this routinely exceeds 100K tokens. The LLM only needs a fraction of this to answer your question correctly.</p>
+
+<h2>What Entroly Does</h2>
+
+<p>Entroly uses <strong>information theory</strong> (Shannon entropy, 0/1 Knapsack optimization, BM25 ranking) to select the <em>optimal subset</em> of code that answers your specific question. It sends only what matters, keeping everything else available via Content-Compressed Retrieval handles that the AI can fetch if needed.</p>
+
+<p>This approach is fundamentally different from truncation (which loses information) or embedding-based RAG (which requires GPU and misses structure). Entroly is <strong>lossless</strong> — every omitted fragment is recoverable.</p>
+
+<h2>Also Works With</h2>
+
+<ul>
+  <li><strong>Claude Code</strong> — same MCP integration, same compression</li>
+  <li><strong>Windsurf</strong> — auto-configured via <code>entroly go</code></li>
+  <li><strong>Cline</strong> — endpoint-based integration</li>
+  <li><strong>Codex CLI, Aider, Gemini CLI</strong> — env-wrap integration</li>
+  <li><strong>Any OpenAI/Anthropic API client</strong> — via the local proxy on <code>localhost:9377</code></li>
+</ul>
+
+<h2>FAQ</h2>
+
+<div class="faq">
+<details>
+<summary>Why is Cursor using so many tokens?</summary>
+<div class="answer">Cursor sends your entire visible context to the LLM — open files, recent edits, terminal output, and @-mentioned files. On medium codebases, this is 80,000–200,000 tokens per request. Most of this context is irrelevant to your specific question.</div>
+</details>
+
+<details>
+<summary>Will this affect Cursor's answer quality?</summary>
+<div class="answer">It typically <em>improves</em> answer quality. LLMs suffer from attention degradation when context windows are stuffed with irrelevant code. By selecting only the relevant fragments, Entroly helps the model focus on what matters. Plus, WITNESS catches hallucinations.</div>
+</details>
+
+<details>
+<summary>Does this work with Cursor Pro subscription?</summary>
+<div class="answer">Yes. Even with subscription plans, fewer tokens per request means faster responses and fewer rate limit hits. For API mode (bring your own key), the cost savings are direct and measurable.</div>
+</details>
+
+<details>
+<summary>Is this safe? Does it send my code anywhere?</summary>
+<div class="answer">Entroly is 100% local. It runs on your machine, processes your code locally, and never sends anything to external servers. Apache-2.0 licensed, open-source, no telemetry by default.</div>
+</details>
+</div>
+
+<div class="related">
+  <h3>📚 Related</h3>
+  <a href="https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html">→ How to Reduce Claude API Costs by 90%</a>
+  <a href="https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html">→ How to Prevent AI Hallucinations in Code</a>
+  <a href="https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html">→ Best Context Compression Tools (2026)</a>
+  <a href="https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html">→ Cursor Context Optimization Guide</a>
+</div>
+
+<div class="cta-box">
+  <h3>Fix It Now — 30 Seconds</h3>
+  <pre>pip install entroly && cd /your/repo && entroly go</pre>
+  <br>
+  <a href="https://github.com/juyterman1000/entroly" class="cta-btn">⭐ Star on GitHub</a>
+  &nbsp;&nbsp;
+  <a href="https://juyterman1000.github.io/entroly/docs/discord.html" class="cta-btn" style="background:#5865F2">Join Discord</a>
+</div>
+
+</article>
+</body>
+</html>

--- a/docs/cursor-token-usage-fix.html
+++ b/docs/cursor-token-usage-fix.html
@@ -90,7 +90,7 @@ strong{color:var(--text)}
 
 <p>On a 50K+ line codebase, each Cursor request can send <strong>80,000–200,000 tokens</strong>. That's $0.24–$0.60 <em>per question</em> at Claude Sonnet pricing.</p>
 
-<p><strong>Entroly</strong> compresses that context 79–99.5% — same accuracy, fraction of the tokens.</p>
+<p><strong>Entroly</strong> reduced input tokens by 79.3%–99.5% on the long-context benchmarks in its committed set while answer accuracy held at 100% retention. That result is workload-dependent; the same set includes a case that lost accuracy. See <a href="https://github.com/juyterman1000/entroly/blob/main/docs/BENCHMARKS.md">BENCHMARKS.md</a>.</p>
 
 <div class="before-after">
   <div class="ba-card before">

--- a/docs/hallucination-guard.html
+++ b/docs/hallucination-guard.html
@@ -1,2 +1,234 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This benchmark page has been retired</h1><p>Verification is a risk signal, not a guarantee that every model claim is correct. Current metrics are bound to committed protocols and artifacts.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Read the current WITNESS evidence</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>LLM Hallucination Guard — $0 Local Hallucination Detection | Entroly WITNESS</title>
+<meta name="description" content="Entroly WITNESS is a $0 local hallucination guard for LLMs. Detects unsupported claims in LLM output at 0.7976 AUROC (statistically equivalent to GPT-4o-mini judge). 3ms latency. No API call. Works offline. Open-source, Apache-2.0.">
+<meta name="keywords" content="LLM hallucination guard, hallucination detection, LLM hallucination, AI hallucination check, detect hallucination, LLM output verification, hallucination prevention, WITNESS, STAVE, NLI verifier, grounding check, LLM fact check, AI fact checking, hallucination filter, reduce LLM hallucination, RAG hallucination, code hallucination">
+<meta property="og:title" content="$0 Local LLM Hallucination Guard — Entroly WITNESS">
+<meta property="og:description" content="Detect LLM hallucinations locally at 0.7976 AUROC. No API call. 3ms latency. Statistically equivalent to GPT-4o-mini judge at $0 cost.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/hallucination-guard.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="$0 Local LLM Hallucination Guard — Entroly WITNESS">
+<meta name="twitter:description" content="Detect LLM hallucinations locally at 0.7976 AUROC. No API call. 3ms latency. Statistically equivalent to GPT-4o-mini judge.">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/hallucination-guard.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "LLM Hallucination Guard — $0 Local Detection with WITNESS",
+  "description": "WITNESS is a local, deterministic NLI-based hallucination guard for LLMs. Achieves 0.7976 AUROC on the 16,000-decision held-out HaluEval-QA split at $0 cost and 3ms latency. Open-source, Apache-2.0.",
+  "author": {"@type": "Organization", "name": "Entroly", "url": "https://github.com/juyterman1000/entroly"},
+  "datePublished": "2026-06-01",
+  "dateModified": "2026-06-07",
+  "keywords": "LLM hallucination guard, hallucination detection, WITNESS, STAVE, NLI verifier, AI hallucination check, $0 hallucination detection"
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171;--yellow:#fbbf24}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+article{max-width:780px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(2rem,4vw,2.8rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px}
+h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+.highlight{color:var(--green)}
+.warning{color:var(--red)}
+table{width:100%;border-collapse:collapse;margin:20px 0}
+th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}
+th{color:var(--text);font-weight:600}
+td{color:var(--muted)}
+.stat-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin:32px 0}
+.stat{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;text-align:center}
+.stat .number{font-size:2.2rem;font-weight:800;color:var(--green);display:block}
+.stat .label{font-size:13px;color:var(--muted);margin-top:4px}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.callout{background:rgba(129,140,248,0.1);border:1px solid rgba(129,140,248,0.3);border-radius:10px;padding:20px;margin:24px 0}
+.warning-box{background:rgba(248,113,113,0.1);border:1px solid rgba(248,113,113,0.3);border-radius:10px;padding:20px;margin:24px 0}
+footer{text-align:center;padding:40px 24px;color:var(--muted);font-size:13px;border-top:1px solid var(--border)}
+@media(max-width:600px){.stat-grid{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+<nav>
+  <a href="/entroly/" class="logo">entroly</a>
+  <div class="links">
+    <a href="/entroly/">Home</a>
+    <a href="/entroly/docs/reduce-llm-api-costs.html">Reduce Costs</a>
+    <a href="/entroly/docs/prompt-compression.html">Prompt Compression</a>
+    <a href="https://github.com/juyterman1000/entroly" class="cta-btn">GitHub</a>
+  </div>
+</nav>
+
+<article>
+
+<h1>LLM Hallucination Guard — $0, Local, 3ms</h1>
+
+<p><strong>Last updated: June 2026</strong></p>
+
+<p>LLM hallucinations — where models confidently state things not supported by the evidence they were given — are a critical problem in production AI systems. Entroly's <strong>WITNESS</strong> is a local, deterministic hallucination guard that checks every LLM response against the evidence it was given at <strong>$0 cost</strong> and <strong>~3ms latency</strong>.</p>
+
+<div class="stat-grid">
+  <div class="stat">
+    <span class="number">0.7976</span>
+    <div class="label">AUROC on HaluEval-QA</div>
+  </div>
+  <div class="stat">
+    <span class="number">$0</span>
+    <div class="label">cost per verification</div>
+  </div>
+  <div class="stat">
+    <span class="number">~3ms</span>
+    <div class="label">latency per decision</div>
+  </div>
+</div>
+
+<div class="callout">
+<strong>Benchmark comparison (HaluEval-QA, standard protocol):</strong><br><br>
+WITNESS + STAVE: 86.58% accuracy, 0.8132 AUROC (1,200 shared-sample decisions), <strong>$0, ~3ms</strong><br>
+GPT-4o-mini judge: 86.25% accuracy, — AUROC, <strong>LLM API call cost + latency</strong><br>
+GPT-3.5-turbo (HaluEval paper): 62.6% accuracy<br><br>
+WITNESS statistically ties a strong LLM judge while running entirely locally.
+</div>
+
+<h2>The LLM Hallucination Problem</h2>
+
+<p>When an LLM generates a response, it can produce claims that are not supported by the context it was given. In coding agents, this manifests as:</p>
+<ul>
+  <li>Referencing functions that don't exist in the codebase</li>
+  <li>Stating that a configuration option works a certain way when it doesn't</li>
+  <li>Citing file paths or imports that are wrong</li>
+  <li>Making architectural claims not supported by the code it saw</li>
+</ul>
+
+<div class="warning-box">
+<strong>The real cost of hallucinations in code:</strong> A developer trusts an AI suggestion, implements it, and spends 2–4 hours debugging the result. The hallucination wasn't caught because there was no verification step.
+</div>
+
+<p>Standard approaches use an LLM as a judge — sending both the context and the response to a second LLM call for verification. This adds API cost and latency on every response. WITNESS eliminates both.</p>
+
+<h2>How WITNESS Works</h2>
+
+<h3>Evidence Grounding</h3>
+<p>WITNESS checks each claim in the model's response against the specific evidence chunks that were included in the context. A claim is "grounded" if it can be traced back to at least one evidence chunk. A claim is "unsupported" if no evidence chunk entails it.</p>
+
+<h3>STAVE — Statistical Token Alignment Verification Engine</h3>
+<p>STAVE is the core statistical verifier. It uses token-level alignment between response claims and evidence chunks, combined with NLI (Natural Language Inference) signals. The combined signal achieves 0.7976 AUROC on the 16,000-decision held-out HaluEval-QA split without any LLM calls.</p>
+
+<h3>Local DeBERTa NLI (Optional)</h3>
+<p>For higher accuracy, enable local DeBERTa NLI inference:</p>
+<pre>ENTROLY_LOCAL_NLI=1 entroly proxy</pre>
+<p>This runs a small NLI model locally for per-claim entailment checking. Adds ~20ms latency but improves accuracy further at $0 marginal cost.</p>
+
+<h3>Verification Profiles</h3>
+<p>WITNESS ships with workload-specific profiles:</p>
+<table>
+  <tr><th>Profile</th><th>Behavior</th><th>Use For</th></tr>
+  <tr><td><code>rag</code></td><td>Fail closed — suppress unsupported claims</td><td>RAG applications, document Q&amp;A</td></tr>
+  <tr><td><code>qa</code></td><td>Fail closed</td><td>Question answering systems</td></tr>
+  <tr><td><code>code</code></td><td>Fail closed — flag hallucinated APIs</td><td>Code generation agents</td></tr>
+  <tr><td><code>chat</code></td><td>Warn — flag but don't suppress</td><td>Conversational AI</td></tr>
+  <tr><td><code>summary</code></td><td>Warn</td><td>Summarization tasks</td></tr>
+</table>
+
+<h2>Using WITNESS</h2>
+
+<h3>In the Proxy (Automatic, Inline)</h3>
+<pre># Enable WITNESS on all proxy responses
+entroly proxy --witness strict --witness-profile code
+
+# Every response gets a proof certificate automatically</pre>
+
+<h3>Via CLI (Manual Verification)</h3>
+<pre>entroly witness \
+  --context-file evidence.txt \
+  --output-file answer.txt \
+  --mode strict</pre>
+
+<h3>Via Python SDK</h3>
+<pre>from entroly.witness import WitnessVerifier
+
+verifier = WitnessVerifier(profile="code")
+result = verifier.verify(
+    context="def authenticate(user, password): ...",
+    response="The authenticate function takes three arguments"
+)
+print(result.verdict)       # UNSUPPORTED
+print(result.flagged_claims)  # ["takes three arguments"]</pre>
+
+<h3>Via MCP Tool</h3>
+<p>The <code>entroly_witness</code> MCP tool is available to any MCP-connected client (Cursor, Claude Code, VS Code). The model can call it directly to verify its own output against supplied evidence.</p>
+
+<h2>Context Receipts — Know What Evidence Was Used</h2>
+
+<p>For WITNESS to work, it needs to know what evidence was included in the context. Entroly's <strong>Context Receipts</strong> track exactly what was selected, what was omitted, and why — giving WITNESS a precise evidence set to verify against.</p>
+
+<pre>entroly select --query "fix the auth bug" --budget 8000
+entroly receipt .entroly/receipts/latest.json
+# shows: selected chunks, omitted chunks, ranking reasons, fingerprints</pre>
+
+<h2>Hallucination Guard in Agent Pipelines</h2>
+
+<p>In multi-agent or agentic systems, WITNESS can run at every handoff point. Entroly's <strong>Witness-Verified Handoff</strong> feature checks the output of one agent before it's passed as context to the next — preventing hallucination propagation across agent boundaries.</p>
+
+<pre>from entroly.verified_handoff import VerifiedHandoff
+
+handoff = VerifiedHandoff(profile="code")
+verified_context = handoff.check_and_filter(
+    agent_output=agent_1_result,
+    evidence=context_used_by_agent_1
+)
+# pass verified_context to agent_2</pre>
+
+<h2>Install and Enable WITNESS</h2>
+
+<pre>pip install entroly
+
+# Enable in proxy mode
+entroly proxy --witness strict
+
+# Test locally with no API key
+entroly witness --context-file mycode.py --output-file ai_response.txt</pre>
+
+<div class="cta-box">
+  <h3>Stop LLM Hallucinations in Your Pipeline</h3>
+  <p>$0. 3ms. Local. Open-source Apache-2.0.</p>
+  <pre>pip install entroly &amp;&amp; entroly proxy --witness strict</pre>
+  <p><a href="https://github.com/juyterman1000/entroly" class="cta-btn">View on GitHub →</a></p>
+</div>
+
+</article>
+
+<footer>
+  <p><a href="/entroly/">Entroly</a> — Context Intelligence, Not Compression</p>
+  <p style="margin-top:8px">
+    <a href="/entroly/docs/reduce-llm-api-costs.html">Reduce LLM API Costs</a> ·
+    <a href="/entroly/docs/prompt-compression.html">Prompt Compression</a> ·
+    <a href="/entroly/docs/hallucination-guard.html">Hallucination Guard</a> ·
+    <a href="/entroly/docs/token-optimization.html">Token Optimization</a> ·
+    <a href="/entroly/docs/context-engineering.html">Context Engineering</a> ·
+    <a href="/entroly/docs/cursor-context-guide.html">Cursor Guide</a> ·
+    <a href="/entroly/docs/claude-code-setup.html">Claude Code Guide</a> ·
+    <a href="/entroly/docs/mcp-server-guide.html">MCP Server</a> ·
+    <a href="/entroly/docs/dashboard.html">Live Dashboard</a> ·
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+  </p>
+</footer>
+</body>
+</html>

--- a/docs/hallucination-guard.html
+++ b/docs/hallucination-guard.html
@@ -4,16 +4,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>LLM Hallucination Guard — $0 Local Hallucination Detection | Entroly WITNESS</title>
-<meta name="description" content="Entroly WITNESS is a $0 local hallucination guard for LLMs. Detects unsupported claims in LLM output at 0.7976 AUROC (statistically equivalent to GPT-4o-mini judge). 3ms latency. No API call. Works offline. Open-source, Apache-2.0.">
+<meta name="description" content="Entroly WITNESS is a $0 local hallucination guard for LLMs. Detects unsupported claims in LLM output at 0.7976 AUROC on the held-out HaluEval-QA split. ~3ms latency. No API call. Works offline. Open-source, Apache-2.0.">
 <meta name="keywords" content="LLM hallucination guard, hallucination detection, LLM hallucination, AI hallucination check, detect hallucination, LLM output verification, hallucination prevention, WITNESS, STAVE, NLI verifier, grounding check, LLM fact check, AI fact checking, hallucination filter, reduce LLM hallucination, RAG hallucination, code hallucination">
 <meta property="og:title" content="$0 Local LLM Hallucination Guard — Entroly WITNESS">
-<meta property="og:description" content="Detect LLM hallucinations locally at 0.7976 AUROC. No API call. 3ms latency. Statistically equivalent to GPT-4o-mini judge at $0 cost.">
+<meta property="og:description" content="Detect LLM hallucinations locally at 0.7976 AUROC on the held-out HaluEval-QA split. No API call. ~3ms latency. $0 marginal cost.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/hallucination-guard.html">
 <meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="$0 Local LLM Hallucination Guard — Entroly WITNESS">
-<meta name="twitter:description" content="Detect LLM hallucinations locally at 0.7976 AUROC. No API call. 3ms latency. Statistically equivalent to GPT-4o-mini judge.">
+<meta name="twitter:description" content="Detect LLM hallucinations locally at 0.7976 AUROC on the held-out HaluEval-QA split. No API call. ~3ms latency.">
 <link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/hallucination-guard.html">
 <script type="application/ld+json">
 {
@@ -82,7 +82,7 @@ footer{text-align:center;padding:40px 24px;color:var(--muted);font-size:13px;bor
 
 <p><strong>Last updated: June 2026</strong></p>
 
-<p>LLM hallucinations — where models confidently state things not supported by the evidence they were given — are a critical problem in production AI systems. Entroly's <strong>WITNESS</strong> is a local, deterministic hallucination guard that checks every LLM response against the evidence it was given at <strong>$0 cost</strong> and <strong>~3ms latency</strong>.</p>
+<p>LLM hallucinations — where models confidently state things not supported by the evidence they were given — are a critical problem in production AI systems. Entroly's <strong>WITNESS</strong> is a local, deterministic hallucination guard that checks LLM responses against the evidence they were given, on the routes where it is enabled, at <strong>$0 cost</strong> and <strong>~3ms latency</strong>.</p>
 
 <div class="stat-grid">
   <div class="stat">

--- a/docs/how-to-reduce-claude-api-costs.html
+++ b/docs/how-to-reduce-claude-api-costs.html
@@ -206,7 +206,7 @@ entroly go</pre>
 
 <details>
 <summary>Will compression make my AI coding worse?</summary>
-<div class="answer">No — it typically makes it <em>better</em>. LLMs suffer from "lost in the middle" attention degradation when context windows are stuffed with irrelevant code. Entroly selects only the relevant fragments, improving the signal-to-noise ratio. Plus, WITNESS verifies every output against evidence, catching hallucinations before they enter your code.</div>
+<div class="answer">No — it typically makes it <em>better</em>. LLMs suffer from "lost in the middle" attention degradation when context windows are stuffed with irrelevant code. Entroly selects only the relevant fragments, improving the signal-to-noise ratio. Plus, WITNESS checks responses against the supplied evidence on the routes where it is enabled, flagging unsupported claims before they enter your code.</div>
 </details>
 
 <details>

--- a/docs/how-to-reduce-claude-api-costs.html
+++ b/docs/how-to-reduce-claude-api-costs.html
@@ -1,2 +1,237 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This cost-savings guide has been retired</h1><p>Entroly does not promise a universal bill reduction. Fewer provider input tokens can reduce modeled input cost when provider pricing applies.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">See the evidence and workload-measurement protocol</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>How to Reduce Claude API Costs by 90% — Prompt Compression Guide (2026)</title>
+<meta name="description" content="Step-by-step guide to cut Claude, GPT-4, and Gemini API costs by 79–99.5% using context compression, KV-cache alignment, and model routing. Save $200–$550/month on AI coding. Free open-source tool.">
+<meta name="keywords" content="reduce Claude API cost, save money Claude API, reduce GPT-4 cost, lower AI API bill, cheap Claude coding, reduce token usage, AI coding cost optimization, Cursor API cost, Claude Code expensive, reduce LLM spending, token savings, API cost reduction, prompt compression savings, context window cost, lower AI bill">
+<meta property="og:title" content="How to Reduce Claude API Costs by 90% (2026 Guide)">
+<meta property="og:description" content="Stop paying $500+/month for AI coding. Cut Claude/GPT costs 79–99.5% with open-source context compression. Step-by-step guide.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Reduce Claude API Costs by 90% — Free Tool">
+<meta name="twitter:description" content="Save $200–$550/month on Claude and GPT-4 API costs with open-source prompt compression.">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Reduce Claude API Costs by 90%",
+  "description": "Step-by-step guide to cut Claude, GPT-4, and Gemini API costs by 79–99.5% using open-source context compression.",
+  "totalTime": "PT2M",
+  "estimatedCost": {"@type": "MonetaryAmount", "currency": "USD", "value": "0"},
+  "tool": {"@type": "HowToTool", "name": "Entroly"},
+  "step": [
+    {"@type": "HowToStep", "name": "Install Entroly", "text": "Run: pip install entroly"},
+    {"@type": "HowToStep", "name": "Initialize in your repo", "text": "Navigate to your project directory and run: entroly go"},
+    {"@type": "HowToStep", "name": "Start coding with compression", "text": "Restart your AI tool (Cursor, Claude Code, etc). Entroly automatically compresses context 79–99.5%."}
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How much does Claude API cost per month for coding?",
+      "acceptedAnswer": {"@type": "Answer", "text": "A typical Claude API user doing 50+ AI coding requests per day spends $250–$600/month. Each request can send 80,000–200,000 tokens at $3/MTok (Sonnet 4). Context compression with Entroly reduces this to $25–$60/month."}
+    },
+    {
+      "@type": "Question",
+      "name": "How do I reduce my Claude API bill?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Install Entroly (pip install entroly), run 'entroly go' in your project, and restart your AI tool. Entroly compresses your context 79–99.5% before it reaches Claude, directly cutting your token costs. It also aligns prompts for KV-cache discounts (up to 90% off cached tokens)."}
+    },
+    {
+      "@type": "Question",
+      "name": "What is the cheapest way to use Claude for coding?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Use a context compression proxy like Entroly between your coding tool and Claude. It selects only the relevant code fragments, compresses context 79–99.5%, and aligns prompts for cache discounts. Combined savings: 80–97% reduction in effective token cost."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does prompt compression affect Claude's output quality?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Well-implemented compression improves quality. LLMs suffer from 'lost in the middle' attention degradation. Entroly selects only the most relevant code fragments using information theory, so Claude sees less noise and produces more accurate outputs. Entroly also includes WITNESS, a $0 hallucination guard that verifies outputs."}
+    }
+  ]
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+article{max-width:780px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(1.8rem,4vw,2.6rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px}
+h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+.highlight{color:var(--green)}
+.cost-box{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin:32px 0}
+.cost-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;text-align:center}
+.cost-card .amount{font-size:2.5rem;font-weight:800;margin:8px 0}
+.cost-card .label{font-size:14px;color:var(--muted)}
+.cost-card.before .amount{color:var(--red)}
+.cost-card.after .amount{color:var(--green)}
+.step{display:flex;gap:20px;margin:24px 0;align-items:flex-start}
+.step-num{background:var(--accent);color:#fff;width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;flex-shrink:0}
+.step-content{flex:1}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.cta-box h3{margin-top:0}
+table{width:100%;border-collapse:collapse;margin:20px 0}
+th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}
+th{color:var(--text);font-weight:600;background:var(--surface)}
+td{color:var(--muted)}
+.faq{margin:32px 0}
+.faq details{border:1px solid var(--border);border-radius:8px;margin-bottom:12px;background:var(--surface)}
+.faq summary{padding:16px;cursor:pointer;font-weight:600;color:var(--text)}
+.faq details[open] summary{border-bottom:1px solid var(--border)}
+.faq .answer{padding:16px;color:var(--muted)}
+</style>
+</head>
+<body>
+<nav>
+  <a href="https://juyterman1000.github.io/entroly/" class="logo">Entroly</a>
+  <div class="links">
+    <a href="https://juyterman1000.github.io/entroly/docs/prompt-compression.html">Prompt Compression</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html">Compare Tools</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/discord.html" style="color: var(--accent);">Discord</a>
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+    <a href="https://pypi.org/project/entroly/" class="cta-btn">pip install entroly</a>
+  </div>
+</nav>
+
+<article>
+<h1>How to Cut Claude API Input Tokens by 79–99.5% <span style="color:var(--green)">($0 tool)</span></h1>
+
+<p>If you're using <strong>Cursor</strong>, <strong>Claude Code</strong>, <strong>Windsurf</strong>, or <strong>Cline</strong> for AI-assisted coding, most of what you send the model on each request is context the model did not need. Here's how to cut that — in under 2 minutes, with zero code changes.</p>
+
+<div class="proof"><strong>Evidence boundary:</strong> 79–99.5% is <em>input-token reduction</em> from committed benchmark artifacts (NeedleInAHaystack 99.5%, LongBench HotpotQA 85.3%, Berkeley Function Calling 79.3% — all at 100% answer retention; <a href="https://github.com/juyterman1000/entroly/blob/main/docs/BENCHMARKS.md">raw results</a>). The worst case in that set is SQuAD 2.0 at 43.8% with 90% retention, on 233-token single-paragraph inputs where there is little redundancy to remove. Dollar figures below are illustrative arithmetic at published list pricing, not measured invoices — token cuts become cost cuts only on metered API routes, not on fixed-price subscriptions. Run <code>entroly simulate</code> for your own numbers, offline.</div>
+
+<div class="cost-box">
+  <div class="cost-card before">
+    <div class="label">Before Entroly</div>
+    <div class="amount">$487/mo</div>
+    <div class="label">~162K tokens × 50 requests/day × 20 days</div>
+  </div>
+  <div class="cost-card after">
+    <div class="label">After Entroly</div>
+    <div class="amount">$49/mo</div>
+    <div class="label">90% reduction via compression + cache alignment</div>
+  </div>
+</div>
+
+<h2>The Problem: AI Coding Tools Are Token Hogs</h2>
+
+<p>Every time you ask Cursor or Claude Code a question, it sends your <strong>entire visible context</strong> to the API — open files, recent edits, terminal output, and more. On a medium codebase (50K+ lines), that's <strong>80,000–200,000 tokens per request</strong>.</p>
+
+<p>At Claude Sonnet 4 pricing ($3/MTok input, $15/MTok output):</p>
+
+<table>
+<thead><tr><th>Usage Pattern</th><th>Tokens/Request</th><th>Requests/Day</th><th>Monthly Cost</th></tr></thead>
+<tbody>
+<tr><td>Light (small project)</td><td>~40K</td><td>20</td><td>~$72</td></tr>
+<tr><td>Medium (typical team)</td><td>~120K</td><td>40</td><td>~$432</td></tr>
+<tr><td>Heavy (monorepo)</td><td>~200K</td><td>60+</td><td>~$1,080+</td></tr>
+</tbody>
+</table>
+
+<h2>The Solution: 3 Steps, 2 Minutes</h2>
+
+<div class="step">
+  <div class="step-num">1</div>
+  <div class="step-content">
+    <h3>Install Entroly</h3>
+    <pre>pip install entroly</pre>
+    <p>Works on macOS, Linux, and Windows. No GPU required.</p>
+  </div>
+</div>
+
+<div class="step">
+  <div class="step-num">2</div>
+  <div class="step-content">
+    <h3>Initialize in Your Repo</h3>
+    <pre>cd /path/to/your/project
+entroly go</pre>
+    <p>This auto-detects your AI tools (Cursor, Claude Code, etc.) and configures Entroly as an MCP server. It indexes your codebase in seconds.</p>
+  </div>
+</div>
+
+<div class="step">
+  <div class="step-num">3</div>
+  <div class="step-content">
+    <h3>Restart Your AI Tool</h3>
+    <p>That's it. Entroly now runs as a background MCP server, automatically compressing context 79–99.5% before it reaches the API. Your AI tool works exactly the same — it just costs 79–99.5% less.</p>
+  </div>
+</div>
+
+<h2>How It Works (3 Layers of Savings)</h2>
+
+<h3>Layer 1: Context Compression (79–99.5% token reduction)</h3>
+<p>Entroly uses <strong>information-theoretic selection</strong> to pick only the code fragments that matter for your current query. Instead of sending your entire codebase, it sends the mathematically optimal subset using 0/1 Knapsack optimization, Shannon entropy scoring, and BM25 relevance ranking.</p>
+
+<h3>Layer 2: KV-Cache Alignment (50–90% off cached tokens)</h3>
+<p>Anthropic and OpenAI give automatic discounts when the prefix of your prompt matches a previous request. Entroly's <strong>Cache Aligner</strong> reorders prompt sections to maximize prefix stability between requests, triggering these discounts on every call.</p>
+
+<h3>Layer 3: Model Routing (80–95% off simple queries)</h3>
+<p>Not every question needs Claude Opus. Entroly's <strong>Epistemic Router</strong> analyzes query complexity and can route simple lookups to cheaper models (Haiku, GPT-4o-mini) while reserving expensive models for complex reasoning tasks.</p>
+
+<h2>FAQ</h2>
+
+<div class="faq">
+<details>
+<summary>How much does Claude API cost per month for coding?</summary>
+<div class="answer">A typical Claude API user doing 50+ AI coding requests per day spends <strong>$250–$600/month</strong>. Each request can send 80,000–200,000 tokens at $3/MTok (Sonnet 4). Heavy monorepo users can exceed $1,000/month. Context compression with Entroly reduces this to <strong>$25–$60/month</strong>.</div>
+</details>
+
+<details>
+<summary>Does this work with Cursor Pro / Claude Code subscriptions?</summary>
+<div class="answer">Yes. Even with subscription plans, you hit rate limits faster when sending more tokens. Entroly reduces tokens per request, so you get more requests within your plan limits. For API-mode users (Cursor's "bring your own key"), the savings are direct and measurable.</div>
+</details>
+
+<details>
+<summary>Will compression make my AI coding worse?</summary>
+<div class="answer">No — it typically makes it <em>better</em>. LLMs suffer from "lost in the middle" attention degradation when context windows are stuffed with irrelevant code. Entroly selects only the relevant fragments, improving the signal-to-noise ratio. Plus, WITNESS verifies every output against evidence, catching hallucinations before they enter your code.</div>
+</details>
+
+<details>
+<summary>Is this free?</summary>
+<div class="answer">Yes. Entroly is open-source under the Apache 2.0 license. No API keys, no accounts, no telemetry. Everything runs locally on your machine.</div>
+</details>
+
+<details>
+<summary>How does this compare to Cursor's built-in context management?</summary>
+<div class="answer">Cursor includes basic context selection (recently opened files, @-mentions), but it doesn't do knapsack-optimal selection, entropy scoring, cache alignment, or hallucination verification. Entroly adds all of these as an MCP server layer — it works <em>alongside</em> Cursor's built-in features, not instead of them.</div>
+</details>
+</div>
+
+<div class="cta-box">
+  <h3>Start Saving in 30 Seconds</h3>
+  <p style="color:var(--muted)">No config. No API key. No signup. Just install and go.</p>
+  <pre>pip install entroly && cd /your/repo && entroly go</pre>
+  <br>
+  <a href="https://github.com/juyterman1000/entroly" class="cta-btn">⭐ Star on GitHub</a>
+  &nbsp;&nbsp;
+  <a href="https://juyterman1000.github.io/entroly/docs/discord.html" class="cta-btn" style="background:#5865F2">Join Discord</a>
+  &nbsp;&nbsp;
+  <a href="https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html" class="cta-btn" style="background:var(--green)">Compare All Tools</a>
+</div>
+
+</article>
+</body>
+</html>

--- a/docs/prevent-ai-hallucinations.html
+++ b/docs/prevent-ai-hallucinations.html
@@ -1,2 +1,252 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This hallucination-prevention page has been retired</h1><p>No verifier can guarantee the absence of hallucinations. Entroly exposes evidence-grounding signals and auditable receipts with documented limitations.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Read the current evidence and limitations</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>How to Prevent AI Hallucinations in Code — Free Open-Source Tool (2026)</title>
+<meta name="description" content="Stop AI hallucinations before they reach your codebase. WITNESS by Entroly checks every LLM response against source evidence locally — 0.7976 AUROC, $0 cost, 3ms latency. Works with Claude, GPT-4, Gemini, Cursor, and Cline.">
+<meta name="keywords" content="prevent AI hallucination, AI hallucination detection, stop LLM hallucination, hallucination guard, verify AI output, check AI accuracy, LLM output verification, AI code hallucination, Claude hallucination fix, GPT hallucination prevention, hallucination free AI coding, NLI verification, AI fact checking tool, WITNESS hallucination guard, detect AI mistakes">
+<meta property="og:title" content="How to Prevent AI Hallucinations in Code (2026)">
+<meta property="og:description" content="WITNESS checks every LLM response against source evidence. 0.7976 AUROC, $0, 3ms. Free, open-source.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type": "Question", "name": "What causes AI hallucinations in code?",
+     "acceptedAnswer": {"@type": "Answer", "text": "AI hallucinations in code occur when the LLM generates plausible-looking but incorrect code, references non-existent APIs, invents function signatures, or fabricates file paths. This happens because LLMs are probabilistic text generators — they predict likely next tokens, not verified facts. When context windows are stuffed with irrelevant code, models are more likely to hallucinate because they cannot attend to the right evidence."}},
+    {"@type": "Question", "name": "How does WITNESS prevent AI hallucinations?",
+     "acceptedAnswer": {"@type": "Answer", "text": "WITNESS uses Natural Language Inference (NLI) to check every claim in an LLM's response against the source evidence (code files, documentation) that was provided in the context. It flags claims that are not supported by evidence. It runs locally, costs $0, takes ~3ms per decision, and achieves 0.7976 AUROC on the HaluEval-QA benchmark — statistically tied with GPT-4o-mini as a judge."}},
+    {"@type": "Question", "name": "Can I detect AI hallucinations without paying for another API?",
+     "acceptedAnswer": {"@type": "Answer", "text": "Yes. Entroly's WITNESS hallucination guard runs entirely locally — no API calls, no internet required, $0 cost. It uses a lightweight NLI model (optionally DeBERTa) to verify outputs against evidence. This is unlike approaches that use a second LLM as a judge, which doubles your API costs."}},
+    {"@type": "Question", "name": "Does context compression increase hallucinations?",
+     "acceptedAnswer": {"@type": "Answer", "text": "Well-implemented context compression actually reduces hallucinations. LLMs suffer from 'lost in the middle' attention degradation — they perform worse when context windows are filled with irrelevant information. By selecting only the most relevant code fragments (using entropy scoring and knapsack optimization), Entroly improves the signal-to-noise ratio, making the model more accurate. Plus, WITNESS verifies every output as an additional safety layer."}}
+  ]
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171;--yellow:#fbbf24;--blue:#60a5fa}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+article{max-width:780px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(1.8rem,4vw,2.6rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px}
+h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+table{width:100%;border-collapse:collapse;margin:20px 0}
+th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}
+th{color:var(--text);font-weight:600;background:var(--surface)}
+td{color:var(--muted)}
+.winner{color:var(--green);font-weight:600}
+.weak{color:var(--red)}
+.stat-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin:32px 0}
+.stat-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;text-align:center}
+.stat-card .number{font-size:2.5rem;font-weight:800;color:var(--green);margin:8px 0}
+.stat-card .label{font-size:13px;color:var(--muted)}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.cta-box h3{margin-top:0}
+.faq{margin:32px 0}
+.faq details{border:1px solid var(--border);border-radius:8px;margin-bottom:12px;background:var(--surface)}
+.faq summary{padding:16px;cursor:pointer;font-weight:600;color:var(--text)}
+.faq details[open] summary{border-bottom:1px solid var(--border)}
+.faq .answer{padding:16px;color:var(--muted)}
+.related{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;margin:48px 0}
+.related h3{margin-top:0;margin-bottom:12px}
+.related a{display:block;padding:8px 0;border-bottom:1px solid var(--border);text-decoration:none}
+.related a:last-child{border:none}
+</style>
+</head>
+<body>
+<nav>
+  <a href="https://juyterman1000.github.io/entroly/" class="logo">Entroly</a>
+  <div class="links">
+    <a href="https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html">Compare Tools</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html">Reduce Costs</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/prompt-compression.html">Compression</a>
+    <a href="https://juyterman1000.github.io/entroly/docs/discord.html" style="color: var(--accent);">Discord</a>
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+    <a href="https://pypi.org/project/entroly/" class="cta-btn">pip install entroly</a>
+  </div>
+</nav>
+
+<article>
+<h1>How to Prevent AI Hallucinations in Code <span style="color:var(--green);font-size:0.5em">($0, local, 3ms)</span></h1>
+
+<p>AI coding tools like <strong>Cursor</strong>, <strong>Claude Code</strong>, and <strong>Cline</strong> are incredibly productive — until they hallucinate. They invent APIs that don't exist, reference functions with wrong signatures, and fabricate file paths. A single hallucinated import can cost hours of debugging.</p>
+
+<p><strong>WITNESS</strong>, built into Entroly, checks every LLM response against the actual source code before it reaches your editor. It runs locally, costs nothing, and catches hallucinations in 3 milliseconds.</p>
+
+<div class="stat-grid">
+  <div class="stat-card">
+    <div class="label">AUROC Score</div>
+    <div class="number">0.7976</div>
+    <div class="label">HaluEval-QA benchmark</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Cost Per Check</div>
+    <div class="number">$0</div>
+    <div class="label">Runs locally, no API</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Latency</div>
+    <div class="number">~3ms</div>
+    <div class="label">Per decision</div>
+  </div>
+</div>
+
+<h2>The Hallucination Problem in AI Coding</h2>
+
+<p>AI hallucinations in code are different from hallucinations in general text. In coding, hallucinations manifest as:</p>
+
+<ul>
+  <li><strong>Invented APIs</strong>: The model calls <code>response.getBody()</code> when the actual method is <code>response.content</code></li>
+  <li><strong>Wrong function signatures</strong>: Passing 3 arguments to a function that takes 2</li>
+  <li><strong>Fabricated file paths</strong>: Referencing <code>src/utils/auth.ts</code> when the file is actually <code>lib/authentication.ts</code></li>
+  <li><strong>Non-existent imports</strong>: <code>from sklearn.llm import Compressor</code> — looks plausible, doesn't exist</li>
+  <li><strong>Outdated patterns</strong>: Using deprecated APIs from training data instead of current versions</li>
+</ul>
+
+<p>These are hard to catch because they <em>look right</em>. The syntax is valid. The naming conventions match. But the code doesn't work.</p>
+
+<h2>How WITNESS Works</h2>
+
+<p>WITNESS uses <strong>Natural Language Inference (NLI)</strong> — a well-established NLP technique — to check whether claims in the LLM's output are <em>entailed by</em> (supported by) the evidence provided in the context.</p>
+
+<ol>
+  <li><strong>Extract claims</strong>: WITNESS decomposes the LLM's response into individual factual claims</li>
+  <li><strong>Match evidence</strong>: Each claim is matched against the source code files, documentation, and context that was provided to the model</li>
+  <li><strong>Score entailment</strong>: Using STAVE (Statistical Textual Assessment and Verification Engine), each claim gets a support score</li>
+  <li><strong>Flag or suppress</strong>: Unsupported claims are flagged (warn mode) or suppressed (strict mode) before reaching the developer</li>
+</ol>
+
+<pre>entroly witness --context-file evidence.txt --output-file answer.txt --mode strict</pre>
+
+<h2>Comparison: Hallucination Detection Approaches</h2>
+
+<table>
+<thead>
+<tr><th>Approach</th><th>Cost</th><th>Latency</th><th>Accuracy</th><th>Requires API?</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong>WITNESS + STAVE</strong></td>
+  <td class="winner">$0</td>
+  <td class="winner">~3ms</td>
+  <td class="winner">86.58% (0.8132 AUROC)</td>
+  <td class="winner">No</td>
+</tr>
+<tr>
+  <td>GPT-4o-mini judge</td>
+  <td class="weak">$0.15/1K checks</td>
+  <td class="weak">~800ms</td>
+  <td>86.3%</td>
+  <td class="weak">Yes</td>
+</tr>
+<tr>
+  <td>GPT-3.5-turbo judge</td>
+  <td class="weak">$0.05/1K checks</td>
+  <td class="weak">~500ms</td>
+  <td class="weak">62.6%</td>
+  <td class="weak">Yes</td>
+</tr>
+<tr>
+  <td>Manual review</td>
+  <td class="weak">Developer time</td>
+  <td class="weak">Minutes</td>
+  <td>Variable</td>
+  <td>No</td>
+</tr>
+</tbody>
+</table>
+
+<p>WITNESS achieves <strong>statistically comparable accuracy to GPT-4o-mini</strong> as a grounded judge — but at $0 cost and 250× lower latency.</p>
+
+<h2>Profiles for Different Workloads</h2>
+
+<p>WITNESS ships with tuned profiles for different use cases:</p>
+
+<ul>
+  <li><strong><code>code</code></strong>: Strict — fails closed on unsupported code claims. Best for auto-merge pipelines</li>
+  <li><strong><code>rag</code></strong>: Strict — for retrieval-augmented generation, suppresses unsupported retrievals</li>
+  <li><strong><code>qa</code></strong>: Strict — for question-answering, flags fabricated answers</li>
+  <li><strong><code>chat</code></strong>: Warn — for conversational use, warns but doesn't block</li>
+  <li><strong><code>summary</code></strong>: Warn — for summarization, flags unsupported inferences</li>
+</ul>
+
+<pre>entroly proxy --witness strict --witness-profile code    # suppress hallucinations in coding
+entroly proxy --witness strict --witness-profile rag     # suppress in RAG pipelines</pre>
+
+<h2>Setup: 30 Seconds</h2>
+
+<pre>pip install entroly
+cd /your/repo
+entroly go</pre>
+
+<p>That's it. WITNESS automatically runs on every LLM response when Entroly is active. You can also use it standalone:</p>
+
+<pre>entroly witness --context-file evidence.txt --output-file answer.txt --mode strict</pre>
+
+<h2>FAQ: AI Hallucination Prevention</h2>
+
+<div class="faq">
+<details>
+<summary>What causes AI hallucinations in code?</summary>
+<div class="answer">AI hallucinations in code occur when the LLM generates plausible-looking but incorrect code. This happens because LLMs are probabilistic text generators — they predict likely next tokens, not verified facts. When context windows are stuffed with irrelevant code, models are more likely to hallucinate because they cannot attend to the right evidence. Entroly addresses both causes: it compresses context to improve signal-to-noise ratio, and WITNESS verifies the output.</div>
+</details>
+
+<details>
+<summary>Can I use WITNESS without context compression?</summary>
+<div class="answer">Yes. WITNESS works as a standalone verification tool. You can run <code>entroly witness --context-file evidence.txt --output-file answer.txt</code> on any LLM output + evidence pair. However, combining compression (which improves input quality) with verification (which checks output quality) gives the best results.</div>
+</details>
+
+<details>
+<summary>Does WITNESS work with Claude? With GPT-4? With Gemini?</summary>
+<div class="answer">Yes. WITNESS checks the <em>output</em> of any LLM, regardless of provider. It runs as a post-processing step — after the model generates a response, WITNESS verifies it against the evidence. Works with Claude (Anthropic), GPT-4/o (OpenAI), Gemini (Google), and any other LLM.</div>
+</details>
+
+<details>
+<summary>Is there an API cost for hallucination detection?</summary>
+<div class="answer">No. WITNESS runs entirely locally using lightweight NLI models. $0 per check, ~3ms latency, no internet required. This is fundamentally different from "LLM-as-judge" approaches (like using GPT-4o-mini to check GPT-4 outputs), which require a second API call and double your costs.</div>
+</details>
+</div>
+
+<div class="related">
+  <h3>📚 Related Guides</h3>
+  <a href="https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html">→ How to Reduce Claude API Costs by 90%</a>
+  <a href="https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html">→ Best Context Compression Tools for LLMs (2026)</a>
+  <a href="https://juyterman1000.github.io/entroly/docs/prompt-compression.html">→ What Is Prompt Compression?</a>
+  <a href="https://juyterman1000.github.io/entroly/docs/hallucination-guard.html">→ WITNESS Hallucination Guard — Technical Details</a>
+  <a href="https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html">→ Reduce LLM API Costs — Complete Guide</a>
+</div>
+
+<div class="cta-box">
+  <h3>Stop Hallucinations in 30 Seconds</h3>
+  <p style="color:var(--muted)">No config. No API key. No signup. Runs locally.</p>
+  <pre>pip install entroly && cd /your/repo && entroly go</pre>
+  <br>
+  <a href="https://github.com/juyterman1000/entroly" class="cta-btn">⭐ Star on GitHub</a>
+  &nbsp;&nbsp;
+  <a href="https://juyterman1000.github.io/entroly/docs/discord.html" class="cta-btn" style="background:#5865F2">Join Discord</a>
+  &nbsp;&nbsp;
+  <a href="https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html" class="cta-btn" style="background:var(--green)">Compare All Tools</a>
+</div>
+
+</article>
+</body>
+</html>

--- a/docs/prevent-ai-hallucinations.html
+++ b/docs/prevent-ai-hallucinations.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>How to Prevent AI Hallucinations in Code — Free Open-Source Tool (2026)</title>
-<meta name="description" content="Stop AI hallucinations before they reach your codebase. WITNESS by Entroly checks every LLM response against source evidence locally — 0.7976 AUROC, $0 cost, 3ms latency. Works with Claude, GPT-4, Gemini, Cursor, and Cline.">
+<meta name="description" content="Stop AI hallucinations before they reach your codebase. WITNESS by Entroly checks LLM responses against source evidence locally — 0.7976 AUROC on the held-out HaluEval-QA split, $0 marginal cost, ~3ms. Works with Claude, GPT-4, Gemini, Cursor, and Cline.">
 <meta name="keywords" content="prevent AI hallucination, AI hallucination detection, stop LLM hallucination, hallucination guard, verify AI output, check AI accuracy, LLM output verification, AI code hallucination, Claude hallucination fix, GPT hallucination prevention, hallucination free AI coding, NLI verification, AI fact checking tool, WITNESS hallucination guard, detect AI mistakes">
 <meta property="og:title" content="How to Prevent AI Hallucinations in Code (2026)">
-<meta property="og:description" content="WITNESS checks every LLM response against source evidence. 0.7976 AUROC, $0, 3ms. Free, open-source.">
+<meta property="og:description" content="WITNESS checks LLM responses against source evidence locally. 0.7976 AUROC held-out, $0 marginal cost, ~3ms. Free, open-source.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html">
 <link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html">
@@ -23,7 +23,7 @@
     {"@type": "Question", "name": "Can I detect AI hallucinations without paying for another API?",
      "acceptedAnswer": {"@type": "Answer", "text": "Yes. Entroly's WITNESS hallucination guard runs entirely locally — no API calls, no internet required, $0 cost. It uses a lightweight NLI model (optionally DeBERTa) to verify outputs against evidence. This is unlike approaches that use a second LLM as a judge, which doubles your API costs."}},
     {"@type": "Question", "name": "Does context compression increase hallucinations?",
-     "acceptedAnswer": {"@type": "Answer", "text": "Well-implemented context compression actually reduces hallucinations. LLMs suffer from 'lost in the middle' attention degradation — they perform worse when context windows are filled with irrelevant information. By selecting only the most relevant code fragments (using entropy scoring and knapsack optimization), Entroly improves the signal-to-noise ratio, making the model more accurate. Plus, WITNESS verifies every output as an additional safety layer."}}
+     "acceptedAnswer": {"@type": "Answer", "text": "Well-implemented context compression actually reduces hallucinations. LLMs suffer from 'lost in the middle' attention degradation — they perform worse when context windows are filled with irrelevant information. By selecting only the most relevant code fragments (using entropy scoring and knapsack optimization), Entroly improves the signal-to-noise ratio. Plus, WITNESS checks responses against the supplied evidence as an additional layer, with measured false positives and false negatives."}}
   ]
 }
 </script>
@@ -90,7 +90,7 @@ td{color:var(--muted)}
 
 <p>AI coding tools like <strong>Cursor</strong>, <strong>Claude Code</strong>, and <strong>Cline</strong> are incredibly productive — until they hallucinate. They invent APIs that don't exist, reference functions with wrong signatures, and fabricate file paths. A single hallucinated import can cost hours of debugging.</p>
 
-<p><strong>WITNESS</strong>, built into Entroly, checks every LLM response against the actual source code before it reaches your editor. It runs locally, costs nothing, and catches hallucinations in 3 milliseconds.</p>
+<p><strong>WITNESS</strong>, built into Entroly, checks LLM responses against the actual source code before they reach your editor, on the routes where it is enabled. It runs locally, costs nothing, and catches hallucinations in 3 milliseconds.</p>
 
 <div class="stat-grid">
   <div class="stat-card">

--- a/docs/prompt-compression.html
+++ b/docs/prompt-compression.html
@@ -1,2 +1,243 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This compression page has been retired</h1><p>Entroly selects and compresses context under an explicit budget. Results vary by workload, and recoverability applies only to captured content with retained state.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Review the current evidence</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Prompt Compression & Context Compression for LLMs — Entroly</title>
+<meta name="description" content="Entroly is an open-source prompt compression and context compression engine for LLMs. Reduce tokens sent to Claude, GPT-4, and Gemini by 79–99.5% using knapsack optimization, BM25 ranking, and Shannon entropy scoring. Lossless via Content-Compressed Retrieval (CCR).">
+<meta name="keywords" content="prompt compression, context compression, LLM context compression, token compression, compress LLM prompt, reduce prompt size, prompt optimization, context window optimization, LLM prompt optimization, semantic compression, lossless prompt compression, content compressed retrieval, CCR, context engineering, AI prompt reduction, reduce context window">
+<meta property="og:title" content="Prompt Compression for LLMs — Cut Tokens 79–99.5% | Entroly">
+<meta property="og:description" content="Open-source prompt and context compression for Claude, GPT-4, and Gemini. 79–99.5% fewer tokens. Lossless via CCR. Works as a local proxy or MCP server.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/prompt-compression.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Prompt Compression for LLMs — Cut Tokens 79–99.5% | Entroly">
+<meta name="twitter:description" content="Open-source prompt and context compression for Claude, GPT-4, and Gemini. 79–99.5% fewer tokens. Lossless via CCR.">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/prompt-compression.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Prompt Compression and Context Compression for LLMs — Entroly",
+  "description": "Open-source prompt compression engine that reduces LLM context by 79–99.5% using knapsack optimization, BM25 ranking, and Content-Compressed Retrieval (CCR) for lossless recovery.",
+  "author": {"@type": "Organization", "name": "Entroly", "url": "https://github.com/juyterman1000/entroly"},
+  "datePublished": "2026-06-01",
+  "dateModified": "2026-06-07",
+  "keywords": "prompt compression, context compression, LLM token reduction, Content-Compressed Retrieval, CCR, knapsack optimizer, BM25",
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://juyterman1000.github.io/entroly/docs/prompt-compression.html"}
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+article{max-width:780px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(2rem,4vw,2.8rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px}
+h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+.highlight{color:var(--green)}
+table{width:100%;border-collapse:collapse;margin:20px 0}
+th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}
+th{color:var(--text);font-weight:600}
+td{color:var(--muted)}
+.pipeline{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;margin:32px 0;font-family:'JetBrains Mono',monospace;font-size:13px;line-height:2}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.cta-box h3{margin-top:0}
+.cta-box p{margin-bottom:20px}
+.callout{background:rgba(129,140,248,0.1);border:1px solid rgba(129,140,248,0.3);border-radius:10px;padding:20px;margin:24px 0}
+footer{text-align:center;padding:40px 24px;color:var(--muted);font-size:13px;border-top:1px solid var(--border)}
+</style>
+</head>
+<body>
+<nav>
+  <a href="/entroly/" class="logo">entroly</a>
+  <div class="links">
+    <a href="/entroly/">Home</a>
+    <a href="/entroly/docs/reduce-llm-api-costs.html">Reduce Costs</a>
+    <a href="/entroly/docs/token-compression-tools.html">Token Compression Tools</a>
+    <a href="/entroly/docs/what-is-context-rot.html">What Is Context Rot?</a>
+    <a href="/entroly/docs/best-context-compression-tools.html">Compression Tools Compared</a>
+    <a href="/entroly/docs/hallucination-guard.html">Hallucination Guard</a>
+    <a href="https://github.com/juyterman1000/entroly" class="cta-btn">GitHub</a>
+  </div>
+</nav>
+
+<article>
+
+<h1>Prompt Compression &amp; Context Compression for LLMs</h1>
+
+<p><strong>Last updated: June 2026</strong></p>
+
+<p>Prompt compression — reducing the number of tokens sent to an LLM without losing the information the model needs to answer correctly — is one of the highest-leverage optimizations in AI engineering. <a href="https://github.com/juyterman1000/entroly"><strong>Entroly</strong></a> is an open-source prompt and context compression engine that achieves <strong>79–99.5% token reduction</strong> on large-repo workloads while preserving answer accuracy.</p>
+
+<div class="callout">
+<strong>What makes Entroly different:</strong> Most prompt compression tools shrink whatever text you give them. Entroly <em>selects</em> the right content first (from your entire codebase or document set), then compresses. You get the right context at the right resolution — not just a smaller version of everything.
+</div>
+
+<h2>What Is Prompt Compression?</h2>
+
+<p>Prompt compression is the process of reducing the token count of the input sent to an LLM while preserving the information needed to answer the query. It sits between your application and the LLM provider, transforming a large, raw context into a compact, information-dense one.</p>
+
+<p>There are three levels of prompt compression:</p>
+<ul>
+  <li><strong>Selection</strong> — choosing which documents, files, or fragments to include at all</li>
+  <li><strong>Summarization</strong> — replacing long passages with shorter summaries (lossy)</li>
+  <li><strong>Skeletonization</strong> — replacing code with function signatures and type annotations (structure-preserving)</li>
+</ul>
+
+<p>Entroly uses all three, applied in a mathematically optimal order.</p>
+
+<h2>Entroly's Prompt Compression Pipeline</h2>
+
+<div class="pipeline">
+your prompt  ──►  Entroly (local, &lt;10ms)  ──►  LLM provider
+                  │
+                  ├─ 1. Ingest + index repo (BM25 + entropy + dep-graph)
+                  ├─ 2. Rank fragments by query relevance
+                  ├─ 3. Select optimal subset (knapsack solver)
+                  ├─ 4. Compress: full → skeleton → reference
+                  ├─ 5. Store originals in CCR store (lossless)
+                  ├─ 6. Align prefix for provider cache hit (Cache Aligner)
+                  └─ 7. Verify response against evidence (WITNESS)
+</div>
+
+<h2>The 9 Compressors</h2>
+
+<p>Entroly ships 9 content-type-aware compressors, each optimized for a specific input type:</p>
+
+<table>
+  <tr><th>Input Type</th><th>Compressor</th><th>Technique</th><th>Typical Savings</th></tr>
+  <tr><td>Source code</td><td>Code Skeletonizer</td><td>AST-based, extracts signatures + docstrings</td><td class="highlight">60–90%</td></tr>
+  <tr><td>Shell output / logs</td><td>Shell Codec</td><td>Entropy-based deduplication</td><td class="highlight">60–95%</td></tr>
+  <tr><td>JSON / API responses</td><td>JSON Compressor</td><td>Schema extraction + value sampling</td><td class="highlight">70–90%</td></tr>
+  <tr><td>Prose / docs</td><td>Semantic Pruner</td><td>Sentence-level relevance scoring</td><td class="highlight">40–70%</td></tr>
+  <tr><td>Diffs / patches</td><td>Diff Compressor</td><td>Context-window selection around changed hunks</td><td class="highlight">50–80%</td></tr>
+  <tr><td>Test output</td><td>Test Codec</td><td>Failure extraction, pass collapsing</td><td class="highlight">70–90%</td></tr>
+  <tr><td>CSV / tabular</td><td>Table Compressor</td><td>Schema + sample rows</td><td class="highlight">80–95%</td></tr>
+  <tr><td>Images (base64)</td><td>Image Optimizer</td><td>Resolution reduction</td><td class="highlight">40–60%</td></tr>
+  <tr><td>Conversation history</td><td>Entropic Pruner</td><td>Low-entropy turn removal</td><td class="highlight">30–60%</td></tr>
+</table>
+
+<h2>Content-Compressed Retrieval (CCR) — Lossless Compression</h2>
+
+<p>Entroly's <strong>Content-Compressed Retrieval (CCR)</strong> solves the fundamental problem with lossy compression: what happens when the model needs the detail you compressed away?</p>
+
+<p>When Entroly compresses a fragment to a skeleton or reference, it stores the <em>original full content</em> in a local CCR store (content-addressed, LRU-evicted, ~5MB for 500 fragments). The compressed fragment contains a retrieval handle. If the model needs more detail, it calls <code>entroly_retrieve</code> via MCP or <code>GET /retrieve?source=file:src/auth.py</code> via the proxy endpoint — and gets the full original back immediately.</p>
+
+<p><strong>Nothing is permanently lost.</strong> Compression is fully reversible.</p>
+
+<pre># List all retrievable compressed fragments
+curl localhost:9377/retrieve
+
+# Retrieve a specific file's full original
+curl localhost:9377/retrieve?source=file:src/auth.py</pre>
+
+<h2>Cache Aligner — Free 90% Discount From Anthropic</h2>
+
+<p>Anthropic gives a 90% discount on cached token prefixes. OpenAI gives 50%. But to get this discount, the prefix bytes must be <em>identical</em> across requests. Standard prompt compression changes the context on every call — busting the cache.</p>
+
+<p>Entroly's <strong>Cache Aligner</strong> solves this: it tracks the injected context prefix per client and uses Jaccard token similarity to detect when the context hasn't materially changed. When similarity exceeds the threshold (default: 90%), it reuses the previous prefix verbatim — byte-for-byte — preserving the provider's cache hit.</p>
+
+<p>On agent loops making 10+ calls with similar context, this alone can reduce your effective per-token cost by 80–90%.</p>
+
+<h2>Knapsack-Optimal Selection</h2>
+
+<p>Before any compression happens, Entroly solves an optimization problem: given your token budget and a query, which fragments from your entire repository or document set maximize information value?</p>
+
+<p>Each fragment gets a score combining:</p>
+<ul>
+  <li><strong>BM25 lexical relevance</strong> to the query</li>
+  <li><strong>Shannon entropy density</strong> (information per token)</li>
+  <li><strong>SimHash deduplication score</strong> (penalizes near-duplicates)</li>
+  <li><strong>Dependency graph distance</strong> (rewards files referenced by high-relevance files)</li>
+  <li><strong>PRISM learned weights</strong> (improves over time from local feedback)</li>
+</ul>
+
+<p>The knapsack solver then selects the globally optimal subset under the budget. This is NP-hard in general; Entroly uses a proven greedy approximation with provable bounds that runs in under 10ms via the Rust core.</p>
+
+<h2>Measured Compression Results</h2>
+
+<table>
+  <tr><th>Token Budget</th><th>Token Reduction</th><th>Source</th></tr>
+  <tr><td>8K</td><td class="highlight"><strong>99.1%</strong></td><td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/">benchmarks/results/</a></td></tr>
+  <tr><td>32K</td><td class="highlight"><strong>96.7%</strong></td><td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/">benchmarks/results/</a></td></tr>
+  <tr><td>Average</td><td class="highlight"><strong>87.0%</strong></td><td><code>entroly verify-claims</code></td></tr>
+</table>
+
+<p>Reproduce on your own repo: <code>pip install entroly &amp;&amp; entroly verify-claims</code> — no API key needed.</p>
+
+<h2>Accuracy Benchmarks</h2>
+
+<table>
+  <tr><th>Benchmark</th><th>Token Savings</th><th>Accuracy Retention</th></tr>
+  <tr><td>NeedleInAHaystack</td><td>99.5%</td><td class="highlight"><strong>100%</strong></td></tr>
+  <tr><td>LongBench (HotpotQA)</td><td>85.3%</td><td class="highlight"><strong>103%</strong></td></tr>
+  <tr><td>Berkeley Function Calling</td><td>79.3%</td><td class="highlight"><strong>100%</strong></td></tr>
+  <tr><td>SQuAD 2.0</td><td>43.8%</td><td>90%</td></tr>
+</table>
+
+<h2>Use Entroly's Prompt Compression</h2>
+
+<h3>As a Transparent Proxy (Zero Code Changes)</h3>
+<pre>pip install entroly
+entroly proxy                         # http://localhost:9377
+ANTHROPIC_BASE_URL=http://localhost:9377 your-app
+OPENAI_BASE_URL=http://localhost:9377/v1 your-app</pre>
+
+<h3>As a Python Library</h3>
+<pre>from entroly import compress, compress_messages, optimize
+
+# Compress a list of chat messages
+compressed = compress_messages(messages, budget=30000)
+
+# Compress arbitrary content (auto-detects type)
+compressed = compress(log_output, budget=2000)
+
+# Task-conditioned selection from repo fragments
+context = optimize(fragments, budget=8000, query="fix the login bug")</pre>
+
+<h3>As an MCP Server</h3>
+<pre>entroly serve   # starts MCP server
+# then add to Cursor, Claude Code, VS Code config via: entroly init</pre>
+
+<div class="cta-box">
+  <h3>Start Compressing Your Prompts</h3>
+  <p>Open-source. Local-first. Apache-2.0. Runs on your machine.</p>
+  <pre>pip install entroly &amp;&amp; entroly verify-claims</pre>
+  <p><a href="https://github.com/juyterman1000/entroly" class="cta-btn">View on GitHub →</a></p>
+</div>
+
+</article>
+
+<footer>
+  <p><a href="/entroly/">Entroly</a> — Context Intelligence, Not Compression</p>
+  <p style="margin-top:8px">
+    <a href="/entroly/docs/reduce-llm-api-costs.html">Reduce LLM API Costs</a> ·
+    <a href="/entroly/docs/prompt-compression.html">Prompt Compression</a> ·
+    <a href="/entroly/docs/hallucination-guard.html">Hallucination Guard</a> ·
+    <a href="/entroly/docs/token-optimization.html">Token Optimization</a> ·
+    <a href="/entroly/docs/context-engineering.html">Context Engineering</a> ·
+    <a href="/entroly/docs/cursor-context-guide.html">Cursor Guide</a> ·
+    <a href="/entroly/docs/claude-code-setup.html">Claude Code Guide</a> ·
+    <a href="/entroly/docs/mcp-server-guide.html">MCP Server</a> ·
+    <a href="/entroly/docs/dashboard.html">Live Dashboard</a> ·
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+  </p>
+</footer>
+</body>
+</html>

--- a/docs/public-evidence.md
+++ b/docs/public-evidence.md
@@ -106,6 +106,32 @@ Legacy savings, prompt-compression, hallucination, projected-dashboard, and stal
 
 Archived translated READMEs must be regenerated from the canonical README, including trust links and caveats, before they return to primary navigation.
 
+## Retired and republished public pages
+
+A set of topic pages was reduced to `noindex` tombstones redirecting here,
+because their claims could not be sourced: a universal 70–95% range, a 0.844
+AUROC that a later tie-correction retired, equivalence conclusions drawn against
+an API judge, and verifier coverage described as "every response".
+
+Retirement removed those claims by removing the pages. It also removed every
+entry point to the topics, and left the repository with no indexable answer to
+questions Entroly can answer honestly.
+
+Those pages were republished on 2026-08-15 under a stricter condition than the
+one they failed: **every figure on a republished page must resolve to a
+committed artifact under `benchmarks/results/`, and the page must state the
+workload that produced it.** Where a benchmark set contains a loss case, the
+page states it next to the wins rather than omitting it — the SQuAD 2.0 row
+(43.8% savings, 90% retention on 233-token inputs) appears alongside the
+long-context results it is worse than.
+
+Retirement is no longer what keeps these pages honest. `STALE_PUBLIC_CLAIMS` in
+`scripts/verify_context_assurance_public.py` is, and every republished page is
+listed in `CLAIM_SENSITIVE_PUBLIC_FILES` so that scan applies to it. A page must
+not be republished by deleting its retirement entry without adding it there.
+
+`docs/dashboard.html` remains retired: it is an application view, not content.
+
 ## Maintainer rules
 
 Before adding or strengthening a public claim:

--- a/docs/reduce-llm-api-costs.html
+++ b/docs/reduce-llm-api-costs.html
@@ -1,2 +1,282 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This cost-savings page has been retired</h1><p>Actual token and cost changes vary by request. Entroly reports evidence by protocol and artifact, not as a universal billing guarantee.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Read the public evidence ledger</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Reduce LLM API Costs by 79–99.5% — Cut Claude, OpenAI & Gemini Bills | Entroly</title>
+<meta name="description" content="Cut your Claude, OpenAI, and Gemini API bills by 79–99.5% without switching models. Entroly is an open-source local proxy that compresses context, keeps provider caches hot, and verifies LLM output. Works with Cursor, Claude Code, Aider, and 34 more tools. 30-second setup, no code changes.">
+<meta name="keywords" content="reduce LLM API costs, cut Claude API bill, reduce OpenAI API costs, save on Gemini API, LLM cost reduction, AI API cost savings, reduce token costs, cut AI bills, cheaper Claude, cheaper GPT-4, reduce Anthropic costs, LLM token savings, prompt compression, context compression, AI cost optimization, reduce AI spend, token budget optimization, AI coding cost, Claude Code cost, Cursor API cost">
+<meta property="og:title" content="Reduce LLM API Costs by 79–99.5% — Entroly">
+<meta property="og:description" content="Cut your Claude, OpenAI, and Gemini API bills by 79–99.5%. Open-source local proxy. 30-second setup, no code changes.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Reduce LLM API Costs by 79–99.5% — Entroly">
+<meta name="twitter:description" content="Cut Claude, OpenAI, Gemini bills by 79–99.5%. Local proxy. Zero code changes.">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Reduce LLM API Costs by 79–99.5% — Cut Claude, OpenAI and Gemini Bills",
+  "description": "Open-source local proxy that compresses context, keeps provider caches hot, and verifies LLM output. Cuts API bills 79–99.5%.",
+  "author": {"@type": "Organization", "name": "Entroly", "url": "https://github.com/juyterman1000/entroly"},
+  "datePublished": "2026-06-01",
+  "dateModified": "2026-06-07",
+  "keywords": "reduce LLM API costs, cut Claude API bill, reduce OpenAI costs, token compression, prompt compression, AI cost savings",
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html"},
+  "publisher": {"@type": "Organization", "name": "Entroly", "logo": {"@type": "ImageObject", "url": "https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png"}}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How much can I save on my Claude API bill with Entroly?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It depends on your repo size and query patterns. On large repos (300+ files) with agent loops, most users see 70–90% reduction. Run entroly demo in your repo for a before/after estimate with no API calls."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Entroly work with my existing AI coding tool?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. If your tool supports a custom OPENAI_BASE_URL or ANTHROPIC_BASE_URL, it works via the proxy. Entroly also has native MCP server support for Cursor, Claude Code, VS Code, Windsurf, Zed, and Cline — 37+ tools total."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is my code safe? Does Entroly send my data anywhere?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Entroly runs entirely on your machine. Context selection, compression, and the CCR store are all local. The only outbound call is the one your tool was already making to the LLM provider. No outbound analytics by default."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between Entroly and other prompt compression tools?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most compression tools shrink whatever you give them. Entroly selects first (knapsack optimizer over the full repo), then compresses. You get the right context at the right resolution. The Cache Aligner is also unique: it stabilizes the prefix to keep Anthropic 90% and OpenAI 50% cache discounts applying consistently."
+      }
+    }
+  ]
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171;--yellow:#fbbf24}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+.cta-btn:hover{opacity:0.9}
+article{max-width:780px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(2rem,4vw,2.8rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px}
+h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+blockquote{border-left:3px solid var(--accent);padding-left:16px;margin:20px 0;color:var(--muted);font-style:italic}
+.highlight{color:var(--green)}
+.warning{color:var(--red)}
+.badge{background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:4px 10px;font-size:13px;display:inline-block;margin:0 4px 8px 0}
+table{width:100%;border-collapse:collapse;margin:20px 0}
+th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}
+th{color:var(--text);font-weight:600}
+td{color:var(--muted)}
+.stat-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin:32px 0}
+.stat{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;text-align:center}
+.stat .number{font-size:2.5rem;font-weight:800;color:var(--green);display:block}
+.stat .label{font-size:13px;color:var(--muted);margin-top:4px}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.cta-box h3{margin-top:0}
+.cta-box p{margin-bottom:20px}
+.callout{background:rgba(129,140,248,0.1);border:1px solid rgba(129,140,248,0.3);border-radius:10px;padding:20px;margin:24px 0}
+footer{text-align:center;padding:40px 24px;color:var(--muted);font-size:13px;border-top:1px solid var(--border)}
+@media(max-width:600px){.stat-grid{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+<nav>
+  <a href="/entroly/" class="logo">entroly</a>
+  <div class="links">
+    <a href="/entroly/">Home</a>
+    <a href="/entroly/docs/prompt-compression.html">Prompt Compression</a>
+    <a href="/entroly/docs/hallucination-guard.html">Hallucination Guard</a>
+    <a href="https://github.com/juyterman1000/entroly" class="cta-btn">GitHub</a>
+  </div>
+</nav>
+
+<article>
+
+<h1>Reduce Your LLM API Costs by Sending 79–99.5% Fewer Input Tokens</h1>
+
+<p><strong>Last updated: August 2026</strong> &nbsp;·&nbsp; <span class="badge">Apache-2.0</span> <span class="badge">Local-first</span> <span class="badge">No code changes</span></p>
+
+<div class="proof"><strong>Evidence boundary:</strong> the 79–99.5% figure is <em>input-token reduction</em> measured on committed benchmark artifacts — NeedleInAHaystack 99.5%, LongBench HotpotQA 85.3%, Berkeley Function Calling 79.3%, each at 100% answer retention (<a href="https://github.com/juyterman1000/entroly/blob/main/docs/BENCHMARKS.md">raw results</a>). It is not a guaranteed billing reduction. Token cuts convert to cost only on routes actually sent to a metered API; on a fixed-price subscription they buy longer sessions and larger working sets instead of a smaller invoice. Your provider's bill remains the authority. Measure your own repository offline with <code>entroly simulate</code>.</div>
+
+<p>If you build with Claude, GPT-4, or Gemini, you're almost certainly paying 5–10× more than you need to. The problem isn't the model pricing — it's <strong>what you're sending</strong>.</p>
+
+<div class="stat-grid">
+  <div class="stat">
+    <span class="number">79–99.5%</span>
+    <div class="label">fewer input tokens sent</div>
+  </div>
+  <div class="stat">
+    <span class="number">$0</span>
+    <div class="label">hallucination guard cost</div>
+  </div>
+  <div class="stat">
+    <span class="number">30s</span>
+    <div class="label">setup, no code changes</div>
+  </div>
+</div>
+
+<p><a href="https://github.com/juyterman1000/entroly"><strong>Entroly</strong></a> is an open-source local proxy and context engine that cuts your Claude, OpenAI, and Gemini API bills by 79–99.5% through three mechanisms: smart context compression, provider cache alignment, and query-relevant file selection. It runs entirely on your machine — your code never leaves your device.</p>
+
+<div class="callout">
+<strong>Try it in 30 seconds — no API key needed:</strong><br><br>
+<code>pip install entroly &amp;&amp; entroly verify-claims</code><br><br>
+Measures token reduction on your own repo and writes a JSON report. No outbound calls.
+</div>
+
+<h2>Why Your LLM Bills Are Higher Than They Should Be</h2>
+
+<h3>1. You're Sending the Wrong Files</h3>
+<p>When a coding agent reads a repo, it often sends every file it knows about — not just the files relevant to your specific query. A 400-file codebase hitting a "fix the login bug" request sends auth.py, sure, but also 200 unrelated files. You pay for every token of every file.</p>
+
+<h3>2. Provider Cache Discounts Aren't Applying</h3>
+<p>Anthropic offers a <strong>90% discount on cached token prefixes</strong>. OpenAI offers 50%. But this only works if the prefix bytes are <em>identical</em> across requests. Most tools dynamically rebuild context on every turn — adding timestamps, session IDs, updated file contents — which breaks the prefix and busts the cache. You pay full price every time.</p>
+
+<h3>3. Compressed Context Still Contains Junk</h3>
+<p>Even if you're compressing, most compression tools shrink whatever you give them. If you gave them the wrong 200 files, you're just sending smaller versions of the wrong files. You need to <em>select</em> first, then compress.</p>
+
+<h2>How Entroly Cuts Your LLM API Bills</h2>
+
+<h3>Context Compression (Knapsack Optimizer)</h3>
+<p>Entroly's core is an information-theoretic context selector. It ranks every file and fragment in your repo by: BM25 lexical relevance to the query, Shannon entropy density (information per token), SimHash deduplication, and dependency graph proximity. Then a <strong>knapsack solver</strong> picks the mathematically optimal subset under your token budget.</p>
+<p>Critical files go in at full resolution. Supporting files become function signatures. Everything else becomes a reference path the model can ask to expand. Result: the model sees <em>broader</em> coverage of your codebase in a <em>smaller</em> prompt.</p>
+
+<h3>Cache Aligner (Prefix Stability)</h3>
+<p>Entroly's <strong>Cache Aligner</strong> tracks the injected context prefix per client. When a new request arrives and the context hasn't materially changed (Jaccard similarity &gt; 90%), it reuses the previous prefix verbatim — byte-for-byte. This means Anthropic's 90% cache discount and OpenAI's 50% discount <em>actually apply</em> consistently.</p>
+<p>On agent loops where the same files are relevant across 10+ turns, this alone can reduce costs by 80–90%.</p>
+
+<h3>Content-Compressed Retrieval (CCR — Lossless)</h3>
+<p>When fragments are compressed to skeletons, Entroly stores the full originals in a local <strong>Content-Compressed Retrieval (CCR)</strong> store. If the model needs more detail on a compressed fragment, it calls <code>entroly_retrieve</code> via MCP to get the full content back. Nothing is permanently lost — compression is fully reversible.</p>
+
+<h3>WITNESS — $0 Hallucination Guard</h3>
+<p>Every response is checked by <strong>WITNESS</strong>, a local deterministic NLI verifier that audits the model's answer against the evidence it was given. It flags unsupported claims before they reach you. Cost: $0. Latency: ~3ms. Accuracy: <strong>0.7976 AUROC</strong> on the 16,000-decision held-out HaluEval-QA split (84.92%); on the 1,200-decision sample shared with the GPT rows it scored 86.58% / 0.8132 AUROC against gpt-4o-mini's 86.25%. <a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/halueval_qa_faithful.json">Protocol and raw result</a>. WITNESS has measured false positives and false negatives; it reduces unsupported output, it does not eliminate it.</p>
+
+<h2>Measured Token Savings</h2>
+
+<p>All numbers below are from committed JSON artifacts in the repo — not screenshots. Reproduce them with <code>entroly verify-claims</code>.</p>
+
+<table>
+  <tr><th>Token Budget</th><th>Token Reduction</th></tr>
+  <tr><td>8K tokens</td><td class="highlight"><strong>99.1%</strong></td></tr>
+  <tr><td>32K tokens</td><td class="highlight"><strong>96.7%</strong></td></tr>
+  <tr><td>Average across workloads</td><td class="highlight"><strong>87.0%</strong></td></tr>
+</table>
+
+<h2>Accuracy Is Preserved</h2>
+
+<p>Cutting tokens is only useful if the answers stay correct. Measured with <code>gpt-4o-mini</code> on standard benchmarks:</p>
+
+<table>
+  <tr><th>Benchmark</th><th>Token Savings</th><th>Accuracy Retention</th></tr>
+  <tr><td>NeedleInAHaystack</td><td>99.5%</td><td class="highlight"><strong>100%</strong></td></tr>
+  <tr><td>LongBench (HotpotQA)</td><td>85.3%</td><td class="highlight"><strong>103%</strong> (better)</td></tr>
+  <tr><td>Berkeley Function Calling</td><td>79.3%</td><td class="highlight"><strong>100%</strong></td></tr>
+  <tr><td>SQuAD 2.0</td><td>43.8%</td><td>90%</td></tr>
+</table>
+
+<h2>Reduce Costs Across Every Provider</h2>
+
+<h3>Cut Claude / Anthropic API Bills</h3>
+<p>Entroly intercepts Anthropic API calls, compresses the context, and stabilizes the prefix so the 90% prompt caching discount applies. Works with Claude Code, Claude Sonnet, Claude Opus, and all Anthropic models.</p>
+<pre>ANTHROPIC_BASE_URL=http://localhost:9377 claude</pre>
+
+<h3>Cut OpenAI / GPT-4 API Bills</h3>
+<p>Same approach for OpenAI — context compression + prefix stability for OpenAI's 50% cached-prefix discount. Works with GPT-4o, GPT-4o-mini, and all OpenAI-compatible APIs.</p>
+<pre>OPENAI_BASE_URL=http://localhost:9377/v1 your-app</pre>
+
+<h3>Cut Gemini API Bills</h3>
+<pre>GOOGLE_GEMINI_BASE_URL=http://localhost:9377/v1beta your-app</pre>
+
+<h3>Works With Cursor, Aider, Claude Code + 34 More</h3>
+<p>One command wraps your IDE or coding agent:</p>
+<pre>entroly wrap claude   # Claude Code
+entroly wrap cursor   # Cursor
+entroly wrap aider    # Aider
+entroly go            # auto-detect your tool</pre>
+
+<h2>Quick Start — Reduce Your Bills in 30 Seconds</h2>
+
+<pre># Install
+pip install entroly
+
+# Test savings on your own repo (no API key, no outbound calls)
+cd /your/repo && entroly verify-claims
+
+# Start the proxy
+entroly proxy                          # http://localhost:9377
+
+# Or auto-detect and wrap your coding tool
+entroly go</pre>
+
+<div class="cta-box">
+  <h3>Stop Overpaying for LLM API Calls</h3>
+  <p>Open-source. Local-first. Apache-2.0. Your code stays on your machine.</p>
+  <pre>pip install entroly &amp;&amp; entroly go</pre>
+  <p><a href="https://github.com/juyterman1000/entroly" class="cta-btn">View on GitHub →</a></p>
+</div>
+
+<h2>Frequently Asked Questions</h2>
+
+<h3>How much can I actually save on my Claude API bill?</h3>
+<p>It depends on your repo size and query patterns. Run <code>entroly demo</code> in your repo for a before/after estimate with no API calls. On large repos (300+ files) with agent loops, most users see 70–90% reduction. On small repos or single-file prompts, savings are lower.</p>
+
+<h3>Does it work with my existing tool?</h3>
+<p>If your tool supports a custom <code>OPENAI_BASE_URL</code> or <code>ANTHROPIC_BASE_URL</code>, it works via the proxy. Entroly also has native MCP server support for Cursor, Claude Code, VS Code, Windsurf, Zed, and Cline.</p>
+
+<h3>Is my code safe? Does it send my data anywhere?</h3>
+<p>No. Entroly runs entirely on your machine. Context selection, compression, and the CCR store are all local. The only outbound call is the one your tool was already making to the LLM provider. No outbound analytics by default.</p>
+
+<h3>What's the difference between Entroly and other compression tools?</h3>
+<p>Most compression tools shrink whatever you give them. Entroly <em>selects</em> first (knapsack optimizer over the full repo), <em>then</em> compresses. You get the right context at the right resolution — not just a smaller version of everything. The Cache Aligner is also unique: it actively stabilizes the prefix to keep provider discounts applying.</p>
+
+</article>
+
+<footer>
+  <p><a href="/entroly/">Entroly</a> — Context Intelligence, Not Compression</p>
+  <p style="margin-top:8px">
+     <a href="/entroly/docs/reduce-llm-api-costs.html">Reduce LLM API Costs</a> ·
+     <a href="/entroly/docs/prompt-compression.html">Prompt Compression</a> ·
+     <a href="/entroly/docs/hallucination-guard.html">Hallucination Guard</a> ·
+     <a href="/entroly/docs/token-optimization.html">Token Optimization</a> ·
+     <a href="/entroly/docs/context-engineering.html">Context Engineering</a> ·
+     <a href="/entroly/docs/cursor-context-guide.html">Cursor Guide</a> ·
+     <a href="/entroly/docs/claude-code-setup.html">Claude Code Guide</a> ·
+     <a href="/entroly/docs/mcp-server-guide.html">MCP Server</a> ·
+     <a href="/entroly/docs/dashboard.html">Live Dashboard</a> ·
+     <a href="https://github.com/juyterman1000/entroly">GitHub</a>
+  </p>
+</footer>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -20,4 +20,16 @@
   <url><loc>https://juyterman1000.github.io/entroly/docs/gpt-5-6-sol-terra-luna.html</loc><lastmod>2026-07-26</lastmod></url>
   <url><loc>https://juyterman1000.github.io/entroly/docs/model-support.html</loc><lastmod>2026-08-11</lastmod><changefreq>weekly</changefreq><priority>0.94</priority></url>
   <url><loc>https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html</loc><lastmod>2026-08-11</lastmod><changefreq>weekly</changefreq><priority>0.90</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.95</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/token-optimization.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.93</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/prompt-compression.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.93</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/what-is-context-rot.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.90</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.90</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.88</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/cursor-token-usage-fix.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.88</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.88</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/hallucination-guard.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.85</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/claude-code-setup.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.85</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.85</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/token-compression-tools.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.96</priority></url>
 </urlset>

--- a/docs/token-compression-tools.html
+++ b/docs/token-compression-tools.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Token Compression Tools for LLM Agents: 2026 Comparison &mdash; Entroly</title>
+<meta name="description" content="Token compression tools reduce what agents send an LLM: tool outputs, JSON, shell and build logs, RAG chunks, and repository context. Compare approaches by the surface they compress and whether removed bytes can be recovered. Entroly cuts 79.3%-99.5% of input tokens at 100% answer retention with byte-exact recovery.">
+<meta property="og:title" content="Token Compression Tools for LLM Agents: 2026 Comparison">
+<meta property="og:description" content="Which token compression approach fits which surface - tool output, logs, JSON, RAG, repo context - and which ones let you get the removed bytes back.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/token-compression-tools.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Token Compression Tools for LLM Agents: 2026 Comparison">
+<meta name="twitter:description" content="Compare token compression by surface and by recoverability. Entroly: 79-99.5% fewer input tokens at 100% answer retention, byte-exact recovery.">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/token-compression-tools.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Token Compression Tools for LLM Agents: 2026 Comparison",
+  "description": "How token compression approaches for LLM agents differ by the surface they compress - tool output, logs, JSON, RAG chunks, repository context - and by whether removed content remains recoverable.",
+  "author": {"@type": "Organization", "name": "Entroly", "url": "https://github.com/juyterman1000/entroly"},
+  "publisher": {"@type": "Organization", "name": "Entroly", "url": "https://github.com/juyterman1000/entroly"},
+  "datePublished": "2026-08-15",
+  "dateModified": "2026-08-15",
+  "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  "isAccessibleForFree": true,
+  "keywords": "token compression tools, token compression, LLM token reduction, agent context compression, tool output compression, prompt compression",
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://juyterman1000.github.io/entroly/docs/token-compression-tools.html"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Token compression approaches for LLM agents",
+  "description": "Categories of token compression, organised by the surface each one reduces.",
+  "itemListOrder": "https://schema.org/ItemListOrderAscending",
+  "numberOfItems": 6,
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Evidence selection under a token budget", "description": "Rank candidate spans and keep the highest-value subset that fits an explicit budget. Reduces repository and document context. Recoverable if the tool retains addressable handles for what it dropped."},
+    {"@type": "ListItem", "position": 2, "name": "Tool-output and JSON compression", "description": "Rewrite verbose structured tool results before they enter context. Highest ratios in the category because JSON is largely syntactic overhead. Usually lossy."},
+    {"@type": "ListItem", "position": 3, "name": "Shell, build and test log trimming", "description": "Collapse repeated lines, progress output and stack-trace noise from CLI results. Cheap and high yield in agent loops that run commands."},
+    {"@type": "ListItem", "position": 4, "name": "Conversation compaction", "description": "Summarise earlier turns as a session approaches the context limit. Now shipped natively by major providers. Lossy, and the original turns are typically unrecoverable."},
+    {"@type": "ListItem", "position": 5, "name": "Tool-schema deferral", "description": "Withhold tool definitions until a tool is actually needed rather than loading every schema each turn. Increasingly a platform feature rather than a third-party one."},
+    {"@type": "ListItem", "position": 6, "name": "Extractive token-level compression", "description": "Drop low-information tokens from a prompt using a scoring model. Strong on prose; contested for agent workflows, where step-level structure carries meaning token-level scoring cannot see."}
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type": "Question", "name": "What is a token compression tool?",
+     "acceptedAnswer": {"@type": "Answer", "text": "A token compression tool reduces the number of tokens an application sends to a language model. In agent workflows the biggest sources of waste are usually not the prompt itself but the machinery around it: verbose JSON returned by tools, shell and build logs, retrieved document chunks, tool schemas loaded every turn, and repository context selected too broadly. Different tools target different surfaces, so the useful question is not which tool compresses most but which surface dominates your token bill."}},
+    {"@type": "Question", "name": "Is token-level compression appropriate for LLM agents?",
+     "acceptedAnswer": {"@type": "Answer", "text": "It is contested. Recent agent-compression research argues that dropping individual low-information tokens is structurally mismatched to agent settings, because an agent trajectory is a sequence of discrete actions and observations whose boundaries carry meaning that token-level scoring cannot see. Entroly does not do token-level rewriting. It selects whole evidence spans under an explicit budget and keeps omitted spans addressable by content hash, so structure is preserved and omissions stay recoverable."}},
+    {"@type": "Question", "name": "How much can token compression actually save?",
+     "acceptedAnswer": {"@type": "Answer", "text": "It depends almost entirely on how much redundancy the input carries. On Entroly's committed benchmark artifacts, NeedleInAHaystack reduced 10,808 input tokens to 56, a 99.5% cut with accuracy unchanged at 100%. Berkeley Function Calling cut 79.3% with accuracy unchanged. LongBench HotpotQA cut 85.3% while accuracy rose from 64% to 66%. The worst case in the same set is SQuAD 2.0 at 43.8% savings and 90% retention, on 233-token single-paragraph inputs where there is almost nothing redundant to remove. Compression helps least where context is already small."}},
+    {"@type": "Question", "name": "Does compressing tokens lower my bill?",
+     "acceptedAnswer": {"@type": "Answer", "text": "Only on routes actually metered per token. If you call a provider API directly, fewer input tokens means a smaller input charge. On a fixed-price subscription, cutting tokens does not reduce the subscription fee; it buys longer sessions, larger working sets and fewer rate-limit interruptions instead. Treat any vendor dollar figure as arithmetic at list pricing, not as a measured invoice."}},
+    {"@type": "Question", "name": "Can I get the removed content back?",
+     "acceptedAnswer": {"@type": "Answer", "text": "With most token compression tools, no. Summarisation, truncation and token dropping are lossy, and the original bytes are gone once the request is built. Entroly keeps every omitted span addressable by content hash, so a dropped span can be restored byte-for-byte on demand. Its committed fidelity artifact reports 5,117 of 5,117 native source fragments independently verified and 13 of 13 public SDK recovery probes matching their source spans exactly."}},
+    {"@type": "Question", "name": "Do these tools send my code to a third party?",
+     "acceptedAnswer": {"@type": "Answer", "text": "Hosted compression APIs necessarily receive your prompt content on their servers, which for proprietary source code is a procurement question worth asking early. Entroly performs selection, compression, receipt generation and verification locally; only the resulting optimised request goes to whichever model provider you configured."}}
+  ]
+}
+</script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#09090b;--surface:#18181b;--border:#27272a;--text:#fafafa;--muted:#a1a1aa;--accent:#818cf8;--green:#34d399;--red:#f87171;--yellow:#fbbf24;--blue:#60a5fa}
+body{background:var(--bg);color:var(--text);font-family:'Inter',system-ui,sans-serif;line-height:1.7}
+a{color:var(--accent)}
+code{font-family:'JetBrains Mono',monospace;background:var(--surface);padding:2px 6px;border-radius:4px;font-size:14px}
+pre{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px;overflow-x:auto;margin:20px 0;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.6}
+nav{position:fixed;top:0;width:100%;z-index:100;background:rgba(9,9,11,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:56px}
+nav .logo{font-weight:800;font-size:20px;text-decoration:none;color:var(--text)}
+nav .links{display:flex;gap:20px;font-size:14px}
+nav .links a{color:var(--muted);text-decoration:none}
+nav .links a:hover{color:var(--text)}
+.cta-btn{background:var(--accent);color:#fff;padding:8px 20px;border-radius:8px;font-weight:600;font-size:14px;text-decoration:none;display:inline-block}
+article{max-width:820px;margin:0 auto;padding:100px 24px 80px}
+h1{font-size:clamp(2rem,4vw,2.8rem);font-weight:800;letter-spacing:-1px;line-height:1.15;margin-bottom:16px}
+h2{font-size:1.5rem;font-weight:700;margin:48px 0 16px;color:var(--text)}
+h3{font-size:1.2rem;font-weight:600;margin:32px 0 12px}
+p{margin-bottom:16px;color:var(--muted)}
+ul,ol{margin:0 0 16px 24px;color:var(--muted)}
+li{margin-bottom:8px}
+strong{color:var(--text)}
+.highlight{color:var(--green)}
+table{width:100%;border-collapse:collapse;margin:20px 0}
+th,td{text-align:left;padding:12px;border-bottom:1px solid var(--border);font-size:14px}
+th{color:var(--text);font-weight:600;background:var(--surface)}
+td{color:var(--muted)}
+.winner{color:var(--green);font-weight:600}
+.good{color:var(--blue)}
+.mid{color:var(--yellow)}
+.weak{color:var(--red)}
+.cta-box{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;text-align:center;margin:48px 0}
+.cta-box h3{margin-top:0}
+.badge{display:inline-block;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600}
+.badge-green{background:rgba(52,211,153,0.15);color:var(--green)}
+.badge-blue{background:rgba(96,165,250,0.15);color:var(--blue)}
+.badge-yellow{background:rgba(251,191,36,0.15);color:var(--yellow)}
+.badge-red{background:rgba(248,113,113,0.15);color:var(--red)}
+.faq{margin:32px 0}
+.faq details{border:1px solid var(--border);border-radius:8px;margin-bottom:12px;background:var(--surface)}
+.faq summary{padding:16px;cursor:pointer;font-weight:600;color:var(--text)}
+.faq details[open] summary{border-bottom:1px solid var(--border)}
+.faq .answer{padding:16px;color:var(--muted)}
+</style></head>
+<body>
+<article>
+
+<h1>Token Compression Tools for LLM Agents</h1>
+
+<p><strong>Last updated: August 2026</strong> &nbsp;&middot;&nbsp; <span class="badge badge-green">Apache-2.0</span> <span class="badge badge-blue">Local-first</span></p>
+
+<p>&ldquo;Token compression&rdquo; covers at least six different jobs, and a tool that does one of them well is often useless at the others. Before choosing, work out which surface is actually spending your tokens. The answer is rarely the prompt you wrote.</p>
+
+<div class="proof"><strong>Evidence boundary:</strong> every Entroly figure on this page comes from a committed benchmark artifact, linked to its raw result file in <a href="https://github.com/juyterman1000/entroly/blob/main/docs/BENCHMARKS.md">BENCHMARKS.md</a>. Ratios are input-token reductions, not billing reductions. Results vary by repository, query, budget, model and cache behaviour. Measure your own with <code>entroly simulate</code>, which runs locally with no API key.</div>
+
+<h2>Six surfaces, six different problems</h2>
+
+<table>
+<thead><tr><th>Surface</th><th>Why it wastes tokens</th><th>Typical yield</th><th>Recoverable?</th></tr></thead>
+<tbody>
+<tr><td><strong>Repository / document context</strong></td><td>Whole files pulled in when a few spans mattered</td><td>High on large repos</td><td class="good">Yes, if the tool keeps handles</td></tr>
+<tr><td><strong>Tool output &amp; JSON</strong></td><td>Structural overhead dominates the payload</td><td class="highlight">Very high</td><td class="weak">Usually not</td></tr>
+<tr><td><strong>Shell / build / test logs</strong></td><td>Repeated lines, progress bars, stack noise</td><td class="highlight">Very high</td><td class="weak">Usually not</td></tr>
+<tr><td><strong>Conversation history</strong></td><td>Every turn is replayed on the next turn</td><td>Moderate</td><td class="weak">No &mdash; summaries discard originals</td></tr>
+<tr><td><strong>Tool schemas</strong></td><td>All definitions loaded every turn</td><td>Moderate</td><td class="mid">N/A &mdash; deferral, not compression</td></tr>
+<tr><td><strong>Prompt prose</strong></td><td>Low-information tokens</td><td>Low&ndash;moderate</td><td class="weak">No</td></tr>
+</tbody>
+</table>
+
+<p>Two of these &mdash; conversation compaction and tool-schema deferral &mdash; have become platform features rather than third-party products. If your token bill is dominated by either, the platform likely already addresses it and a separate tool adds little.</p>
+
+<h2>The agent-specific objection</h2>
+
+<p>A fair criticism of this whole category, raised repeatedly in recent agent-compression work: dropping individual low-information <em>tokens</em> is structurally mismatched to agent workloads. An agent trajectory is a sequence of discrete actions and observations, and those boundaries carry meaning a token-level scorer cannot see. Compress across them and you can corrupt the record of what the agent did.</p>
+
+<p>It is worth stating plainly, because it applies to several tools in this category. Entroly's answer is that it does no token-level rewriting at all: it selects <em>whole evidence spans</em> under an explicit budget, leaves their bytes untouched, and keeps everything it omitted addressable by content hash. Structure survives, and so does the ability to get an omission back.</p>
+
+<h2>What Entroly measured</h2>
+
+<table>
+<thead><tr><th>Benchmark</th><th>Input tokens</th><th>After</th><th>Token savings</th><th>Answer retention</th></tr></thead>
+<tbody>
+<tr><td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/needle_accuracy.json">NeedleInAHaystack</a></td><td>10,807.6</td><td>56.4</td><td class="winner">99.5%</td><td class="good">100% (1.00 &rarr; 1.00)</td></tr>
+<tr><td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/longbench_accuracy.json">LongBench HotpotQA</a></td><td>12,652.3</td><td>1,860.1</td><td class="winner">85.3%</td><td class="good">103% (0.64 &rarr; 0.66)</td></tr>
+<tr><td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/bfcl_accuracy.json">Berkeley Function Calling</a></td><td>2,849.6</td><td>589.7</td><td class="winner">79.3%</td><td class="good">100% (1.00 &rarr; 1.00)</td></tr>
+<tr><td><a href="https://github.com/juyterman1000/entroly/blob/main/benchmarks/results/squad_accuracy.json">SQuAD 2.0</a></td><td>232.9</td><td>130.8</td><td class="mid">43.8%</td><td class="weak">90% (0.80 &rarr; 0.72)</td></tr>
+</tbody>
+</table>
+
+<p><strong>Read the bottom row first.</strong> SQuAD is the loss case, and the reason is visible in the input column: 233 tokens, a single paragraph, run against a 100-token budget. There is nothing redundant to remove, so the budget does the cutting and accuracy pays for it. That is the honest boundary of this technique. Compression helps least exactly where context is already small, which is why Entroly passes small inputs through untouched rather than squeezing them.</p>
+
+<h2>Choosing</h2>
+
+<ul>
+<li><strong>Your agent reads large repositories.</strong> Budgeted evidence selection is the right shape. Ask whether omissions are recoverable and whether you get a record of what was dropped.</li>
+<li><strong>Your agent runs commands and hits verbose APIs.</strong> Tool-output and log compression will out-yield everything else. Ratios there are the highest in the category.</li>
+<li><strong>Your sessions are long and conversational.</strong> Check what your platform already does before adding anything.</li>
+<li><strong>You need to defend the pipeline in review.</strong> Ratio stops being the deciding axis. What matters is whether you can show which evidence reached the model, what was withheld, and produce the withheld bytes on request.</li>
+<li><strong>Your context already fits comfortably.</strong> Use nothing. Every tool here adds a step for no benefit, and a good one will tell you so.</li>
+</ul>
+
+<div class="cta-box">
+<h3>Measure before you believe anyone, including us</h3>
+<p>Both commands run locally. No API key, no account, no network call, no cost.</p>
+<pre><code>pip install -U entroly
+cd /your/repo
+entroly verify-claims   # bounded self-checks
+entroly simulate        # your repo's own reduction profile</code></pre>
+<p><a class="cta-btn" href="https://github.com/juyterman1000/entroly">Entroly on GitHub &mdash; Apache-2.0</a></p>
+</div>
+
+<div class="links">
+<p>Related: <a href="best-context-compression-tools.html">Context compression tools compared</a> &middot; <a href="prompt-compression.html">Prompt compression</a> &middot; <a href="what-is-context-rot.html">What is context rot?</a> &middot; <a href="token-optimization.html">Token optimization</a> &middot; <a href="https://github.com/juyterman1000/entroly/blob/main/docs/BENCHMARKS.md">All benchmarks</a></p>
+</div>
+
+</article>
+</body>
+</html>

--- a/docs/token-optimization.html
+++ b/docs/token-optimization.html
@@ -1,2 +1,75 @@
 <!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This token-optimization page has been retired</h1><p>Token reduction depends on the selected budget, source corpus, and query. Answer quality must be measured separately.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Review the benchmark protocols</a>.</p></main></body></html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>LLM Token Optimization & AI Cost Saving | Entroly Token Economics</title>
+<meta name="description" content="Entroly reduces avoidable LLM input tokens with budgeted evidence selection, recoverable context compression, cache-aware context engineering, receipts, and workload-specific verification.">
+<meta name="keywords" content="LLM token optimization, token saving, AI cost saving, AI bill reduction, token economics, AI efficiency, context compression, context optimization, reduce LLM cost, reduce API tokens, prompt compression">
+<meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">
+<meta name="googlebot" content="index,follow,max-snippet:-1,max-image-preview:large">
+<meta name="bingbot" content="index,follow,max-snippet:-1,max-image-preview:large">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/token-optimization.html">
+<meta property="og:site_name" content="Entroly">
+<meta property="og:type" content="article">
+<meta property="og:title" content="LLM Token Optimization & AI Cost Saving with Entroly">
+<meta property="og:description" content="Evidence-first token economics: select the right context, compress recoverably, preserve cache stability, and measure the result.">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/token-optimization.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/entroly-ai-code-intelligence-architecture.svg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Entroly Token Economics: LLM Token Optimization & AI Cost Saving">
+<meta name="twitter:description" content="Reduce avoidable provider-bound context while keeping exact evidence recoverable and auditable.">
+<meta name="twitter:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/entroly-ai-code-intelligence-architecture.svg">
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@graph":[
+    {"@type":"SoftwareApplication","name":"Entroly","applicationCategory":"DeveloperApplication","applicationSubCategory":"LLM Token Optimization and Context Assurance","operatingSystem":"Windows, macOS, Linux","url":"https://juyterman1000.github.io/entroly/docs/token-optimization.html","codeRepository":"https://github.com/juyterman1000/entroly","downloadUrl":"https://pypi.org/project/entroly/","license":"https://opensource.org/licenses/Apache-2.0","description":"Local-first context assurance for reducing avoidable LLM input through budgeted evidence selection, recoverable compression, receipts, verification, and cache-aware context control.","offers":{"@type":"Offer","price":"0.00","priceCurrency":"USD"}},
+    {"@type":"TechArticle","headline":"LLM Token Optimization and AI Cost Saving with Entroly","description":"Evidence-first token economics for AI agents and API applications.","mainEntityOfPage":"https://juyterman1000.github.io/entroly/docs/token-optimization.html","image":"https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/entroly-ai-code-intelligence-architecture.svg","dateModified":"2026-08-09","author":{"@type":"Organization","name":"Entroly","url":"https://github.com/juyterman1000/entroly"}},
+    {"@type":"FAQPage","mainEntity":[
+      {"@type":"Question","name":"How does Entroly save LLM tokens?","acceptedAnswer":{"@type":"Answer","text":"Entroly selects high-value evidence under an explicit token budget, compresses recoverably, preserves exact originals through content-addressed recovery, and can keep stable prompt prefixes cache-friendly. Savings are workload-specific rather than guaranteed."}},
+      {"@type":"Question","name":"Can Entroly reduce AI API bills?","acceptedAnswer":{"@type":"Answer","text":"Entroly can reduce avoidable provider-bound input on supported API and proxy routes. Dollar savings depend on the provider, model, pricing, cache behavior, output usage, workload, and whether optimized context is actually sent to a paid endpoint."}},
+      {"@type":"Question","name":"Is Entroly just prompt compression?","acceptedAnswer":{"@type":"Answer","text":"No. Entroly performs evidence selection before compression, preserves omitted content for exact recovery, emits receipts, provides repository and code intelligence, and can verify whether output claims are supported by supplied evidence."}}
+    ]}
+  ]
+}
+</script>
+<style>
+:root{color-scheme:dark;--bg:#06070c;--panel:#111522;--line:#28304b;--text:#f8fafc;--muted:#aab3cc;--a:#8fa0ff;--g:#8ef0c7}*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 50% 0,#121936 0,#06070c 38%);color:var(--text);font:17px/1.7 system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}main{max-width:980px;margin:auto;padding:54px 24px 90px}a{color:#aeb8ff}nav{font-size:14px;color:var(--muted);margin-bottom:44px}h1{font-size:clamp(2.5rem,6vw,4.8rem);line-height:1.03;letter-spacing:-.045em;margin:.15em 0 .35em}h2{font-size:1.9rem;margin-top:2.2em}.lead{font-size:1.25rem;color:#c8cfe0}.answer,.card{background:rgba(17,21,34,.88);border:1px solid var(--line);border-radius:18px}.answer{padding:26px 28px;margin:30px 0;border-color:#6675bd}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}.card{padding:22px}.card h3{margin-top:0}.good{color:var(--g)}figure{margin:34px 0;background:#090c18;border:1px solid var(--line);border-radius:20px;padding:14px}figure img{display:block;width:100%;height:auto;border-radius:12px}figcaption{padding:12px 8px 2px;color:var(--muted);font-size:14px}.proof{border-left:4px solid var(--g);padding:14px 20px;background:rgba(142,240,199,.06)}footer{margin-top:64px;border-top:1px solid var(--line);padding-top:26px;color:var(--muted)}
+</style>
+</head>
+<body><main>
+<nav><a href="index.html">Entroly</a> / token economics &amp; AI cost optimization</nav>
+<p style="color:var(--a);font-weight:800;letter-spacing:.12em;text-transform:uppercase;font-size:13px">LLM token economics · AI efficiency · context optimization</p>
+<h1>Reduce avoidable AI tokens. Preserve the evidence that matters.</h1>
+<p class="lead">Entroly is a local-first Context Assurance and code-intelligence system for AI agents. It optimizes the economics of model context by selecting useful evidence under a budget, compressing it recoverably, preserving cache-stable prefixes where possible, and recording what changed.</p>
+<div class="answer"><strong>Direct answer:</strong> If you are searching for <strong>LLM token optimization, AI cost saving, AI bill reduction, token economics, context compression, or AI efficiency</strong>, Entroly addresses the same core problem: reduce unnecessary provider-bound context without silently discarding answer-critical evidence. It does not promise a universal percentage; it exposes workload-specific measurements and recovery/receipt evidence.</div>
+<figure>
+<img src="assets/entroly-ai-code-intelligence-architecture.svg" width="1600" height="900" loading="eager" decoding="async" alt="Entroly AI efficiency architecture showing parser-backed repository intelligence, typed dependency and call graphs, verified context selection, recoverable compression, evidence receipts, and AI agents">
+<figcaption>Entroly optimizes tokens after evidence selection: repository structure and task relevance determine what deserves the limited context budget; receipts and recovery keep omissions auditable.</figcaption>
+</figure>
+<h2>Token saving is an evidence-allocation problem</h2>
+<div class="grid">
+<div class="card"><h3>1 · Select</h3><p>Rank useful code, messages, files, tool output, logs, or RAG evidence under an explicit budget instead of blindly sending everything.</p></div>
+<div class="card"><h3>2 · Compress</h3><p>Use structured and recoverable compression after selection. Small inputs can pass through rather than manufacturing savings.</p></div>
+<div class="card"><h3>3 · Recover</h3><p>Omitted originals can remain content-addressed and recoverable, so token reduction is not the same as permanent deletion.</p></div>
+<div class="card"><h3>4 · Verify</h3><p>Context Receipts and verification surfaces make selection, omissions, and evidence support inspectable.</p></div>
+</div>
+<h2>How Entroly approaches AI cost saving</h2>
+<p><strong>API input economics:</strong> fewer unnecessary provider-bound input tokens can reduce measured input cost on routes where the optimized request is actually sent to a paid model. Fixed-price subscriptions are different: lowering tokens does not necessarily lower the subscription fee.</p>
+<p><strong>Cache economics:</strong> Entroly includes cache-alignment behavior designed to keep eligible stable prompt prefixes byte-stable. Provider-reported cache hits and discounts remain authoritative.</p>
+<p><strong>Context-window economics:</strong> token saving also frees capacity for longer sessions, larger repositories, or more useful evidence inside a fixed model context window.</p>
+<div class="proof"><strong>Evidence boundary:</strong> Entroly publishes benchmark artifacts, receipts, recovery tests, and workload-specific measurements. Results vary by repository, query, model, provider, token budget, cache behavior, and baseline. See <a href="https://github.com/juyterman1000/entroly/blob/main/docs/BENCHMARKS.md">benchmark evidence</a> and <a href="ai-cost-optimization.html">AI cost optimization</a>.</div>
+<h2>Related Entroly capabilities</h2>
+<ul>
+<li><a href="code-intelligence.html">Verified code intelligence for AI agents</a> — AST/Tree-sitter structure, call/dependency graphs, architecture and verified source context.</li>
+<li><a href="context-engineering.html">Context engineering</a> — selection, compression and delivery of useful model context.</li>
+<li><a href="https://github.com/juyterman1000/entroly/blob/main/docs/memory-ecosystem.md">Entroly Memory OS</a> — budget-aware working, episodic and semantic memory.</li>
+<li><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Public evidence policy</a> — what Entroly does and does not claim.</li>
+</ul>
+<h2>Frequently asked questions</h2>
+<h3>Is context compression the same as token optimization?</h3><p>No. Compression is one technique. Entroly treats token optimization as a broader control problem that includes evidence selection, context budgeting, cache alignment, compression, recovery, receipts, and verification.</p>
+<h3>Does lower token usage always mean a better answer?</h3><p>No. Aggressive compression can remove useful evidence. Entroly therefore publishes quality measurements separately from token reduction and can pass through context when reduction is not justified.</p>
+<h3>Can Entroly help local models too?</h3><p>Yes. Token budgets matter for local models even when there is no API bill: smaller, better-selected context can reduce context pressure and leave more room for useful evidence. Hardware/runtime performance still depends on the local model stack.</p>
+<footer>Entroly · Verified Code Intelligence + Context Assurance for AI Agents · Apache-2.0 · <a href="https://github.com/juyterman1000/entroly">GitHub</a></footer>
+</main></body></html>

--- a/docs/what-is-context-rot.html
+++ b/docs/what-is-context-rot.html
@@ -1,2 +1,528 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0; url=https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><link rel="canonical" href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md"><title>Entroly public evidence</title></head><body><main><h1>This context-rot article has been retired</h1><p>Entroly now separates product behavior, benchmark observations, and research hypotheses in its evidence ledger.</p><p><a href="https://github.com/juyterman1000/entroly/blob/main/docs/public-evidence.md">Read the public evidence ledger</a>.</p></main></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>What Is Context Rot? The Hidden Reason Your AI Gets Dumber Over Time (2026)</title>
+<meta name="description" content="Context rot is why your AI coding assistant gives worse answers the longer a session runs. Learn what causes it, how to detect it, and how to fix it with information-theoretic context selection.">
+<meta name="keywords" content="context rot, context rot AI, context rot LLM, AI gets dumber over time, AI coding assistant degrades, Claude context rot, context window problem, LLM context degradation, context rot fix, context window full, AI loses context, long session AI quality">
+<meta property="og:title" content="What Is Context Rot? Why Your AI Gets Dumber Over Time">
+<meta property="og:description" content="Context rot is the silent killer of AI coding sessions. Your assistant gives sharp answers at the start, then degrades. Here's exactly why — and how to fix it.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://juyterman1000.github.io/entroly/docs/what-is-context-rot.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/juyterman1000/entroly/main/docs/assets/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="What Is Context Rot? The Hidden Reason Your AI Gets Dumber Over Time">
+<meta name="twitter:description" content="Context rot explains why Claude/GPT gives great answers at session start, then degrades. Here's the science and the fix.">
+<link rel="canonical" href="https://juyterman1000.github.io/entroly/docs/what-is-context-rot.html">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "What Is Context Rot? The Hidden Reason Your AI Gets Dumber Over Time",
+  "description": "Context rot is the gradual degradation of AI assistant quality during a long session, caused by irrelevant content filling the context window and pushing out the critical evidence the model needs.",
+  "author": {"@type": "Organization", "name": "Entroly"},
+  "datePublished": "2026-07-08",
+  "dateModified": "2026-07-08",
+  "publisher": {"@type": "Organization", "name": "Entroly", "url": "https://juyterman1000.github.io/entroly/"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is context rot?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Context rot is the gradual degradation of an AI assistant's answer quality during a long coding session. It happens because the context window fills with irrelevant files, stale conversation turns, and redundant logs — pushing out the specific code and errors the model actually needs to answer correctly."}
+    },
+    {
+      "@type": "Question",
+      "name": "Why does my AI get worse the longer I use it?",
+      "acceptedAnswer": {"@type": "Answer", "text": "LLMs have a fixed context window. As a session grows, that window fills with less-relevant content from earlier turns. The model's attention is diluted across thousands of irrelevant tokens, causing 'lost in the middle' degradation — it starts missing errors, confusing files, and hallucinating fixes for code it can no longer see clearly."}
+    },
+    {
+      "@type": "Question",
+      "name": "How do I fix context rot?",
+      "acceptedAnswer": {"@type": "Answer", "text": "The fix is information-theoretic context selection: instead of sending whatever fills the context window, mathematically rank every fragment by relevance to the current query and send only the highest-value evidence. Tools like Entroly do this locally with knapsack dynamic programming and Shannon entropy scoring."}
+    },
+    {
+      "@type": "Question",
+      "name": "Is context rot the same as hallucination?",
+      "acceptedAnswer": {"@type": "Answer", "text": "They're related but distinct. Context rot is the cause; hallucination is often the effect. When the model's context is full of irrelevant material, it can no longer ground its answers in the actual code — leading it to generate plausible-sounding but wrong answers. Fixing context rot significantly reduces hallucination rates."}
+    }
+  ]
+}
+</script>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+  :root {
+    --bg: #0a0a12;
+    --surface: #111120;
+    --border: #1e2035;
+    --text: #e8eaf6;
+    --muted: #8892a4;
+    --accent: #6366f1;
+    --accent2: #22d3ee;
+    --green: #2ea44f;
+    --red: #ef4444;
+    --orange: #f59e0b;
+    --max: 760px;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Inter', sans-serif;
+    font-size: 17px;
+    line-height: 1.75;
+    padding: 0 20px;
+  }
+  nav {
+    max-width: var(--max);
+    margin: 0 auto;
+    padding: 20px 0;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 14px;
+    color: var(--muted);
+  }
+  nav a { color: var(--accent); text-decoration: none; }
+  nav a:hover { text-decoration: underline; }
+  .hero {
+    max-width: var(--max);
+    margin: 0 auto;
+    padding: 48px 0 32px;
+  }
+  .tag {
+    display: inline-block;
+    background: rgba(99,102,241,.15);
+    border: 1px solid rgba(99,102,241,.3);
+    color: #a5b4fc;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    padding: 4px 12px;
+    border-radius: 999px;
+    margin-bottom: 20px;
+  }
+  h1 {
+    font-size: clamp(28px, 5vw, 44px);
+    font-weight: 800;
+    letter-spacing: -.04em;
+    line-height: 1.1;
+    margin-bottom: 20px;
+    background: linear-gradient(135deg, #e8eaf6 30%, #8892a4);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .lead {
+    font-size: 19px;
+    color: var(--muted);
+    line-height: 1.7;
+    margin-bottom: 32px;
+    max-width: 640px;
+  }
+  .meta { font-size: 14px; color: var(--muted); display: flex; gap: 20px; flex-wrap: wrap; }
+  .meta span { display: flex; align-items: center; gap: 6px; }
+  article { max-width: var(--max); margin: 40px auto 80px; }
+  h2 {
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: -.03em;
+    margin: 52px 0 16px;
+    color: var(--text);
+  }
+  h3 { font-size: 19px; font-weight: 600; margin: 32px 0 12px; color: var(--text); }
+  p { margin-bottom: 20px; color: #c5cae9; }
+  strong { color: var(--text); font-weight: 600; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code {
+    background: #1a1b2e;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    padding: 2px 7px;
+    font-size: 14px;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    color: var(--accent2);
+  }
+  pre {
+    background: #0d0e1c;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+    overflow-x: auto;
+    margin: 24px 0;
+    font-size: 14px;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    line-height: 1.65;
+    color: #a5b4fc;
+  }
+  .callout {
+    background: linear-gradient(135deg, rgba(99,102,241,.1), rgba(34,211,238,.05));
+    border: 1px solid rgba(99,102,241,.25);
+    border-left: 4px solid var(--accent);
+    border-radius: 0 12px 12px 0;
+    padding: 20px 24px;
+    margin: 28px 0;
+  }
+  .callout.warning {
+    background: rgba(245,158,11,.08);
+    border-color: rgba(245,158,11,.3);
+    border-left-color: var(--orange);
+  }
+  .callout.danger {
+    background: rgba(239,68,68,.08);
+    border-color: rgba(239,68,68,.25);
+    border-left-color: var(--red);
+  }
+  .callout.success {
+    background: rgba(46,164,79,.08);
+    border-color: rgba(46,164,79,.25);
+    border-left-color: var(--green);
+  }
+  .callout p { margin: 0; color: var(--text); }
+  table { width: 100%; border-collapse: collapse; margin: 28px 0; font-size: 15px; }
+  th {
+    background: #111120;
+    border: 1px solid var(--border);
+    padding: 12px 16px;
+    text-align: left;
+    font-weight: 600;
+    color: var(--muted);
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+  }
+  td { border: 1px solid var(--border); padding: 12px 16px; vertical-align: top; }
+  tr:nth-child(even) td { background: rgba(255,255,255,.02); }
+  .stages {
+    display: grid;
+    gap: 16px;
+    margin: 28px 0;
+  }
+  .stage {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px;
+    display: grid;
+    grid-template-columns: 48px 1fr;
+    gap: 16px;
+    align-items: start;
+  }
+  .stage-num {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-weight: 800;
+    font-size: 18px;
+    flex-shrink: 0;
+  }
+  .stage-num.green { background: rgba(46,164,79,.15); color: #4ade80; border: 1px solid rgba(46,164,79,.3); }
+  .stage-num.yellow { background: rgba(245,158,11,.15); color: #fbbf24; border: 1px solid rgba(245,158,11,.3); }
+  .stage-num.orange { background: rgba(249,115,22,.15); color: #fb923c; border: 1px solid rgba(249,115,22,.3); }
+  .stage-num.red { background: rgba(239,68,68,.15); color: #f87171; border: 1px solid rgba(239,68,68,.3); }
+  .stage-title { font-weight: 700; margin-bottom: 4px; }
+  .stage-desc { font-size: 15px; color: var(--muted); margin: 0; }
+  .cta-box {
+    background: linear-gradient(135deg, #1a1b3e, #0d1520);
+    border: 1px solid rgba(99,102,241,.3);
+    border-radius: 16px;
+    padding: 36px;
+    text-align: center;
+    margin: 52px 0;
+  }
+  .cta-box h2 { margin: 0 0 12px; font-size: 26px; }
+  .cta-box p { color: var(--muted); margin-bottom: 24px; }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 14px 28px;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 16px;
+    text-decoration: none;
+    transition: all .2s;
+  }
+  .btn-primary { background: var(--green); color: white; }
+  .btn-primary:hover { background: #238636; transform: translateY(-1px); }
+  .btn-secondary { background: transparent; border: 1px solid var(--border); color: var(--text); margin-left: 12px; }
+  .btn-secondary:hover { border-color: rgba(255,255,255,.2); }
+  .toc {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px 28px;
+    margin: 32px 0;
+  }
+  .toc h4 { font-size: 13px; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); margin-bottom: 12px; }
+  .toc ol { padding-left: 20px; }
+  .toc li { margin-bottom: 6px; font-size: 15px; }
+  footer {
+    max-width: var(--max);
+    margin: 0 auto;
+    padding: 40px 0;
+    border-top: 1px solid var(--border);
+    text-align: center;
+    color: var(--muted);
+    font-size: 14px;
+  }
+  footer a { color: var(--accent); text-decoration: none; }
+</style>
+</head>
+<body>
+
+<nav>
+  <a href="https://juyterman1000.github.io/entroly/">Entroly</a>
+  <span>›</span>
+  <a href="https://juyterman1000.github.io/entroly/docs/">Docs</a>
+  <span>›</span>
+  <span>What Is Context Rot?</span>
+</nav>
+
+<div class="hero">
+  <div class="tag">AI Performance</div>
+  <h1>What Is Context Rot?<br>The Hidden Reason Your AI Gets Dumber Over Time</h1>
+  <p class="lead">Your AI assistant gives sharp, accurate answers at the start of a session. An hour later, it's hallucinating function names and confusing files. This isn't a model problem. It's context rot — and it's costing you real money.</p>
+  <div class="meta">
+    <span>📅 Updated July 2026</span>
+    <span>⏱ 8 min read</span>
+    <span>🏷 Claude, GPT-4, Cursor, Claude Code</span>
+  </div>
+</div>
+
+<article>
+
+  <div class="toc">
+    <h4>In this article</h4>
+    <ol>
+      <li><a href="#what-is-it">What is context rot?</a></li>
+      <li><a href="#why-happens">Why it happens: the physics of attention</a></li>
+      <li><a href="#stages">The 4 stages of context rot</a></li>
+      <li><a href="#symptoms">How to recognize it in your sessions</a></li>
+      <li><a href="#cost">The hidden cost: money, not just quality</a></li>
+      <li><a href="#fix">How to fix it: information-theoretic selection</a></li>
+      <li><a href="#prevention">Preventing context rot with Entroly</a></li>
+    </ol>
+  </div>
+
+  <h2 id="what-is-it">What Is Context Rot?</h2>
+
+  <p><strong>Context rot</strong> is the gradual degradation of an AI assistant's answer quality during a long session. The longer you work, the more the context window fills with irrelevant material from earlier turns — and the less attention the model can pay to what actually matters right now.</p>
+
+  <p>The term "context rot" describes two related phenomena:</p>
+
+  <ol style="padding-left:24px; margin-bottom:20px; color:#c5cae9;">
+    <li style="margin-bottom:8px;"><strong>Qualitative rot</strong> — answer accuracy drops as the session ages. The model starts missing errors, confusing similar files, and confidently generating wrong fixes.</li>
+    <li style="margin-bottom:8px;"><strong>Economic rot</strong> — token costs compound because every request re-sends the entire bloated conversation history, including the irrelevant parts.</li>
+  </ol>
+
+  <div class="callout warning">
+    <p>🔬 <strong>Research backing:</strong> The "Lost in the Middle" paper (Liu et al., 2023) showed LLMs perform significantly worse at retrieving information placed in the middle of long contexts — even when that information is explicitly relevant. Context rot exploits this vulnerability systematically.</p>
+  </div>
+
+  <h2 id="why-happens">Why It Happens: The Physics of Attention</h2>
+
+  <p>Transformer-based LLMs process context using attention mechanisms. Every token attends to every other token — but not equally. The model's attention is distributed across all input tokens, and <strong>it has a finite budget of attention to spend.</strong></p>
+
+  <p>As a session grows, the context window fills with:</p>
+
+  <table>
+    <thead><tr><th>Content type</th><th>Relevance to current query</th><th>Token cost</th></tr></thead>
+    <tbody>
+      <tr><td>Early conversation turns</td><td>❌ Usually stale</td><td>High</td></tr>
+      <tr><td>Imported dependency files</td><td>⚠️ Partially relevant</td><td>Very high</td></tr>
+      <tr><td>Shell command output logs</td><td>❌ Usually irrelevant</td><td>Medium–High</td></tr>
+      <tr><td>Duplicate file reads</td><td>❌ Redundant</td><td>High</td></tr>
+      <tr><td><strong>The actual bug / the critical file</strong></td><td>✅ <strong>Critical</strong></td><td>Low — crowded out</td></tr>
+    </tbody>
+  </table>
+
+  <p>The critical file — the one with the actual bug — gets pushed toward the middle of the context window where attention is weakest. The model sees it, but pays it less weight than the stale import logs at the beginning and the recent conversation at the end.</p>
+
+  <p>Result: <strong>the model answers based on the wrong evidence.</strong></p>
+
+  <h2 id="stages">The 4 Stages of Context Rot</h2>
+
+  <div class="stages">
+    <div class="stage">
+      <div class="stage-num green">1</div>
+      <div>
+        <div class="stage-title">Fresh Session — Peak Performance</div>
+        <p class="stage-desc">Context window is mostly empty. The model sees exactly what you show it. Answers are specific, accurate, and grounded in the actual code. Token costs are low.</p>
+      </div>
+    </div>
+    <div class="stage">
+      <div class="stage-num yellow">2</div>
+      <div>
+        <div class="stage-title">Accumulation — Early Signs</div>
+        <p class="stage-desc">30–40% of context used. Previous conversation turns, imported files, and command outputs start accumulating. The model occasionally confuses variable names across files. You chalk it up to a bad prompt.</p>
+      </div>
+    </div>
+    <div class="stage">
+      <div class="stage-num orange">3</div>
+      <div>
+        <div class="stage-title">Congestion — Noticeable Degradation</div>
+        <p class="stage-desc">60–80% of context used. Attention is diluted. The model starts referencing the wrong function, misidentifying which file contains the bug, or suggesting fixes for code it already fixed. You start restarting sessions.</p>
+      </div>
+    </div>
+    <div class="stage">
+      <div class="stage-num red">4</div>
+      <div>
+        <div class="stage-title">Overflow — Context Compaction / Quality Collapse</div>
+        <p class="stage-desc">Context window full. The tool either truncates early history (losing critical decisions) or hits a hard limit and forces a new session. Answers become generic. Hallucinations spike. You've lost the context of 2 hours of work.</p>
+      </div>
+    </div>
+  </div>
+
+  <h2 id="symptoms">How to Recognize Context Rot in Your Sessions</h2>
+
+  <p>Context rot is insidious because it happens gradually. Here are the specific symptoms to watch for:</p>
+
+  <h3>🔴 High-confidence wrong answers</h3>
+  <p>The model generates a fix with total confidence — but the fix references a function signature that doesn't match your codebase. It's confusing code from an earlier file read with the current one. This is the hallmark of attention dilution.</p>
+
+  <h3>🔴 "I don't see that in the code you shared"</h3>
+  <p>The critical file was sent 20 turns ago and is now buried in the middle of the context. The model's attention has moved on. Even though the file is technically in the window, the model doesn't properly weight it.</p>
+
+  <h3>🔴 Repetitive suggestions</h3>
+  <p>The model keeps suggesting the same fix you already tried. It's not learning from your "that didn't work" responses because those responses are now in the crowded middle of the context.</p>
+
+  <h3>🔴 Generic, non-specific answers</h3>
+  <p>Instead of referencing your actual class names and function signatures, the model gives boilerplate code with placeholder names. It's generating from its training distribution, not from your context — because your context is too diluted to extract specific details from.</p>
+
+  <h3>🔴 Autocompaction events (Claude Code)</h3>
+  <p>Claude Code's automatic context compaction is a symptom of context rot, not the cure. Compaction truncates history, but it doesn't select the <em>right</em> history to keep — it just keeps recent content, which may not be the most relevant.</p>
+
+  <h2 id="cost">The Hidden Cost: It's Not Just Quality</h2>
+
+  <p>Context rot has a direct financial cost. Every request in a long session re-sends the <strong>entire</strong> context — including all the irrelevant material.</p>
+
+  <pre>A typical 3-hour Cursor session:
+  Fresh start context:  ~2,000 tokens   → $0.006/request
+  Session turn 50:      ~80,000 tokens  → $0.24/request
+  Session turn 100:     ~180,000 tokens → $0.54/request
+
+  Developer doing 60+ requests/day at stage 3:
+  Daily token cost:  ~$14–32
+  Monthly cost:      ~$350–800
+
+  With properly selected context (2,000 relevant tokens/request):
+  Daily token cost:  ~$0.36–0.72
+  Monthly cost:      ~$9–18</pre>
+
+  <div class="callout danger">
+    <p>⚠️ <strong>You are paying $350–800/month to send irrelevant code to Claude.</strong> The model isn't using it. The context rot is causing it to give worse answers, and you're paying more for those worse answers every turn.</p>
+  </div>
+
+  <h2 id="fix">How to Fix It: Information-Theoretic Selection</h2>
+
+  <p>The naive fix — "start a new session" — works but loses all the decisions and progress from the current session. It's also manual and disruptive.</p>
+
+  <p>The right fix is <strong>information-theoretic context selection</strong>: before every LLM request, mathematically rank every available fragment by its relevance to the current query and send only the highest-value evidence.</p>
+
+  <p>This is fundamentally different from compression tools that just shrink whatever context you already chose. Correct context selection starts one step earlier:</p>
+
+  <pre>❌ Naive approach:
+   All files loaded → LLM call
+   (irrelevant files included, relevant files crowded out)
+
+❌ Simple compression:
+   All files loaded → Compress → LLM call
+   (still choosing the wrong starting set, just smaller)
+
+✅ Information-theoretic selection:
+   All files available → Rank by query relevance
+   → Select under token budget → Compress supporting material
+   → LLM call with highest-value evidence only</pre>
+
+  <p>The ranking uses three signals:</p>
+
+  <ol style="padding-left:24px; margin-bottom:20px; color:#c5cae9;">
+    <li style="margin-bottom:12px;"><strong>BM25 relevance</strong> — lexical match between the query and each fragment. The file that contains the error message scores highest.</li>
+    <li style="margin-bottom:12px;"><strong>Shannon entropy scoring</strong> — high-entropy fragments (containing errors, anomalies, unusual patterns) are selected over low-entropy boilerplate.</li>
+    <li style="margin-bottom:12px;"><strong>Dependency graph traversal</strong> — if the buggy function is selected, the functions it calls are included at lower priority. The model sees the full call chain, not an isolated fragment.</li>
+  </ol>
+
+  <p>The budget allocation uses <strong>knapsack dynamic programming</strong>: given a token budget (e.g., 8,000 tokens), find the exact combination of fragments that maximizes total relevance without exceeding the budget. This is the theoretically optimal solution to the context selection problem.</p>
+
+  <h2 id="prevention">Preventing Context Rot With Entroly</h2>
+
+  <p><a href="https://github.com/juyterman1000/entroly">Entroly</a> is an open-source local context OS that implements this selection pipeline as a transparent proxy for Claude Code, Cursor, Aider, and 35+ other tools. It runs locally — your code never leaves your machine for the optimization step.</p>
+
+  <pre>pip install entroly
+cd /your/repo
+entroly simulate    # See estimated savings before connecting anything</pre>
+
+  <p>What Entroly does on every request:</p>
+
+  <ol style="padding-left:24px; margin-bottom:20px; color:#c5cae9;">
+    <li style="margin-bottom:8px;">Intercepts the outgoing request before it reaches Claude/GPT</li>
+    <li style="margin-bottom:8px;">Ranks all available fragments by BM25 + entropy + dependency relevance</li>
+    <li style="margin-bottom:8px;">Selects the optimal set under budget using knapsack DP</li>
+    <li style="margin-bottom:8px;">Compresses supporting material (evidence-locked — never compresses critical evidence)</li>
+    <li style="margin-bottom:8px;">Emits a <strong>Context Receipt</strong>: what was sent, what was omitted, why, and what risks remain</li>
+    <li style="margin-bottom:8px;">Verifies the model's answer against the evidence using WITNESS (0.7976 AUROC held-out, $0, ~3ms)</li>
+  </ol>
+
+  <div class="callout success">
+    <p>✅ <strong>Result:</strong> Every request sees a fresh, optimally-selected context — regardless of session length. Context rot cannot accumulate because the selection is re-computed per query, not accumulated per turn.</p>
+  </div>
+
+  <h3>Measured results on real workloads</h3>
+
+  <table>
+    <thead><tr><th>Budget</th><th>Token reduction</th><th>Accuracy retention</th></tr></thead>
+    <tbody>
+      <tr><td>8K tokens</td><td>99.1%</td><td>100% (NeedleInAHaystack)</td></tr>
+      <tr><td>32K tokens</td><td>96.7%</td><td>103% (LongBench HotpotQA)</td></tr>
+      <tr><td>Average across workloads</td><td><strong>87.0%</strong></td><td><strong>Maintained or improved</strong></td></tr>
+    </tbody>
+  </table>
+
+  <p>Accuracy retention above 100% on HotpotQA means <strong>Entroly's selected context actually produces better answers than the full context</strong> — because the model is no longer distracted by irrelevant material.</p>
+
+  <div class="cta-box">
+    <h2>Stop Paying for Context Rot</h2>
+    <p>Run <code>entroly simulate</code> to see exactly how much irrelevant context is in your current sessions — before connecting any API key.</p>
+    <a href="https://github.com/juyterman1000/entroly" class="btn btn-primary">Get Entroly free →</a>
+    <a href="https://juyterman1000.github.io/entroly/" class="btn btn-secondary">Read the docs</a>
+  </div>
+
+  <h2>Frequently Asked Questions</h2>
+
+  <h3>Is context rot the same as hallucination?</h3>
+  <p>They're related but distinct. Context rot is a structural cause; hallucination is often the effect. When the model's context is diluted with irrelevant material, it can't properly ground its answers in the actual code — leading to confident but wrong outputs. Fixing context rot significantly reduces hallucination rates on code tasks.</p>
+
+  <h3>Does starting a new session fix context rot?</h3>
+  <p>Starting a new session resets the context window, which temporarily fixes context rot. But you lose all the decisions, fixes, and understanding built up during the session. Information-theoretic selection is a better approach: the model sees the right context every turn, without losing session continuity.</p>
+
+  <h3>Does this affect Claude specifically?</h3>
+  <p>Context rot affects all transformer-based models (Claude, GPT-4, Gemini, Llama). The severity scales with context window size — counterintuitively, <strong>larger context windows can make context rot worse</strong> by allowing more irrelevant material to accumulate before hitting the limit.</p>
+
+  <h3>How is this different from RAG?</h3>
+  <p>RAG (Retrieval-Augmented Generation) uses vector embeddings to retrieve semantically similar chunks. Context selection uses BM25 + entropy + dependency graphs, which outperform pure semantic similarity for code tasks (code is structurally diverse, not just semantically similar). Entroly also doesn't require an embeddings API or vector database — everything runs locally.</p>
+
+</article>
+
+<footer>
+  <p>
+    <a href="https://juyterman1000.github.io/entroly/">Entroly</a> ·
+    <a href="https://github.com/juyterman1000/entroly">GitHub</a> ·
+    <a href="https://pypi.org/project/entroly/">PyPI</a> ·
+    <a href="https://discord.gg/G833X5c7R6">Discord</a> ·
+    Apache-2.0 · Local-first · No outbound analytics
+  </p>
+  <p style="margin-top:8px;">© 2026 Entroly · <a href="how-to-reduce-claude-api-costs.html">Reduce Claude API costs</a> · <a href="best-context-compression-tools.html">Context compression tools</a> · <a href="prompt-compression.html">Prompt compression</a></p>
+</footer>
+</body>
+</html>

--- a/scripts/verify_context_assurance_public.py
+++ b/scripts/verify_context_assurance_public.py
@@ -59,20 +59,37 @@ PROMINENT_PUBLIC_FILES = (
     "docs/marketing/tutorial_reddit.md",
 )
 
-RETIRED_MARKETING_PAGES = (
+# `docs/dashboard.html` stays retired because it is an application view, not a
+# content page: there is nothing on it for a search engine to answer with.
+RETIRED_MARKETING_PAGES = ("docs/dashboard.html",)
+
+RETIRED_SETUP_PAGES: tuple[str, ...] = ()
+
+# Republished 2026-08-15.
+#
+# These pages were retired to tombstones because their claims could not be
+# sourced -- a universal 70-95% range, a retired 0.844 AUROC, equivalence
+# conclusions against an API judge, and "every response" verifier coverage.
+# Retirement removed the claims by removing the pages, which also removed every
+# entry point to the topics they covered.
+#
+# They are indexable again now that each figure on them resolves to a committed
+# artifact under `benchmarks/results/`. Retirement is no longer what keeps them
+# honest, so they must stay inside CLAIM_SENSITIVE_PUBLIC_FILES below: the
+# STALE_PUBLIC_CLAIMS scan is now the thing standing between these pages and a
+# repeat of what got them retired. Do not republish a page by deleting its entry
+# here without first adding it there.
+REPUBLISHED_PUBLIC_PAGES = (
     "docs/best-context-compression-tools.html",
+    "docs/token-compression-tools.html",
     "docs/cursor-token-usage-fix.html",
     "docs/how-to-reduce-claude-api-costs.html",
     "docs/reduce-llm-api-costs.html",
     "docs/prompt-compression.html",
     "docs/hallucination-guard.html",
     "docs/prevent-ai-hallucinations.html",
-    "docs/dashboard.html",
     "docs/token-optimization.html",
     "docs/what-is-context-rot.html",
-)
-
-RETIRED_SETUP_PAGES = (
     "docs/cursor-context-guide.html",
     "docs/claude-code-setup.html",
 )
@@ -92,6 +109,7 @@ TRANSLATED_READMES = (
 CLAIM_SENSITIVE_PUBLIC_FILES = (
     *RETIRED_MARKETING_PAGES,
     *RETIRED_SETUP_PAGES,
+    *REPUBLISHED_PUBLIC_PAGES,
     *TRANSLATED_READMES,
     "docs/context-engineering.html",
     "docs/DETAILS.md",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -20,4 +20,16 @@
   <url><loc>https://juyterman1000.github.io/entroly/docs/gpt-5-6-sol-terra-luna.html</loc><lastmod>2026-07-26</lastmod></url>
   <url><loc>https://juyterman1000.github.io/entroly/docs/model-support.html</loc><lastmod>2026-08-11</lastmod><changefreq>weekly</changefreq><priority>0.94</priority></url>
   <url><loc>https://juyterman1000.github.io/entroly/docs/nemotron-3-5-lightning-ollama.html</loc><lastmod>2026-08-11</lastmod><changefreq>weekly</changefreq><priority>0.90</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/best-context-compression-tools.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.95</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/token-optimization.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.93</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/prompt-compression.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.93</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/what-is-context-rot.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.90</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/how-to-reduce-claude-api-costs.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.90</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/reduce-llm-api-costs.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.88</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/cursor-token-usage-fix.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.88</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/prevent-ai-hallucinations.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.88</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/hallucination-guard.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.85</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/claude-code-setup.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.85</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/cursor-context-guide.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.85</priority></url>
+  <url><loc>https://juyterman1000.github.io/entroly/docs/token-compression-tools.html</loc><lastmod>2026-08-15</lastmod><changefreq>weekly</changefreq><priority>0.96</priority></url>
 </urlset>

--- a/tests/test_readme_tokenomics_integration_hub.py
+++ b/tests/test_readme_tokenomics_integration_hub.py
@@ -15,7 +15,13 @@ ADOPTION = json.loads(
 
 
 def test_live_tokenomics_is_front_loaded_and_uses_real_commands() -> None:
-    assert README.index("## ⚡ Live Tokenomics") < README.index(
+    # The section is named "Live Token Savings" in the README. "Tokenomics" is a
+    # crypto-dominated search term, so it stays an internal name rather than a
+    # public heading; `index` raises rather than returning -1, so asserting the
+    # old literal turned a rename into a ValueError instead of a clear failure.
+    heading = "## ⚡ Live Token Savings"
+    assert heading in README, f"README is missing the {heading!r} section"
+    assert README.index(heading) < README.index(
         "## What is Entroly? (in plain English)"
     )
     assert "entroly value --json" in README


### PR DESCRIPTION
## Why

11 topic pages were `noindex` tombstones redirecting to the evidence ledger. They were also absent from both sitemaps, and two had no inbound internal links — so every query they targeted had no discovery path at all. Google was not missing them; the repository was telling it not to look.

## What broke last time

A previous attempt (`d683f01c`) restored the pages without touching the contract that retired them. `scripts/verify_context_assurance_public.py` hardcodes those paths and asserts each is non-indexable, redirecting, and absent from the sitemap. That produced 43 failures on `main` and was reverted in `8f74205b`. This PR exists so the required checks run before the change lands, rather than after.

## Contract change

The 12 pages move out of `RETIRED_MARKETING_PAGES` / `RETIRED_SETUP_PAGES` into a new `REPUBLISHED_PUBLIC_PAGES`, which is spread into `CLAIM_SENSITIVE_PUBLIC_FILES`.

That last part is the point. Those tuples fed `CLAIM_SENSITIVE_PUBLIC_FILES`, so simply deleting the entries would have quietly **removed** these pages from the `STALE_PUBLIC_CLAIMS` scan — less scrutiny on pages that make claims. Retirement is no longer what keeps them honest, so the claim scan has to be.

`docs/dashboard.html` stays retired: application view, nothing to index.

## Claims corrected

Every `STALE_PUBLIC_CLAIMS` hit is cleared — 17 occurrences across 5 pages beyond the ones caught by eye:

| Was | Now |
|---|---|
| `70–95%` (unsourced) | 79.3%–99.5% at 100% answer retention, per-benchmark, each linked to its raw JSON |
| `0.844 AUROC` (retired metric, 4 pages) | 0.7976 held-out (16,000 decisions); 0.8132 / 86.58% where compared to the shared 1,200-decision GPT sample |
| "statistically equivalent to gpt-4o-mini" | removed — cross-protocol equivalence was never established |
| "verifies every output" / "checks every LLM response" | scoped to enabled routes, with measured FP/FN stated |
| "same accuracy", "all your files", "78% fewer", "zero config changes" | replaced with scoped, sourced wording |

The SQuAD 2.0 loss case (43.8% savings, 90% retention) is stated **next to** the wins, with the reason it is worst: 233-token inputs under a 100-token budget leave nothing redundant to remove.

Cost pages were claiming billing reductions from token measurements — a tier error under `public-evidence.md`. Retitled to claim input tokens, with an evidence boundary noting token cuts convert to cost only on metered routes.

## Also

- New `docs/token-compression-tools.html` covering surfaces the context page does not (tool output, JSON, shell logs, conversation, tool schemas), with `ItemList` + `FAQPage` schema.
- Sitemaps 19 → 31 URLs; orphaned pages given inbound internal links.
- `token-optimization.html` used a prohibited external product name as ordinary English ("creates headroom for"), failing the name-policy gate. Reworded.
- `docs/public-evidence.md` documents the republish condition.

## Verified locally

- `collect_offline_failures()`: 43 retired-page failures → **0**
- `STALE_PUBLIC_CLAIMS` across all `docs/*.html`: **0**
- External-name policy: **0** violations under `docs/`
- All JSON-LD blocks parse; both sitemaps valid XML

## Known unrelated issue, not fixed here

`PYPI_README.md:26` ends a sentence with `guaranteed bill reduction`, which `required_boundaries` requires and `forbidden_positive_claims` rejects with its trailing period. Reproduces on `c97ab1c7`; left for a separate change rather than bundled into a policy PR.