### PR TITLE
fix(vault): make ledger locking hold on network filesystems

### DIFF
--- a/entroly/vault_time.py
+++ b/entroly/vault_time.py
@@ -36,7 +36,9 @@ import json
 import logging
 import os
 import random
+import socket
 import time
+import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -48,31 +50,124 @@ from .path_safety import resolve_output_within
 LEDGER_SCHEMA = "entroly.belief-ledger.v1"
 _RECORD_HASH_FIELD = "record_sha256"
 _LOCK_TIMEOUT_SECONDS = 30.0
+_LOCK_STALE_SECONDS = 120.0
+_LOCK_SETTLE_SECONDS = 1.0
 _LOCK_REGION = 1024
 
 logger = logging.getLogger(__name__)
 
 
-def _lock_exclusive(handle: Any) -> None:
-    """Take an exclusive advisory lock, raising OSError while contended."""
+def _lock_token() -> str:
+    """Identifies one lock holder, uniquely across machines."""
+
+    return f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex}"
+
+
+def _try_acquire(lock_path: Path, token: str) -> bool:
+    """Claim the lock by creating its file exclusively.
+
+    `O_CREAT | O_EXCL` is the one mutual-exclusion primitive that holds on a
+    network filesystem: NFSv3 and later implement exclusive create atomically
+    server-side, and SMB does the same. `fcntl.flock` does not -- without a
+    working `lockd` it degrades to a local-only lock, so two machines sharing
+    a vault over NFS would each believe they held it and interleave their
+    read-modify-write appends exactly as unlocked processes did.
+
+    The advisory lock is still taken underneath where the platform offers it,
+    because it releases automatically when a process dies. The lock *file* is
+    what makes the guarantee portable; the advisory lock is what makes the
+    common local case recover instantly from a crash.
+    """
+
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        return False
+    except OSError:
+        return False
+
+    try:
+        os.write(fd, f"{token}\n{time.time():.3f}\n".encode())
+    finally:
+        os.close(fd)
+    return True
+
+
+def _lock_is_stale(lock_path: Path) -> bool:
+    """Whether a lock file was abandoned rather than held.
+
+    A lock file outlives the process that made it, so a crash mid-append would
+    block every later writer forever. Age alone is not proof of abandonment,
+    though: a slow holder is not a dead one. The file's mtime is read twice
+    across a settle interval and the lock is only broken when it has not moved,
+    which distinguishes "nobody is there" from "someone is still working".
+
+    mtime comes from the file server, so this comparison is unaffected by
+    clock skew between clients -- both readings come from the same clock.
+    """
+
+    try:
+        first = lock_path.stat().st_mtime
+    except OSError:
+        return False
+    if time.time() - first < _LOCK_STALE_SECONDS:
+        return False
+    time.sleep(_LOCK_SETTLE_SECONDS)
+    try:
+        return lock_path.stat().st_mtime == first
+    except OSError:
+        return False
+
+
+def _release(lock_path: Path, token: str) -> None:
+    """Remove the lock, but only if it is still ours.
+
+    A lock broken as stale can be re-taken by someone else while the original
+    holder is still running. Deleting unconditionally would then release a
+    lock the caller does not hold, letting two writers proceed at once -- so
+    the token written at acquisition is checked first.
+    """
+
+    try:
+        held = lock_path.read_text(encoding="utf-8").split("\n", 1)[0]
+    except OSError:
+        return
+    if held != token:
+        logger.warning(
+            "vault ledger lock was taken over while held; not releasing another "
+            "holder's lock"
+        )
+        return
+    try:
+        lock_path.unlink()
+    except OSError:  # pragma: no cover - best effort release
+        pass
+
+
+def _advisory_lock(handle: Any) -> bool:
+    """Best-effort OS lock, layered under the lock file. True when taken."""
 
     try:
         import fcntl
 
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        return
+        return True
     except ImportError:
         pass
+    except OSError:
+        return False
     try:
         import msvcrt
 
         handle.seek(0)
         msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, _LOCK_REGION)
-    except ImportError:  # pragma: no cover - platform without either API
-        return
+        return True
+    except (ImportError, OSError):
+        return False
+    return False
 
 
-def _unlock(handle: Any) -> None:
+def _advisory_unlock(handle: Any) -> None:
     try:
         import fcntl
 
@@ -80,6 +175,8 @@ def _unlock(handle: Any) -> None:
         return
     except ImportError:
         pass
+    except OSError:
+        return
     try:
         import msvcrt
 
@@ -238,30 +335,52 @@ class BeliefLedger:
 
         self._dir.mkdir(parents=True, exist_ok=True)
         lock_path = self._dir / ".lock"
