### PR TITLE
fix(vault): stop metadata updates corrupting beliefs and losing writes

### DIFF
--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import logging
 import os
+import random
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -62,6 +64,9 @@ class VaultConfig:
 # Belief Artifact Schema
 # â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
 
+_ATOMIC_REPLACE_ATTEMPTS = 18
+
+
 def _atomic_write_text(path: Path, text: str) -> None:
     """Write a vault artifact so a reader never sees a partial one.
 
@@ -73,16 +78,64 @@ def _atomic_write_text(path: Path, text: str) -> None:
     makes the replacement atomic on POSIX and Windows alike.
     """
 
-    temp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    # The token must be unique per *write*, not per process: threads in one
+    # process share a pid, so a pid-only name made concurrent writers collide
+    # on the same temp file and fail with EACCES on Windows. Atomicity held --
+    # readers never saw a torn file -- but the writes themselves crashed.
+    temp_path = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
     try:
         temp_path.write_text(text, encoding="utf-8")
-        os.replace(temp_path, path)
+        # Windows refuses to rename over a file another handle has open, so a
+        # concurrent reader makes `os.replace` raise EACCES. Retrying is what
+        # keeps the swap both atomic and available: readers hold the file for
+        # microseconds, and without this the durability fix would have traded
+        # torn reads for lost writes. POSIX takes the first attempt every time.
+        delay = 0.002
+        for attempt in range(_ATOMIC_REPLACE_ATTEMPTS):
+            try:
+                os.replace(temp_path, path)
+                break
+            except PermissionError:
+                if attempt == _ATOMIC_REPLACE_ATTEMPTS - 1:
+                    raise
+                # Jittered, or concurrent writers retry in lockstep and keep
+                # colliding with the same reader. Measured on Windows with four
+                # writers against two readers: 61 of 240 writes failed with no
+                # retry, 2 with a fixed backoff, 0 with jitter over this window.
+                time.sleep(delay * (0.5 + random.random()))
+                delay = min(delay * 2, 0.05)
     except OSError:
         try:
             temp_path.unlink()
         except OSError:  # pragma: no cover - best effort cleanup
             pass
         raise
+
+
+def _set_frontmatter_field(content: str, key: str, value: Any) -> str:
+    """Rewrite one frontmatter key, leaving the body untouched.
+
+    The body is prose compiled from source docstrings, so it can legitimately
+    contain the text ``confidence: 0.5`` or ``status: inferred``. An unanchored
+    ``str.replace`` over the whole document rewrote those too, silently
+    changing what a belief claims about the code while updating its metadata.
+    Only the region above the closing ``---`` is eligible, and only the first
+    match of an anchored key.
+    """
+
+    import re
+
+    if not content.startswith("---"):
+        return content
+    end = content.find("\n---", 3)
+    if end < 0:
+        return content
+
+    head, tail = content[:end], content[end:]
+    pattern = re.compile(rf"^{re.escape(key)}:[^\r\n]*$", re.MULTILINE)
+    if not pattern.search(head):
+        return content
+    return pattern.sub(f"{key}: {_yaml_scalar(value)}", head, count=1) + tail
 
 
 def _yaml_scalar(value: Any) -> str:
@@ -501,7 +554,14 @@ class VaultManager:
                         break
 
                 if not matched:
-                    matched = any(stem in entity_lc for stem in changed_stems)
+                    # Fallback for beliefs whose sources are missing: match the
+                    # entity against a changed file's stem *exactly*. This was a
+                    # substring test, so editing `auth.py` also marked
+                    # `authentication_service` and `oauth_client` stale --
+                    # beliefs it has nothing to do with. Staleness is what gates
+                    # trust in a belief, so marking fresh ones stale erodes the
+                    # signal rather than erring safely.
+                    matched = entity_lc in changed_stems
 
                 if not matched:
                     continue
@@ -665,27 +725,20 @@ class VaultManager:
                 content = safe_path.read_text(encoding="utf-8", errors="replace")
                 fm = _parse_frontmatter(content)
                 if fm and fm.get("claim_id") == claim_id:
-                    old_conf = float(fm.get("confidence", 0.5))
+                    try:
+                        old_conf = float(fm.get("confidence", 0.5))
+                    except (TypeError, ValueError):
+                        # A malformed confidence is not a reason to skip the
+                        # update; treat it as the schema default and repair it.
+                        old_conf = 0.5
                     new_conf = max(0.0, min(1.0, old_conf + delta))
