### PR TITLE
feat(vault): record source provenance and retract ungrounded beliefs

### DIFF
--- a/entroly/belief_compiler.py
+++ b/entroly/belief_compiler.py
@@ -106,6 +106,22 @@ _RS_CONST = re.compile(r'^(?:pub\s+)?(?:const|static)\s+(\w+)', re.M)
 _RS_DOC = re.compile(r'///\s*(.*)')
 
 
+def _root_label(root: Path) -> str:
+    """The compiled directory, expressed relative to the project root.
+
+    Stored on each belief so a later groundedness check can rejoin it with a
+    source path and land on exactly one file. Returns "" when the directory is
+    outside the project, because a label that cannot be rejoined is worse than
+    no label: it would be trusted and resolve to nothing.
+    """
+
+    try:
+        relative = root.resolve().relative_to(Path.cwd().resolve())
+    except (ValueError, OSError):
+        return ""
+    return relative.as_posix() if relative.as_posix() != "." else ""
+
+
 def extract_entities(content: str, file_path: str) -> list[CodeEntity]:
     """Extract code entities from a source file."""
     ext = Path(file_path).suffix.lower()
@@ -518,7 +534,9 @@ class BeliefCompiler:
         # Phase 3: Generate beliefs for each module
         for rel_path, module in all_modules.items():
             try:
-                belief = self._module_to_belief(module, rel_path, resolver)
+                belief = self._module_to_belief(
+                    module, rel_path, resolver, source_root=_root_label(root)
+                )
                 self._vault.write_belief(belief)
                 result.beliefs_written += 1
                 result.belief_ids.append(belief.claim_id)
@@ -584,6 +602,7 @@ class BeliefCompiler:
         module: ModuleMap,
         file_path: str,
         resolver: EntityResolver | None = None,
+        source_root: str = "",
     ) -> BeliefArtifact:
         """Convert a ModuleMap to a BeliefArtifact."""
         # Build body
@@ -648,6 +667,10 @@ class BeliefCompiler:
             confidence=0.75,  # auto-compiled → moderate confidence
             status="inferred",
             sources=sources,
+            # Sources above are relative to the compiled directory. Recording
+            # which directory that was is what lets a later groundedness check
+            # resolve them to exactly one file instead of guessing.
+            source_root=source_root,
             derived_from=["belief_compiler", "sast"],
         )
 

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -5325,6 +5325,21 @@ def cmd_compile(args):
         for e in result.errors[:5]:
             print(f"    {C.GRAY}- {e}{C.RESET}")
 
+    # Compilation only ever adds. Without this pass a belief outlives the file
+    # it was compiled from, keeps its confidence, and is returned beside live
+    # beliefs with nothing marking it dead -- so a refresh is also when the
+    # vault should let go of what is no longer there.
+    retraction = vault.mark_beliefs_ungrounded([target])
+    retracted = retraction.get("retracted_entities", [])
+    if retracted:
+        shown = ", ".join(retracted[:5])
+        more = f" (+{len(retracted) - 5} more)" if len(retracted) > 5 else ""
+        print(
+            f"  {C.YELLOW}Retracted:{C.RESET}          {len(retracted)} belief(s) "
+            f"whose source is gone"
+        )
+        print(f"    {C.GRAY}{shown}{more}{C.RESET}")
+
     coverage = vault.coverage_index()
     print(f"\n  {C.CYAN}Vault coverage:{C.RESET} {coverage['total_beliefs']} beliefs")
     print(f"  {C.CYAN}Avg confidence:{C.RESET} {coverage['average_confidence']:.2f}")

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -5329,16 +5329,23 @@ def cmd_compile(args):
     # it was compiled from, keeps its confidence, and is returned beside live
     # beliefs with nothing marking it dead -- so a refresh is also when the
     # vault should let go of what is no longer there.
