### PR TITLE
fix(vault): stop chain verification false-alarming during concurrent writes

### DIFF
--- a/entroly/vault_time.py
+++ b/entroly/vault_time.py
@@ -720,9 +720,27 @@ class BeliefLedger:
         )
 
     def verify_chain(self) -> dict[str, Any]:
-        """Recompute the hash chain. Fail-closed: reports the first break."""
+        """Recompute the hash chain. Fail-closed: reports the first break.
+
+        Held under the append lock. The log and the head are two files, and
+        reading them at different instants let a concurrent append land in
+        between: the log was counted before the append and the head read after
+        it, so a healthy ledger reported "truncated: head expects 299, found
+        298". A soak of three writers against a maintainer produced six such
+        alarms in a minute, on a chain that was intact at the end.
+
+        A tamper alarm that fires on healthy data is worse than none, so the
+        verification takes a consistent snapshot rather than tolerating a
+        window -- tolerating one would have blunted real truncation detection
+        by exactly the amount of the tolerance.
+        """
+
         if not self._log.exists():
             return {"status": "empty", "records": 0}
+        with self._exclusive():
+            return self._verify_locked()
+
+    def _verify_locked(self) -> dict[str, Any]:
         prev_hash = ""
         count = 0
         for line_no, line in enumerate(

--- a/tests/test_vault_faults.py
+++ b/tests/test_vault_faults.py
@@ -201,3 +201,50 @@ def test_an_unreadable_belief_does_not_break_a_vault_scan(tmp_path):
     assert _parse_frontmatter(
         Path(survivor["path"]).read_text(encoding="utf-8")
     ) is not None
+
+
+def test_verification_during_concurrent_writes_does_not_false_alarm(tmp_path):
+    """The log and the head are two files.
+
+    Reading them at different instants let a concurrent append land between:
+    the log counted before it, the head read after it, and a healthy ledger
+    reported "truncated: head expects 299, found 298". A soak of three writers
+    against a maintainer produced six such alarms in a minute on a chain that
+    was intact throughout. A tamper alarm that fires on healthy data is worse
+    than none.
+    """
+
+    import threading
+
+    vault = _vault(tmp_path)
+    vault.write_belief(
+        BeliefArtifact(entity="seed", title="t", body="b", sources=["a.py:1"])
+    )
+    ledger = BeliefLedger(vault._base)
+    stop = False
+    false_alarms: list[str] = []
+
+    def verify_loop() -> None:
+        while not stop:
+            report = ledger.verify_chain()
+            if report["status"] != "intact":
+                false_alarms.append(str(report.get("reason", report)))
+
+    def write_loop() -> None:
+        for index in range(60):
+            vault.write_belief(
+                BeliefArtifact(entity=f"w{index}", title="t", body=f"b{index}",
+                               sources=["a.py:1"])
+            )
+
+    verifier = threading.Thread(target=verify_loop)
+    verifier.start()
+    writers = [threading.Thread(target=write_loop) for _ in range(2)]
+    for thread in writers:
+        thread.start()
+    for thread in writers:
+        thread.join()
+    stop = True
+    verifier.join()
+
+    assert false_alarms == [], f"verification false-alarmed: {false_alarms[:3]}"


### PR DESCRIPTION
## Found by soaking, not by reasoning

I ran a sustained mixed-workload soak — three writers, two readers and a
maintainer against one vault — instead of recommending one. It failed on the
first run:

```
chain:ledger truncated: head expects 299 record(s), found 298
chain:ledger truncated: head expects 430 record(s), found 429
… 6 alarms in 60 seconds
```

**Nothing was wrong with the data.** 1,219 writes produced 1,219 ledger
records and the chain verified intact at the end.

## The bug

The log and the head are two files, and `verify_chain` read them at different
instants. A concurrent append landing between the two reads meant the records
were counted *before* it and the head read *after* it — so a healthy ledger
looked truncated by exactly one record.

On a deployment that pages on tamper detection, that is an alert firing on
healthy state. An alarm that cries wolf is the reason the real one gets
ignored, which makes this a defect in the audit trail's usefulness rather than
a cosmetic issue.

## The fix, and the option I rejected

Verification now takes its snapshot under the append lock.

The alternative was to tolerate a small head-ahead window. That is worse: it
would blunt real truncation detection by exactly the size of the tolerance, on
the **one direction that actually means records were removed**. Correct
detection in the direction that matters is worth briefly blocking an append.

## Re-soaked

```
soak 120s  writers=3 readers=2 maintainer=1
  writes=2505  reads=188  maintenance=40
  worker errors      : 0
  belief files       : 2505
  unreadable beliefs : 0
  stray temp files   : 0
  ledger records     : 2505  (writes=2505)
  chain              : intact
  VERDICT            : PASS
```

Ledger records match writes exactly — no lost appends across six concurrent
processes.

## Trust and compatibility

- [x] Receipt honesty and recoverability are preserved or not affected.
- [x] Verification remains fail-closed where confidence is claimed.
- [x] No surprise network call or credential surface is added.

## Verification

43 tests pass across vault faults, time, integrity, network lock and
multiprocess; ruff clean. One new test runs `verify_chain` in a loop
concurrently with two writers and asserts zero false alarms.
