### PR TITLE
fix(mcp): warn when a populated index sits at an inherited non-project root

### DIFF
--- a/entroly/server.py
+++ b/entroly/server.py
@@ -38,7 +38,7 @@ import re
 import sys
 import threading
 import uuid
-from functools import wraps
+from functools import lru_cache, wraps
 from pathlib import Path
 from typing import Any, Callable
 
@@ -2858,6 +2858,71 @@ def _compact_health_report_for_wire(raw: str) -> str:
     return json.dumps(report, indent=2)
 
 
+_PROJECT_ROOT_MARKERS: tuple[str, ...] = (
+    ".git", ".hg", ".svn",
+    "pyproject.toml", "setup.py", "requirements.txt",
+    "package.json", "Cargo.toml", "go.mod",
+    "pom.xml", "build.gradle", "Gemfile", "composer.json",
+    ".entrolyignore",
+)
+
+
+@lru_cache(maxsize=64)
+def _root_has_project_marker(source_root: str) -> bool:
+    """True when ``source_root`` looks like something a person would index.
+
+    Cheap filesystem probe, cached because every retrieval call asks.
+    """
+    try:
+        root = Path(source_root)
+        return any((root / marker).exists() for marker in _PROJECT_ROOT_MARKERS)
+    except (OSError, ValueError):
+        return False
+
+
+def _source_root_is_suspicious(source_root: str) -> bool:
+    """True when the indexed root was inherited rather than chosen, and does
+    not look like a project.
+
+    An MCP host launches this server with its *own* working directory. When
+    ``ENTROLY_SOURCE`` is unset that directory becomes the index root, and
+    ``auto_index`` falls back from ``git ls-files`` to walking the filesystem
+    (auto_index.py: ``discovery = "walk"``). Walking an application bundle
+    yields plenty of files, so ``ingested_count`` is healthy and every
+    emptiness check passes -- while retrieval answers from a corpus that has
+    nothing to do with the user's repository.
+
+    Requiring an explicit ``ENTROLY_SOURCE`` would break the legitimate
+    "cd into a repo and run" path, so this only fires when the root was both
+    inherited *and* carries no project marker.
+    """
+    if os.environ.get("ENTROLY_SOURCE"):
+        return False  # explicitly chosen by the operator; their call
+    return not _root_has_project_marker(source_root)
+
+
+def _source_root_guidance(source_root: str) -> dict[str, Any] | None:
+    """Warn when a populated index is probably the wrong corpus."""
+    if not _source_root_is_suspicious(source_root):
+        return None
+    return {
+        "status": "suspicious_source_root",
+        "message": (
+            "This server indexed files, but its root was inherited from the "
+            "host process and contains no project marker "
+            f"({', '.join(_PROJECT_ROOT_MARKERS[:4])}, ...). Results may come "
+            "from an unrelated directory such as the MCP client's application "
+            "bundle rather than your repository."
+        ),
+        "resolve": [
+            "Set ENTROLY_SOURCE to your repository root and restart the "
+            "server (restart is required; the root is read once at startup).",
+            "Confirm with get_stats that the fragment sources are your files.",
+        ],
+        "resolved_source_root": source_root,
+    }
+
+
 def _empty_context_guidance(
     ingested_count: int, source_root: str
 ) -> dict[str, Any] | None:
@@ -2872,7 +2937,11 @@ def _empty_context_guidance(
     an error and gets no guidance).
     """
     if ingested_count > 0:
-        return None
+        # A populated index is not proof of a *correct* index. The original
+        # guard treated "something was ingested" as success, so a server rooted
+        # at the MCP host's app bundle -- which walks up plenty of files --
+        # passed silently and answered from the wrong corpus.
+        return _source_root_guidance(source_root)
     return {
         "status": "no_codebase_indexed",
         "message": (
@@ -3892,6 +3961,15 @@ def create_mcp_server(
                 "slim view (source + score + snippet). Call "
                 "recall_relevant(query, full=True) for complete fragment bodies."
             )
+        # Ranked results always look plausible: BM25 returns a best match for
+        # any corpus, so a mis-rooted server answers a question about the user's
+        # repository with confident scores over someone else's files. Say so
+        # here rather than leaving the caller to notice the sources are wrong.
+        _root_guidance = _source_root_guidance(
+            os.environ.get("ENTROLY_SOURCE", os.getcwd())
+        )
+        if _root_guidance is not None:
+            payload["guidance"] = _root_guidance
         # Same hardening as optimize_context: strip invisible chars, flag
         # injection patterns. injection_scan attaches to the payload dict.
         try:

--- a/tests/test_empty_context_guidance.py
+++ b/tests/test_empty_context_guidance.py
@@ -21,10 +21,45 @@ def test_guidance_emitted_when_nothing_indexed():
     assert "restart" in joined
 
 
-def test_no_guidance_when_fragments_present():
+def test_no_guidance_when_fragments_present(tmp_path, monkeypatch):
     # A genuinely empty query match (with a populated session) is not an error.
-    assert _empty_context_guidance(1, "/repo") is None
-    assert _empty_context_guidance(900, "/repo") is None
+    # The root must look like a project: this assertion previously used a
+    # non-existent "/repo", which is indistinguishable from the mis-rooted case
+    # the suspicious-root check now catches.
+    monkeypatch.delenv("ENTROLY_SOURCE", raising=False)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    assert _empty_context_guidance(1, str(tmp_path)) is None
+    assert _empty_context_guidance(900, str(tmp_path)) is None
+
+
+def test_populated_index_at_an_inherited_non_project_root_is_flagged(
+    tmp_path, monkeypatch
+):
+    """The dangerous half of the dogfood finding.
+
+    A server rooted at the MCP host's app bundle walks up plenty of files, so
+    ingested_count is healthy and every emptiness check passes -- while recall
+    answers from a corpus unrelated to the user's repository. Ranked results
+    always look plausible, so nothing downstream can notice.
+    """
+    monkeypatch.delenv("ENTROLY_SOURCE", raising=False)
+    bundle = tmp_path / "app-1.20186.0" / "resources"
+    bundle.mkdir(parents=True)
+    (bundle / "vendor.js").write_text("const a=1")
+
+    guidance = _empty_context_guidance(20, str(tmp_path / "app-1.20186.0"))
+    assert guidance is not None, "populated index at a non-project root must warn"
+    assert guidance["status"] == "suspicious_source_root"
+    joined = " ".join(guidance["resolve"]).lower()
+    assert "entroly_source" in joined
+    assert "restart" in joined
+
+
+def test_explicit_entroly_source_is_respected(tmp_path, monkeypatch):
+    # An operator who names the root deliberately is not second-guessed, even
+    # when it carries no project marker.
+    monkeypatch.setenv("ENTROLY_SOURCE", str(tmp_path))
+    assert _empty_context_guidance(20, str(tmp_path)) is None
 
 
 def test_guidance_is_json_safe():


### PR DESCRIPTION
## The failure

While dogfooding, `recall_relevant` returned five results scored 0.53–0.54 for a query about this repository's Merkle receipt log. Every hit was a **minified JavaScript bundle from the MCP client's own installation directory**. No error, no warning — just confident scores over the wrong corpus.

## Root cause, five layers

| layer | behaviour |
|---|---|
| `server.py` | `ENTROLY_SOURCE` unset → root falls back to `os.getcwd()`, which under MCP is the **host app's** directory |
| `auto_index.py:1490` | `git ls-files` returns nothing for a non-repo → silent fallback to `_walk_fallback()`, which walks the app bundle |
| `discovery_method` | computed, returned in the result dict, **and logged** — consumed by nothing |
| `_empty_context_guidance` | returns `None` as soon as `ingested_count > 0` |
| `recall_relevant` | emits no guidance at all |

**Layer 4 is the interesting one.** A guard for exactly this already exists — its own test docstring credits an earlier dogfood finding. But it fires only when *nothing* was indexed.

It was written against the symptom that got noticed, not the failure mode. An empty index is **loud**: obviously broken, someone reports it. A wrong index is **silent**: 20 fragments, 300,331 tokens, healthy stats, plausible scores. The previous fix solved the visible half and left the half that silently corrupts an agent's reasoning.

BM25 returns a best match for any corpus, so nothing downstream can notice.

## The fix

Treat "root was inherited **and** carries no project marker" as a first-class signal:

- `_root_has_project_marker()` — cached probe for `.git`, `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, …
- `_source_root_is_suspicious()` — fires only when `ENTROLY_SOURCE` is unset *and* no marker is present
- `_empty_context_guidance()` returns `suspicious_source_root` when populated-but-implausible
- `recall_relevant` now carries the guidance

Requiring an explicit `ENTROLY_SOURCE` would break the ordinary "cd into a repo and run" path — the marker check is what separates the two cases.

| case | result |
|---|---|
| populated index, app-bundle root (the bug) | **`suspicious_source_root`** |
| populated index, real repository | silent — no false positive |
| `ENTROLY_SOURCE` set explicitly | silent — operator's choice respected |
| empty index | `no_codebase_indexed` — original behaviour preserved |

## Scope

This makes the failure **visible**; it does not **correct** the root. That needs the MCP `roots` capability or per-client configuration — deliberately left to a separate change.

`path_safety` is untouched. The boundary is not widened; the root resolution is made honest about itself.

## One existing test changed, deliberately

`_empty_context_guidance(1, "/repo") is None` used a path that does not exist — indistinguishable from the mis-rooted case this now catches. Its intent (a populated session with an empty query match is not an error) is preserved with a real root, plus regression cover for the populated-wrong-root and explicit-`ENTROLY_SOURCE` cases.

## Verification

- **38 passed** — guidance, hardening, MCP wire budget, MCP startup
- `ruff check entroly/server.py` clean