-    retraction = vault.mark_beliefs_ungrounded([target])
-    retracted = retraction.get("retracted_entities", [])
-    if retracted:
-        shown = ", ".join(retracted[:5])
-        more = f" (+{len(retracted) - 5} more)" if len(retracted) > 5 else ""
-        print(
-            f"  {C.YELLOW}Retracted:{C.RESET}          {len(retracted)} belief(s) "
-            f"whose source is gone"
-        )
-        print(f"    {C.GRAY}{shown}{more}{C.RESET}")
+    #
+    # It writes to beliefs, so it is escapable: a groundedness check that
+    # misfires on an unusual layout must not leave a user with no way to
+    # compile. `--no-retract` skips it; the beliefs stay as they were.
+    if getattr(args, "no_retract", False) or os.environ.get("ENTROLY_NO_RETRACT"):
+        print(f"  {C.GRAY}Retraction skipped (--no-retract).{C.RESET}")
+    else:
+        retraction = vault.mark_beliefs_ungrounded([target])
+        retracted = retraction.get("retracted_entities", [])
+        if retracted:
+            shown = ", ".join(retracted[:5])
+            more = f" (+{len(retracted) - 5} more)" if len(retracted) > 5 else ""
+            print(
+                f"  {C.YELLOW}Retracted:{C.RESET}          {len(retracted)} belief(s) "
+                f"whose source is gone"
+            )
+            print(f"    {C.GRAY}{shown}{more}{C.RESET}")
 
     coverage = vault.coverage_index()
     print(f"\n  {C.CYAN}Vault coverage:{C.RESET} {coverage['total_beliefs']} beliefs")
@@ -6709,6 +6716,14 @@ def main():
     compile_parser.add_argument(
         "--max-files", type=int, default=0,
         help="Maximum files to process (default: 0 = unlimited)",
+    )
+    compile_parser.add_argument(
+        "--no-retract", action="store_true",
+        help=(
+            "Keep beliefs whose source file no longer exists. By default a "
+            "compile also retracts them, since they would otherwise be "
+            "returned beside live beliefs at full confidence."
+        ),
     )
 
     # entroly verify

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -438,6 +438,107 @@ class VaultManager:
             "already_stale": already_stale,
         }
 
+    def mark_beliefs_ungrounded(
+        self, roots: list[str] | None = None
+    ) -> dict[str, Any]:
+        """Retract beliefs whose every cited source file is gone from disk.
+
+        Compilation is additive: it writes a belief when it sees a file and
+        never revisits one whose file was deleted or moved. The belief then
+        keeps its original confidence forever, and retrieval returns it beside
+        live beliefs with nothing to tell them apart -- a confident claim about
+        code that no longer exists, which is the failure mode the fail-closed
+        rule exists to prevent.
+
+        Sources are recorded relative to whichever directory compilation was
+        given, and a belief does not record which directory that was, so each
+        source is resolved against the project root and against every supplied
+        root before it is called missing. A belief is retracted only when no
+        candidate resolves; the bias is deliberately toward leaving a belief
+        alone, because wrongly retracting a live belief loses knowledge while
+        wrongly keeping a dead one is merely noise this scan will catch again.
+
+        The belief is marked, never deleted: it stays auditable, and the next
+        compilation that sees the file again restores it.
+        """
+
+        # Function-local, matching mark_beliefs_stale_for_files: `vault` sits in
+        # the import cycle CLAUDE.md flags as load-bearing.
+        import re
+
+        self.ensure_structure()
+
+        search_roots = [self._base.resolve().parent.parent]
+        for root in roots or []:
+            try:
+                search_roots.append(Path(root).resolve())
+            except (OSError, ValueError):
+                continue
+
+        # A source is matched by path *suffix*, not by joining it to a guessed
+        # base. `entroly compile scripts` records `_release_artifacts.py` while
+        # `entroly compile entroly` records `adaptive_budget.py`, and the belief
+        # stores neither root, so resolving against a fixed base marks live
+        # beliefs as dead: joining against the project root alone retracted 275
+        # of 715 here, nearly all of them real files one directory down.
+        known = _path_suffix_index(search_roots)
+
+        def _grounded(source: str) -> bool:
+            raw = source.split(":", 1)[0].replace("\\", "/").strip().lstrip("./")
+            if not _is_path_like(raw):
+                # `write_belief` substitutes the sentinel `unknown` when a
+                # belief carries no provenance, and callers pass bare labels
+                # too. "Provenance was never recorded" is the opposite of
+                # "the file is gone" and must never retract anything.
+                return True
+            return raw in known
+
+        retracted: list[str] = []
+        already: list[str] = []
+        beliefs_dir = self._base / "beliefs"
+        for md in beliefs_dir.rglob("*.md"):
+            try:
+                safe_path = resolve_file_within(beliefs_dir, md)
+                if safe_path is None:
+                    continue
+                content = safe_path.read_text(encoding="utf-8", errors="replace")
+                fm = _parse_frontmatter(content)
+                if not fm:
+                    continue
+
+                sources = _extract_sources(content)
+                if not sources:
+                    continue  # nothing to verify against; leave it alone
+                if any(_grounded(src) for src in sources):
+                    continue
+
+                entity = fm.get("entity", md.stem)
+                if fm.get("status", "") == "ungrounded":
+                    already.append(entity)
+                    continue
+
+                updated = content
+                if "status:" in updated:
+                    updated = re.sub(
+                        r"^status:\s+.+$", "status: ungrounded", updated, count=1, flags=re.M
+                    )
+                # Confidence is the number retrieval ranks on. A belief with no
+                # surviving source has no evidence left to justify one.
+                if "confidence:" in updated:
+                    updated = re.sub(
+                        r"^confidence:\s+.+$", "confidence: 0.0", updated, count=1, flags=re.M
+                    )
+                safe_path.write_text(updated, encoding="utf-8")
+                retracted.append(entity)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug(f"Vault: failed to check groundedness for {md}: {e}")
+
+        return {
+            "status": "updated",
+            "retracted_entities": retracted,
+            "already_ungrounded": already,
+        }
+
     # â”€â”€ Private Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     def _update_belief_confidence(