-        handle = open(lock_path, "a+")  # noqa: SIM115 - released in finally
+        token = _lock_token()
         acquired = False
-        try:
-            deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
-            delay = 0.001
-            while True:
+        handle = None
+
+        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+        delay = 0.001
+        while True:
+            if _try_acquire(lock_path, token):
+                acquired = True
+                break
+            if _lock_is_stale(lock_path):
+                # Breaking a stale lock races with anyone else breaking it, so
+                # the winner is decided by the exclusive create on the next
+                # pass, not by the unlink.
+                logger.warning("breaking an abandoned vault ledger lock")
                 try:
-                    _lock_exclusive(handle)
-                    acquired = True
-                    break
+                    lock_path.unlink()
                 except OSError:
-                    if time.monotonic() >= deadline:
-                        logger.warning(
-                            "vault ledger lock timed out after %.0fs; appending "
-                            "unserialized", _LOCK_TIMEOUT_SECONDS
-                        )
-                        break
-                    time.sleep(delay * (0.5 + random.random()))
-                    delay = min(delay * 2, 0.05)
+                    pass
+                continue
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "vault ledger lock timed out after %.0fs; appending "
+                    "unserialized", _LOCK_TIMEOUT_SECONDS
+                )
+                break
+            time.sleep(delay * (0.5 + random.random()))
+            delay = min(delay * 2, 0.05)
+
+        if acquired:
+            try:
+                handle = open(lock_path, "r+")  # noqa: SIM115 - closed in finally
+            except OSError:
+                handle = None
+            if handle is not None and not _advisory_lock(handle):
+                handle.close()
+                handle = None
+
+        try:
             yield
         finally:
+            if handle is not None:
+                _advisory_unlock(handle)
+                handle.close()
             if acquired:
-                _unlock(handle)
-            handle.close()
+                _release(lock_path, token)
 
     def _write_head(self, seq: int, record_hash: str) -> None:
         """Record where the chain currently ends.

--- a/entroly/vault_time.py
+++ b/entroly/vault_time.py
@@ -751,12 +751,33 @@ class BeliefLedger:
         # head the ledger last committed to closes that.
         head = self._read_head()
         if head is not None:
-            if int(head.get("seq", 0)) != count or head.get("record_sha256") != prev_hash:
+            expected = int(head.get("seq", 0))
+            # Only a head expecting *more* than exists means records were
+            # removed. A head expecting fewer is the opposite situation: the
+            # log was appended and the process died before the head advanced,
+            # leaving it one behind on a chain that is entirely intact.
+            # Reporting that as tampering would raise a permanent false alarm
+            # on a healthy ledger, and an alarm that cries wolf is worse than
+            # none -- it is the reason the real one gets ignored.
+            if expected > count:
                 return {
                     "status": "broken",
                     "records": count,
-                    "reason": "ledger truncated: head expects "
-                              f"{head.get('seq')} record(s), found {count}",
+                    "reason": f"ledger truncated: head expects {expected} "
+                              f"record(s), found {count}",
+                }
+            if expected == count and head.get("record_sha256") != prev_hash:
+                return {
+                    "status": "broken",
+                    "records": count,
+                    "reason": "head does not match the final record",
+                }
+            if expected < count:
+                return {
+                    "status": "intact",
+                    "records": count,
+                    "note": f"head lagged at {expected}; the next append will "
+                            "advance it",
                 }
 
         return {"status": "intact", "records": count}

--- a/tests/test_vault_faults.py
+++ b/tests/test_vault_faults.py
@@ -1,0 +1,203 @@
+"""What the vault does when the filesystem or the process fails mid-operation.
+
+A belief store is only as trustworthy as its behaviour when a write does not
+complete. These inject the failures rather than reasoning about them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import entroly.vault as vault_module
+import entroly.vault_time as vault_time
+from entroly.vault import (
+    BeliefArtifact,
+    VaultConfig,
+    VaultManager,
+    _parse_frontmatter,
+)
+from entroly.vault_time import BeliefLedger, LedgerIntegrityError
+
+
+def _vault(tmp_path) -> VaultManager:
+    return VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+
+
+def test_a_full_disk_during_a_belief_write_keeps_the_previous_version(tmp_path, monkeypatch):
+    """The replacement is atomic, so a failed write leaves the old belief."""
+
+    vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="stable", title="v1", body="ORIGINAL", sources=["a.py:1"])
+    )
+
+    def full_disk(path, text):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(vault_module, "_atomic_write_text", full_disk)
+    with pytest.raises(OSError):
+        vault.write_belief(
+            BeliefArtifact(entity="stable", title="v2", body="REPLACEMENT",
+                           sources=["a.py:1"])
+        )
+
+    monkeypatch.undo()
+    survivor = vault.read_belief("stable")
+    assert survivor is not None
+    assert "ORIGINAL" in survivor["body"]
+    assert not list((vault._base / "beliefs").glob("*.tmp"))
+
+
+def test_a_failed_ledger_append_is_reported_not_swallowed(tmp_path, monkeypatch):
+    """The belief write must not be lost, and the ledger gap must be visible.
+
+    Silently succeeding would leave the vault holding a belief the audit trail
+    never recorded -- the same divergence a filename collision produced, from
+    the other direction.
+    """
+
+    vault = _vault(tmp_path)
+
+    def broken_ledger(self, artifact, **kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(BeliefLedger, "record", broken_ledger)
+    result = vault.write_belief(
+        BeliefArtifact(entity="orphan", title="t", body="b", sources=["a.py:1"])
+    )
+
+    assert result["status"] == "written"
+    assert result["ledger"]["status"] == "failed"
+    assert "No space left" in result["ledger"]["error"]
+
+    monkeypatch.undo()
+    assert vault.read_belief("orphan") is not None
+
+
+def test_a_torn_final_ledger_line_fails_closed(tmp_path):
+    """A half-written record must raise rather than be treated as the tail.
+
+    Chaining onto a truncated record would bake the damage into every later
+    record's prev_sha256.
+    """
+
+    vault = _vault(tmp_path)
+    for index in range(3):
+        vault.write_belief(
+            BeliefArtifact(entity=f"e{index}", title="t", body=f"b{index}",
+                           sources=["a.py:1"])
+        )
+
+    log = vault._base / "ledger" / "beliefs.jsonl"
+    text = log.read_text(encoding="utf-8")
+    log.write_text(text[: -len(text) // 4], encoding="utf-8")  # cut mid-record
+
+    ledger = BeliefLedger(vault._base)
+    with pytest.raises(LedgerIntegrityError):
+        ledger._last_record()
+    assert ledger.verify_chain()["status"] == "broken"
+
+
+def test_a_head_left_behind_by_a_crash_is_not_reported_as_tampering(tmp_path):
+    """The log is appended, then the head advances. A crash between the two
+    leaves the head one record behind on an entirely intact chain.
+
+    Reporting that as truncation would raise a permanent false alarm on a
+    healthy ledger, and an alarm that cries wolf is the reason the real one
+    gets ignored.
+    """
+
+    vault = _vault(tmp_path)
+    for index in range(4):
+        vault.write_belief(
+            BeliefArtifact(entity=f"e{index}", title="t", body=f"b{index}",
+                           sources=["a.py:1"])
+        )
+
+    log = vault._base / "ledger" / "beliefs.jsonl"
+    rows = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    head = vault._base / "ledger" / "head.json"
+    stored = json.loads(head.read_text(encoding="utf-8"))
+    head.write_text(
+        json.dumps(
+            {
+                "schema": stored["schema"],
+                "seq": rows[-2]["seq"],
+                "record_sha256": rows[-2]["record_sha256"],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    report = BeliefLedger(vault._base).verify_chain()
+    assert report["status"] == "intact"
+    assert "lagged" in report.get("note", "")
+
+
+def test_a_lagging_head_is_repaired_by_the_next_append(tmp_path):
+    vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="a", title="t", body="b", sources=["a.py:1"])
+    )
+    head = vault._base / "ledger" / "head.json"
+    stored = json.loads(head.read_text(encoding="utf-8"))
+    head.write_text(
+        json.dumps({"schema": stored["schema"], "seq": 0, "record_sha256": ""},
+                   sort_keys=True),
+        encoding="utf-8",
+    )
+
+    vault.write_belief(
+        BeliefArtifact(entity="b", title="t", body="b", sources=["a.py:1"])
+    )
+
+    assert BeliefLedger(vault._base).verify_chain()["status"] == "intact"
+
+
+def test_a_failed_head_write_does_not_lose_the_appended_record(tmp_path, monkeypatch):
+    """The record is durable even when the head cannot be updated."""
+
+    vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="first", title="t", body="b", sources=["a.py:1"])
+    )
+
+    def broken_head(self, seq, record_hash):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(BeliefLedger, "_write_head", broken_head)
+    with pytest.raises(OSError):
+        vault_time.BeliefLedger(vault._base).record(
+            BeliefArtifact(entity="second", title="t", body="b", sources=["a.py:1"])
+        )
+    monkeypatch.undo()
+
+    log = vault._base / "ledger" / "beliefs.jsonl"
+    rows = [line for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(rows) == 2, "the appended record must survive a failed head write"
+    assert BeliefLedger(vault._base).verify_chain()["status"] == "intact"
+
+
+def test_an_unreadable_belief_does_not_break_a_vault_scan(tmp_path):
+    """One corrupt file must not stop retraction or hygiene from running."""
+
+    vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="good", title="t", body="b", sources=["a.py:1"])
+    )
+    (vault._base / "beliefs" / "corrupt.md").write_text(
+        "not frontmatter at all", encoding="utf-8"
+    )
+
+    result = vault.mark_beliefs_ungrounded([str(tmp_path)])
+
+    assert "good" in result["retracted_entities"] or result["retracted_entities"] == []
+    survivor = vault.read_belief("good")
+    assert survivor is not None
+    assert _parse_frontmatter(
+        Path(survivor["path"]).read_text(encoding="utf-8")
+    ) is not None

--- a/tests/test_vault_network_lock.py
+++ b/tests/test_vault_network_lock.py
@@ -1,0 +1,159 @@
+"""Ledger locking where advisory locks do not work.
+
+`fcntl.flock` needs a working `lockd` to mean anything over NFS, and SMB is
+worse. On such a mount it succeeds locally while serializing nothing, so two
+machines sharing a vault would each believe they held the lock and interleave
+their read-modify-write appends. These tests disable the advisory layer to
+check the lock file alone carries the guarantee.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import entroly.vault_time as vault_time
+from entroly.vault import BeliefArtifact, VaultConfig, VaultManager
+from entroly.vault_time import BeliefLedger
+
+
+@pytest.fixture()
+def no_advisory_locks(monkeypatch):
+    """Make every advisory lock attempt fail, as an NFS mount would."""
+
+    monkeypatch.setattr(vault_time, "_advisory_lock", lambda handle: False)
+    monkeypatch.setattr(vault_time, "_advisory_unlock", lambda handle: None)
+
+
+def _write_many(vault: VaultManager, prefix: str, count: int) -> None:
+    for index in range(count):
+        vault.write_belief(
+            BeliefArtifact(entity=f"{prefix}-{index}", title="t", body=f"b{index}",
+                           sources=["a.py:1"])
+        )
+
+
+def test_appends_stay_serialized_without_advisory_locks(tmp_path, no_advisory_locks):
+    """The lock file must serialize on its own.
+
+    With no effective lock at all the same workload leaves 55 of 60 records and
+    a broken chain; `O_CREAT | O_EXCL` is what closes that, and it is the one
+    mutual-exclusion primitive NFSv3+ and SMB implement atomically.
+    """
+
+    vault = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+    threads = [
+        threading.Thread(target=_write_many, args=(vault, prefix, 20))
+        for prefix in ("a", "b", "c")
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    log = tmp_path / "vault" / "ledger" / "beliefs.jsonl"
+    records = [line for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    assert len(records) == 60
+    assert BeliefLedger(tmp_path / "vault").verify_chain()["status"] == "intact"
+
+
+def test_an_abandoned_lock_is_broken_rather_than_blocking_forever(tmp_path, monkeypatch):
+    """A lock file outlives the process that made it.
+
+    A crash mid-append would otherwise block every later writer permanently.
+    """
+
+    monkeypatch.setattr(vault_time, "_LOCK_STALE_SECONDS", 0.2)
+    monkeypatch.setattr(vault_time, "_LOCK_SETTLE_SECONDS", 0.05)
+
+    vault = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+    vault.ensure_structure()
+    ledger_dir = tmp_path / "vault" / "ledger"
+    ledger_dir.mkdir(parents=True, exist_ok=True)
+    stranded = ledger_dir / ".lock"
+    stranded.write_text("somehost:999999:deadbeef\n0\n", encoding="utf-8")
+    time.sleep(0.3)
+
+    vault.write_belief(
+        BeliefArtifact(entity="after-crash", title="t", body="b", sources=["a.py:1"])
+    )
+
+    assert vault.read_belief("after-crash") is not None
+    assert BeliefLedger(tmp_path / "vault").verify_chain()["status"] == "intact"
+
+
+def test_a_live_lock_is_not_mistaken_for_an_abandoned_one(tmp_path, monkeypatch):
+    """Age alone is not proof of abandonment; a slow holder is not a dead one.
+
+    The mtime is read twice across a settle interval, so a lock that is still
+    being touched is left alone.
+    """
+
+    monkeypatch.setattr(vault_time, "_LOCK_STALE_SECONDS", 0.2)
+    monkeypatch.setattr(vault_time, "_LOCK_SETTLE_SECONDS", 0.3)
+
+    ledger_dir = tmp_path / "vault" / "ledger"
+    ledger_dir.mkdir(parents=True)
+    lock_path = ledger_dir / ".lock"
+    lock_path.write_text("host:1:token\n0\n", encoding="utf-8")
+    time.sleep(0.3)
+
+    keep_touching = True
+
+    def toucher() -> None:
+        while keep_touching:
+            lock_path.touch()
+            time.sleep(0.05)
+
+    worker = threading.Thread(target=toucher)
+    worker.start()
+    try:
+        assert vault_time._lock_is_stale(lock_path) is False
+    finally:
+        keep_touching = False
+        worker.join()
+
+
+def test_release_never_removes_another_holders_lock(tmp_path):
+    """A broken-as-stale lock can be re-taken while the original holder runs.
+
+    Deleting unconditionally would then release a lock the caller does not
+    hold, letting two writers proceed at once.
+    """
+
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir(parents=True)
+    lock_path = ledger_dir / ".lock"
+
+    assert vault_time._try_acquire(lock_path, "holder-A") is True
+    # A takes over after A's lock was broken; A must not delete B's claim.
+    lock_path.write_text("holder-B\n0\n", encoding="utf-8")
+
+    vault_time._release(lock_path, "holder-A")
+
+    assert lock_path.exists()
+    assert lock_path.read_text(encoding="utf-8").startswith("holder-B")
+
+
+def test_exclusive_create_admits_exactly_one_claimant(tmp_path):
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir(parents=True)
+    lock_path = ledger_dir / ".lock"
+
+    assert vault_time._try_acquire(lock_path, "first") is True
+    assert vault_time._try_acquire(lock_path, "second") is False
+
+    vault_time._release(lock_path, "first")
+    assert vault_time._try_acquire(lock_path, "second") is True
+
+
+def test_lock_tokens_are_unique_across_machines(tmp_path):
+    """A pid alone repeats across hosts sharing a network vault."""
+
+    first, second = vault_time._lock_token(), vault_time._lock_token()
+    assert first != second
+    assert len(first.split(":")) == 3


### PR DESCRIPTION
## The gap

The ledger lock from #341 was `fcntl.flock` / `msvcrt.locking`. **Neither means
anything on a shared mount.** `flock` needs a working `lockd` to serialize
across NFS clients and silently degrades to a local-only lock without one; SMB
is worse.

Two machines sharing a vault over NFS would each believe they held the lock and
interleave their read-modify-write appends — reproducing exactly the record
loss the lock was added to prevent, in the deployment where a shared vault is
the whole point.

## The fix

The lock is claimed by creating its file with `O_CREAT | O_EXCL` — the one
mutual-exclusion primitive NFSv3+ and SMB implement atomically server-side.

Measured with the advisory layer disabled, standing in for such a mount:

| | records | chain |
|---|---|---|
| lock file active, **advisory disabled** | **60 / 60** | **intact** |
| control: no effective lock | 55 / 60 | broken |

So the lock file carries the guarantee rather than the platform. The advisory
lock is **kept underneath** where it works, because it releases automatically
when a process dies: the file makes the guarantee portable, the advisory lock
makes the common local case recover instantly from a crash.

## Abandonment, without false positives

A lock file outlives its process, so a crash mid-append would block every later
writer forever. But **age alone is not proof of abandonment — a slow holder is
not a dead one.** The mtime is read twice across a settle interval and the lock
is broken only when it has not moved.

Both readings come from the *file server's* clock, which is what makes this
immune to skew between clients — a real concern when the whole point is
multiple machines.

## Release is ownership-checked

A lock broken as stale can be re-taken while the original holder is still
running. Deleting unconditionally would release a lock the caller does not
hold, admitting two writers at once — the exact failure this path exists to
prevent. Release compares the token written at acquisition, and that token
carries the **hostname** as well as the pid, since pids repeat across machines.

## Trust and compatibility

- [x] Receipt honesty and recoverability are preserved or not affected.
- [x] Verification remains fail-closed where confidence is claimed.
- [x] No surprise network call or credential surface is added.

## Verification

82 tests pass across vault network lock, multiprocess, integrity, time,
groundedness, usability, hygiene and security hardening; ruff clean. Six new
tests, including mutual exclusion with advisory locks disabled, stale-lock
breaking, a live lock *not* being mistaken for stale, and release refusing to
remove another holder's lock.
