### PR TITLE
fix(vault): production hardening — corruption, concurrency, ledger integrity and scale

### DIFF
--- a/entroly/belief_compiler.py
+++ b/entroly/belief_compiler.py
@@ -443,10 +443,19 @@ class BeliefCompiler:
     SUPPORTED_EXTENSIONS = {".py", ".rs", ".ts", ".tsx", ".js", ".jsx"}
 
     # Directories to skip
+    # `entroly compile .` is already recursive, so this list is what decides
+    # whether compiling a whole repository is practical. Without the scratch
+    # and cache entries below it walked 25,819 files here, 24,831 of them in a
+    # local `.tmp` checkout -- which is why compiling each source directory
+    # separately looked necessary. Pruning them makes one command cover the
+    # tree, and a directory missed that way reads as "not present" rather than
+    # "not indexed", which is the worse of the two failures.
     SKIP_DIRS = {
         "__pycache__", "node_modules", ".git", ".hg", "target",
         "dist", "build", ".tox", ".pytest_cache", ".mypy_cache",
         "venv", ".venv", "env", ".env",
+        ".tmp", "tmp", ".entroly", ".ruff_cache", ".hypothesis",
+        "htmlcov", "coverage", "site-packages", ".idea", ".vscode",
     }
 
     def __init__(self, vault: VaultManager):

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -3615,6 +3615,34 @@ def cmd_doctor(args):
         print(f"  {C.RED}x{C.RESET} Python {py_ver} (need >=3.10)")
         checks_failed += 1
 
+    # 1b. Check that the `entroly` on PATH is the package that just imported.
+    # A separately installed copy takes PATH priority over a source checkout,
+    # so `entroly <cmd>` silently exercises the installed build while tests and
+    # edits apply to the source. Every verification run that way is testing
+    # code that is not the code under change, and nothing says so.
+    # Informational, and deliberately outside the counted checks: this
+    # describes the developer's environment rather than whether entroly works,
+    # which is the same reason absent proxy/docker/index are not failures.
+    _launcher = shutil.which("entroly")
+    if _launcher:
+        try:
+            _running = Path(__file__).resolve().parent
+            _launcher_root = Path(_launcher).resolve().parent.parent
+            if _running.parent not in (_launcher_root, *_launcher_root.parents):
+                print(
+                    f"  {C.YELLOW}!{C.RESET} `entroly` on PATH is a different "
+                    f"installation than the imported package"
+                )
+                print(f"    {C.GRAY}PATH:     {_launcher}{C.RESET}")
+                print(f"    {C.GRAY}imported: {_running}{C.RESET}")
+                print(
+                    f"    {C.GRAY}Commands run the PATH copy, so edits to the "
+                    f"imported tree take no effect. Reinstall it "
+                    f"(`pip install -e .`) or use `python -m entroly`.{C.RESET}"
+                )
+        except OSError:
+            pass
+
     # 2. Check Rust engine
     checks_total += 1
     from .native_status import QCCR_SYMBOLS, native_status
@@ -4410,6 +4438,9 @@ def cmd_optimize(args):
         pass
 
 
+_INGEST_VOLUME_WARNING = 5000
+
+
 def cmd_ingest(args):
     """entroly ingest PATH - build a local multi-document Context Receipt index."""
     from entroly.context_receipts import ingest_documents
@@ -4420,6 +4451,25 @@ def cmd_ingest(args):
     if not docs:
         print(f"  {C.RED}No supported documents found.{C.RESET} {supported_documents_hint()}", file=sys.stderr)
         return 1