@@ -514,6 +615,65 @@ def _parse_frontmatter(content: str) -> dict[str, str] | None:
             if key and value:
                 result[key] = value
     return result if result else None
+
+
+_GROUNDEDNESS_SKIP_DIRS = frozenset({
+    ".git", ".venv", "venv", "node_modules", "target", "__pycache__",
+    ".entroly", ".mypy_cache", ".pytest_cache", ".ruff_cache", "dist", "build",
+    ".tmp", "site-packages",
+})
+
+
+def _is_path_like(value: str) -> bool:
+    """Whether a recorded source names a file rather than a bare label.
+
+    Beliefs cite `src/mod.py:12`, but also carry sentinels: `write_belief`
+    stores `unknown` when no provenance was given. A token with no directory
+    separator and no extension is a label, and treating one as a missing file
+    would retract a belief for never having recorded where it came from.
+    """
+
+    if not value:
+        return False
+    return "/" in value or bool(Path(value).suffix)
+
+
+def _path_suffix_index(roots: list[Path]) -> set[str]:
+    """Every trailing path fragment of every real file under ``roots``.
+
+    Indexing suffixes rather than full paths is what makes a belief's source
+    resolvable without knowing which directory was compiled: `x.py`,
+    `pkg/x.py` and `a/pkg/x.py` all hit the same file. Heavy generated trees
+    are pruned -- on this repository they are three orders of magnitude larger
+    than the source and contain nothing a belief can cite.
+    """
+
+    index: set[str] = set()
+    seen_roots: set[Path] = set()
+    for root in roots:
+        if root in seen_roots or not root.is_dir():
+            continue
+        seen_roots.add(root)
+        stack = [root]
+        while stack:
+            directory = stack.pop()
+            try:
+                entries = list(directory.iterdir())
+            except OSError:
+                continue
+            for entry in entries:
+                if entry.name in _GROUNDEDNESS_SKIP_DIRS:
+                    continue
+                if entry.is_dir():
+                    stack.append(entry)
+                elif entry.is_file():
+                    try:
+                        parts = entry.relative_to(root).as_posix().split("/")
+                    except ValueError:  # pragma: no cover - defensive
+                        continue
+                    for start in range(len(parts)):
+                        index.add("/".join(parts[start:]))
+    return index
 
 
 def _extract_sources(content: str) -> list[str]:

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -76,11 +76,19 @@ class BeliefArtifact:
     derived_from: list[str] = field(default_factory=list)
     title: str = ""
     body: str = ""
