### PR TITLE
fix(openclaw): state the real bridge v2 floor instead of a swept release number

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -65,8 +65,9 @@ After the first agent turn, run `/entroly-context` in any connected channel to
 see the estimated before/after context size, reduction, warnings, and receipt.
 Run `/entroly-context doctor` to verify the configured Python executable and
 local JSONL bridge before inviting users onto the Gateway. The plugin requires
-the Entroly 1.0.64 bridge v2 protocol; doctor reports an actionable upgrade
-instead of accepting an older, incompatible Python installation.
+the `entroly.openclaw.bridge.v2` protocol, which shipped in Entroly 1.0.57;
+doctor reports an actionable upgrade instead of accepting an older,
+incompatible Python installation.
 
 OpenClaw's resolved prompt token budget is authoritative. When an older or
 degraded host cannot provide one, Entroly automatically resolves a conservative


### PR DESCRIPTION
## Outcome

The OpenClaw README and the bridge client stop contradicting each other about
which Entroly version the plugin needs.

## The contradiction

`integrations/openclaw/README.md` said the plugin "requires the Entroly 1.0.64
bridge v2 protocol". `integrations/openclaw/bridge-client.js` tells users, in
the error they actually hit:

```
Incompatible Entroly Python bridge; install entroly>=1.0.57 with `python -m pip install -U entroly`
```

Same requirement, two different numbers. A user who follows the doctor error
installs a version the README calls unsupported.

## Which one is right

1.0.57. `validateBridgeHealth` checks exactly four things —
`ENTROLY_BRIDGE_SCHEMA` (`entroly.openclaw.bridge.v2`), `ok`,
`provider_independent`, and `receipt_commit_protocol: "two_phase"` — and all of
them landed together in 9bfa46c3 *"Make OpenClaw context provider-independent
(v1.0.57)"* (#128). Nothing about the protocol changed in 1.0.64.

The `1.0.64` arrived in 3cdb53a4 *"release: bump version to 1.0.64"* — a release
bump that swept a compatibility floor along with the release surfaces.

That is precisely the failure mode `scripts/sync_release_version.py` exists to
prevent. Its transform for this file rewrites only the two
`pip install "entroly>=X"` install pins and deliberately leaves prose about
protocol compatibility alone. This line predates that discipline and was never
corrected — which is why the 1.0.78 bump in #332 moved the install pins to
1.0.78 and correctly left this sentence untouched, stale value and all.

The replacement names the schema string rather than a bare version, so the
requirement is checkable against `validateBridgeHealth` instead of against the
changelog.

## Trust and compatibility

- [x] Receipt honesty and recoverability are preserved or not affected.
- [x] Verification remains fail-closed where confidence is claimed.
- [x] No surprise network call or credential surface is added.

## Verification

71 tests pass across `test_agent_integration_packages.py`,
`test_integrations_smoke.py` and `test_openclaw_bridge.py`.
