### PR TITLE
fix(ci): give the suite-running jobs a budget that fits the suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,15 @@ jobs:
   integration:
     name: Build Wheel + Functional Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # This cap has to leave room for the suite rather than track it. It sat at
+    # 15 minutes from v1.0, when the suite was a fraction of its current size,
+    # and by 2026-08-17 all five matrix entries were finishing in 13.7-14.3
+    # minutes — under 80 seconds of margin each. The 3.11 entry then crossed
+    # the line on ordinary runner variance and cancelled the job mid-suite:
+    # 3825 tests passing, nothing broken, main red. The per-test `--timeout=60`
+    # below is the real hang guard; this number only has to stay clear of
+    # normal variance.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -320,7 +328,10 @@ jobs:
       - name: Run Python tests
         run: |
           .venv/bin/pip install pytest pytest-timeout --timeout 120 --retries 5
-          .venv/bin/pytest tests/ -v --tb=short -x --timeout=60
+          # --durations prints the slowest tests on every run, so the growth
+          # that consumed the old budget stays visible in the log instead of
+          # only surfacing the next time it runs out of one.
+          .venv/bin/pytest tests/ -v --tb=short -x --timeout=60 --durations=15
 
       - name: Run entroly-core integration tests
         run: |
@@ -337,7 +348,9 @@ jobs:
     # pins the base-install surface so that class of regression can't recur.
     name: Pure-Python Fallback (base `pip install entroly`, no Rust engine)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Same stale-budget problem as 'integration', one push behind it: measured
+    # at 11.8 minutes against the old 15, and it grows from the same suite.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
         with:
@@ -384,7 +397,7 @@ jobs:
           # excluded — they belong to the 'integration' job. Everything else,
           # including the compress()/universal_compress non-annihilation
           # contract, MUST pass on the base install.
-          pytest tests/ -v --tb=short --timeout=60 -p no:cacheprovider \
+          pytest tests/ -v --tb=short --timeout=60 --durations=15 -p no:cacheprovider \
             --ignore=tests/functional_test.py \
             --ignore=tests/test_e2e.py \
             --ignore=tests/test_ios.py \


### PR DESCRIPTION
## What broke

Run [32006855019](https://github.com/juyterman1000/entroly/actions/runs/32006855019) went red on `main` with nothing actually broken. The `Build Wheel + Functional Test (Python 3.11)` job was cancelled 13m53s into `Run Python tests` because it hit the job's `timeout-minutes: 15`. No test failed — the suite was still running when the runner pulled the plug.

## Why

The cap has been `15` since v1.0 (`dc24db33`) and was never revisited as the suite grew to **3825 tests / 763s**. Measured on the last green run on `main` ([32003097699](https://github.com/juyterman1000/entroly/actions/runs/32003097699)), every matrix entry was already spending its whole budget:

| Job | Duration | Cap | Margin |
|---|---|---|---|
| integration (3.11) | 14.3m | 15m | 42s |
| integration (3.12) | 14.0m | 15m | 60s |
| integration (3.14) | 13.8m | 15m | 72s |
| integration (3.13) | 13.7m | 15m | 78s |
| integration (3.10) | 13.7m | 15m | 78s |
| python-fallback | 11.8m | 15m | 3.2m |

Six jobs at 79-96% of budget, so which one dies is decided by runner speed, not by the code. The re-run of the *same commit* finished in 11.4m — a ~30% swing against a cap that only tolerates 5%.

## The change

- `integration` 15 → **30**, `python-fallback` 15 → **25**. Sized to measured runtime with real margin rather than tracking it. The per-test `--timeout=60` is unchanged and is the actual hang guard, so a genuinely hung test still fails in 60s — it never needed the job cap to catch it.
- `--durations=15` on both pytest steps, so the next stretch of growth shows up as a named slow test in every log instead of surfacing as a cancelled job once it exhausts the budget.

No test, source, or packaging change; the diff is 4 lines of YAML plus comments recording the measurement.

## Note on the second commit

The first push failed `test_current_tree_respects_external_name_policy` at `.github/workflows/ci.yml:270`. The explanatory comment I added used an ordinary English word for spare capacity which normalizes to a prohibited name, and the gate stores names as digests to stay brand-neutral, so it can only report `file:line`. Reworded to "margin"; no behaviour change. Worth knowing that the word is a natural one to reach for when writing about timeout budgets specifically.

## Trust and compatibility

- [x] Receipt honesty and recoverability are preserved or not affected.
- [x] Verification remains fail-closed where confidence is claimed.
- [x] No surprise network call or credential surface is added.
- [x] No test is skipped, weakened, or excluded — the same 3825 tests run.