+    # Directory the sources are relative to, itself relative to the project
+    # root. `entroly compile scripts` records `helper.py` as a source and
+    # `scripts` here, so the pair resolves to exactly one file. Without it a
+    # source is only a suffix and can be matched against the wrong file, or
+    # against none. Empty on beliefs written before this field existed, and
+    # omitted from the frontmatter in that case so their bytes do not change.
+    source_root: str = ""
 
     def to_markdown(self) -> str:
         """Render as markdown with YAML frontmatter."""
         sources_yaml = "\n".join(f"  - {s}" for s in self.sources) if self.sources else "  - unknown"
         derived_yaml = "\n".join(f"  - {d}" for d in self.derived_from) if self.derived_from else "  - system"
+        source_root_yaml = f"source_root: {self.source_root}\n" if self.source_root else ""
 
         return (
             f"---\n"
@@ -89,6 +97,7 @@ class BeliefArtifact:
             f"status: {self.status}\n"
             f"confidence: {self.confidence}\n"
             f"sources:\n{sources_yaml}\n"
+            f"{source_root_yaml}"
             f"last_checked: {self.last_checked}\n"
             f"derived_from:\n{derived_yaml}\n"
             f"---\n\n"
@@ -475,15 +484,19 @@ class VaultManager:
             except (OSError, ValueError):
                 continue
 
-        # A source is matched by path *suffix*, not by joining it to a guessed
-        # base. `entroly compile scripts` records `_release_artifacts.py` while
-        # `entroly compile entroly` records `adaptive_budget.py`, and the belief
-        # stores neither root, so resolving against a fixed base marks live
-        # beliefs as dead: joining against the project root alone retracted 275
-        # of 715 here, nearly all of them real files one directory down.
-        known = _path_suffix_index(search_roots)
+        project_root = search_roots[0]
 
-        def _grounded(source: str) -> bool:
+        # Legacy beliefs carry no `source_root`, so their sources can only be
+        # matched by path *suffix*: `entroly compile scripts` recorded
+        # `_release_artifacts.py` and `entroly compile entroly` recorded
+        # `adaptive_budget.py`, with nothing saying which directory either came
+        # from. Joining those against the project root alone retracted 275 of
+        # 715 real beliefs here. The index is built lazily because a vault
+        # written entirely by current code never needs it.
+        suffix_index: set[str] | None = None
+
+        def _grounded(source: str, source_root: str) -> bool:
+            nonlocal suffix_index
             raw = source.split(":", 1)[0].replace("\\", "/").strip().lstrip("./")
             if not _is_path_like(raw):
                 # `write_belief` substitutes the sentinel `unknown` when a
@@ -491,7 +504,19 @@ class VaultManager:
                 # too. "Provenance was never recorded" is the opposite of
                 # "the file is gone" and must never retract anything.
                 return True
-            return raw in known
+            if source_root:
+                # Exact: the belief recorded the directory its sources are
+                # relative to, so there is exactly one file to look for.
+                return (project_root / source_root / raw).exists()
+            if suffix_index is None:
+                suffix_index = _path_suffix_index(search_roots)
+            # Deliberately permissive: a bare `helper.py` matches any file of
+            # that name anywhere in the tree, so a belief about a deleted
+            # `scripts/helper.py` survives while a `tests/helper.py` exists.
+            # That is the safe direction -- wrongly retracting loses knowledge,
+            # wrongly keeping is noise the next scan catches -- and it only
+            # affects beliefs written before `source_root` existed.
+            return raw in suffix_index
 
         retracted: list[str] = []
         already: list[str] = []
@@ -509,7 +534,11 @@ class VaultManager:
                 sources = _extract_sources(content)
                 if not sources:
                     continue  # nothing to verify against; leave it alone
-                if any(_grounded(src) for src in sources):
+                source_root = str(fm.get("source_root", "") or "").strip()
+                # One surviving source is enough. A belief citing ten entities
+                # in a file that still exists is still about real code; only a
+                # belief with nothing left standing has lost its evidence.
+                if any(_grounded(src, source_root) for src in sources):
                     continue
 
                 entity = fm.get("entity", md.stem)

--- a/entroly/vault_hygiene.py
+++ b/entroly/vault_hygiene.py
@@ -42,6 +42,26 @@ def _content_tokens(text: str) -> frozenset[str]:
     )
 
 
