### PR TITLE
fix(docs): keep verified proof value when community savings total is $0

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1547,6 +1547,19 @@
         if (!Number.isSafeInteger(reportedTokens) || reportedTokens < 0) return;
         if (!Number.isFinite(reportedUsd) || reportedUsd < 0) return;
 
+        // Every community contribution is rounded down to whole tokens and whole
+        // cents, so a freshly launched aggregate reports exactly 0. Rendering
+        // "$0.00 reported" reads as "Entroly saved nothing" — the opposite of the
+        // verified proof. Until the aggregate crosses one reportable cent, keep the
+        // evidence-backed proof value on screen and frame the community total as
+        // forthcoming (a future value that accrues), never as a measured zero.
+        if (reportedTokens === 0 || reportedUsd === 0) {
+          showingCommunity = false;
+          statusNode.textContent = 'Verified proof today · community savings accruing';
+          statusNode.classList.remove('live');
+          return;
+        }
+
         showingCommunity = true;
         tokenNode.textContent = new Intl.NumberFormat('en-US').format(reportedTokens);
         usdNode.textContent = new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
## Problem

The homepage USD savings card (`docs/index.html`, `renderCommunitySavings`) polls the community-savings aggregate endpoint and overwrites the **verified proof** ($0.71 / 709,927 tokens) with whatever the aggregate returns.

The aggregate rounds every contribution **down** to whole tokens and whole cents, so a freshly launched counter reports exactly `0`. The card then renders **"$0.00 · Reported modeled input cost avoided"** — which reads as *"Entroly saved nothing,"* the opposite of the honest, evidence-backed proof.

## Fix

Guard `renderCommunitySavings` so a **zero** aggregate no longer replaces the proof:

- Keep the evidence-backed proof value on screen ($0.71 / 709,927 tokens).
- Frame the community total as forthcoming — status reads **"Verified proof today · community savings accruing"** (a future value that accrues), never a measured zero.
- **Non-zero** aggregates still take over exactly as before — unchanged behavior once real opted-in installs cross one reportable cent.

No fabricated projection and no invented number: this only prevents a rounding-artifact `0` from clobbering the real proof. Honors the **no-overclaim / benchmark-honesty** trust invariant.

## Scope

- Single file: `docs/index.html` (13 lines added, 0 removed).
- Pure presentation guard — no data, endpoint, or claim values changed.

## Verification

- Aggregate endpoint currently returns `reported_provider_tokens_saved: 0`, `reported_modeled_input_cost_avoided_usd: 0` → card now holds the proof value instead of showing `$0.00`.
- Simulating a non-zero aggregate → card switches to the live community total (pre-existing path, untouched).