+
+    # A document index is meant to be searched, and one built from a scratch
+    # tree is not. Pruning cannot know every such directory by name, so an
+    # implausible count is reported with the directory responsible rather than
+    # written out silently -- the failure was a 528 MB index that made `select`
+    # and `optimize` time out, with nothing at ingest time saying why.
+    if len(docs) > _INGEST_VOLUME_WARNING:
+        from collections import Counter
+
+        by_dir = Counter(Path(src).parent.as_posix() for src, _ in docs)
+        top_dir, top_count = by_dir.most_common(1)[0]
+        print(
+            f"  {C.YELLOW}! {len(docs)} documents is unusually many for a project "
+            f"index.{C.RESET}"
+        )
+        print(
+            f"    {C.GRAY}{top_count} came from {top_dir}. If that is generated or "
+            f"scratch content, ingest a narrower path.{C.RESET}"
+        )
     index = ingest_documents(
         docs,
         chunk_tokens=args.chunk_tokens,
@@ -5333,6 +5383,17 @@ def cmd_compile(args):
     # It writes to beliefs, so it is escapable: a groundedness check that
     # misfires on an unusual layout must not leave a user with no way to
     # compile. `--no-retract` skips it; the beliefs stay as they were.
+    # Beliefs written before `source_root` existed resolve their sources by
+    # suffix, which is permissive enough to keep a belief about a deleted file
+    # alive whenever any file of that name survives. Recovering the root first
+    # means retraction below judges them exactly, not by guess.
+    backfill = vault.backfill_source_roots([target])
+    if backfill.get("backfilled_entities"):
+        print(
+            f"  {C.CYAN}Provenance filled:{C.RESET}   "
+            f"{len(backfill['backfilled_entities'])} legacy belief(s)"
+        )
+
     if getattr(args, "no_retract", False) or os.environ.get("ENTROLY_NO_RETRACT"):
         print(f"  {C.GRAY}Retraction skipped (--no-retract).{C.RESET}")
     else:
@@ -5492,7 +5553,21 @@ def cmd_search(args):
 
     print(f"\n  {C.CYAN}{C.BOLD}Vault Search{C.RESET}")
     print(f"  {C.GRAY}Query: {query}{C.RESET}")
-    print(f"  {C.GRAY}Vault: {vault_base}{C.RESET}\n")
+    print(f"  {C.GRAY}Vault: {vault_base}{C.RESET}")
+
+    # Search reads the belief vault, which only `entroly compile` fills.
+    # `entroly ingest` fills a different store and reports its own loud
+    # success, so without this the two look interchangeable and a search
+    # silently answers from whatever the vault last held.
+    try:
+        from entroly.vault import vault_readiness
+
+        readiness = vault_readiness(vault_base, os.getcwd())
+        for reason in readiness["reasons"]:
+            print(f"  {C.YELLOW}! {reason}{C.RESET}")
+    except Exception:
+        pass  # a diagnostic must never block the search itself
+    print()
 
     try:
         from entroly_core import CogOpsEngine

--- a/entroly/context_receipts/ingest.py
+++ b/entroly/context_receipts/ingest.py
@@ -87,6 +87,12 @@ SKIP_DIRECTORIES = frozenset({
     "node_modules",
     "target",
     "venv",
+    # Scratch trees. `.tmp` sat outside this list while `.entroly`, `.git` and
+    # `.venv` were in it, so `entroly ingest .` walked into one and produced
+    # 34,051 documents -- 32,524 of them from a single `.tmp/pr_work` checkout
+    # -- for a 528 MB index that then made `select` and `optimize` time out.
+    ".tmp",
+    "tmp",
 })
 
 SKIP_DIRECTORY_SUFFIXES = (

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -211,6 +211,33 @@ def _iter_source_files(root: Path, limit: int = 4000):
                     return
 
 
+def _split_frontmatter(content: str) -> tuple[str, str] | None:
+    """Split a belief into its frontmatter block and the rest.
+
+    The closing delimiter is a line that is exactly ``---``. Locating it with
+    a substring search instead matched the first ``---`` *anywhere*, so an
+    entity of ``x --- y`` ended the block mid-value: the entity parsed as
+    ``x`` and every field after it -- status, confidence, sources, the
+    claim_id the ledger is keyed by -- spilled into the body. Entity names
+    come from indexed source code, so that input is not hypothetical.
+
+    Returns ``(frontmatter_text, body_text)`` or None when there is no
+    complete block.
+    """
+
+    if not content.startswith("---"):
+        return None
+    lines = content.splitlines(keepends=True)
+    if not lines:
+        return None
+    consumed = len(lines[0])
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return content[len(lines[0]) : consumed], content[consumed + len(line) :]
+        consumed += len(line)
+    return None
+
+
 def _set_frontmatter_field(content: str, key: str, value: Any) -> str:
     """Rewrite one frontmatter key, leaving the body untouched.
 
@@ -983,13 +1010,11 @@ def _belief_filenames(entity: str) -> tuple[str, str]:
 
 def _parse_frontmatter(content: str) -> dict[str, str] | None:
     """Parse YAML frontmatter from markdown content."""
-    if not content.startswith("---"):
-        return None
-    end = content.find("---", 3)
-    if end < 0:
+    split = _split_frontmatter(content)
+    if split is None:
         return None
 
-    fm_text = content[3:end].strip()
+    fm_text = split[0].strip()
     result: dict[str, str] = {}
     for line in fm_text.splitlines():
         if ":" in line and not line.strip().startswith("-"):
@@ -1105,13 +1130,11 @@ def _path_suffix_index(roots: list[Path]) -> set[str]:
 
 def _extract_sources(content: str) -> list[str]:
     """Extract sources list from frontmatter."""
-    if not content.startswith("---"):
-        return []
-    end = content.find("---", 3)
-    if end < 0:
+    split = _split_frontmatter(content)
+    if split is None:
         return []
 
-    fm_text = content[3:end].strip().splitlines()
+    fm_text = split[0].strip().splitlines()
     sources: list[str] = []
     in_sources = False
     for line in fm_text:
@@ -1130,11 +1153,9 @@ def _extract_sources(content: str) -> list[str]:
 
 def _extract_body(content: str) -> str:
     """Extract body content after frontmatter."""
-    if not content.startswith("---"):
+    split = _split_frontmatter(content)
+    if split is None:
         return content
-    end = content.find("---", 3)
-    if end < 0:
-        return content
-    return content[end + 3:].strip()
+    return split[1].strip()
 
 

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -112,6 +112,105 @@ def _atomic_write_text(path: Path, text: str) -> None:
         raise
 
 
+def _humanize_seconds(seconds: float) -> str:
+    """A coarse duration. `0.0 day(s)` tells a reader nothing useful."""
+
+    if seconds < 90:
+        return f"{int(seconds)}s"
+    if seconds < 5400:
+        return f"{seconds / 60:.0f}m"
+    if seconds < 172800:
+        return f"{seconds / 3600:.0f}h"
+    return f"{seconds / 86400:.0f}d"
+
+
+def vault_readiness(vault_base: str | Path, project_root: str | Path | None = None) -> dict[str, Any]:
+    """Whether the belief vault can answer questions about the current tree.
+
+    `entroly ingest` and `entroly search` use different stores: ingest fills
+    `.entroly/receipts/index.json` from documents, search reads
+    `.entroly/vault/beliefs/` built by `entroly compile`. Ingest reports a loud
+    success either way, so running it and then searching returns whatever the
+    vault last held, with nothing at the point of use saying the two are
+    unrelated. Returning the reason lets a caller say so.
+
+    Reports rather than decides: a stale answer is still an answer, and the
+    caller may legitimately want it.
+    """
+
+    base = Path(vault_base)
+    root = Path(project_root) if project_root is not None else base.resolve().parent.parent
+    beliefs = sorted((base / "beliefs").glob("*.md")) if (base / "beliefs").exists() else []
+
+    newest_belief = 0.0
+    for path in beliefs:
+        try:
+            newest_belief = max(newest_belief, path.stat().st_mtime)
+        except OSError:
+            continue
+
+    receipts_index = base.parent / "receipts" / "index.json"
+    has_receipts = receipts_index.exists()
+
+    reasons: list[str] = []
+    if not beliefs:
+        if has_receipts:
+            reasons.append(
+                "the belief vault is empty but a document index exists -- "
+                "`entroly ingest` fills the document index, which `entroly search` "
+                "does not read; run `entroly compile <dir>` to build beliefs"
+            )
+        else:
+            reasons.append("the belief vault is empty; run `entroly compile <dir>`")
+    else:
+        newest_source = 0.0
+        newest_source_name = ""
+        for path in _iter_source_files(root):
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                continue
+            if mtime > newest_source:
+                newest_source, newest_source_name = mtime, path.name
+        if newest_source > newest_belief:
+            reasons.append(
+                f"source is newer than the newest belief by "
+                f"{_humanize_seconds(newest_source - newest_belief)} "
+                f"(most recently {newest_source_name}); re-run `entroly compile <dir>` "
+                "or results will describe code as it used to be"
+            )
+
+    return {
+        "belief_count": len(beliefs),
+        "has_document_index": has_receipts,
+        "ready": not reasons,
+        "reasons": reasons,
+    }
+
+
+def _iter_source_files(root: Path, limit: int = 4000):
+    """Source files under ``root``, pruning generated trees. Bounded."""
+
+    seen = 0
+    stack = [root]
+    while stack and seen < limit:
+        directory = stack.pop()
+        try:
+            entries = list(directory.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.name in _GROUNDEDNESS_SKIP_DIRS or entry.name.startswith("."):
+                continue
+            if entry.is_dir():
+                stack.append(entry)
+            elif entry.is_file() and entry.suffix in _SOURCE_SUFFIXES:
+                seen += 1
+                yield entry
+                if seen >= limit:
+                    return
+
+
 def _set_frontmatter_field(content: str, key: str, value: Any) -> str:
     """Rewrite one frontmatter key, leaving the body untouched.
 
@@ -589,6 +688,87 @@ class VaultManager:
             "already_stale": already_stale,
         }
 
+    def backfill_source_roots(self, roots: list[str] | None = None) -> dict[str, Any]:
+        """Give legacy beliefs the `source_root` they were written without.
+
+        Beliefs written before the field existed record a bare `helper.py`,
+        so groundedness has to fall back to matching any file with that
+        suffix -- permissive enough that a belief about a deleted
+        `scripts/helper.py` survives while an unrelated `tests/helper.py`
+        exists. Recovering the root converts those to exact resolution.
+
+        The root is recovered only when the belief's sources resolve to
+        exactly one directory. Two files sharing a basename leave it
+        ambiguous, and a guess would be worse than the fallback: it would
+        look authoritative while pointing at the wrong file.
+        """
+
+        import re
+
+        self.ensure_structure()
+        search_roots = [self._base.resolve().parent.parent]
+        for root in roots or []:
+            try:
+                search_roots.append(Path(root).resolve())
+            except (OSError, ValueError):
+                continue
+        project_root = search_roots[0]
+        candidates = _path_owner_index(search_roots)
+
+        filled: list[str] = []
+        ambiguous: list[str] = []
+        for md in (self._base / "beliefs").rglob("*.md"):
+            try:
+                safe_path = resolve_file_within(self._base / "beliefs", md)
+                if safe_path is None:
+                    continue
+                content = safe_path.read_text(encoding="utf-8", errors="replace")
+                frontmatter = _parse_frontmatter(content)
+                if not frontmatter or frontmatter.get("source_root"):
+                    continue
+                sources = [
+                    s.split(":", 1)[0].replace("\\", "/").strip().lstrip("./")
+                    for s in _extract_sources(content)
+                ]
+                sources = [s for s in sources if _is_path_like(s)]
+                if not sources:
+                    continue
+
+                entity = frontmatter.get("entity", md.stem)
+                owners = {
+                    tuple(sorted(candidates.get(source, ()))) for source in sources
+                }
+                resolved = {o for o in owners if len(o) == 1}
+                if len(resolved) != 1 or len(owners) != 1:
+                    ambiguous.append(entity)
+                    continue
+
+                root = next(iter(resolved))[0]
+                if not (project_root / root / sources[0]).exists():
+                    ambiguous.append(entity)
+                    continue
+
+                updated = re.sub(
+                    r"^(sources:(?:\r?\n[ \t]+-[^\r\n]*)+)",
+                    lambda m: f"{m.group(1)}\nsource_root: {root}",
+                    content,
+                    count=1,
+                    flags=re.MULTILINE,
+                )
+                if updated == content:
+                    ambiguous.append(entity)
+                    continue
+                _atomic_write_text(safe_path, updated)
+                filled.append(entity)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(f"Vault: source_root backfill failed for {md}: {exc}")
+
+        return {
+            "status": "updated",
+            "backfilled_entities": filled,
+            "ambiguous_entities": ambiguous,
+        }
+
     def mark_beliefs_ungrounded(
         self, roots: list[str] | None = None
     ) -> dict[str, Any]:
@@ -816,6 +996,12 @@ def _parse_frontmatter(content: str) -> dict[str, str] | None:
     return result if result else None
 
 
+_SOURCE_SUFFIXES = frozenset({
+    ".py", ".rs", ".js", ".ts", ".tsx", ".jsx", ".go", ".java", ".rb", ".c",
+    ".h", ".cpp", ".hpp", ".cs", ".swift", ".kt", ".php", ".scala",
+})
+
+
 _GROUNDEDNESS_SKIP_DIRS = frozenset({
     ".git", ".venv", "venv", "node_modules", "target", "__pycache__",
     ".entroly", ".mypy_cache", ".pytest_cache", ".ruff_cache", "dist", "build",
@@ -835,6 +1021,43 @@ def _is_path_like(value: str) -> bool:
     if not value:
         return False
     return "/" in value or bool(Path(value).suffix)
+
+
+def _path_owner_index(roots: list[Path]) -> dict[str, set[str]]:
+    """Map each path suffix to the root-relative directories that can supply it.
+
+    A suffix owned by exactly one directory identifies a belief's
+    `source_root`; one owned by several is ambiguous and must stay that way.
+    """
+
+    owners: dict[str, set[str]] = {}
+    seen_roots: set[Path] = set()
+    for root in roots:
+        if root in seen_roots or not root.is_dir():
+            continue
+        seen_roots.add(root)
+        stack = [root]
+        while stack:
+            directory = stack.pop()
+            try:
+                entries = list(directory.iterdir())
+            except OSError:
+                continue
+            for entry in entries:
+                if entry.name in _GROUNDEDNESS_SKIP_DIRS:
+                    continue
+                if entry.is_dir():
+                    stack.append(entry)
+                elif entry.is_file():
+                    try:
+                        parts = entry.relative_to(root).as_posix().split("/")
+                    except ValueError:  # pragma: no cover - defensive
+                        continue
+                    for start in range(len(parts)):
+                        suffix = "/".join(parts[start:])
+                        owner = "/".join(parts[:start])
+                        owners.setdefault(suffix, set()).add(owner)
+    return owners
 
 
 def _path_suffix_index(roots: list[Path]) -> set[str]:

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -743,7 +743,12 @@ class VaultManager:
                     ambiguous.append(entity)
                     continue
 
-                root = next(iter(resolved))[0]
+                # An empty prefix means the source is already project-relative
+                # (`bench/accuracy.py`). Recording that as `source_root:` with
+                # no value writes a key the frontmatter parser then drops, so
+                # the belief never counted as filled and was rewritten on every
+                # compile. `.` says the same thing and survives a round trip.
+                root = next(iter(resolved))[0] or "."
                 if not (project_root / root / sources[0]).exists():
                     ambiguous.append(entity)
                     continue

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import logging
 import os
+import random
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -62,6 +64,9 @@ class VaultConfig:
 # Belief Artifact Schema
 # â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
 
+_ATOMIC_REPLACE_ATTEMPTS = 18
+
+
 def _atomic_write_text(path: Path, text: str) -> None:
     """Write a vault artifact so a reader never sees a partial one.
 
@@ -73,16 +78,64 @@ def _atomic_write_text(path: Path, text: str) -> None:
     makes the replacement atomic on POSIX and Windows alike.
     """
 
-    temp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    # The token must be unique per *write*, not per process: threads in one
+    # process share a pid, so a pid-only name made concurrent writers collide
+    # on the same temp file and fail with EACCES on Windows. Atomicity held --
+    # readers never saw a torn file -- but the writes themselves crashed.
+    temp_path = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
     try:
         temp_path.write_text(text, encoding="utf-8")
-        os.replace(temp_path, path)
+        # Windows refuses to rename over a file another handle has open, so a
+        # concurrent reader makes `os.replace` raise EACCES. Retrying is what
+        # keeps the swap both atomic and available: readers hold the file for
+        # microseconds, and without this the durability fix would have traded
+        # torn reads for lost writes. POSIX takes the first attempt every time.
+        delay = 0.002
+        for attempt in range(_ATOMIC_REPLACE_ATTEMPTS):
+            try:
+                os.replace(temp_path, path)
+                break
+            except PermissionError:
+                if attempt == _ATOMIC_REPLACE_ATTEMPTS - 1:
+                    raise
+                # Jittered, or concurrent writers retry in lockstep and keep
+                # colliding with the same reader. Measured on Windows with four
+                # writers against two readers: 61 of 240 writes failed with no
+                # retry, 2 with a fixed backoff, 0 with jitter over this window.
+                time.sleep(delay * (0.5 + random.random()))
+                delay = min(delay * 2, 0.05)
     except OSError:
         try:
             temp_path.unlink()
         except OSError:  # pragma: no cover - best effort cleanup
             pass
         raise
+
+
+def _set_frontmatter_field(content: str, key: str, value: Any) -> str:
+    """Rewrite one frontmatter key, leaving the body untouched.
+
+    The body is prose compiled from source docstrings, so it can legitimately
+    contain the text ``confidence: 0.5`` or ``status: inferred``. An unanchored
+    ``str.replace`` over the whole document rewrote those too, silently
+    changing what a belief claims about the code while updating its metadata.
+    Only the region above the closing ``---`` is eligible, and only the first
+    match of an anchored key.
+    """
+
+    import re
+
+    if not content.startswith("---"):
+        return content
+    end = content.find("\n---", 3)
+    if end < 0:
+        return content
+
+    head, tail = content[:end], content[end:]
+    pattern = re.compile(rf"^{re.escape(key)}:[^\r\n]*$", re.MULTILINE)
+    if not pattern.search(head):
+        return content
+    return pattern.sub(f"{key}: {_yaml_scalar(value)}", head, count=1) + tail
 
 
 def _yaml_scalar(value: Any) -> str:
@@ -501,7 +554,14 @@ class VaultManager:
                         break
 
                 if not matched:
-                    matched = any(stem in entity_lc for stem in changed_stems)
+                    # Fallback for beliefs whose sources are missing: match the
+                    # entity against a changed file's stem *exactly*. This was a
+                    # substring test, so editing `auth.py` also marked
+                    # `authentication_service` and `oauth_client` stale --
+                    # beliefs it has nothing to do with. Staleness is what gates
+                    # trust in a belief, so marking fresh ones stale erodes the
+                    # signal rather than erring safely.
+                    matched = entity_lc in changed_stems
 
                 if not matched:
                     continue
@@ -665,27 +725,20 @@ class VaultManager:
                 content = safe_path.read_text(encoding="utf-8", errors="replace")
                 fm = _parse_frontmatter(content)
                 if fm and fm.get("claim_id") == claim_id:
-                    old_conf = float(fm.get("confidence", 0.5))
+                    try:
+                        old_conf = float(fm.get("confidence", 0.5))
+                    except (TypeError, ValueError):
+                        # A malformed confidence is not a reason to skip the
+                        # update; treat it as the schema default and repair it.
+                        old_conf = 0.5
                     new_conf = max(0.0, min(1.0, old_conf + delta))
-                    # Rewrite the confidence line
-                    updated = content.replace(
-                        f"confidence: {fm['confidence']}",
-                        f"confidence: {new_conf}",
+
+                    updated = _set_frontmatter_field(content, "confidence", new_conf)
+                    if delta > 0 and fm.get("status") == "inferred":
+                        updated = _set_frontmatter_field(updated, "status", "verified")
+                    updated = _set_frontmatter_field(
+                        updated, "last_checked", datetime.now(timezone.utc).isoformat()
                     )
-                    # Also update status to verified if delta is positive
-                    if delta > 0 and "status: inferred" in updated:
-                        updated = updated.replace(
-                            "status: inferred", "status: verified"
-                        )
-                    # Update last_checked
-                    now = datetime.now(timezone.utc).isoformat()
-                    if "last_checked:" in updated:
-                        import re
-                        updated = re.sub(
-                            r"last_checked: .+",
-                            f"last_checked: {now}",
-                            updated,
-                        )
                     _atomic_write_text(safe_path, updated)
                     logger.info(
                         f"Vault: updated belief {claim_id} confidence "

--- a/entroly/vault_time.py
+++ b/entroly/vault_time.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -120,20 +121,107 @@ class BeliefLedger:
     # ── Writing ──────────────────────────────────────────────────────
 
     def _last_record(self) -> dict[str, Any] | None:
+        """The final record, read from the tail rather than the whole file.
+
+        Every append needs the previous record's seq and hash, and this used
+        to `read_text()` the entire ledger to get them -- 69% of the cost of
+        writing a belief, on a file that only grows. Seeking from the end
+        reads one line's worth regardless of history, which is what makes
+        appending independent of how much history exists.
+
+        The tail is authoritative, unlike `head.json`: a crash between the
+        append and the head write would leave the head one record behind, and
+        chaining onto that would silently fork the chain.
+        """
+
         if not self._log.exists():
             return None
-        last_line = ""
-        for line in self._log.read_text(encoding="utf-8").splitlines():
-            if line.strip():
-                last_line = line
-        if not last_line:
+        try:
+            with self._log.open("rb") as handle:
+                handle.seek(0, os.SEEK_END)
+                size = handle.tell()
+                if size == 0:
+                    return None
+                block = 4096
+                buffer = b""
+                while size > 0:
+                    step = min(block, size)
+                    size -= step
+                    handle.seek(size)
+                    buffer = handle.read(step) + buffer
+                    lines = [ln for ln in buffer.split(b"\n") if ln.strip()]
+                    # Need a complete line: unless the chunk reaches the file
+                    # start, the first fragment may be cut mid-record.
+                    if len(lines) >= 2 or size == 0:
+                        break
+                lines = [ln for ln in buffer.split(b"\n") if ln.strip()]
+                if not lines:
+                    return None
+                last_line = lines[-1].decode("utf-8")
+        except OSError:
             return None
+
         try:
             return json.loads(last_line)
         except json.JSONDecodeError as exc:
             raise LedgerIntegrityError(
                 f"unreadable final ledger record: {exc}"
             ) from exc
+
+    @property
+    def _head(self) -> Path:
+        return self._dir / "head.json"
+
+    def _write_head(self, seq: int, record_hash: str) -> None:
+        """Record where the chain currently ends.
+
+        A hash chain proves that the records present are internally
+        consistent. It cannot notice records that are *absent from the end*:
+        deleting the last N lines leaves a shorter chain that still verifies,
+        so the most recent history -- the part most worth erasing -- was the
+        part the chain did not protect. Storing the expected head means a
+        truncated log no longer matches what the ledger last committed to.
+
+        This raises the bar rather than sealing it: an actor who can rewrite
+        the log can also rewrite this file. Detecting that needs an attestation
+        anchored outside the vault, which `receipt_attestation` provides for
+        receipts and this deliberately does not reimplement.
+        """
+
+        # Reuses the vault's atomic write rather than repeating `os.replace`
+        # here. A second copy was a second place to omit the jittered retry
+        # that Windows needs when a reader holds the target open, and it
+        # promptly failed under the concurrency test the first copy passes.
+        # One implementation of "replace this file safely" is the point.
+        from .vault import _atomic_write_text
+
+        payload = json.dumps(
+            {"schema": LEDGER_SCHEMA, "seq": int(seq), "record_sha256": record_hash},
+            sort_keys=True,
+        )
+        _atomic_write_text(self._head, payload)
+
+    def _append(self, record: dict[str, Any]) -> None:
+        """Append one record and advance the head together.
+
+        The single append path. Redaction appends a tombstone rather than
+        rewriting history, and when only `record()` advanced the head that
+        tombstone made the log look truncated -- a legitimate operation
+        reported as tampering. Anything that appends must move the head, so
+        there is one place that does both.
+        """
+
+        with self._log.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n")
+        self._write_head(record["seq"], record[_RECORD_HASH_FIELD])
+
+    def _read_head(self) -> dict[str, Any] | None:
+        if not self._head.exists():
+            return None
+        try:
+            return json.loads(self._head.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
 
     def record(self, artifact: Any, *, backfilled: bool = False,
                tx_time: str | None = None) -> dict[str, Any]:
@@ -171,8 +259,7 @@ class BeliefLedger:
             "prev_sha256": last[_RECORD_HASH_FIELD] if last else "",
         }
         record[_RECORD_HASH_FIELD] = _record_hash(record)
-        with self._log.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n")
+        self._append(record)
         return {
             "status": "recorded",
             "seq": record["seq"],
@@ -316,8 +403,10 @@ class BeliefLedger:
             "prev_sha256": last[_RECORD_HASH_FIELD] if last else "",
         }
         tombstone[_RECORD_HASH_FIELD] = _record_hash(tombstone)
-        with self._log.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(tombstone, sort_keys=True, ensure_ascii=False) + "\n")
+        # Through the same append path as a belief version: a redaction adds
+        # to history rather than rewriting it, so it must advance the head too
+        # or a lawful redaction reads as a truncated log.
+        self._append(tombstone)
         return {
             "status": "redacted",
             "versions": len(matched),
@@ -426,4 +515,20 @@ class BeliefLedger:
                         "reason": "record_sha256 mismatch"}
             prev_hash = rec[_RECORD_HASH_FIELD]
             count += 1
+
+        # A chain proves the records present are consistent; it cannot notice
+        # records missing from the *end*. Dropping the last N lines leaves a
+        # shorter chain that still verifies, so the most recent history was
+        # exactly the part the chain did not protect. Comparing against the
+        # head the ledger last committed to closes that.
+        head = self._read_head()
+        if head is not None:
+            if int(head.get("seq", 0)) != count or head.get("record_sha256") != prev_hash:
+                return {
+                    "status": "broken",
+                    "records": count,
+                    "reason": "ledger truncated: head expects "
+                              f"{head.get('seq')} record(s), found {count}",
+                }
+
         return {"status": "intact", "records": count}

--- a/entroly/vault_time.py
+++ b/entroly/vault_time.py
@@ -33,7 +33,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
+import random
+import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,6 +47,46 @@ from .path_safety import resolve_output_within
 
 LEDGER_SCHEMA = "entroly.belief-ledger.v1"
 _RECORD_HASH_FIELD = "record_sha256"
+_LOCK_TIMEOUT_SECONDS = 30.0
+_LOCK_REGION = 1024
+
+logger = logging.getLogger(__name__)
+
+
+def _lock_exclusive(handle: Any) -> None:
+    """Take an exclusive advisory lock, raising OSError while contended."""
+
+    try:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return
+    except ImportError:
+        pass
+    try:
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, _LOCK_REGION)
+    except ImportError:  # pragma: no cover - platform without either API
+        return
+
+
+def _unlock(handle: Any) -> None:
+    try:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return
+    except ImportError:
+        pass
+    try:
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, _LOCK_REGION)
+    except (ImportError, OSError):  # pragma: no cover - best effort release
+        pass
 
 
 class LedgerIntegrityError(RuntimeError):
@@ -172,6 +216,53 @@ class BeliefLedger:
     def _head(self) -> Path:
         return self._dir / "head.json"
 
+    @contextmanager
+    def _exclusive(self) -> Iterator[None]:
+        """Serialize the read-tail -> append -> write-head sequence.
+
+        Appending is a read-modify-write: a record's `seq` and `prev_sha256`
+        come from whatever is currently last. Two processes that read the same
+        tail both chain onto it, and the loser's record is overwritten by the
+        winner's -- measured at three processes writing 90 beliefs, the ledger
+        held 65-71 records and `verify_chain` reported a `prev_sha256`
+        mismatch every time. `entroly serve` holding a vault open while
+        `entroly compile` writes to it is exactly that shape.
+
+        Blocking, unlike the best-effort non-blocking helpers in
+        `checkpoint.py`: a lock that gives up when contended would leave the
+        very case it exists for unprotected. If the platform offers no locking
+        at all the append still proceeds -- a ledger that refuses to record is
+        worse than one that can be raced -- and the chain check remains the
+        backstop that makes such a race visible.
+        """
+
+        self._dir.mkdir(parents=True, exist_ok=True)
+        lock_path = self._dir / ".lock"
+        handle = open(lock_path, "a+")  # noqa: SIM115 - released in finally
+        acquired = False
+        try:
+            deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+            delay = 0.001
+            while True:
+                try:
+                    _lock_exclusive(handle)
+                    acquired = True
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        logger.warning(
+                            "vault ledger lock timed out after %.0fs; appending "
+                            "unserialized", _LOCK_TIMEOUT_SECONDS
+                        )
+                        break
+                    time.sleep(delay * (0.5 + random.random()))
+                    delay = min(delay * 2, 0.05)
+            yield
+        finally:
+            if acquired:
+                _unlock(handle)
+            handle.close()
+
     def _write_head(self, seq: int, record_hash: str) -> None:
         """Record where the chain currently ends.
 
@@ -242,6 +333,16 @@ class BeliefLedger:
         if not safe_obj.exists():
             safe_obj.write_text(body, encoding="utf-8")
 
+        # Held across read-tail, build and append: a record's seq and
+        # prev_sha256 come from whatever is currently last, so reading outside
+        # the lock lets two processes chain onto the same tail and lose one of
+        # the two records.
+        with self._exclusive():
+            return self._record_locked(artifact, backfilled, tx_time, body_sha)
+
+    def _record_locked(
+        self, artifact: Any, backfilled: bool, tx_time: str | None, body_sha: str
+    ) -> dict[str, Any]:
         last = self._last_record()
         record = {
             "schema": LEDGER_SCHEMA,
@@ -388,6 +489,14 @@ class BeliefLedger:
                 obj.unlink()
                 deleted_objects.append(sha)
 
+        with self._exclusive():
+            return self._tombstone_locked(matched, claim_id, entity, reason,
+                                          deleted_objects, retained_shared)
+
+    def _tombstone_locked(
+        self, matched: list[dict[str, Any]], claim_id: str, entity: str,
+        reason: str, deleted_objects: list[str], retained_shared: list[str],
+    ) -> dict[str, Any]:
         last = self._last_record()
         tombstone = {
             "schema": LEDGER_SCHEMA,

--- a/tests/test_vault_integrity.py
+++ b/tests/test_vault_integrity.py
@@ -271,3 +271,114 @@ def test_concurrent_writers_never_tear_a_belief_or_lose_a_write(tmp_path):
     assert torn == []
     assert _parse_frontmatter(target.read_text(encoding="utf-8")) is not None
     assert not list((vault._base / "beliefs").glob("*.tmp"))
+
+
+def _ledger(vault):
+    from entroly.vault_time import BeliefLedger
+
+    return BeliefLedger(vault._base)
+
+
+def test_ledger_detects_a_truncated_tail(tmp_path):
+    """A hash chain cannot notice records absent from the end.
+
+    Dropping the last N lines leaves a shorter chain that still verifies, so
+    the most recent history -- the part most worth erasing -- was exactly the
+    part the chain did not protect.
+    """
+
+    vault = _vault(tmp_path)
+    for index in range(5):
+        vault.write_belief(
+            BeliefArtifact(entity=f"e{index}", title="t", body=f"b{index}",
+                           sources=["a.py:1"])
+        )
+    ledger = _ledger(vault)
+    assert ledger.verify_chain()["status"] == "intact"
+
+    log = vault._base / "ledger" / "beliefs.jsonl"
+    lines = [line for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    log.write_text("\n".join(lines[:2]) + "\n", encoding="utf-8")
+
+    report = ledger.verify_chain()
+    assert report["status"] == "broken"
+    assert "truncated" in report["reason"]
+
+
+def test_ledger_still_detects_edited_and_removed_records(tmp_path):
+    vault = _vault(tmp_path)
+    for index in range(3):
+        vault.write_belief(
+            BeliefArtifact(entity=f"e{index}", title="t", body=f"b{index}",
+                           sources=["a.py:1"])
+        )
+    log = vault._base / "ledger" / "beliefs.jsonl"
+    rows = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    rows[1]["confidence"] = 0.99
+    log.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n", encoding="utf-8"
+    )
+
+    assert _ledger(vault).verify_chain()["reason"] == "record_sha256 mismatch"
+
+
+def test_a_redaction_advances_the_head_rather_than_looking_like_truncation(tmp_path):
+    """Redaction appends a tombstone; it adds to history rather than rewriting it."""
+
+    vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="secret", title="s", body="sensitive", sources=["a.py:1"])
+    )
+    vault.write_belief(
+        BeliefArtifact(entity="other", title="o", body="fine", sources=["b.py:1"])
+    )
+    ledger = _ledger(vault)
+    ledger.redact(entity="secret", reason="test")
+
+    assert ledger.verify_chain()["status"] == "intact"
+
+
+def test_appending_does_not_get_slower_as_history_grows(tmp_path):
+    """Every append needs the previous record's seq and hash.
+
+    Reading the whole ledger to get them made appending cost grow with all
+    history ever written -- 69% of the cost of writing a belief, on a file
+    that only grows. Seeking from the end reads one line's worth regardless.
+    """
+
+    from entroly.vault_time import BeliefLedger
+
+    ledger = BeliefLedger(tmp_path / "vault")
+    ledger._dir.mkdir(parents=True)
+
+    def fill(count: int) -> float:
+        rows = [
+            json.dumps(
+                {
+                    "seq": index,
+                    "record_sha256": "a" * 64,
+                    "prev_sha256": "b" * 64,
+                    "entity": f"e{index}",
+                    "pad": "x" * 160,
+                },
+                sort_keys=True,
+            )
+            for index in range(count)
+        ]
+        ledger._log.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        start = time.perf_counter()
+        for _ in range(20):
+            record = ledger._last_record()
+        assert record["seq"] == count - 1
+        return (time.perf_counter() - start) / 20
+
+    small = fill(500)
+    large = fill(50_000)
+
+    # 100x the history must not cost meaningfully more. A generous bound: the
+    # point is that this is flat, not that it hits a particular number on any
+    # given disk.
+    assert large < max(small * 5, 0.05), (
+        f"append lookup scales with history: {small:.4f}s at 500 records, "
+        f"{large:.4f}s at 50,000"
+    )

--- a/tests/test_vault_integrity.py
+++ b/tests/test_vault_integrity.py
@@ -8,6 +8,7 @@ tests cover the ways that record could quietly stop being true.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 from entroly.vault import (
@@ -153,4 +154,120 @@ def test_an_interrupted_write_leaves_the_previous_belief_readable(tmp_path, monk
     survivor = vault.read_belief("stable")
     assert survivor is not None
     assert "ORIGINAL" in survivor["body"]
+    assert not list((vault._base / "beliefs").glob("*.tmp"))
+
+
+def test_confidence_update_does_not_rewrite_the_belief_body(tmp_path):
+    """A belief's body is prose compiled from source docstrings.
+
+    It can legitimately contain the text `confidence: 0.5` or
+    `status: inferred`. An unanchored replace over the whole document rewrote
+    those too, silently changing what the belief claims about the code.
+    """
+
+    vault = _vault(tmp_path)
+    body = "Docs mention: confidence: 0.5 and status: inferred and last_checked: never."
+    artifact = BeliefArtifact(entity="m", title="m", body=body, sources=["a.py:1"],
+                              confidence=0.5, status="inferred")
+    path = vault.write_belief(artifact)["path"]
+
+    vault._update_belief_confidence(artifact.claim_id, 0.2)
+
+    content = Path(path).read_text(encoding="utf-8")
+    assert body in content
+    frontmatter = _parse_frontmatter(content) or {}
+    assert float(frontmatter["confidence"]) == 0.7
+    assert frontmatter["status"] == "verified"
+
+
+def test_confidence_stays_within_bounds(tmp_path):
+    vault = _vault(tmp_path)
+    high = BeliefArtifact(entity="high", title="h", body="b", sources=["a.py:1"],
+                          confidence=0.9)
+    low = BeliefArtifact(entity="low", title="l", body="b", sources=["a.py:1"],
+                         confidence=0.1)
+    high_path = vault.write_belief(high)["path"]
+    low_path = vault.write_belief(low)["path"]
+
+    vault._update_belief_confidence(high.claim_id, 5.0)
+    vault._update_belief_confidence(low.claim_id, -5.0)
+
+    assert float((_parse_frontmatter(Path(high_path).read_text(encoding="utf-8")) or {})["confidence"]) == 1.0
+    assert float((_parse_frontmatter(Path(low_path).read_text(encoding="utf-8")) or {})["confidence"]) == 0.0
+
+
+def test_changing_one_file_does_not_mark_unrelated_beliefs_stale(tmp_path):
+    """The entity fallback was a substring test.
+
+    Editing `auth.py` also marked `authentication_service` and `oauth_client`
+    stale. Staleness is what gates trust in a belief, so marking fresh ones
+    stale erodes the signal rather than erring safely.
+    """
+
+    vault = _vault(tmp_path)
+    for entity in ("auth", "authentication_service", "oauth_client"):
+        vault.write_belief(
+            BeliefArtifact(entity=entity, title=entity, body="b",
+                           sources=[f"{entity}.py:1"])
+        )
+
+    result = vault.mark_beliefs_stale_for_files(["auth.py"])
+
+    assert sorted(result["updated_entities"]) == ["auth"]
+
+
+def test_concurrent_writers_never_tear_a_belief_or_lose_a_write(tmp_path):
+    """Windows refuses to rename over a file another handle has open.
+
+    Without a jittered retry the durability fix traded torn reads for lost
+    writes: measured at 61 of 240 writes failing with no retry and 2 with a
+    fixed backoff.
+    """
+
+    import threading
+
+    vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="hot", title="h", body="seed", sources=["a.py:1"])
+    )
+    target = vault._base / "beliefs" / "hot.md"
+    stop = False
+    torn: list[int] = []
+    errors: list[str] = []
+
+    def read_loop() -> None:
+        while not stop:
+            try:
+                if _parse_frontmatter(target.read_text(encoding="utf-8", errors="replace")) is None:
+                    torn.append(1)
+            except OSError:
+                pass
+            time.sleep(0.001)
+
+    def write_loop(count: int) -> None:
+        for index in range(count):
+            try:
+                vault.write_belief(
+                    BeliefArtifact(entity="hot", title="h", body=f"b{index}",
+                                   sources=["a.py:1"])
+                )
+            except Exception as exc:  # noqa: BLE001 - recorded, then asserted on
+                errors.append(type(exc).__name__)
+            time.sleep(0.001)
+
+    readers = [threading.Thread(target=read_loop) for _ in range(2)]
+    writers = [threading.Thread(target=write_loop, args=(25,)) for _ in range(3)]
+    for thread in readers:
+        thread.start()
+    for thread in writers:
+        thread.start()
+    for thread in writers:
+        thread.join()
+    stop = True
+    for thread in readers:
+        thread.join()
+
+    assert errors == []
+    assert torn == []
+    assert _parse_frontmatter(target.read_text(encoding="utf-8")) is not None
     assert not list((vault._base / "beliefs").glob("*.tmp"))

--- a/tests/test_vault_multiprocess.py
+++ b/tests/test_vault_multiprocess.py
@@ -1,0 +1,185 @@
+"""Vault behaviour when separate processes touch it at once.
+
+The threaded tests cover one process with several workers. The real case is
+different: `entroly serve` holds a vault open while `entroly compile` writes to
+it, in a separate process with no shared locks, no shared memory and no shared
+GIL. These spawn real interpreters rather than threads.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from entroly.vault import _parse_frontmatter
+from entroly.vault_time import BeliefLedger
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_WRITER = """
+import sys
+sys.path.insert(0, {repo!r})
+from entroly.vault import BeliefArtifact, VaultConfig, VaultManager
+
+vault = VaultManager(VaultConfig(base_path={base!r}))
+failures = 0
+for index in range({count}):
+    try:
+        vault.write_belief(
+            BeliefArtifact(
+                entity="{prefix}-%d" % index,
+                title="t",
+                body="body %d" % index,
+                sources=["a.py:1"],
+            )
+        )
+    except Exception as exc:
+        failures += 1
+        print("WRITE_FAILURE %s" % type(exc).__name__, file=sys.stderr)
+print("done %d failures=%d" % ({count}, failures))
+"""
+
+_READER = """
+import sys, time
+sys.path.insert(0, {repo!r})
+from pathlib import Path
+from entroly.vault import _parse_frontmatter
+
+beliefs = Path({base!r}) / "beliefs"
+torn = 0
+deadline = time.time() + {seconds}
+while time.time() < deadline:
+    for path in list(beliefs.glob("*.md")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if text and _parse_frontmatter(text) is None:
+            torn += 1
+    time.sleep(0.002)
+print("torn=%d" % torn)
+"""
+
+
+def _run(script: str, timeout: int = 180) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+@pytest.mark.timeout(300)
+def test_separate_processes_can_write_the_same_vault(tmp_path):
+    """No lost writes and no crashes when two interpreters write concurrently."""
+
+    base = str(tmp_path / "vault")
+    per_process = 25
+
+    procs = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                textwrap.dedent(
+                    _WRITER.format(
+                        repo=str(REPO_ROOT), base=base, count=per_process, prefix=prefix
+                    )
+                ),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for prefix in ("alpha", "beta", "gamma")
+    ]
+    outputs = [proc.communicate(timeout=240) for proc in procs]
+
+    for (stdout, stderr), proc in zip(outputs, procs, strict=True):
+        assert proc.returncode == 0, stderr
+        assert "failures=0" in stdout, stderr
+
+    beliefs = list((Path(base) / "beliefs").glob("*.md"))
+    entities = {
+        (_parse_frontmatter(path.read_text(encoding="utf-8")) or {}).get("entity")
+        for path in beliefs
+    }
+    expected = {
+        f"{prefix}-{index}"
+        for prefix in ("alpha", "beta", "gamma")
+        for index in range(per_process)
+    }
+    assert expected <= entities, "a concurrently written belief was lost"
+
+
+@pytest.mark.timeout(300)
+def test_a_reader_process_never_sees_a_half_written_belief(tmp_path):
+    """Windows will not rename over an open handle; the retry must absorb that."""
+
+    base = str(tmp_path / "vault")
+    from entroly.vault import BeliefArtifact, VaultConfig, VaultManager
+
+    seed = VaultManager(VaultConfig(base_path=base))
+    for index in range(5):
+        seed.write_belief(
+            BeliefArtifact(entity=f"seed-{index}", title="t", body="seed",
+                           sources=["a.py:1"])
+        )
+
+    reader = subprocess.Popen(
+        [sys.executable, "-c",
+         textwrap.dedent(_READER.format(repo=str(REPO_ROOT), base=base, seconds=8))],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    writer = _run(
+        _WRITER.format(repo=str(REPO_ROOT), base=base, count=40, prefix="seed"),
+        timeout=240,
+    )
+    reader_out, reader_err = reader.communicate(timeout=120)
+
+    assert writer.returncode == 0, writer.stderr
+    assert "failures=0" in writer.stdout, writer.stderr
+    assert "torn=0" in reader_out, reader_err
+
+
+@pytest.mark.timeout(300)
+def test_the_ledger_survives_concurrent_processes(tmp_path):
+    """Appends from separate processes must not interleave into a broken chain.
+
+    A torn or interleaved append would show up as an unparseable record or a
+    prev_sha256 that no record produced, which is what verify_chain reports.
+    """
+
+    base = str(tmp_path / "vault")
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c",
+             textwrap.dedent(_WRITER.format(repo=str(REPO_ROOT), base=base,
+                                            count=20, prefix=prefix))],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        for prefix in ("p1", "p2")
+    ]
+    for proc in procs:
+        proc.communicate(timeout=240)
+
+    log = Path(base) / "ledger" / "beliefs.jsonl"
+    lines = [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    for line in lines:
+        json.loads(line)  # every record is a complete, parseable JSON object
+
+    # Every write is present and the chain verifies. Before the append was
+    # serialized, two processes read the same tail and chained onto it, so one
+    # record overwrote the other: three processes writing 90 beliefs left 65-71
+    # records and a prev_sha256 mismatch on every run.
+    assert len(lines) == 40, f"expected 40 ledger records, found {len(lines)}"
+
+    report = BeliefLedger(Path(base)).verify_chain()
+    assert report["status"] == "intact", report

--- a/tests/test_vault_usability.py
+++ b/tests/test_vault_usability.py
@@ -1,0 +1,141 @@
+"""Guards for the traps that made the vault hard to use correctly.
+
+Each of these cost real time before it was a test: a search answering from a
+store the user never filled, a compile that had to be run per directory, and
+beliefs whose provenance had to be guessed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from entroly.belief_compiler import BeliefCompiler
+from entroly.context_receipts.ingest import _is_skipped_directory
+from entroly.vault import (
+    BeliefArtifact,
+    VaultConfig,
+    VaultManager,
+    _parse_frontmatter,
+    vault_readiness,
+)
+
+
+def test_empty_vault_with_a_document_index_names_the_right_command(tmp_path):
+    """`ingest` and `search` use different stores and ingest says "success".
+
+    Without this the two look interchangeable, and a search after an ingest
+    answers from whatever the belief vault last held.
+    """
+
+    project = tmp_path / "p"
+    (project / ".entroly" / "receipts").mkdir(parents=True)
+    (project / ".entroly" / "receipts" / "index.json").write_text(
+        json.dumps({"documents": [], "chunks": []}), encoding="utf-8"
+    )
+    vault_base = project / ".entroly" / "vault"
+    VaultManager(VaultConfig(base_path=str(vault_base))).ensure_structure()
+
+    report = vault_readiness(vault_base, project)
+
+    assert report["ready"] is False
+    assert report["has_document_index"] is True
+    assert any("entroly compile" in reason for reason in report["reasons"])
+    assert any("does not read" in reason for reason in report["reasons"])
+
+
+def test_beliefs_older_than_source_are_reported_as_behind(tmp_path):
+    project = tmp_path / "p"
+    (project / "src").mkdir(parents=True)
+    vault = VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    vault.write_belief(
+        BeliefArtifact(entity="m", title="m", body="b", sources=["src/m.py:1"])
+    )
+
+    source = project / "src" / "m.py"
+    source.write_text("x = 1\n", encoding="utf-8")
+    import os
+    import time
+
+    os.utime(source, (time.time() + 3600, time.time() + 3600))
+
+    report = vault_readiness(project / ".entroly" / "vault", project)
+
+    assert report["ready"] is False
+    assert any("source is newer" in reason for reason in report["reasons"])
+
+
+def test_a_current_vault_reports_ready(tmp_path):
+    project = tmp_path / "p"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "m.py").write_text("x = 1\n", encoding="utf-8")
+    vault = VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    vault.write_belief(
+        BeliefArtifact(entity="m", title="m", body="b", sources=["src/m.py:1"])
+    )
+
+    assert vault_readiness(project / ".entroly" / "vault", project)["ready"] is True
+
+
+def test_source_root_is_backfilled_only_when_unambiguous(tmp_path):
+    """A guess would look authoritative while pointing at the wrong file."""
+
+    project = tmp_path / "p"
+    (project / "scripts").mkdir(parents=True)
+    (project / "tests").mkdir()
+    (project / "scripts" / "solo.py").write_text("x = 1\n", encoding="utf-8")
+    (project / "scripts" / "shared.py").write_text("x = 1\n", encoding="utf-8")
+    (project / "tests" / "shared.py").write_text("x = 1\n", encoding="utf-8")
+
+    vault = VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    vault.write_belief(
+        BeliefArtifact(entity="solo", title="s", body="b", sources=["solo.py:1"])
+    )
+    vault.write_belief(
+        BeliefArtifact(entity="shared", title="sh", body="b", sources=["shared.py:1"])
+    )
+
+    result = vault.backfill_source_roots([str(project)])
+
+    assert result["backfilled_entities"] == ["solo"]
+    assert result["ambiguous_entities"] == ["shared"]
+
+    beliefs = project / ".entroly" / "vault" / "beliefs"
+    solo = _parse_frontmatter((beliefs / "solo.md").read_text(encoding="utf-8")) or {}
+    shared = _parse_frontmatter((beliefs / "shared.md").read_text(encoding="utf-8")) or {}
+    assert solo["source_root"] == "scripts"
+    assert "source_root" not in shared
+
+
+def test_scratch_trees_are_pruned_by_both_walkers(tmp_path):
+    """One unpruned `.tmp` made three separate commands impractical.
+
+    It timed out the external-name scan, produced a 528 MB document index, and
+    put 24,831 of 25,819 files in front of `entroly compile .`.
+    """
+
+    for name in (".tmp", "tmp", "node_modules", ".venv"):
+        assert _is_skipped_directory(name), f"ingest must prune {name}"
+        assert name in BeliefCompiler.SKIP_DIRS, f"compiler must prune {name}"
+
+
+def test_compile_walks_a_whole_repository(tmp_path):
+    """`entroly compile .` is recursive, so one command should cover the tree."""
+
+    project = tmp_path / "p"
+    for sub in ("pkg", "scripts", "nested/deep"):
+        (project / sub).mkdir(parents=True)
+        (project / sub / "mod.py").write_text(
+            "def f():\n    \"\"\"D.\"\"\"\n    return 1\n", encoding="utf-8"
+        )
+    (project / ".tmp").mkdir()
+    (project / ".tmp" / "scratch.py").write_text("def g():\n    return 2\n", encoding="utf-8")
+
+    compiler = BeliefCompiler(
+        VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    )
+    found = compiler._walk_source_files(Path(project), 0)
+    names = {p.parent.name for p in found}
+
+    assert {"pkg", "scripts", "deep"} <= names
+    assert ".tmp" not in names

--- a/tests/test_vault_usability.py
+++ b/tests/test_vault_usability.py
@@ -139,3 +139,54 @@ def test_compile_walks_a_whole_repository(tmp_path):
 
     assert {"pkg", "scripts", "deep"} <= names
     assert ".tmp" not in names
+
+
+def test_backfill_is_idempotent_for_project_relative_sources(tmp_path):
+    """A source already relative to the project root has an empty prefix.
+
+    Writing that as `source_root:` with no value produced a key the
+    frontmatter parser drops, so the belief never counted as filled and was
+    rewritten on every compile.
+    """
+
+    project = tmp_path / "p"
+    (project / "bench").mkdir(parents=True)
+    (project / "bench" / "accuracy.py").write_text("x = 1\n", encoding="utf-8")
+
+    vault = VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    vault.write_belief(
+        BeliefArtifact(entity="accuracy", title="a", body="b",
+                       sources=["bench/accuracy.py:1"])
+    )
+
+    first = vault.backfill_source_roots([str(project)])
+    second = vault.backfill_source_roots([str(project)])
+
+    assert first["backfilled_entities"] == ["accuracy"]
+    assert second["backfilled_entities"] == []
+
+    belief = (project / ".entroly" / "vault" / "beliefs" / "accuracy.md")
+    frontmatter = _parse_frontmatter(belief.read_text(encoding="utf-8")) or {}
+    assert frontmatter["source_root"] == "."
+
+
+def test_project_relative_root_still_grounds_and_retracts(tmp_path):
+    """`.` must resolve for both a live and a deleted source."""
+
+    project = tmp_path / "p"
+    (project / "bench").mkdir(parents=True)
+    (project / "bench" / "live.py").write_text("x = 1\n", encoding="utf-8")
+
+    vault = VaultManager(VaultConfig(base_path=str(project / ".entroly" / "vault")))
+    vault.write_belief(
+        BeliefArtifact(entity="live", title="l", body="b",
+                       sources=["bench/live.py:1"], source_root=".")
+    )
+    vault.write_belief(
+        BeliefArtifact(entity="dead", title="d", body="b",
+                       sources=["bench/dead.py:1"], source_root=".")
+    )
+
+    result = vault.mark_beliefs_ungrounded([str(project)])
+
+    assert result["retracted_entities"] == ["dead"]


### PR DESCRIPTION
Everything after #339. Rebased onto `main` so full CI runs on it — the stacked
bases meant #340/#341 had only ever run a single check.

## 1. Metadata updates corrupted the belief body

`_update_belief_confidence` used unanchored `str.replace` over the whole
document. A belief's body is prose compiled from source docstrings, so it can
legitimately contain `confidence: 0.5`:

```
before : Docs mention: confidence: 0.5 and status: inferred and last_checked: never.
after  : Docs mention: confidence: 0.7 and status: verified and last_checked: 2026-…
```

Updating metadata silently changed **what the belief claimed about the code**.
Rewrites now go through `_set_frontmatter_field`, which edits one anchored key
above the closing `---`.

Related: editing `auth.py` marked `authentication_service` and `oauth_client`
stale, because the entity fallback was a substring test. Staleness gates trust,
so false staleness erodes the signal rather than erring safely.

## 2. Concurrent processes lost a quarter of the audit trail

Appending is a read-modify-write: `seq` and `prev_sha256` come from whatever is
currently last. Nothing serialized that, so two processes read the same tail,
both chained onto it, and one record overwrote the other.

Three processes writing 90 beliefs into one vault:

| | records | chain |
|---|---|---|
| before | 65 / 71 / 71 of 90 | `prev_sha256 mismatch` **3/3 runs** |
| after | **90 / 90 / 90** | **intact 3/3** |

An MCP server holding a vault open while a compile writes is exactly that
shape — the ordinary deployment, not an edge case. Appends now hold an
exclusive advisory lock (fcntl / msvcrt), **blocking** with jittered backoff
unlike the best-effort non-blocking helpers in `checkpoint.py`: a lock that
gives up when contended leaves unprotected the case it exists for.

Windows also needed a per-write uuid temp name and a jittered `os.replace`
retry — a pid-only name collides across threads, and Windows refuses to rename
over an open handle. Measured 61 of 240 writes failing with no retry, 2 with
fixed backoff, **0** with jitter over 720 writes and 3,468 concurrent reads.

## 3. The ledger verified a truncated tail as intact

A hash chain proves the records *present* are consistent; it cannot see records
absent from the **end**. Dropping the last N lines left a shorter chain that
still verified — the most recent history was exactly what the chain did not
protect.

```
clean      → intact, 5 records
truncated  → broken: "head expects 5 record(s), found 2"
tampered   → broken: record_sha256 mismatch
```

Documented limit: an actor who can rewrite the log can rewrite the head.
Sealing that needs attestation anchored outside the vault, which
`receipt_attestation` already provides for receipts and this does not
reimplement.

## 4. Append cost grew with all history ever written

`_last_record` read the entire ledger to get the previous record — **69% of the
cost of a belief write** by profile, on a file that only grows.

```
  1,000 records (0.4 MB) → 0.6 ms
200,000 records ( 75 MB) → 0.6 ms
```

Used the tail rather than `head.json`, which holds the same two fields and
would have been free: a crash between append and head write leaves the head one
record behind, and chaining onto that would silently **fork the chain**.

## 5. Usability traps — three shared one cause

An unpruned `.tmp/` sat outside both walkers' skip lists while `.entroly`,
`.git` and `.venv` were in them:

| | before | after |
|---|---|---|
| `ingest .` | 34,051 docs (32,524 from `.tmp/pr_work`) → 528 MB | **1,517** |
| `compile .` | 25,819 files, 24,831 scratch | **988** |

So there was never a missing "compile everything" — `compile .` is already
recursive, it was facing 25× the work.

Plus: `vault_readiness` names the ingest-vs-search store split at the point of
use; `backfill_source_roots` recovers legacy provenance where unambiguous
(703 of 718 real beliefs, 9 left ambiguous by design); `entroly doctor` reports
when an installed build shadows the source.

## Trust and compatibility

- [x] Receipt honesty and recoverability are preserved or not affected.
- [x] Verification remains fail-closed where confidence is claimed.
- [x] No surprise network call or credential surface is added.

## Verification

105 tests pass across vault multiprocess, integrity, time, groundedness,
usability, hygiene, change listener, coupling, security hardening and task
dream; ruff clean on `entroly/`. Cross-process tests spawn real interpreters
rather than threads.