+def _source_exists(source: str, known_paths: set[str]) -> bool:
+    """Whether a belief's cited source still resolves to a real file.
+
+    ``known_paths`` is the suffix index built by ``vault._path_suffix_index``,
+    shared with the retraction path so both answer this question identically.
+    A source is stored relative to whichever directory was compiled and the
+    belief does not record which one, so `helper.py` and `scripts/helper.py`
+    can name the same file; suffix matching resolves both. Anything
+    unparseable counts as present -- this answer is used to discard a belief,
+    so it must never guess.
+    """
+
+    from .vault import _is_path_like
+
+    raw = source.split(":", 1)[0].replace("\\", "/").strip().lstrip("./")
+    if not _is_path_like(raw):
+        return True  # a sentinel such as `unknown`, not a file reference
+    return raw in known_paths
+
+
 def _jaccard(a: frozenset[str], b: frozenset[str]) -> float:
     if not a or not b:
         return 0.0
@@ -60,8 +80,18 @@ class VaultHygiene:
         overlap_prefilter: float = 0.1,
         max_age_days: int = 30,
         max_pairs: int = 2000,
+        project_root: str | Path | None = None,
     ):
         self._base = Path(vault_base)
+        # Belief sources are recorded relative to whichever directory was
+        # compiled, which is not stored on the belief. The vault normally sits
+        # at `<project>/.entroly/vault`, so its grandparent is the project
+        # root; a caller with better knowledge can pass one.
+        self._project_root = (
+            Path(project_root).resolve()
+            if project_root is not None
+            else self._base.resolve().parent.parent
+        )
         self.contradiction_threshold = contradiction_threshold
         self.duplicate_threshold = duplicate_threshold
         self.overlap_prefilter = overlap_prefilter
@@ -69,7 +99,7 @@ class VaultHygiene:
         self.max_pairs = max_pairs
 
     def _load_beliefs(self) -> list[dict[str, Any]]:
-        from .vault import _extract_body, _parse_frontmatter
+        from .vault import _extract_body, _extract_sources, _parse_frontmatter
 
         beliefs = []
         beliefs_dir = self._base / "beliefs"
@@ -85,6 +115,7 @@ class VaultHygiene:
                 "status": fm.get("status", "unknown"),
                 "confidence": float(fm.get("confidence", 0.0) or 0.0),
                 "last_checked": fm.get("last_checked", ""),
+                "sources": _extract_sources(content),
                 "body": body,
                 "tokens": _content_tokens(body),
             })
@@ -150,6 +181,32 @@ class VaultHygiene:
                     "suggestion": "refresh_beliefs",
                 })
 
+        # Groundedness. Staleness above asks "when was this last checked"; this
+        # asks the prior question, "does the code it describes still exist".
+        # Compilation only ever adds, so a belief outlives the file it came
+        # from and keeps its confidence, ranking beside live beliefs with
+        # nothing to distinguish it. That is worse than an old belief: it is a
+        # confident claim with no evidence behind it at all.
+        from .vault import _path_suffix_index
+
+        known_paths = _path_suffix_index([self._project_root])
+        ungrounded: list[dict[str, Any]] = []
+        for belief in beliefs:
+            sources = belief["sources"]
+            if not sources:
+                continue  # nothing to verify against
+            if any(_source_exists(src, known_paths) for src in sources):
+                continue
+            ungrounded.append({
+                "entity": belief["entity"],
+                "claim_id": belief["claim_id"],
+                "confidence": belief["confidence"],
+                "missing_sources": sorted(
+                    {s.split(":", 1)[0].replace("\\", "/") for s in sources}
+                )[:5],
+                "suggestion": "retract_belief",
+            })
+
         return {
             "schema": HYGIENE_SCHEMA,
             "scanned_at": now.isoformat(),
@@ -159,7 +216,14 @@ class VaultHygiene:
             "contradictions": contradictions,
             "duplicates": duplicates,
             "stale": stale,
+            "ungrounded": ungrounded,
             "confidence_flapping": self._flapping(),
+            # `ungrounded` is reported but deliberately kept out of this
+            # verdict, alongside `stale`. Groundedness depends on inferring a
+            # project root that the belief never recorded, so a vault read from
+            # an unexpected working directory would report every belief dead.
+            # A finding that can be wrong for environmental reasons should
+            # inform a caller, not fail a health gate.
             "healthy": not (contradictions or duplicates),
         }
 