-                    # Rewrite the confidence line
-                    updated = content.replace(
-                        f"confidence: {fm['confidence']}",
-                        f"confidence: {new_conf}",
+
+                    updated = _set_frontmatter_field(content, "confidence", new_conf)
+                    if delta > 0 and fm.get("status") == "inferred":
+                        updated = _set_frontmatter_field(updated, "status", "verified")
+                    updated = _set_frontmatter_field(
+                        updated, "last_checked", datetime.now(timezone.utc).isoformat()
                     )
-                    # Also update status to verified if delta is positive
-                    if delta > 0 and "status: inferred" in updated:
-                        updated = updated.replace(
-                            "status: inferred", "status: verified"
-                        )
-                    # Update last_checked
-                    now = datetime.now(timezone.utc).isoformat()
-                    if "last_checked:" in updated:
-                        import re
-                        updated = re.sub(
-                            r"last_checked: .+",
-                            f"last_checked: {now}",
-                            updated,
-                        )
                     _atomic_write_text(safe_path, updated)
                     logger.info(
                         f"Vault: updated belief {claim_id} confidence "

--- a/tests/test_vault_integrity.py
+++ b/tests/test_vault_integrity.py
@@ -8,6 +8,7 @@ tests cover the ways that record could quietly stop being true.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 from entroly.vault import (
@@ -153,4 +154,120 @@ def test_an_interrupted_write_leaves_the_previous_belief_readable(tmp_path, monk
     survivor = vault.read_belief("stable")
     assert survivor is not None
     assert "ORIGINAL" in survivor["body"]
+    assert not list((vault._base / "beliefs").glob("*.tmp"))
+
+
+def test_confidence_update_does_not_rewrite_the_belief_body(tmp_path):
+    """A belief's body is prose compiled from source docstrings.
+
+    It can legitimately contain the text `confidence: 0.5` or
+    `status: inferred`. An unanchored replace over the whole document rewrote
+    those too, silently changing what the belief claims about the code.
+    """
+
+    vault = _vault(tmp_path)
+    body = "Docs mention: confidence: 0.5 and status: inferred and last_checked: never."
+    artifact = BeliefArtifact(entity="m", title="m", body=body, sources=["a.py:1"],
+                              confidence=0.5, status="inferred")
+    path = vault.write_belief(artifact)["path"]
+
+    vault._update_belief_confidence(artifact.claim_id, 0.2)
+
+    content = Path(path).read_text(encoding="utf-8")
+    assert body in content
+    frontmatter = _parse_frontmatter(content) or {}
+    assert float(frontmatter["confidence"]) == 0.7
+    assert frontmatter["status"] == "verified"
+
+
+def test_confidence_stays_within_bounds(tmp_path):
+    vault = _vault(tmp_path)
+    high = BeliefArtifact(entity="high", title="h", body="b", sources=["a.py:1"],
+                          confidence=0.9)
+    low = BeliefArtifact(entity="low", title="l", body="b", sources=["a.py:1"],
+                         confidence=0.1)
+    high_path = vault.write_belief(high)["path"]
+    low_path = vault.write_belief(low)["path"]
+
+    vault._update_belief_confidence(high.claim_id, 5.0)
+    vault._update_belief_confidence(low.claim_id, -5.0)
+
+    assert float((_parse_frontmatter(Path(high_path).read_text(encoding="utf-8")) or {})["confidence"]) == 1.0
+    assert float((_parse_frontmatter(Path(low_path).read_text(encoding="utf-8")) or {})["confidence"]) == 0.0
+
+
+def test_changing_one_file_does_not_mark_unrelated_beliefs_stale(tmp_path):
+    """The entity fallback was a substring test.
+
+    Editing `auth.py` also marked `authentication_service` and `oauth_client`
+    stale. Staleness is what gates trust in a belief, so marking fresh ones
+    stale erodes the signal rather than erring safely.
+    """
+
+    vault = _vault(tmp_path)
+    for entity in ("auth", "authentication_service", "oauth_client"):
+        vault.write_belief(
+            BeliefArtifact(entity=entity, title=entity, body="b",
+                           sources=[f"{entity}.py:1"])
+        )
+
+    result = vault.mark_beliefs_stale_for_files(["auth.py"])
+
+    assert sorted(result["updated_entities"]) == ["auth"]
+
+
+def test_concurrent_writers_never_tear_a_belief_or_lose_a_write(tmp_path):
+    """Windows refuses to rename over a file another handle has open.
+
+    Without a jittered retry the durability fix traded torn reads for lost
+    writes: measured at 61 of 240 writes failing with no retry and 2 with a
+    fixed backoff.
+    """
+
+    import threading
+
+    vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="hot", title="h", body="seed", sources=["a.py:1"])
+    )
+    target = vault._base / "beliefs" / "hot.md"
+    stop = False
+    torn: list[int] = []
+    errors: list[str] = []
+
+    def read_loop() -> None:
+        while not stop:
+            try:
+                if _parse_frontmatter(target.read_text(encoding="utf-8", errors="replace")) is None:
+                    torn.append(1)
+            except OSError:
+                pass
+            time.sleep(0.001)
+
+    def write_loop(count: int) -> None:
+        for index in range(count):
+            try:
+                vault.write_belief(
+                    BeliefArtifact(entity="hot", title="h", body=f"b{index}",
+                                   sources=["a.py:1"])
+                )
+            except Exception as exc:  # noqa: BLE001 - recorded, then asserted on
+                errors.append(type(exc).__name__)
+            time.sleep(0.001)
+
+    readers = [threading.Thread(target=read_loop) for _ in range(2)]
+    writers = [threading.Thread(target=write_loop, args=(25,)) for _ in range(3)]
+    for thread in readers:
+        thread.start()
+    for thread in writers:
+        thread.start()
+    for thread in writers:
+        thread.join()
+    stop = True
+    for thread in readers:
+        thread.join()
+
+    assert errors == []
+    assert torn == []
+    assert _parse_frontmatter(target.read_text(encoding="utf-8")) is not None
     assert not list((vault._base / "beliefs").glob("*.tmp"))


### PR DESCRIPTION
Stacked on #339.

Three more failures, found by testing the paths the first audit stopped short
of: confidence updates, staleness marking, and concurrent access.

## 1. A confidence update rewrote the belief's body

`_update_belief_confidence` used unanchored `str.replace` over the whole
document. A belief's body is prose compiled from source docstrings, so it can
legitimately contain the text `confidence: 0.5` or `status: inferred`:

```
body before : Docs mention: confidence: 0.5 and status: inferred and last_checked: never.
body after  : Docs mention: confidence: 0.7 and status: verified and last_checked: 2026-08-16T21:46:47…
```

Updating metadata silently changed **what the belief claimed about the code**.

Rewrites now go through `_set_frontmatter_field`, which edits one anchored key
above the closing `---`. A malformed confidence is repaired to the schema
default rather than aborting the update, and bounds are asserted at `[0, 1]`.

## 2. Editing one file marked unrelated beliefs stale

The entity fallback in `mark_beliefs_stale_for_files` was a substring test:

```
changed auth.py  →  marked stale: ['auth', 'authentication_service', 'oauth_client']
```

`oauth_client` has nothing to do with `auth.py`. Staleness is what gates trust
in a belief, so marking fresh ones stale **erodes the signal** rather than
erring safely. The fallback now matches a changed file's stem exactly; the
precise source-path match above it is untouched.

## 3. Concurrent writes failed on Windows

Two bugs, both surfaced by stress rather than reading:

- the atomic-write temp file was named with `os.getpid()`, which **threads in
  one process share** — concurrent writers collided on the same temp path;
- Windows **refuses to rename over a file another handle has open**, so any
  concurrent reader made `os.replace` raise `EACCES`.

The durability fix from #339 had traded torn reads for **lost writes**. A
per-write uuid token and a jittered bounded retry close both:

| configuration | failed writes / 240 | torn reads |
|---|---|---|
| no retry | 61 | 0 |
| fixed backoff | 2 | 0 |
| **jittered backoff** | **0** (over 720 writes, 3,468 concurrent reads) | **0** |

No torn read was observed in any configuration — that is the guarantee the
rename was for, and it held throughout. What needed fixing was availability,
not atomicity.

## Trust and compatibility

- [x] Receipt honesty and recoverability are preserved or not affected.
- [x] Verification remains fail-closed where confidence is claimed.
- [x] No surprise network call or credential surface is added.

## Verification

138 tests pass across vault integrity, groundedness, hygiene, time, change
listener, coupling, security hardening, task dream and zero-token autonomy;
ruff clean. Four new tests, one per failure above.
