### PR TITLE
fix(mcp): make entroly --install attach the server on Claude CLI and Windows

### DIFF
--- a/entroly/session_attach.py
+++ b/entroly/session_attach.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import secrets
+import shutil
 import sqlite3
 import subprocess
 import time
@@ -447,7 +448,11 @@ def attachment_install_commands(
     )
     source_env = f"ENTROLY_SOURCE={grant.project_root}"
     if grant.client == "claude":
-        return (("claude", "mcp", "add", "--scope", "local", "-e", source_env, name, "--", *server),)
+        # The Claude CLI's `-e/--env` is a greedy variadic option: if it appears
+        # before the server <name> positional it swallows the name as a second
+        # env var ("Invalid environment variable format"). Keep <name> first and
+        # terminate the env list with `--` so exactly one env var is parsed.
+        return (("claude", "mcp", "add", name, "--scope", "local", "-e", source_env, "--", *server),)
     if grant.client == "codex":
         return (("codex", "mcp", "add", name, "--env", source_env, "--", *server),)
     if grant.client == "copilot":
@@ -477,11 +482,24 @@ def attachment_remove_commands(grant: AttachmentGrant) -> tuple[tuple[str, ...],
     raise ValueError(f"unsupported attachment client: {grant.client}")
 
 
+def _run_client_command(command, **kwargs):
+    """Default runner that resolves the client launcher through PATHEXT.
+
+    Windows CLI launchers installed by npm are ``.cmd`` shims (``claude.cmd``),
+    and ``CreateProcess`` does not apply PATHEXT to a bare ``"claude"`` argument,
+    so a plain ``subprocess.run(["claude", ...])`` fails with WinError 2. Resolve
+    the executable with ``shutil.which`` first; on POSIX this is a no-op.
+    """
+    resolved = shutil.which(command[0])
+    argv = [resolved, *command[1:]] if resolved else list(command)
+    return subprocess.run(argv, **kwargs)
+
+
 def install_attachment(
     issued: IssuedAttachment,
     *,
     store: AttachmentStore | None = None,
-    runner=subprocess.run,
+    runner=_run_client_command,
 ) -> tuple[subprocess.CompletedProcess[str], ...]:
     results: list[subprocess.CompletedProcess[str]] = []
     for command in issued.install_commands:
@@ -521,7 +539,7 @@ def install_attachment(
 def uninstall_attachment(
     grant: AttachmentGrant,
     *,
-    runner=subprocess.run,
+    runner=_run_client_command,
 ) -> tuple[subprocess.CompletedProcess[str], ...]:
     """Remove a client entry after access has already been revoked."""
     results: list[subprocess.CompletedProcess[str]] = []

--- a/tests/test_session_attach.py
+++ b/tests/test_session_attach.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import subprocess
 
 import pytest
 
@@ -73,6 +74,44 @@ def test_attachment_install_commands_never_contain_raw_token(tmp_path):
         assert issued.grant.grant_id in rendered
         assert str(issued.token_file) in rendered
         assert f"ENTROLY_SOURCE={tmp_path.resolve()}" in rendered
+
+
+def test_claude_install_command_places_name_before_greedy_env_flag(tmp_path):
+    store = AttachmentStore(tmp_path / "state")
+    issued = store.create(client="claude", project_root=tmp_path, ttl_seconds=60)
+    (command,) = issued.install_commands
+
+    assert command[:3] == ("claude", "mcp", "add")
+    name = f"entroly-{issued.grant.grant_id}"
+    # The Claude CLI's -e/--env is variadic; the server name must precede it or
+    # it is swallowed as an env var. Guard the ordering explicitly.
+    assert command[3] == name
+    assert command.index(name) < command.index("-e")
+    # Exactly one env var reaches the CLI: `--` must immediately follow it.
+    env_index = command.index("-e")
+    assert command[env_index + 2] == "--"
+
+
+def test_default_install_runner_resolves_launcher_through_pathext(tmp_path, monkeypatch):
+    from entroly import session_attach
+
+    store = AttachmentStore(tmp_path / "state")
+    issued = store.create(client="claude", project_root=tmp_path, ttl_seconds=60)
+
+    launcher = tmp_path / "claude.cmd"
+    launcher.write_text("@echo off\n", encoding="utf-8")
+    seen: list[str] = []
+
+    monkeypatch.setattr(session_attach.shutil, "which", lambda name: str(launcher))
+
+    def fake_run(argv, **_kwargs):
+        seen.append(argv[0])
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(session_attach.subprocess, "run", fake_run)
+    session_attach.install_attachment(issued, store=store)
+
+    assert seen == [str(launcher)]
 
 
 def test_mcp_access_policy_removes_ungranted_tools_and_reauthorizes_each_call():


### PR DESCRIPTION
## Problem

`entroly` issues a short-lived MCP attachment grant and then runs the client's own `mcp add` to register the server (`install_attachment`). Two environment-specific bugs made that one-command attach fail before the server was ever registered - the grant was created, but the client never got the server.

## Fix (two bugs, `entroly/session_attach.py`)

**1. Claude CLI argument order.** `claude mcp add`'s `-e/--env` is a greedy variadic option. With the flag ahead of the server `<name>` positional, the CLI swallowed `<name>` as a second env var and aborted with `Invalid environment variable format`. Reordered to:

```
claude mcp add <name> --scope local -e ENTROLY_SOURCE=... -- <server...>
```

`<name>` first, env list closed by `--`, so exactly one env var is parsed.

**2. Windows launcher resolution.** npm installs these CLIs as `.cmd` shims (`claude.cmd`). `CreateProcess` doesn't apply PATHEXT to a bare `"claude"` argv[0], so `subprocess.run(["claude", ...])` failed with `WinError 2` even though `claude` works in a shell. A shared default runner now resolves argv[0] via `shutil.which` before spawning (no-op on POSIX), applied to both install and uninstall.

## Tests

`tests/test_session_attach.py` (+2):
- `test_claude_install_command_places_name_before_greedy_env_flag` - `<name>` precedes `-e`, and `--` immediately follows the single env var.
- `test_default_install_runner_resolves_launcher_through_pathext` - the default runner spawns the resolved `claude.cmd`, not the bare name.

Targeted run: `pytest tests/test_session_attach.py tests/test_empty_context_guidance.py` -> **14 passed**.

## Scope / trust invariants

- Touches only `entroly/session_attach.py` and its test. No change to grant scope, TTL, hashing, or the token-never-in-argv guarantee (`test_attachment_install_commands_never_contain_raw_token` still passes).
- Independent of #324 (the suspicious-source-root warning), which stays on its own branch.