--- a/tests/test_vault_groundedness.py
+++ b/tests/test_vault_groundedness.py
@@ -1,0 +1,126 @@
+"""Retraction of beliefs whose source file is gone (entroly/vault.py).
+
+Compilation is additive: it writes a belief when it sees a file and never
+revisits one whose file was deleted or moved, so the belief keeps its original
+confidence forever and retrieval returns it beside live beliefs with nothing to
+tell them apart.
+"""
+
+from __future__ import annotations
+
+from entroly.vault import BeliefArtifact, VaultConfig, VaultManager
+
+
+def _vault(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    return project, VaultManager(
+        VaultConfig(base_path=str(project / ".entroly" / "vault"))
+    )
+
+
+def _status_and_confidence(vault, entity: str) -> tuple[str, float]:
+    record = vault.read_belief(entity)
+    assert record is not None, f"belief {entity!r} disappeared"
+    frontmatter = record["frontmatter"]
+    return str(frontmatter.get("status", "")), float(frontmatter.get("confidence", -1.0))
+
+
+def test_belief_with_a_missing_source_is_retracted(tmp_path):
+    project, vault = _vault(tmp_path)
+    (project / "src").mkdir()
+    (project / "src" / "live.py").write_text("x = 1\n", encoding="utf-8")
+
+    vault.write_belief(
+        BeliefArtifact(entity="live", title="live", body="Real module.",
+                       sources=["src/live.py:1"])
+    )
+    vault.write_belief(
+        BeliefArtifact(entity="removed", title="removed", body="Deleted module.",
+                       sources=["src/removed.py:1"])
+    )
+
+    result = vault.mark_beliefs_ungrounded([str(project)])
+
+    assert result["retracted_entities"] == ["removed"]
+    assert _status_and_confidence(vault, "removed") == ("ungrounded", 0.0)
+    # The live belief keeps both its status and the confidence retrieval ranks on.
+    status, confidence = _status_and_confidence(vault, "live")
+    assert status != "ungrounded"
+    assert confidence > 0.0
+
+
+def test_source_relative_to_the_compiled_dir_is_not_retracted(tmp_path):
+    """`entroly compile scripts` records `helper.py`, not `scripts/helper.py`.
+
+    The belief never records which directory was compiled, so resolving a
+    source against the project root alone marks live beliefs dead. Doing that
+    retracted 275 of 715 real beliefs on the entroly repository.
+    """
+
+    project, vault = _vault(tmp_path)
+    (project / "scripts").mkdir()
+    (project / "scripts" / "helper.py").write_text("y = 2\n", encoding="utf-8")
+
+    vault.write_belief(
+        BeliefArtifact(entity="helper", title="helper", body="From scripts/.",
+                       sources=["helper.py:1"])
+    )
+
+    result = vault.mark_beliefs_ungrounded([str(project)])
+
+    assert result["retracted_entities"] == []
+
+
+def test_belief_without_sources_is_never_retracted(tmp_path):
+    """No sources means nothing to verify against, which is not evidence of death."""
+
+    project, vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="sourceless", title="sourceless", body="No sources.",
+                       sources=[])
+    )
+
+    result = vault.mark_beliefs_ungrounded([str(project)])
+
+    assert result["retracted_entities"] == []
+
+
+def test_retraction_is_idempotent(tmp_path):
+    """A second pass reports the belief as already retracted rather than again."""
+
+    project, vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="gone", title="gone", body="Deleted module.",
+                       sources=["src/gone.py:1"])
+    )
+
+    first = vault.mark_beliefs_ungrounded([str(project)])
+    second = vault.mark_beliefs_ungrounded([str(project)])
+
+    assert first["retracted_entities"] == ["gone"]
+    assert second["retracted_entities"] == []
+    assert second["already_ungrounded"] == ["gone"]
+
+
+def test_a_restored_file_lets_compilation_bring_the_belief_back(tmp_path):
+    """Retraction marks, never deletes, so the belief stays auditable."""
+
+    project, vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="returning", title="returning", body="Module.",
+                       sources=["src/returning.py:1"])
+    )
+    vault.mark_beliefs_ungrounded([str(project)])
+    assert _status_and_confidence(vault, "returning") == ("ungrounded", 0.0)
+
+    (project / "src").mkdir()
+    (project / "src" / "returning.py").write_text("z = 3\n", encoding="utf-8")
+    vault.write_belief(
+        BeliefArtifact(entity="returning", title="returning", body="Module.",
+                       sources=["src/returning.py:1"])
+    )
+
+    status, confidence = _status_and_confidence(vault, "returning")
+    assert status != "ungrounded"
+    assert confidence > 0.0

--- a/tests/test_vault_groundedness.py
+++ b/tests/test_vault_groundedness.py
@@ -124,3 +124,56 @@ def test_a_restored_file_lets_compilation_bring_the_belief_back(tmp_path):
     status, confidence = _status_and_confidence(vault, "returning")
     assert status != "ungrounded"
     assert confidence > 0.0
+
+
+def test_recorded_source_root_resolves_exactly(tmp_path):
+    """`source_root` removes the guessing entirely.
+
+    With it, a source is rejoined to one directory and there is exactly one
+    file to look for -- so a belief about a deleted `scripts/helper.py` is
+    retracted even while an unrelated `tests/helper.py` exists, which suffix
+    matching alone cannot distinguish.
+    """
+
+    project, vault = _vault(tmp_path)
+    (project / "scripts").mkdir()
+    (project / "tests").mkdir()
+    (project / "tests" / "helper.py").write_text("decoy = 1\n", encoding="utf-8")
+
+    vault.write_belief(
+        BeliefArtifact(entity="helper", title="helper", body="From scripts/.",
+                       sources=["helper.py:1"], source_root="scripts")
+    )
+
+    result = vault.mark_beliefs_ungrounded([str(project)])
+
+    assert result["retracted_entities"] == ["helper"]
+
+
+def test_recorded_source_root_keeps_a_live_belief(tmp_path):
+    project, vault = _vault(tmp_path)
+    (project / "scripts").mkdir()
+    (project / "scripts" / "helper.py").write_text("y = 2\n", encoding="utf-8")
+
+    vault.write_belief(
+        BeliefArtifact(entity="helper", title="helper", body="From scripts/.",
+                       sources=["helper.py:1"], source_root="scripts")
+    )
+
+    result = vault.mark_beliefs_ungrounded([str(project)])
+
+    assert result["retracted_entities"] == []
+
+
+def test_source_root_is_omitted_when_absent(tmp_path):
+    """Beliefs written before the field existed must not change shape."""
+
+    _, vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="legacy", title="legacy", body="No root.",
+                       sources=["mod.py:1"])
+    )
+
+    record = vault.read_belief("legacy")
+    assert record is not None
+    assert "source_root" not in record["frontmatter"]

--- a/tests/test_vault_hygiene.py
+++ b/tests/test_vault_hygiene.py
@@ -78,3 +78,76 @@ def test_clean_vault_reports_healthy(vault):
     assert report["healthy"] is True
     assert report["contradictions"] == []
     assert report["duplicates"] == []
+
+
+def test_reports_belief_whose_source_is_gone(tmp_path):
+    """Compilation only ever adds, so a belief outlives the file it came from.
+
+    Nothing previously distinguished such a belief from a live one: it kept
+    its confidence and ranked beside beliefs that still have evidence.
+    """
+
+    project = tmp_path / "project"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "live.py").write_text("x = 1\n", encoding="utf-8")
+
+    vault = VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    vault.write_belief(
+        BeliefArtifact(entity="live", title="live", body="Describes a real module.",
+                       sources=["src/live.py:1"])
+    )
+    vault.write_belief(
+        BeliefArtifact(entity="removed", title="removed", body="Describes a deleted module.",
+                       sources=["src/removed.py:1"])
+    )
+
+    report = VaultHygiene(vault._base).scan()
+    entities = {row["entity"] for row in report["ungrounded"]}
+
+    assert "removed" in entities
+    assert "live" not in entities
+
+
+def test_source_recorded_relative_to_the_compiled_dir_is_still_grounded(tmp_path):
+    """A belief does not record which directory was compiled.
+
+    `entroly compile scripts` writes `helper.py` while `entroly compile .`
+    writes `scripts/helper.py`, for the same file. Resolving only against the
+    project root marks the first form dead -- which is what made a naive check
+    retract 275 of 715 real beliefs on the entroly repo.
+    """
+
+    project = tmp_path / "project"
+    (project / "scripts").mkdir(parents=True)
+    (project / "scripts" / "helper.py").write_text("y = 2\n", encoding="utf-8")
+
+    vault = VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    vault.write_belief(
+        BeliefArtifact(entity="helper", title="helper", body="Compiled from scripts/.",
+                       sources=["helper.py:1"])
+    )
+
+    report = VaultHygiene(vault._base).scan()
+
+    assert [row["entity"] for row in report["ungrounded"]] == []
+
+
+def test_groundedness_is_reported_but_does_not_fail_the_health_verdict(tmp_path):
+    """Groundedness depends on inferring a root the belief never recorded.
+
+    A vault read from an unexpected working directory would otherwise report
+    every belief dead, so the finding informs a caller instead of gating.
+    """
+
+    project = tmp_path / "project"
+    project.mkdir()
+    vault = VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    vault.write_belief(
+        BeliefArtifact(entity="orphan", title="orphan", body="No file backs this.",
+                       sources=["nowhere/at/all.py:1"])
+    )
+
+    report = VaultHygiene(vault._base).scan()
+
+    assert report["ungrounded"]
+    assert report["healthy"] is True


### PR DESCRIPTION
## The defect

Belief compilation is **additive**. It writes a belief when it sees a file and
never revisits one whose file was deleted or moved — so the belief keeps its
confidence forever, and retrieval returns it beside live beliefs with nothing
to tell them apart.

On this repository, **27 of 715 beliefs** described `entroly-wasm/src/*.rs`
modules that had since moved to `entroly-engine/src`. They ranked *above* live
results for the same query, at `conf=0.75`.

This is worse than staleness. Staleness asks *when a claim was last checked*;
groundedness asks *whether the thing it describes still exists*. A confident
claim whose evidence is gone is precisely what the fail-closed rule exists to
prevent.

## The fix is in the data model, not the query

The root cause is that a belief never recorded **which directory its sources
are relative to**. `entroly compile scripts` writes `helper.py`;
`entroly compile .` writes `scripts/helper.py` — for the same file, and nothing
said which.

`BeliefArtifact.source_root` now records it, so a source rejoins to exactly one
path. The field is omitted from frontmatter when empty, so beliefs written
before it existed do not change shape.

Legacy beliefs fall back to path-suffix matching, built **lazily** and only
when such a belief is found. What `source_root` buys is pinned by a test suffix
matching cannot pass:

> a deleted `scripts/helper.py` is retracted **even while an unrelated
> `tests/helper.py` exists**

The opposite regression is pinned too: resolving sources against the project
root with no fallback retracted **275 of 715** real beliefs here.

## Safety

`mark_beliefs_ungrounded` marks and zeroes confidence — confidence being what
retrieval ranks on. It **never deletes**: the belief stays auditable, and the
next compilation that sees the file restores it.

Three cases never retract:

| case | why |
|---|---|
| source is not path-like | `write_belief` stores the sentinel `unknown`; "provenance was never recorded" is the opposite of "the file is gone" |
| belief has no sources | nothing to verify against |
| any one source survives | a belief citing ten entities in a file that still exists is still about real code |

The bias is deliberate: wrongly retracting loses knowledge, wrongly keeping is
noise the next scan catches.

`--no-retract` / `ENTROLY_NO_RETRACT` skips the pass — a groundedness check
that misfires on an unusual layout must not leave a user unable to compile.

`vault_hygiene` reports the same finding without acting, matching its
report-only contract, sharing one definition of the check. **`healthy` is
unchanged**: groundedness depends on inferring a project root, so a vault read
from an unexpected working directory would report every belief dead — a finding
that can be wrong for environmental reasons should inform a caller, not fail a
health gate.

## Trust and compatibility

- [x] Receipt honesty and recoverability are preserved or not affected.
- [x] Verification remains fail-closed where confidence is claimed.
- [x] No surprise network call or credential surface is added.

## Verification

End to end through `python -m entroly compile` — **not** the globally installed
build, which lacks these changes:

```
Beliefs written:    2
Retracted:          1 belief(s) whose source is gone
doomed.md:status: ungrounded    live.md:status: inferred
```

`--no-retract` leaves it `inferred`. 76 tests pass across vault groundedness,
vault hygiene, vault time and zero-token autonomy; ruff clean.
