### PR TITLE
fix(engine): make the shipped install run the code the benchmarks measure

### DIFF
--- a/.github/workflows/publish-core-wheels.yml
+++ b/.github/workflows/publish-core-wheels.yml
@@ -48,6 +48,44 @@ jobs:
           name: wheels-linux-aarch64
           path: dist
 
+  # musl wheels exist because entroly-core is a REQUIRED dependency of entroly
+  # (see pyproject.toml). entroly-core publishes no sdist -- deliberately, per
+  # the abi3 note above -- so a platform without a wheel cannot resolve the
+  # dependency at all and `pip install entroly` fails outright there. glibc
+  # wheels do not install on musl, which would break every Alpine-based image.
+  # Keep these jobs in the `publish` needs list.
+  linux-musl-x86_64:
+    name: Linux musl (x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --out dist --manifest-path entroly-core/Cargo.toml
+          manylinux: musllinux_1_2
+          target: x86_64-unknown-linux-musl
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-linux-musl-x86_64
+          path: dist
+
+  linux-musl-aarch64:
+    name: Linux musl (aarch64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --out dist --manifest-path entroly-core/Cargo.toml
+          manylinux: musllinux_1_2
+          target: aarch64-unknown-linux-musl
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-linux-musl-aarch64
+          path: dist
+
   macos-universal:
     name: macOS (universal2)
     runs-on: macos-14
@@ -101,7 +139,14 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [rust-gate, linux-x86_64, linux-aarch64, macos-universal, windows]
+    needs:
+      - rust-gate
+      - linux-x86_64
+      - linux-aarch64
+      - linux-musl-x86_64
+      - linux-musl-aarch64
+      - macos-universal
+      - windows
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Do not merge a change that weakens these invariants:
 - **Receipt honesty:** selected context, omitted evidence, risks, hashes, and token ratios must be inspectable.
 - **Reversibility:** compressed or summarized context must remain traceable back to source spans.
 - **Fail-closed verification:** WITNESS, RAVS, and native-status checks must degrade safely, not silently claim confidence.
-- **Local-first operation:** no surprise remote calls for ranking, receipts, verification, or diagnostics.
+- **Local-first operation:** no surprise remote calls for ranking, receipts, verification, or diagnostics. The single carve-out is engine repair: when the native engine is missing, `entroly/self_heal.py` installs `entroly-core` from PyPI before measuring, because without it selection never reads the query and any reported saving is budget arithmetic. It is a package install — no code, prompts, or telemetry leave the machine — it is skipped when the engine is present, and `ENTROLY_NO_SELF_HEAL=1` disables it. Do not extend this carve-out to anything else, and never repair from an import path.
 - **Cache stability:** prompt prefixes should remain byte-stable unless intentionally changed.
 - **Release consistency:** Python, Rust, WASM, npm, Homebrew, docs, and native minimum versions must agree.
 - **Benchmark honesty:** claims must include baseline, token budget, workload, and caveats.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -59,6 +59,16 @@ server. Failures are ignored. Set `ENTROLY_DISABLE_UPDATE_CHECK=1` to disable
 the request. The proxy does not probe LLM provider hosts at startup unless you
 explicitly set `ENTROLY_CHECK_UPSTREAM=1`.
 
+When the native engine (`entroly-core`) is missing, commands that measure
+context — `simulate`, `demo`, `perf`, and the MCP/proxy services at startup —
+install it from PyPI before running. Without it, context selection cannot read
+your query, so any reported saving would be budget arithmetic rather than a
+measured result. This is an ordinary package install from PyPI, not an
+Entroly-operated server: no code, prompts, file contents, queries, or telemetry
+are transmitted. It is skipped entirely when the engine is already present, it
+never runs from a library import path, and `ENTROLY_NO_SELF_HEAL=1` disables it —
+in which case Entroly reports the figure explicitly labelled as unearned.
+
 `entroly telemetry on` stores a local preference only. No outbound telemetry
 uploader is included in this release.
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ that safe to do:
 use — Claude Code, Cursor, Copilot and 30+ others — and runs in the background.
 
 **Do I need to pay for anything to try it?** No. The two commands in the
-[Install](#install) section below run entirely on your own machine, with no API
-key, and show you real numbers on your own project before you connect anything
-paid.
+[Install](#install) section below run on your own machine, with no API key, and
+show you real numbers on your own project before you connect anything paid.
+(They will install the native engine from PyPI if it is missing — see the note
+under [Install](#install).)
 
 ---
 ## Install
@@ -111,7 +112,7 @@ paid.
 | 🦀 **Rust** (source build) | `cd entroly-core && cargo build --release --bin entroly-rs --features proxy` | One self-contained program, no Python or Node needed |
 | 🍺 **Homebrew** | `brew install juyterman1000/entroly/entroly` | The command-line tool on macOS/Linux |
 | 🐳 **Docker** | `docker pull ghcr.io/juyterman1000/entroly:latest` | Runs in a container, nothing installed on your machine |
-**Now check that it worked — free, offline, no API key:**
+**Now check that it worked — free, no API key:**
 
 ```bash
 cd /your/repo
@@ -120,6 +121,14 @@ entroly simulate
 ```
 
 <sub>Both run locally. Neither one calls an AI or costs anything.</sub>
+
+<sub>One exception to "offline": if the native engine is missing, Entroly installs
+it from PyPI before measuring, because without it selection cannot read your
+query and any savings figure would be budget arithmetic rather than a measured
+result. That is the only outbound call these commands make, it is a package
+install and nothing about your code leaves the machine, and it does not happen
+when the engine is already present. Set `ENTROLY_NO_SELF_HEAL=1` to disable it —
+Entroly then reports the figure explicitly labelled as unearned.</sub>
 
 Extras (`entroly[proxy]`, `entroly[native]`, `entroly[full]`), the standalone
 Rust binary, and uninstall steps: [Engine & install options](docs/DETAILS.md#engine--install-options).
@@ -138,6 +147,18 @@ Rust binary, and uninstall steps: [Engine & install options](docs/DETAILS.md#eng
 | **"I use Claude Code / Cursor / Windsurf / VS Code."** *(MCP user)* | `entroly attach create --client claude --project . --ttl 4h --install` (or `entroly init` for Cursor/VS Code) | Your editor gets compression, receipts, and recovery as built-in tools — access expires on its own, and you change zero code |
 | **"I'm building my own app in Python."** *(SDK user)* | `from entroly import compress, compress_messages, optimize` | Call it straight from your code, anywhere you assemble a prompt |
 | **"I have an API key and my own app."** *(proxy user)* | `entroly proxy` → point `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `GOOGLE_GEMINI_BASE_URL` at `localhost:9377` | Every request gets optimized on the way past — no code changes on your side |
+
+<sub>**Runaway-session rescue — automatic on the proxy, callable everywhere else.**
+When a long agent session approaches the provider's context limit, bulky tool
+output is compacted in flight: no manual `/compact`, the prompt prefix stays
+byte-stable so your warm provider cache survives, and every omitted span is
+recoverable. The proxy does it for you because it sees the outbound request.
+Anywhere else — pip, SDK, a provider-SDK wrapper, or an MCP host that passes its
+transcript — hand the conversation over and get the same policy:
+`from entroly import rescue_session`. `entroly capabilities` reports which
+protections apply to how you are running. See
+[session rescue](docs/session-rescue.md).</sub>
+
 **Why bother:** less unnecessary context reaches the model (lower bill, less
 distraction for the model), nothing is silently lost (every drop is
 recoverable and receipted), and you can prove it — `entroly verify-claims`
@@ -276,7 +297,7 @@ No. Entroly reads your files and decides what to send to the AI. It never edits,
 <details>
 <summary><b>Does my code get uploaded anywhere?</b></summary>
 <br>
-No. All selecting, compressing, and checking happens on your own machine. Entroly makes no outbound calls of its own — the only thing that leaves your computer is the request you were already sending to your AI provider, just smaller. There are no analytics on by default.
+No. All selecting, compressing, and checking happens on your own machine. Your code is never uploaded, and there are no analytics on by default. Entroly makes exactly one kind of outbound call of its own: if the native engine is missing it installs that package from PyPI, because without it selection cannot read your query. That is a package download — no code, prompts, or telemetry are sent — and `ENTROLY_NO_SELF_HEAL=1` turns it off. Otherwise the only thing that leaves your computer is the request you were already sending to your AI provider, just smaller.
 </details>
 
 <details>

--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -170,20 +170,33 @@ Keep failures in benchmark denominators. Publish repository revision, package ve
 
 ## Engine & install options
 
-Python is the reference runtime. The optional Rust core accelerates supported
-compute-heavy paths through PyO3, and a separate Node runtime ships through
-WASM. The base Python install does not imply that the Rust extension is active;
-`entroly verify-claims` reports the engine mode it actually exercised.
+Python orchestrates; the Rust core (`entroly-core`, via PyO3) does the
+compute-heavy work, and a separate Node runtime ships through WASM. The Rust
+core is a **required** dependency of the base install, not an extra: query
+conditioned selection is gated on it, so an install without it fills the token
+budget without ever reading the query. `entroly verify-claims` reports the
+engine mode it actually exercised.
 
 ```bash
-pip install entroly            # core: MCP server + Python engine
+pip install entroly            # MCP server + Rust engine
 pip install entroly[proxy]     # + HTTP proxy
-pip install entroly[native]    # + Rust engine
 pip install entroly[full]      # everything
 
 npm install -g entroly         # WASM runtime, no Python needed
 docker pull ghcr.io/juyterman1000/entroly:latest
 ```
+
+`entroly[native]` still resolves — it is kept as a compatibility alias for
+install instructions already published, and now installs the same thing as a
+plain `pip install entroly`.
+
+abi3 wheels are published for macOS universal2, Linux glibc and musl
+(x86_64/aarch64), and Windows x64. On a platform with no published wheel the
+install fails rather than silently degrading; build the core from source
+(`cd entroly-core && maturin develop --release`) for those. If the engine is
+missing at runtime, Entroly installs it from PyPI before measuring anything —
+see the note under [Install](../README.md#install); `ENTROLY_NO_SELF_HEAL=1`
+disables that, and the reported figure is then labelled unearned.
 
 **Single binary, no Python** — a standalone Rust proxy that auto-detects Anthropic/OpenAI/Gemini and stays cache-aligned:
 

--- a/entroly/__init__.py
+++ b/entroly/__init__.py
@@ -26,6 +26,24 @@ Quick Setup (Claude Code)::
 
 __version__ = "1.0.78"
 
+# Explicit repair for library users. The CLI restores a missing native engine
+# automatically, but an import path must never do that: installing a package
+# while a module is being imported risks re-entrant imports, partially
+# initialised state, and multiprocessing deadlock. So SDK users opt in by
+# calling it:
+#
+#     import entroly
+#     entroly.repair()          # installs the native engine if it is missing
+#     entroly.native_engine_ready()
+#
+# Without the native engine, `compress`/`optimize` still return results and
+# still respect the token budget, but selection does not read the query --
+# see entroly/self_heal.py for the measurement.
+try:
+    from .self_heal import native_engine_ready, repair  # noqa: F401
+except ImportError:  # pragma: no cover - stdlib-only module
+    pass
+
 try:
     from .sdk import (  # noqa: F401
         compress,
@@ -198,6 +216,21 @@ try:
         compress_evidence_locked,
         compress_payload_messages,
         detect_heavy_content_type,
+    )
+except ImportError:
+    pass
+
+# Runaway-session rescue, for callers that assemble their own prompts.
+# The proxy applies this automatically because it sees the outbound request;
+# every other surface has to hand the conversation over, so it needs a name.
+# Below the soft watermark it returns the conversation untouched, which makes
+# it safe to call on every turn -- and calling every turn is what lets the
+# watermark policy see the growth it acts on.
+try:
+    from .session_rescue import (  # noqa: F401
+        SessionRescuePolicy,
+        SessionRescueResult,
+        rescue_session,
     )
 except ImportError:
     pass

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -663,7 +663,9 @@ def cmd_serve(args):
             force=True,
         )
 
-    # Import and run
+    # Engine repair is not done here: `server.main()` does it, which also covers
+    # bare `entroly` under an MCP host (piped stdin routes through
+    # `_docker_launcher._run_native()` and never reaches this subcommand).
     from entroly.server import main
     main()
 
@@ -948,6 +950,10 @@ def cmd_proxy(args):
     # Gap #28: --bypass flag sets env var consumed by proxy
     if getattr(args, "bypass", False):
         os.environ["ENTROLY_BYPASS"] = "1"
+
+    rc = _auto_repair_for_service("proxy")
+    if rc is not None:
+        sys.exit(rc)
 
     try:
         from entroly.auto_index import auto_index, start_incremental_watcher
@@ -2902,7 +2908,15 @@ def cmd_demo(args):
     ``demo``, ``simulate``, and ``perf`` must measure the same indexed
     surface. A separate auto-index path previously bypassed the file cap
     and could spend minutes ingesting a large repository before printing.
+
+    This is the command most likely to be someone's first contact with
+    Entroly, and it reports dollars as well as tokens, so a degraded engine
+    here produces both an unearned percentage and an unearned cost figure.
+    Repair runs before anything is measured.
     """
+    rc = _auto_repair_before_measuring(args)
+    if rc is not None:
+        sys.exit(rc)
     report = _run_local_simulation(args)
     if getattr(args, "json", False):
         print(json.dumps(report, indent=2))
@@ -2988,9 +3002,33 @@ def _load_local_simulation_engine(max_files: int | None = None):
         auto_index_module.MAX_FILES = old_max_files
 
 
+def _query_conditioned_selection_active(engine) -> bool:
+    """True when the query actually influences which fragments are selected.
+
+    Query-conditioned selection (QCCR) is gated on the native engine in
+    ``EntrolyEngine.optimize_context``: its candidate set comes from
+    ``self._rust.export_fragments()``, which has no pure-Python equivalent. When
+    the gate is closed the optimizer still returns fragments and still fills the
+    budget -- it just never reads the query. Measured on this repo, three
+    unrelated questions (including a nonsense control) produced a byte-identical
+    23 fragments / 7,588 tokens / "76.29% saved".
+
+    A percentage that is identical for every possible question is not a saving
+    the tool earned, so callers must be able to tell the two modes apart.
+    """
+    if not getattr(engine, "_use_rust", False):
+        return False
+    try:
+        from .qccr import _HAS_RUST
+    except Exception:
+        return False
+    return bool(_HAS_RUST)
+
+
 def _run_local_simulation(args) -> dict:
     max_files = int(getattr(args, "max_files", 100) or 0)
     engine, files_indexed, total_tokens, index_status = _load_local_simulation_engine(max_files)
+    query_conditioned = _query_conditioned_selection_active(engine)
     budget = int(getattr(args, "budget", 4096) or 4096)
     queries = _simulation_queries(args)
     baseline = int(getattr(args, "baseline", 0) or 0)
@@ -3055,11 +3093,17 @@ def _run_local_simulation(args) -> dict:
             "p95": round(latencies_sorted[p95_idx], 2) if latencies_sorted else 0.0,
             "max": round(max(latencies_ms), 2) if latencies_ms else 0.0,
         },
+        "query_conditioned_selection": query_conditioned,
+        "selection_engine": "qccr-native" if query_conditioned else "python-fallback-unranked",
         "limitations": [
             "No LLM call was made; quality is not judged here.",
             "Savings are estimated against the stated local baseline, not your provider bill.",
             "Provider cache discounts, output tokens, and retries are excluded.",
-        ],
+        ] + ([] if query_conditioned else [
+            "The native engine is unavailable, so selection did not read the query: "
+            "these figures are budget arithmetic and are NOT a measured saving. "
+            'Install it with: pip install -U "entroly[native]"',
+        ]),
     }
 
 
@@ -3076,14 +3120,42 @@ def _print_local_simulation(report: dict, *, title: str, include_perf: bool) -> 
         f"  {C.BOLD}Baseline:{C.RESET} {report['baseline_tokens_per_query']:,} "
         f"tokens/query  {C.BOLD}Budget:{C.RESET} {report['budget']:,} tokens"
     )
+    # Without the native engine the optimizer never reads the query, so every
+    # question returns the same fragments and the same percentage. Automatic
+    # repair (self_heal) normally prevents anyone seeing this at all; it is
+    # reached when repair is disabled, blocked, or offline.
+    #
+    # The figure is still shown rather than withheld -- a first run that reports
+    # nothing is worthless to the user -- but it is labelled in the same block
+    # as the number, because on its own it is `(baseline - selected_tokens) /
+    # baseline`: decided by the budget, identical for every possible question,
+    # and silent about whether the answer-bearing evidence survived. A claim and
+    # its caveat have to travel together or the caveat does not exist.
+    degraded = not report.get("query_conditioned_selection", True)
+    if degraded:
+        print()
+        print(
+            f"  {C.RED}{C.BOLD}Relevance ranking is OFF -- native engine not "
+            f"installed.{C.RESET}"
+        )
+        print(
+            f"  {C.YELLOW}Selection did not read your query, so every question "
+            f"returns the same fragments{C.RESET}"
+        )
+        print(
+            f"  {C.YELLOW}and the same percentage. The numbers below are budget "
+            f"arithmetic, not a measured saving.{C.RESET}"
+        )
+        print(f'  {C.BOLD}Fix:{C.RESET} pip install -U "entroly[native]"')
     print()
     for row in report["queries"]:
         print(f"    {C.CYAN}Q:{C.RESET} {row['query'][:80]}")
+        suffix = f" {C.GRAY}[unearned]{C.RESET}" if degraded else ""
         print(
             f"       {row['selected_fragments']} fragments, "
             f"{row['selected_tokens']:,} tokens "
             f"({row['reduction_pct']:.1f}% fewer; "
-            f"{row['tokens_saved']:,} tokens saved)"
+            f"{row['tokens_saved']:,} tokens saved){suffix}"
         )
         if include_perf:
             print(f"       latency: {row['latency_ms']:.2f} ms")
@@ -3098,7 +3170,13 @@ def _print_local_simulation(report: dict, *, title: str, include_perf: bool) -> 
     # Gating on fit alone printed "there is nothing to save yet" directly under
     # "1,104 tokens saved".
     nothing_saved = report.get("budget_narrowed_to_demonstrate") and avg <= 0.0
-    if nothing_saved:
+    if degraded:
+        print(
+            f"  {C.YELLOW}{C.BOLD}Average reduction: {avg:.1f}%{C.RESET} "
+            f"{C.RED}-- unearned{C.RESET}{C.GRAY}: selection was unranked, so "
+            f"this is the budget, not a measured saving.{C.RESET}"
+        )
+    elif nothing_saved:
         # A project smaller than the budget has nothing to drop, so every query
         # honestly reports 0.0%. Printing that bare number is the most common
         # first run and reads as "this tool does nothing". Say what actually
@@ -3135,8 +3213,113 @@ def _print_local_simulation(report: dict, *, title: str, include_perf: bool) -> 
 from .cli_recover import cmd_compress, cmd_recover  # noqa: E402
 
 
+def _auto_repair_before_measuring(args) -> int | None:
+    """Restore the native engine before measuring anything.
+
+    Runs *before* the simulation rather than after a disappointing result: the
+    check is a cheap import probe, and repairing first means the user sees one
+    correct run instead of a wrong one followed by a right one.
+
+    Returns an exit code when the caller must stop because the command was
+    re-executed in a repaired interpreter, or None to continue in-process.
+
+    This performs a network install. `ENTROLY_NO_SELF_HEAL=1` disables it; every
+    failure path falls through to the labelled report in
+    `_print_local_simulation` rather than raising.
+    """
+    from . import self_heal
+
+    if self_heal.native_engine_ready():
+        return None
+    if self_heal.disabled() or self_heal.already_healed():
+        return None
+
+    # --json must stay machine-parseable, so progress goes to stderr there.
+    quiet = bool(getattr(args, "json", False))
+    stream = sys.stderr if quiet else sys.stdout
+    print(
+        f"\n  {C.YELLOW}Native engine missing -- selection cannot read your "
+        f"query. Repairing first...{C.RESET}",
+        file=stream,
+    )
+
+    outcome = self_heal.repair_native()
+    for name, ok, detail in outcome.steps:
+        mark = f"{C.GREEN}ok{C.RESET}" if ok else f"{C.RED}failed{C.RESET}"
+        print(f"  {name}: {mark} ({detail})", file=stream)
+
+    if outcome.needs_reexec:
+        print(
+            f"  {C.GREEN}Engine installed. Re-running with it.{C.RESET}\n",
+            file=stream,
+        )
+        return self_heal.reexec_after_repair()
+
+    if outcome.blocked:
+        print(
+            f"  {C.GRAY}Continuing without it: {outcome.blocked_reason}.{C.RESET}\n",
+            file=stream,
+        )
+    return None
+
+
+def _auto_repair_for_service(label: str) -> int | None:
+    """Repair a degraded engine once, at service startup.
+
+    Long-lived surfaces (MCP server, HTTP proxy) must repair at boot and never
+    per request: a per-request install would fire concurrently under load.
+
+    All output goes to **stderr**. The MCP server speaks JSON-RPC over stdout,
+    so a single stray progress line there corrupts the protocol stream and the
+    client drops the connection.
+
+    Returns an exit code when the service was re-executed, else None.
+    """
+    from . import self_heal
+
+    if self_heal.native_engine_ready():
+        return None
+
+    # Repair being switched off must never make the degradation silent -- a
+    # long-lived service has no other place to report it.
+    if self_heal.disabled() or self_heal.already_healed():
+        print(
+            f"[entroly] WARNING: starting {label} without the native engine. "
+            f"Context selection will not read the query -- every request "
+            f"returns the same fragments. Install entroly-core, or unset "
+            f"{self_heal.ENV_DISABLE} to let Entroly install it.",
+            file=sys.stderr,
+        )
+        return None
+
+    print(
+        f"[entroly] {label}: native engine missing, so context selection would "
+        f"ignore the query. Repairing before start...",
+        file=sys.stderr,
+    )
+    outcome = self_heal.repair_native()
+    for name, ok, detail in outcome.steps:
+        print(
+            f"[entroly] {name}: {'ok' if ok else 'failed'} ({detail})",
+            file=sys.stderr,
+        )
+    if outcome.needs_reexec:
+        print(f"[entroly] engine installed; restarting {label}.", file=sys.stderr)
+        return self_heal.reexec_after_repair()
+    if outcome.blocked:
+        print(
+            f"[entroly] starting {label} without the native engine: "
+            f"{outcome.blocked_reason}. Selection will not read the query.",
+            file=sys.stderr,
+        )
+    return None
+
+
 def cmd_simulate(args):
     """entroly simulate -- local no-LLM savings estimate for this repo."""
+    rc = _auto_repair_before_measuring(args)
+    if rc is not None:
+        sys.exit(rc)
     report = _run_local_simulation(args)
     if getattr(args, "json", False):
         print(json.dumps(report, indent=2))
@@ -3146,6 +3329,9 @@ def cmd_simulate(args):
 
 def cmd_perf(args):
     """entroly perf -- local no-LLM savings and optimizer latency."""
+    rc = _auto_repair_before_measuring(args)
+    if rc is not None:
+        sys.exit(rc)
     report = _run_local_simulation(args)
     if getattr(args, "json", False):
         print(json.dumps(report, indent=2))
@@ -4296,9 +4482,12 @@ def cmd_optimize(args):
     # head-to-head in quality_eval on code-retrieval tasks); fall back to
     # knapsack when there's no query to condition on.
     if selector == "auto":
-        # QCCR and DOPT need the Rust fragment export API. The default CLI
-        # install intentionally works without entroly-core, so the Python
-        # fallback must choose the selector that has a native Python path.
+        # QCCR and DOPT need the Rust fragment export API. entroly-core is now
+        # a hard dependency and `_auto_repair_before_measuring` restores it when
+        # it is missing, so the engine-less branch is no longer the default
+        # install -- it is the residue: a platform with no published wheel, or a
+        # run with ENTROLY_NO_SELF_HEAL=1. Keep the knapsack fallback for those,
+        # because it is the selector with a real pure-Python path.
         selector = "qccr" if task and getattr(engine, "_use_rust", False) else "knapsack"
     if selector in ("dopt", "qccr"):
         if not getattr(engine, "_use_rust", False):
@@ -4333,7 +4522,23 @@ def cmd_optimize(args):
                 "total_tokens": sum(f.get("token_count") or (len(f.get("content", "")) // 4) for f in selected),
                 "recommended_budget": budget,
                 "task_type": "",
+                "total_fragments": len(candidates),
             }
+            # This branch hand-builds its result instead of calling
+            # `optimize_context`, so it also has to apply the guard that lives
+            # there. Without this, the no-match contract ran only on the
+            # engine-less fallback above -- present where ranking does not
+            # happen, absent on the default path where it does.
+            #
+            # `scores_are_ranked=False`: QCCR's synthetic fragments carry a
+            # relevance that is a match *indicator*, not a rank -- measured at
+            # 1.0 for a matching query and 0.0 for a non-matching one, uniform
+            # across fragments. A spread test reads that as "degenerate" and
+            # would discard every successful selection, so it is disabled here
+            # and `_evidence_backed` (score > 0) carries that signal instead.
+            from entroly.server import apply_no_match_contract
+            apply_no_match_contract(opt, task, scores_are_ranked=False)
+            selected = opt.get("selected_fragments", [])
     else:
         opt = engine.optimize_context(token_budget=budget, query=task)
         selected = opt.get("selected_fragments", []) or opt.get("selected", [])

--- a/entroly/pyproject.toml
+++ b/entroly/pyproject.toml
@@ -40,6 +40,11 @@ dependencies = [
     "httpx>=0.28.1",
     "starlette>=1.3.1",
     "uvicorn>=0.51.0",
+    # Required, not optional -- see the root pyproject.toml for the measurement.
+    # Query-conditioned selection (QCCR) is gated on this module, so an install
+    # without it fills the token budget without ever reading the query and
+    # reports an identical "saving" for every possible question.
+    "entroly-core>=1.0.78,<2",
 ]
 
 [project.optional-dependencies]
@@ -48,6 +53,8 @@ proxy = [
     "starlette>=1.3.1",
     "uvicorn>=0.51.0",
 ]
+# Compatibility alias: the native engine now ships with the base install, so
+# `entroly[native]` and a plain `entroly` resolve to the same thing.
 native = [
     "entroly-core>=1.0.78,<2",
 ]

--- a/entroly/runtime_capabilities.py
+++ b/entroly/runtime_capabilities.py
@@ -77,6 +77,36 @@ def runtime_capabilities() -> dict[str, Any]:
             "anthropic_messages": {"implemented": True, "connectivity_verified": False},
             "gemini_generate_content": {"implemented": True, "connectivity_verified": False},
         },
+        # Some protections are installed everywhere but can only be *active* in
+        # the mode that sees the data they protect. Reporting them as a flat
+        # "implemented: true" is how a user ends up believing an inactive
+        # guard is running, so the mode is part of the capability.
+        "session_protection": {
+            "implemented": True,
+            # The distinction is automatic vs available, not proxy vs nothing.
+            # `SessionRescueController` is pure policy -- it imports nothing
+            # HTTP-aware -- so any caller that can hand over its conversation
+            # can drive it via `entroly.rescue_session`. What the proxy alone
+            # provides is doing it *for* you: rescue rewrites the outbound
+            # provider request, and the proxy is the only surface Entroly owns
+            # that sees one. MCP tools are invoked with their own arguments and
+            # never receive the host's transcript, so an MCP host that wants
+            # rescue has to pass the conversation in.
+            "automatic_modes": ["proxy"],
+            "callable_from": ["sdk", "cli", "mcp-host", "provider-sdk-wrapper"],
+            "entry_point": "entroly.rescue_session",
+            "reason_not_automatic_elsewhere": (
+                "session rescue rewrites the outbound provider request; only "
+                "the proxy sees one, so every other surface must pass its "
+                "conversation to entroly.rescue_session"
+            ),
+            "enable_with": "entroly proxy",
+            "disable_env": "ENTROLY_SESSION_RESCUE",
+            # Both are properties of the rescue itself, not of the mode, and are
+            # what separate it from summarizing compaction.
+            "omissions_recoverable": True,
+            "prefix_cache_stable": True,
+        },
         "operations": {
             "doctor": True,
             "proxy": True,
@@ -97,6 +127,7 @@ def render_capabilities_text(report: dict[str, Any]) -> str:
     """Render a concise human-readable view without adding new claims."""
     engine = report["engine"]
     dependencies = report["dependencies"]
+    session = report.get("session_protection") or {}
     lines = [
         f"Entroly {report['package']['version']} runtime capabilities",
         f"  Engine: {engine['active']}",
@@ -105,6 +136,22 @@ def render_capabilities_text(report: dict[str, Any]) -> str:
             "  HTTP proxy dependencies: "
             + ("installed" if dependencies["http_proxy"]["installed"] else "missing")
         ),
+    ]
+    if session:
+        # Two facts, because reporting only the first reads as "you don't have
+        # this": where it happens for you, and how to invoke it where it does
+        # not. The user's real question is "am I protected right now", and the
+        # answer depends on how they are running Entroly.
+        lines.append(
+            "  Runaway-session rescue: automatic in "
+            + ", ".join(session["automatic_modes"])
+            + " (`"
+            + session["enable_with"]
+            + "`); callable anywhere via `"
+            + session["entry_point"]
+            + "`"
+        )
+    lines += [
         "  Provider connectivity: not checked (offline report)",
         "  Benchmark leadership: not implied",
     ]

--- a/entroly/self_heal.py
+++ b/entroly/self_heal.py
@@ -1,0 +1,232 @@
+"""Automatic repair of a degraded Entroly install.
+
+Entroly's value depends on query-conditioned selection (QCCR), which is gated on
+the native engine: `EntrolyEngine.optimize_context` only takes the QCCR path
+`if self._use_rust`, and its candidate set comes from
+`self._rust.export_fragments()`, which has no pure-Python equivalent. Without the
+native module the optimizer still returns fragments and still fills the token
+budget -- it just never reads the query.
+
+Measured on this repository with the engine absent, three unrelated questions --
+including the nonsense control "banana bicycle weather forecast tuna sandwich" --
+returned a byte-identical 23 fragments / 7,588 tokens and the same "76.29%
+saved", because that figure is `(baseline - selected_tokens) / baseline` and
+nothing about the query can move it. With the engine present the same three
+queries returned 12/5,386, 11/3,180 and 12/4,827.
+
+Before this module, eight separate places told the user to install the engine
+(`cli.py`, `dashboard.py`, `parser_compatibility.py`, `hardening.py`, `qccr.py`).
+Everywhere told; nowhere fixed. This module fixes it instead, and is the single
+remediation path those sites should call.
+
+**This performs an outbound network install.** That is a deliberate product
+decision and a departure from Entroly's otherwise strictly opt-in outbound
+behaviour (`cli._check_for_update` requires `ENTROLY_ENABLE_UPDATE_CHECK=1`).
+Set `ENTROLY_NO_SELF_HEAL=1` to disable it -- appropriate for locked or audited
+environments, reproducible CI, and air-gapped builds. When repair is disabled or
+impossible, callers must fall back to reporting the figure *labelled* as
+unearned rather than silently presenting it as a measured saving.
+
+Never call this from an import path. Installing a package while a module is
+being imported risks re-entrant imports, partially initialised state, and
+multiprocessing deadlock, so `entroly/__init__.py` and `entroly/sdk.py` must
+not. SDK users call `entroly.repair()` explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .native_status import MIN_ENTROLY_CORE_VERSION, QCCR_SYMBOLS, native_status
+
+# Set to "1" to disable automatic repair entirely.
+ENV_DISABLE = "ENTROLY_NO_SELF_HEAL"
+# Set by the re-exec below so a repaired process never tries to repair again.
+ENV_GUARD = "ENTROLY_SELF_HEAL_DONE"
+
+_REQUIREMENT = f"entroly-core>={MIN_ENTROLY_CORE_VERSION},<2"
+
+# A wheel is ~6.4 MB. Generous enough for a slow link, short enough that a
+# hung index server or a captive-portal proxy cannot wedge the CLI.
+INSTALL_TIMEOUT_SECONDS = 180
+
+# Repair is attempted at most once per process even without the re-exec, so a
+# failing install cannot turn one command into an install loop.
+_attempted_in_this_process = False
+
+
+@dataclass
+class RepairOutcome:
+    """What repair did, and whether the caller must re-exec to benefit."""
+
+    attempted: bool = False
+    healed: bool = False
+    needs_reexec: bool = False
+    blocked_reason: str | None = None
+    steps: list[tuple[str, bool, str]] = field(default_factory=list)
+
+    @property
+    def blocked(self) -> bool:
+        return self.blocked_reason is not None
+
+
+def native_engine_ready() -> bool:
+    """True when the native engine is present, complete, and new enough."""
+    return native_status(QCCR_SYMBOLS).ok
+
+
+def disabled() -> bool:
+    return os.environ.get(ENV_DISABLE, "0") == "1"
+
+
+def already_healed() -> bool:
+    return os.environ.get(ENV_GUARD, "0") == "1"
+
+
+def _externally_managed() -> bool:
+    """True when PEP 668 forbids installing into this interpreter.
+
+    Debian/Ubuntu system Pythons and Homebrew Python ship an
+    ``EXTERNALLY-MANAGED`` marker; pip refuses to install there without
+    ``--break-system-packages``, which this must never pass. A virtualenv is
+    always safe, and its own stdlib directory carries no marker.
+    """
+    if sys.prefix != sys.base_prefix:  # inside a venv
+        return False
+    stdlib = sysconfig.get_path("stdlib")
+    return bool(stdlib) and Path(stdlib).with_name("EXTERNALLY-MANAGED").exists()
+
+
+def _installer_command() -> list[str] | None:
+    """The command that can install into *this* interpreter, or None.
+
+    `uv` is checked first only when Entroly is already running inside a
+    uv-managed environment; otherwise `pip` targeted at `sys.executable` is the
+    correct tool, because installing into some other interpreter would leave the
+    running one just as broken.
+    """
+    if _externally_managed():
+        return None
+
+    if os.environ.get("UV_PROJECT_ENVIRONMENT") or os.environ.get("VIRTUAL_ENV"):
+        uv = shutil.which("uv")
+        if uv:
+            return [uv, "pip", "install", "--python", sys.executable, "-U", _REQUIREMENT]
+
+    try:
+        import pip  # noqa: F401
+    except Exception:
+        return None
+    return [sys.executable, "-m", "pip", "install", "--no-input", "-U", _REQUIREMENT]
+
+
+def install_native_engine() -> tuple[bool, str]:
+    """Install the native engine. Returns (ok, human-readable detail).
+
+    Never raises: every failure mode here (offline, proxy, PEP 668, read-only
+    filesystem, resolver conflict) is expected in real deployments and must
+    degrade to a labelled report rather than an exception.
+    """
+    command = _installer_command()
+    if command is None:
+        if _externally_managed():
+            return False, (
+                "this Python is externally managed (PEP 668), so Entroly will not "
+                "install into it"
+            )
+        return False, "no usable installer (pip is unavailable in this interpreter)"
+
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=INSTALL_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"install exceeded {INSTALL_TIMEOUT_SECONDS}s"
+    except Exception as exc:  # pragma: no cover - platform specific
+        return False, f"install could not start: {exc}"
+
+    if completed.returncode != 0:
+        tail = (completed.stderr or completed.stdout or "").strip().splitlines()
+        detail = tail[-1] if tail else f"exit code {completed.returncode}"
+        return False, detail[:200]
+    return True, f"installed {_REQUIREMENT}"
+
+
+def repair_native(*, force: bool = False) -> RepairOutcome:
+    """Install the native engine when it is missing.
+
+    `force` bypasses the once-per-process guard for an explicit `entroly doctor`
+    style invocation; automatic callers should leave it False.
+    """
+    global _attempted_in_this_process
+
+    outcome = RepairOutcome()
+    if native_engine_ready():
+        outcome.healed = True
+        return outcome
+
+    if disabled():
+        outcome.blocked_reason = f"repair disabled by {ENV_DISABLE}=1"
+        return outcome
+    if already_healed() and not force:
+        outcome.blocked_reason = "already repaired once in this process tree"
+        return outcome
+    if _attempted_in_this_process and not force:
+        outcome.blocked_reason = "repair already attempted in this process"
+        return outcome
+
+    _attempted_in_this_process = True
+    outcome.attempted = True
+
+    ok, detail = install_native_engine()
+    outcome.steps.append(("install native engine", ok, detail))
+    if not ok:
+        outcome.blocked_reason = detail
+        return outcome
+
+    # The engine object in this process was already built with _use_rust=False,
+    # and native_status.usable_core() is lru_cached, so importing the freshly
+    # installed module here would still leave a half-native process -- the exact
+    # mixed state usable_core() exists to prevent. Re-exec instead.
+    outcome.healed = True
+    outcome.needs_reexec = True
+    return outcome
+
+
+def reexec_after_repair() -> int:
+    """Re-run this command in a fresh interpreter. Returns its exit code.
+
+    `os.execv` is avoided deliberately: on Windows it returns control to the
+    parent shell before the replacement finishes, which reorders output and
+    breaks exit-code propagation for callers such as the `entroly-mcp` npm
+    bridge, which spawns the CLI with `spawnSync` and forwards its status.
+    """
+    env = dict(os.environ)
+    env[ENV_GUARD] = "1"
+    command = [sys.executable, "-m", "entroly", *sys.argv[1:]]
+    try:
+        return subprocess.run(command, env=env, check=False).returncode
+    except Exception:  # pragma: no cover - platform specific
+        return 1
+
+
+def repair() -> RepairOutcome:
+    """Public entry point for SDK users.
+
+    Import paths must never repair implicitly, so library users who want the
+    native engine restored call this explicitly:
+
+        import entroly
+        entroly.repair()
+    """
+    return repair_native(force=True)

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -644,17 +644,209 @@ def _selection_matches_query(query: str, selected: list) -> bool:
     terms = _query_terms(query)
     if not terms:
         return True          # no lexical intent to satisfy; not a no-match
+
+    # Token membership with stemming, not raw substring containment.
+    #
+    # Substring matching fails on ordinary English morphology, and the failure
+    # is silent and one-directional: it reports "no term in common" for a
+    # selection that plainly answers the question. Measured on a two-file
+    # corpus, the query "How are credit cards charged?" against
+    # `charge_card(customer.card, amount)` matched nothing -- "cards" is not a
+    # substring of "card" and "charged" is not a substring of "charge" -- so a
+    # correct selection was discarded as a no-match. Natural-language queries
+    # are the normal case, and plurals and past tense are not exotic.
+    #
+    # `sufficiency._lexical_terms` is the tokenizer this repository already
+    # standardised on for exactly this question; its own `attainable()` says
+    # "use token membership, never unsafe raw-substring matching". One
+    # definition of "a term appears here" is worth more than two.
+    try:
+        from .sufficiency import _lexical_terms, stem
+    except Exception:  # pragma: no cover - sufficiency is always present
+        _lexical_terms = None
+
+    if _lexical_terms is None:
+        for frag in selected or []:
+            if not isinstance(frag, dict) or frag.get("is_pinned"):
+                continue
+            haystack = (
+                str(frag.get("content") or "") + " " + str(frag.get("source") or "")
+            ).lower()
+            if any(t in haystack for t in terms):
+                return True
+        return False
+
+    # Both sides through the *same* tokenizer, or the comparison is meaningless.
+    # `_query_terms` keeps `parse_manifest` whole while `_lexical_terms` splits
+    # the haystack into `parse`/`manifest`, so passing raw query words here made
+    # every snake_case identifier -- the most precise thing a developer can
+    # type -- fail to match the code that defines it. Substring matching used to
+    # paper over this; token membership cannot, so the query gets tokenised too.
+    wanted = {t for t in terms}
+    wanted |= {s for s in (stem(t) for t in terms) if s}
+    for term in terms:
+        wanted |= _lexical_terms(term)
     for frag in selected or []:
         if not isinstance(frag, dict) or frag.get("is_pinned"):
             continue
-        haystack = (
-            str(frag.get("content") or "")
-            + " "
-            + str(frag.get("source") or "")
-        ).lower()
-        if any(t in haystack for t in terms):
+        # Per fragment rather than over the whole selection: a match on the
+        # first fragment costs one tokenisation, not all of them.
+        present = _lexical_terms(
+            str(frag.get("content") or "") + " " + str(frag.get("source") or "")
+        )
+        if wanted & present:
             return True
     return False
+
+
+def apply_no_match_contract(
+    result: dict,
+    query: str,
+    *,
+    scores_are_ranked: bool = True,
+) -> dict:
+    """Refuse to pass off unrelated context as a match. Mutates and returns.
+
+    A query matching nothing still yields a ranked list, so the tool used to
+    hand back confident-looking unrelated files and bill the omitted corpus as
+    "savings". Say so explicitly instead: keep pinned/required evidence
+    (operator policy, not relevance), drop the rest, and credit zero savings.
+    Withholding context because nothing matched is not a saving, and unrelated
+    context is worse than none.
+
+    This lives outside ``optimize_context`` because that is not the only place
+    selection happens. ``cli.cmd_optimize`` deliberately bypasses
+    ``optimize_context`` on its default path -- it re-selects over the full
+    fragment store rather than through ``recall()``, which caps at ~25 items --
+    so for a long time the guard ran only on the engine-less fallback branch,
+    where ranking does not happen anyway. It was present exactly where it was
+    useless and absent exactly where it mattered. One implementation, applied by
+    every selection surface, is the fix; do not re-inline it.
+
+    ``scores_are_ranked=False`` disables the variance discriminator for callers
+    whose fragments carry a flat relevance by construction. QCCR is one:
+    ``_rust_select`` returns synthetic per-file fragments scored 1.0 for a
+    matching query and 0.0 for a non-matching one -- measured, not assumed --
+    so every QCCR selection looks "degenerate" to a spread test while
+    ``_evidence_backed`` and ``_selection_matches_query`` still separate the two
+    cases cleanly. Leaving the variance test on for that caller would wipe every
+    successful selection; leaving the whole contract off, which is what happened
+    before, lets a nonsense query return twelve confident files.
+    """
+    if not query:
+        return result
+
+    selected = result.get("selected_fragments") or result.get("selected") or []
+    if not selected:
+        return result
+
+    # Nothing was excluded -> there was no selection decision to be wrong about.
+    #
+    # "Unrelated context is worse than none" is a claim about *displacing*
+    # relevant evidence under a budget. When the optimizer returned every
+    # candidate it had, nothing was displaced, so withholding is pure loss.
+    # Measured: a two-file, 47-token repository against an 8,000-token budget
+    # asked "How does the authentication flow work?" returned both files and
+    # was then wiped to zero, because `stem("authentication")` is None and never
+    # reaches the token `auth` -- the whole corpus discarded over a vocabulary
+    # gap, with no budget pressure that discarding could possibly relieve.
+    #
+    # The guard still applies wherever the optimizer actually chose: a selection
+    # of 23 fragments drawn from 140 candidates is a decision, and a wrong one
+    # costs the user the budget it consumed.
+    considered = result.get("total_fragments")
+    try:
+        if considered and len(selected) >= int(considered):
+            return result
+    except (TypeError, ValueError):
+        pass
+
+    degenerate = scores_are_ranked and _score_distribution_is_degenerate(selected)
+    evidence = _evidence_signal(selected)
+    lexical = _selection_matches_query(query, selected)
+
+    # Unmeasured relevance must not vote. For a measured selection this is
+    # exactly the old condition -- `evidence is False` is `not _evidence_backed`
+    # and `D or not (E and M)` expands to `D or not E or not M` -- so nothing
+    # changes for any caller that ranks. When no score exists at all, the
+    # lexical check decides alone rather than a missing field convicting a
+    # selection that was never scored. Strictly fewer trips, never more.
+    if not (degenerate or evidence is False or not lexical):
+        return result
+
+    pinned = [f for f in selected if isinstance(f, dict) and f.get("is_pinned")]
+    result["selected_fragments"] = pinned
+    result["selected"] = pinned
+    result["selected_count"] = len(pinned)
+    result["tokens_used"] = sum(int(f.get("token_count", 0) or 0) for f in pinned)
+    result["total_tokens"] = result["tokens_used"]
+    result["tokens_saved"] = 0
+    result["tokens_saved_this_call"] = 0
+    result["status"] = "no_match"
+    result["no_match"] = {
+        "reason": (
+            "the ranker produced no discrimination for this query "
+            "(flat score distribution) or the returned text shared "
+            "no term with it; returning pinned evidence only rather "
+            "than unrelated files"
+        ),
+        "degenerate_ranking": degenerate,
+        # Says which signal convicted. `false` here means the selection carried
+        # no relevance at all and the lexical check decided on its own -- report
+        # what was measured rather than implying a score was consulted.
+        "evidence_measured": evidence is not None,
+        "lexical_match": lexical,
+        "query": query,
+        "candidates_considered": result.get("total_fragments", 0),
+        "pinned_retained": len(pinned),
+        "remediation": (
+            "rephrase with identifiers from the codebase, or run "
+            "`entroly health` to confirm the repository is indexed"
+        ),
+    }
+    return result
+
+
+def _evidence_signal(selected: list) -> bool | None:
+    """Three-valued relevance verdict: True, False, or **unmeasured**.
+
+    ``True``  at least one non-pinned fragment carries a positive score.
+    ``False`` scores are present on non-pinned fragments and none is positive.
+    ``None``  no non-pinned fragment carries a score at all -- the question was
+              never asked, so it has no answer.
+
+    The third state is not pedantry. Relevance is computed *during* selection
+    and is not stored on a fragment, so a selection replayed from somewhere
+    other than a ranker arrives without it -- the fast path replays a
+    crystallized recipe straight out of the fragment store, and those fragments
+    carry ``id``/``source``/``content``/``token_count`` and no score. Collapsing
+    "never scored" into "scored zero" would read every one of those as
+    unrelated and discard a selection that was promoted precisely because it was
+    measured to work.
+
+    Absence of evidence is not evidence of absence, and this codebase already
+    settled that argument once: the sufficiency certificate reports
+    ``boundary_exposure_measured=False`` rather than claiming an exposure of
+    zero it could not compute. Same discipline here.
+
+    Pinned fragments are excluded throughout: they are included by operator
+    policy, not by evidence, so they must never make a no-match look matched.
+    """
+    measured = False
+    for frag in selected or []:
+        if not isinstance(frag, dict) or frag.get("is_pinned"):
+            continue
+        for key in ("relevance", "relevance_score", "score"):
+            if key in frag:
+                try:
+                    value = float(frag[key] or 0.0)
+                except (TypeError, ValueError):
+                    continue
+                measured = True
+                if value > 0.0:
+                    return True
+                break
+    return False if measured else None
 
 
 def _evidence_backed(selected: list) -> bool:
@@ -666,21 +858,12 @@ def _evidence_backed(selected: list) -> bool:
     on this repo: the nonsense query "zzqqxx blorptastic wubbleflux" selected 8
     files at ~0.6 relevance, sharing its top hits with a real query.
 
-    Pinned fragments are excluded from this test: they are included by operator
-    policy, not by evidence, so they must never make a no-match look matched.
+    Kept as the two-valued view for callers that only need "is there evidence".
+    Unmeasured reads as False here, which is the safe answer to that question;
+    callers that must distinguish "no evidence" from "no measurement" -- the
+    no-match contract among them -- use `_evidence_signal` instead.
     """
-    for frag in selected or []:
-        if not isinstance(frag, dict) or frag.get("is_pinned"):
-            continue
-        for key in ("relevance", "relevance_score", "score"):
-            if key in frag:
-                try:
-                    if float(frag[key] or 0.0) > 0.0:
-                        return True
-                except (TypeError, ValueError):
-                    continue
-                break
-    return False
+    return _evidence_signal(selected) is True
 
 
 def _honest_tokens_saved(selected: list, tokens_saved: int) -> int:
@@ -1142,6 +1325,21 @@ class EntrolyEngine:
         # is over.
         fp_result = self._try_fast_path(query, token_budget)
         if fp_result is not None:
+            # The fast path returns before the whole pipeline, so it also
+            # returns before the no-match contract at the far end of this
+            # method. A promoted skill is fitness-gated and freshness-checked,
+            # but its trigger is a regex over the query: a pattern that fires
+            # too broadly replays a recipe that has nothing to do with what was
+            # asked, and that is precisely the "confident unrelated files"
+            # failure the contract exists to stop.
+            #
+            # `scores_are_ranked=False` because there is no ranking here to be
+            # degenerate -- the selection is a memoized decision, not a scored
+            # one. Its fragments come straight from the store and carry no
+            # relevance, so `_evidence_signal` reports unmeasured and the
+            # lexical check decides alone. Passing True instead would read every
+            # fast-path hit as unranked and discard it.
+            apply_no_match_contract(fp_result, query, scores_are_ranked=False)
             return fp_result
 
         # Query refinement: expand vague queries using in-memory file context.
@@ -1533,6 +1731,26 @@ class EntrolyEngine:
             except Exception as e:
                 logger.debug("OnlinePrism observation error: %s", e)
 
+            # ── No-match contract ────────────────────────────────────────
+            # This is the engine method every non-MCP caller reaches: the CLI,
+            # the SDK, the proxy. The guard used to exist only on the MCP tool
+            # handler of the same name nested inside `create_mcp_server`, so a
+            # query matching nothing returned confident unrelated files
+            # everywhere except MCP. Verified before this line existed: a
+            # selection scoring `relevance: 0.0` with no query term in the
+            # delivered text came back as an ordinary success.
+            #
+            # `selector` is set to "qccr" by the query path above. QCCR's
+            # relevance is a match indicator (uniform 1.0 matched / 0.0 not),
+            # not a rank, so the variance discriminator cannot read it and is
+            # switched off for that path; `_evidence_backed` carries the signal
+            # instead. The native knapsack path does produce a real ranking, so
+            # it keeps the variance test.
+            apply_no_match_contract(
+                result,
+                query,
+                scores_are_ranked=result.get("selector") != "qccr",
+            )
             return result
         finally:
             gc.enable()
@@ -3564,51 +3782,7 @@ def create_mcp_server(
             }
 
         # ── No-match contract ────────────────────────────────────────
-        # A query matching nothing still yields a ranked list, so the tool used
-        # to hand back confident-looking unrelated files and bill the omitted
-        # corpus as "savings". Say so explicitly instead: keep pinned/required
-        # evidence (operator policy, not relevance), drop the rest, and credit
-        # zero savings. Withholding context because nothing matched is not a
-        # saving, and unrelated context is worse than none.
-        if query:
-            _sel = result.get("selected_fragments") or result.get("selected") or []
-            _degenerate = _score_distribution_is_degenerate(_sel)
-            if _sel and (
-                _degenerate
-                or not (
-                    _evidence_backed(_sel)
-                    and _selection_matches_query(query, _sel)
-                )
-            ):
-                _pinned = [
-                    f for f in _sel if isinstance(f, dict) and f.get("is_pinned")
-                ]
-                result["selected_fragments"] = _pinned
-                result["selected"] = _pinned
-                result["selected_count"] = len(_pinned)
-                result["tokens_used"] = sum(
-                    int(f.get("token_count", 0) or 0) for f in _pinned
-                )
-                result["total_tokens"] = result["tokens_used"]
-                result["tokens_saved"] = 0
-                result["tokens_saved_this_call"] = 0
-                result["status"] = "no_match"
-                result["no_match"] = {
-                    "reason": (
-                        "the ranker produced no discrimination for this query "
-                        "(flat score distribution) or the returned text shared "
-                        "no term with it; returning pinned evidence only rather "
-                        "than unrelated files"
-                    ),
-                    "degenerate_ranking": _degenerate,
-                    "query": query,
-                    "candidates_considered": result.get("total_fragments", 0),
-                    "pinned_retained": len(_pinned),
-                    "remediation": (
-                        "rephrase with identifiers from the codebase, or run "
-                        "`entroly health` to confirm the repository is indexed"
-                    ),
-                }
+        apply_no_match_contract(result, query)
 
         # CCR: compressed IOS variants must remain exactly recoverable.
         # Attach content-addressed handles before serializing the MCP result.
@@ -6671,8 +6845,118 @@ def _start_background_services(engine: EntrolyEngine) -> threading.Thread:
     return t
 
 
+def _repair_native_engine_at_startup() -> None:
+    """Install the native engine before serving, then restart into it.
+
+    Without it, ``optimize_context`` never takes the QCCR path and selection
+    ignores the query -- every request returns the same fragments. That is worse
+    on a long-lived server than on a one-shot CLI run, because the client keeps
+    receiving confidently-wrong context for the life of the session.
+
+    All output goes to stderr: this server speaks JSON-RPC over stdout, and one
+    stray line there desynchronises the client.
+    """
+    from . import self_heal
+
+    if self_heal.native_engine_ready():
+        return
+
+    # Repair being switched off must never mean the degradation is silent. A
+    # long-lived server has no other place to say this: the client just keeps
+    # receiving context selected without reference to the query, indefinitely.
+    if self_heal.disabled() or self_heal.already_healed():
+        print(
+            f"[entroly] WARNING: serving without the native engine. Context "
+            f"selection will not read the query -- every request returns the "
+            f"same fragments. Install entroly-core, or unset "
+            f"{self_heal.ENV_DISABLE} to let Entroly install it.",
+            file=sys.stderr,
+        )
+        return
+
+    print(
+        "[entroly] native engine missing; context selection would ignore the "
+        "query. Repairing before serving...",
+        file=sys.stderr,
+    )
+    outcome = self_heal.repair_native()
+    for name, ok, detail in outcome.steps:
+        print(
+            f"[entroly] {name}: {'ok' if ok else 'failed'} ({detail})",
+            file=sys.stderr,
+        )
+    if outcome.needs_reexec:
+        print("[entroly] engine installed; restarting server.", file=sys.stderr)
+        sys.exit(self_heal.reexec_after_repair())
+    if outcome.blocked:
+        print(
+            f"[entroly] serving without the native engine: "
+            f"{outcome.blocked_reason}. Selection will not read the query.",
+            file=sys.stderr,
+        )
+
+
+# Announced once per process: a server restarted by its host should say it
+# again, but a single boot should not repeat itself.
+_SESSION_PROTECTION_ANNOUNCED = False
+
+
+def _announce_session_protection_mode() -> None:
+    """State once, at startup, which runaway-session protection is in force.
+
+    Runaway-session rescue (``entroly/session_rescue.py``) compacts an
+    append-only conversation before it crosses the provider context limit,
+    keeping the prompt prefix byte-stable and every omitted span recoverable.
+    It rewrites the *outbound provider request*, and only the proxy sees one:
+    MCP tools are invoked with their own arguments and never receive the host's
+    transcript, so this surface has no conversation to rescue.
+
+    That boundary is architectural and is not going to be closed here. What can
+    be closed is the user not knowing about it -- the failure mode is someone
+    running long agent sessions over MCP who believes the runaway protection
+    they read about is running. Same contract as the ``no_match`` payload and
+    the ``[unearned]`` label: when Entroly cannot do a thing, it says so.
+
+    stderr only: this server speaks JSON-RPC over stdout and one stray line
+    there desynchronises the client.
+    """
+    global _SESSION_PROTECTION_ANNOUNCED
+    if _SESSION_PROTECTION_ANNOUNCED:
+        return
+    _SESSION_PROTECTION_ANNOUNCED = True
+
+    # An operator who switched rescue off does not need to be told how to switch
+    # it on; that is nagging, not reporting.
+    if os.environ.get("ENTROLY_SESSION_RESCUE", "1").lower() not in {
+        "1", "true", "yes", "on",
+    }:
+        return
+
+    print(
+        "[entroly] runaway-session rescue is not automatic on the MCP surface: "
+        "MCP tools are called with their own arguments and never receive the "
+        "conversation, so there is nothing here to compact. Route agent traffic "
+        "through `entroly proxy` to get it applied for you, or call "
+        "`entroly.rescue_session(...)` with the transcript from a host that can "
+        "pass it. (`entroly capabilities` reports this per mode.)",
+        file=sys.stderr,
+    )
+
+
 def main():
-    """Entry point for the entroly MCP server."""
+    """Entry point for the entroly MCP server.
+
+    Engine repair lives here rather than in ``cli.cmd_serve`` because this is
+    where every MCP entry path converges. Bare ``entroly`` under an MCP host has
+    a piped stdin, so ``_docker_launcher.launch`` calls ``_run_native()`` and
+    reaches this function without going through the CLI subcommand at all --
+    and that is the path Claude Code and the ``entroly-mcp`` npm bridge use.
+    Hooking only the subcommand would have left the primary surface unrepaired.
+    The session-protection notice rides the same convergence point.
+    """
+    _repair_native_engine_at_startup()
+    _announce_session_protection_mode()
+
     engine_type = "Rust" if _RUST_AVAILABLE else "Python"
     # Prefer the constant on the loaded package — guaranteed to match the code
     # actually running. `importlib.metadata.version()` can return a stale value

--- a/entroly/session_rescue.py
+++ b/entroly/session_rescue.py
@@ -25,6 +25,9 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any, Sequence
 
+import os
+from pathlib import Path
+
 from .compression_retrieval_store_secure import CompressionRetrievalStore
 from .evidence_locked_compression import compress_evidence_locked, estimate_tokens
 
@@ -547,9 +550,131 @@ class SessionRescueController:
             }
 
 
+# ── surface-neutral entry point ──────────────────────────────────────────────
+#
+# The controller above is pure policy: it takes a message list and returns a
+# transformed one. Nothing in it is HTTP-aware. It was reachable only through
+# `entroly proxy` for no better reason than that being its first caller, which
+# left every pip, npm, SDK and provider-SDK user without a capability their
+# install already contained.
+#
+# What *is* proxy-specific is being automatic. Rescue must run on the outbound
+# request, and the proxy is the only surface Entroly owns that sees one. Any
+# caller that can hand over its conversation can drive the same policy; this is
+# that entry point.
+
+_DEFAULT_CONTROLLER: SessionRescueController | None = None
+_DEFAULT_CONTROLLER_LOCK = threading.Lock()
+
+
+def default_controller() -> SessionRescueController:
+    """The process-wide controller, created on first use.
+
+    Sharing one controller per process is load-bearing, not convenience. The
+    freeze semantics that keep the prompt prefix byte-stable live in its
+    per-conversation state: once a message has been compacted, its transformed
+    bytes are reused for the rest of the session instead of being recomputed.
+    A caller that built a fresh controller per turn would recompress the old
+    prefix every time, changing bytes the provider cache is keyed on -- turning
+    a cache-preserving rescue into a cache-destroying one.
+
+    Honours the same `ENTROLY_DIR` / `ENTROLY_SESSION_RESCUE_STORE` settings as
+    the proxy, so a machine running both writes recovery records to one store
+    and `entroly recover` finds spans from either surface.
+    """
+    global _DEFAULT_CONTROLLER
+    if _DEFAULT_CONTROLLER is not None:
+        return _DEFAULT_CONTROLLER
+    with _DEFAULT_CONTROLLER_LOCK:
+        if _DEFAULT_CONTROLLER is None:
+            root = Path(os.environ.get("ENTROLY_DIR", str(Path.home() / ".entroly")))
+            path = Path(
+                os.environ.get(
+                    "ENTROLY_SESSION_RESCUE_STORE",
+                    str(root / "session_rescue_recovery.json"),
+                )
+            )
+            path.parent.mkdir(parents=True, exist_ok=True)
+            _DEFAULT_CONTROLLER = SessionRescueController(
+                recovery_store=CompressionRetrievalStore(path)
+            )
+    return _DEFAULT_CONTROLLER
+
+
+def rescue_session(
+    conversation_id: str,
+    messages: Sequence[dict[str, Any]],
+    *,
+    context_window: int,
+    query: str = "",
+    loop_detected: bool = False,
+    cache_warm: bool = False,
+    controller: SessionRescueController | None = None,
+) -> SessionRescueResult:
+    """Compact a conversation that is approaching the provider context limit.
+
+    The same policy the proxy runs, callable from anywhere that assembles a
+    prompt -- the Python SDK, a provider-SDK wrapper, a CLI pipeline, or an MCP
+    host that chooses to pass its transcript in::
+
+        from entroly.session_rescue import rescue_session
+
+        result = rescue_session(
+            conversation_id=session_id,
+            messages=messages,
+            context_window=200_000,
+            cache_warm=True,          # defer while a warm prefix would be lost
+        )
+        messages = result.messages    # unchanged unless a watermark was crossed
+
+    Below the soft watermark this returns the conversation untouched, so it is
+    safe to call on every turn; that is how it is meant to be used, because the
+    watermark policy needs to see the growth to act on it.
+
+    Omitted spans are persisted to the recovery store *before* the returned copy
+    is changed, so nothing is dropped that cannot be recovered.
+
+    `cache_warm=True` tells the policy that a warm provider cache would be
+    sacrificed by compacting now; it defers under soft pressure and overrides
+    only at the hard watermark or on a detected retry loop. Callers that cannot
+    tell should leave it False.
+
+    **What actually gets compacted, and what does not.** Candidates are tool and
+    function messages (and, once past the hard watermark or on a detected loop,
+    older assistant turns) outside the protected tail. Within those, only
+    content the evidence-locked compressor recognises as compressible is
+    touched -- bulky structured output: logs, JSON, tables, build chatter. Plain
+    prose reasoning is left alone rather than paraphrased, which is the point:
+    this compacts machine output, it does not summarise your conversation.
+
+    A consequence worth stating plainly, because a silent no-op is the failure
+    mode this project keeps having: a conversation over the watermark whose bulk
+    is prose comes back with ``action="pressure-observed"`` and
+    ``tokens_saved=0``. That is the honest answer -- nothing safely compressible
+    was found -- not a malfunction. Check ``result.action`` rather than assuming
+    a call did something.
+
+    ``query`` is accepted for interface parity with the proxy and is **not** used
+    to choose what to drop. Compaction is deliberately query-independent so that
+    the same historical message always compresses to the same bytes; letting the
+    newest question reshape old content would churn the very prefix the provider
+    cache is keyed on.
+    """
+    return (controller or default_controller()).rescue(
+        conversation_id,
+        messages,
+        context_window=context_window,
+        query=query,
+        loop_detected=loop_detected,
+        cache_warm=cache_warm,
+    )
+
+
 __all__ = [
     "SessionRescueController",
     "SessionRescuePolicy",
     "SessionRescueResult",
+    "default_controller",
     "estimate_message_tokens",
+    "rescue_session",
 ]

--- a/marketing/launch/show-hn.md
+++ b/marketing/launch/show-hn.md
@@ -34,6 +34,13 @@ entroly verify-claims
 entroly simulate
 ```
 
+One disclosure, because it will be asked: if the native engine is missing,
+`simulate` installs it from PyPI before measuring. Without it, selection never
+reads the query, so the percentage would be decided by the token budget rather
+than by anything the tool did. It is a package install — no code or prompts
+leave the machine — and `ENTROLY_NO_SELF_HEAL=1` disables it, in which case the
+figure is reported labelled as unearned rather than withheld.
+
 `verify-claims` performs bounded installation, compression, receipt, recovery,
 and routing checks. `simulate` estimates context reduction on the repository
 without calling a model.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,26 @@ dependencies = [
     "httpx>=0.28.1",
     "starlette>=1.3.1",
     "uvicorn>=0.51.0",
+    # The native engine is a REQUIRED dependency, not an extra.
+    #
+    # Query-conditioned selection (QCCR) is gated on the native module: the
+    # candidate set comes from `self._rust.export_fragments()`, which has no
+    # pure-Python equivalent, so `optimize_context` skips relevance ranking
+    # entirely without it (server.py). The measured effect of shipping this as
+    # an extra: three unrelated queries -- including a nonsense control --
+    # returned a byte-identical selection (23 fragments / 7,588 tokens) and the
+    # same "76.29% saved", because the reported figure is baseline-minus-budget
+    # arithmetic and nothing depended on the query. Every accuracy benchmark in
+    # this repo (needle/longbench/squad/bfcl/mmlu/gsm8k/truthfulqa) measures the
+    # QCCR path, so an install without it does not run the code that was
+    # benchmarked.
+    #
+    # `pip install entroly` is the command in the README, the quickstart, and
+    # every integration doc. It must produce the engine those docs describe.
+    # abi3 wheels are published for macOS universal2, glibc+musl Linux
+    # x86_64/aarch64, and Windows x64; the pure-Python fallback remains for any
+    # platform without a wheel.
+    "entroly-core>=1.0.78,<2",
 ]
 
 [project.urls]
@@ -56,6 +76,9 @@ proxy = [
     "starlette>=1.3.1",
     "uvicorn>=0.51.0",
 ]
+# Retained as a compatibility alias for existing install instructions. The
+# native engine now ships with the base install, so `entroly[native]` and a
+# plain `entroly` resolve to the same thing.
 native = [
     "entroly-core>=1.0.78,<2",
 ]

--- a/tests/test_memory_package_metadata.py
+++ b/tests/test_memory_package_metadata.py
@@ -58,13 +58,33 @@ def test_root_pyproject_defines_documented_full_extra() -> None:
         assert dependency in full_section
 
 
-def test_root_pyproject_keeps_native_engine_optional() -> None:
+def test_root_pyproject_requires_native_engine() -> None:
+    """The native engine is a hard dependency, not an extra.
+
+    This assertion used to read `"entroly-core" not in hard_deps`. Shipping it
+    as an extra meant `pip install entroly` -- the command in the README, the
+    quickstart, and every integration doc -- produced an install where
+    query-conditioned selection (QCCR) never runs: it is gated on the native
+    module in `EntrolyEngine.optimize_context`, and its candidate set comes from
+    `self._rust.export_fragments()`, which has no pure-Python equivalent.
+
+    Measured consequence on this repo: three unrelated queries, including the
+    nonsense control "banana bicycle weather forecast tuna sandwich", returned a
+    byte-identical 23 fragments / 7,588 tokens and the same "76.29% saved",
+    because the figure is baseline-minus-budget arithmetic that nothing about
+    the query can move. Every accuracy benchmark here measures the QCCR path, so
+    the default install did not run the code that was benchmarked.
+
+    The pure-Python fallback still exists for platforms without a wheel; it is
+    just no longer what a normal install silently gets.
+    """
     text = Path("pyproject.toml").read_text(encoding="utf-8")
     hard_deps = text.split("dependencies = [", 1)[1].split("]", 1)[0]
     native_extra = text.split("native = [", 1)[1].split("]", 1)[0]
 
     assert "mcp" in hard_deps
-    assert "entroly-core" not in hard_deps
+    assert "entroly-core" in hard_deps
+    # Retained as a compatibility alias for existing install instructions.
     assert "entroly-core" in native_extra
 
 
@@ -87,7 +107,9 @@ def test_nested_pyproject_dependency_shape_matches_root() -> None:
         test_extra = text.split("test = [", 1)[1].split("]", 1)[0]
 
         assert "mcp" in hard_deps
-        assert "entroly-core" not in hard_deps
+        # Required in both manifests -- see
+        # test_root_pyproject_requires_native_engine for why this flipped.
+        assert "entroly-core" in hard_deps
         assert "entroly-core" in native_extra
         assert "entroly-core" in full_extra
         assert "pytest" in test_extra

--- a/tests/test_no_match_honesty.py
+++ b/tests/test_no_match_honesty.py
@@ -147,3 +147,373 @@ def test_pinned_scores_do_not_create_false_spread():
         {"relevance": 0.08} for _ in range(3)
     ]
     assert _score_distribution_is_degenerate(salted) is True
+
+
+# ── the contract itself, and the wiring that applies it ──────────────────────
+#
+# Every test above this line checks a *predicate* in isolation. None of them
+# checked that anything calls the contract, and that is exactly how the bug
+# below survived: `_evidence_backed`, `_selection_matches_query` and
+# `_score_distribution_is_degenerate` were all correct and all tested, while the
+# guard composed from them lived only in the MCP tool handler nested inside
+# `create_mcp_server`. `EntrolyEngine.optimize_context` -- the method the CLI,
+# the SDK and the proxy every one of them call -- had no guard at all, so a
+# query matching nothing returned confident unrelated files everywhere but MCP.
+#
+# Correct parts, unwired. The tests below pin the composition and the wiring.
+
+def _selection(relevance, text="def handler(session_token): return validate(token)"):
+    """A selection whose scores are whatever the caller says they are.
+
+    Pass a sequence for a real ranking, a scalar for a flat one -- the
+    difference is load-bearing, since a flat distribution is itself the
+    degeneracy signal.
+    """
+    scores = relevance if isinstance(relevance, (list, tuple)) else [relevance] * 4
+    return [
+        {"source": f"file:mod_{i}.py", "content": text, "relevance": score,
+         "token_count": 40}
+        for i, score in enumerate(scores)
+    ]
+
+
+def test_contract_wipes_to_pinned_and_says_why():
+    from entroly.server import apply_no_match_contract
+
+    result = {
+        "selected_fragments": _selection(0.0, text="unrelated cache economics"),
+        "total_tokens": 160,
+        "tokens_saved": 99_999,
+        "total_fragments": 12,
+    }
+
+    apply_no_match_contract(result, "zzqqxx blorptastic wubbleflux")
+
+    assert result["status"] == "no_match"
+    assert result["selected_fragments"] == []
+    # Withholding context because nothing matched is not a saving.
+    assert result["tokens_saved"] == 0
+    assert result["total_tokens"] == 0
+    assert result["no_match"]["candidates_considered"] == 12
+    assert result["no_match"]["remediation"]
+
+
+def test_contract_keeps_pinned_evidence_through_a_no_match():
+    """Pinned fragments are operator policy, not relevance."""
+    from entroly.server import apply_no_match_contract
+
+    pinned = {"source": "file:policy.py", "content": "x", "is_pinned": True,
+              "token_count": 7}
+    result = {"selected_fragments": _selection(0.0, text="unrelated") + [pinned]}
+
+    apply_no_match_contract(result, "zzqqxx blorptastic wubbleflux")
+
+    assert result["selected_fragments"] == [pinned]
+    assert result["no_match"]["pinned_retained"] == 1
+    assert result["tokens_used"] == 7
+
+
+def test_contract_leaves_a_real_match_alone():
+    from entroly.server import apply_no_match_contract
+
+    # A real ranking separates its candidates; a flat one would trip the
+    # variance discriminator, which is the point of that discriminator.
+    result = {
+        "selected_fragments": _selection([0.91, 0.74, 0.66, 0.52]),
+        "tokens_saved": 1_234,
+    }
+
+    apply_no_match_contract(result, "validate session token")
+
+    assert "status" not in result
+    assert len(result["selected_fragments"]) == 4
+    assert result["tokens_saved"] == 1_234
+
+
+def test_flat_indicator_scores_do_not_trip_when_they_are_not_a_ranking():
+    """QCCR relevance is a match indicator, not a rank.
+
+    `_rust_select` returns synthetic per-file fragments scored uniformly -- 1.0
+    when the query matched, 0.0 when it did not. A spread test reads every one
+    of those as "degenerate", so leaving the variance discriminator on for that
+    caller would discard every successful selection. Measured, not assumed.
+    """
+    from entroly.server import apply_no_match_contract
+
+    matched = {"selected_fragments": _selection(1.0)}
+    apply_no_match_contract(matched, "validate session token",
+                            scores_are_ranked=False)
+    assert "status" not in matched
+
+    # ...and the same shape with the variance test on would be wiped, which is
+    # why the caller has to declare what its scores mean.
+    wiped = {"selected_fragments": _selection(1.0)}
+    apply_no_match_contract(wiped, "validate session token",
+                            scores_are_ranked=True)
+    assert wiped["status"] == "no_match"
+
+
+def _calls_the_contract(function_node) -> bool:
+    import ast
+
+    return any(
+        isinstance(node, ast.Call)
+        and getattr(node.func, "id", getattr(node.func, "attr", None))
+        == "apply_no_match_contract"
+        for node in ast.walk(function_node)
+    )
+
+
+def _find_function(qualifier: str, name: str):
+    import ast
+    from pathlib import Path
+
+    tree = ast.parse(
+        Path("entroly/server.py").read_text(encoding="utf-8", errors="replace")
+    )
+    for outer in ast.walk(tree):
+        if getattr(outer, "name", None) != qualifier:
+            continue
+        for inner in ast.walk(outer):
+            if (
+                isinstance(inner, ast.FunctionDef)
+                and inner.name == name
+                and inner is not outer
+            ):
+                return inner
+    raise AssertionError(f"{qualifier}.{name} not found")
+
+
+def test_engine_optimize_context_is_wired_to_the_contract():
+    """The regression that matters: the guard must be *called*, not just exist.
+
+    `EntrolyEngine.optimize_context` is the method the CLI, SDK and proxy use.
+    It went without this guard while a same-named MCP handler had it.
+    """
+    assert _calls_the_contract(_find_function("EntrolyEngine", "optimize_context"))
+
+
+def test_mcp_tool_handler_is_wired_to_the_contract():
+    """The MCP surface keeps its guard as the engine gains one."""
+    assert _calls_the_contract(_find_function("create_mcp_server", "optimize_context"))
+
+
+# ── unmeasured relevance is not zero relevance ───────────────────────────────
+#
+# Relevance is computed during selection and never stored on a fragment, so a
+# selection that did not come from a ranker arrives without one. The fast path
+# is exactly that: it replays a crystallized recipe out of the fragment store,
+# and those fragments carry id/source/content/token_count and no score.
+#
+# Reading "never scored" as "scored zero" would convict every fast-path hit --
+# a selection promoted *because* its fitness was measured -- of being unrelated.
+# The sufficiency certificate settled this argument once already by reporting
+# `boundary_exposure_measured=False` instead of a zero it could not compute.
+
+def _unscored(text="def login(user): return authenticate(user)"):
+    """A replayed selection: store shape, no relevance field."""
+    return [
+        {"id": f"frag-{i}", "source": f"file:auth_{i}.py", "content": text,
+         "token_count": 30}
+        for i in range(3)
+    ]
+
+
+def test_evidence_signal_separates_absent_from_zero():
+    from entroly.server import _evidence_signal
+
+    assert _evidence_signal(_selection(0.7)) is True
+    assert _evidence_signal(_selection(0.0)) is False
+    assert _evidence_signal(_unscored()) is None
+    # Pinned-only carries no measurable evidence either way.
+    assert _evidence_signal([{"source": "p.py", "relevance": 0.9,
+                              "is_pinned": True}]) is None
+
+
+def test_evidence_backed_keeps_its_two_valued_contract():
+    """The bool view must not shift under callers that only ask yes/no."""
+    from entroly.server import _evidence_backed
+
+    assert _evidence_backed(_selection(0.7)) is True
+    assert _evidence_backed(_selection(0.0)) is False
+    assert _evidence_backed(_unscored()) is False
+    assert _evidence_backed([]) is False
+
+
+def test_unscored_selection_survives_when_the_text_answers_the_query():
+    """A missing field must not convict a selection nothing ever scored."""
+    from entroly.server import apply_no_match_contract
+
+    result = {"selected_fragments": _unscored()}
+
+    apply_no_match_contract(result, "how does login authenticate",
+                            scores_are_ranked=False)
+
+    assert "status" not in result
+    assert len(result["selected_fragments"]) == 3
+
+
+def test_unscored_selection_still_trips_when_it_shares_nothing():
+    """Unmeasured relevance abstains; it does not grant immunity.
+
+    A regex-triggered skill that fires too broadly replays a recipe unrelated to
+    what was asked. With no score to consult, the lexical check has to decide --
+    and it must still be able to say no.
+    """
+    from entroly.server import apply_no_match_contract
+
+    result = {"selected_fragments": _unscored(text="unrelated cache economics")}
+
+    apply_no_match_contract(result, "zzqqxx blorptastic wubbleflux",
+                            scores_are_ranked=False)
+
+    assert result["status"] == "no_match"
+    assert result["no_match"]["evidence_measured"] is False
+    assert result["no_match"]["lexical_match"] is False
+
+
+def test_payload_reports_which_signal_convicted():
+    from entroly.server import apply_no_match_contract
+
+    scored = {"selected_fragments": _selection(0.0, text="unrelated cache")}
+    apply_no_match_contract(scored, "zzqqxx blorptastic")
+
+    assert scored["no_match"]["evidence_measured"] is True
+
+
+def test_fast_path_return_is_wired_to_the_contract():
+    """The fast path exits before the pipeline, so it needs its own call.
+
+    A promoted skill is fitness-gated and freshness-checked, but it is triggered
+    by a regex over the query; a pattern that fires too broadly replays a recipe
+    that has nothing to do with the question.
+    """
+    import ast
+
+    engine_method = _find_function("EntrolyEngine", "optimize_context")
+    for node in ast.walk(engine_method):
+        if not isinstance(node, ast.If):
+            continue
+        source = ast.dump(node)
+        if "fp_result" in source and "apply_no_match_contract" in source:
+            return
+    raise AssertionError("fast-path early return does not apply the contract")
+
+
+# ── morphology: token membership, not substring containment ──────────────────
+#
+# The lexical check is the one signal the scoring pipeline cannot fabricate, so
+# it decides alone whenever relevance is unmeasured. That makes its precision
+# load-bearing. Raw substring containment fails on ordinary English morphology
+# in the direction that discards good work: it reports "no term in common" for
+# a selection that answers the question.
+#
+# Found by `test_simulate_small_project`: the query "How are credit cards
+# charged?" against `charge_card(customer.card, amount)` matched nothing --
+# "cards" is not a substring of "card", "charged" is not a substring of
+# "charge" -- so a correct selection was discarded as a no-match the moment the
+# contract was wired into the engine method.
+
+def test_plural_query_term_matches_singular_source_token():
+    from entroly.server import _selection_matches_query
+
+    billing = [{
+        "source": "src/billing.py",
+        "content": "def charge_card(customer, amount):\n"
+                   "    return StripeGateway().charge(customer.card, amount)\n",
+    }]
+    assert _selection_matches_query("How are credit cards charged?", billing) is True
+
+
+def test_past_tense_query_term_matches_present_tense_source_token():
+    from entroly.server import _selection_matches_query
+
+    frags = [{"source": "a.py", "content": "def verify_password(user, pw): ..."}]
+    assert _selection_matches_query("who verifies the password", frags) is True
+
+
+def test_stemming_does_not_make_unrelated_words_match():
+    """Recall must not be bought with precision.
+
+    A matcher loose enough to call anything a match would silently retire the
+    guard -- the same outcome as not running it, which is what this whole
+    contract exists to prevent.
+    """
+    from entroly.server import _selection_matches_query
+
+    frags = [{"source": "src/billing.py",
+              "content": "def charge_card(customer, amount): ..."}]
+    assert _selection_matches_query(
+        "zzqqxx blorptastic wubbleflux", frags
+    ) is False
+    # "discharge" must not match "charge" -- stems, not substrings.
+    assert _selection_matches_query("discharge the capacitor", frags) is False
+
+
+# ── the guard only judges an actual choice ───────────────────────────────────
+
+def test_selection_of_every_candidate_is_never_a_no_match():
+    """Nothing excluded means no selection decision to be wrong about.
+
+    "Unrelated context is worse than none" is a claim about *displacing*
+    relevant evidence under a budget. When the optimizer returned everything it
+    had, nothing was displaced and withholding is pure loss.
+
+    Measured: a two-file, 47-token repository against an 8,000-token budget,
+    asked "How does the authentication flow work?", returned both files and was
+    then wiped to zero -- `stem("authentication")` is None and never reaches the
+    token `auth`, so the whole corpus was discarded over a vocabulary gap that
+    no amount of discarding could relieve.
+    """
+    from entroly.server import apply_no_match_contract
+
+    result = {
+        "selected_fragments": _selection(0.0, text="unrelated cache economics"),
+        "total_fragments": 4,
+    }
+
+    apply_no_match_contract(result, "zzqqxx blorptastic wubbleflux")
+
+    assert "status" not in result
+    assert len(result["selected_fragments"]) == 4
+
+
+def test_the_guard_still_judges_a_real_subset():
+    """A selection drawn from a wider corpus is a decision, and can be wrong."""
+    from entroly.server import apply_no_match_contract
+
+    result = {
+        "selected_fragments": _selection(0.0, text="unrelated cache economics"),
+        "total_fragments": 140,
+    }
+
+    apply_no_match_contract(result, "zzqqxx blorptastic wubbleflux")
+
+    assert result["status"] == "no_match"
+
+
+# ── query and haystack must share a tokenizer ────────────────────────────────
+
+def test_snake_case_identifier_matches_the_code_that_defines_it():
+    """The most precise thing a developer can type must not fail to match.
+
+    `_query_terms` keeps `parse_manifest` whole; `_lexical_terms` splits the
+    haystack into `parse`/`manifest`. Comparing across two tokenizers made
+    every snake_case identifier a no-match. Substring matching hid this;
+    token membership cannot, so the query is tokenised the same way.
+    """
+    from entroly.server import _selection_matches_query
+
+    frags = [{
+        "source": "file:parser.py",
+        "content": "def parse_manifest(path):\n    return decode_manifest(path)\n",
+    }]
+    assert _selection_matches_query("parse_manifest decode_manifest", frags) is True
+
+
+def test_tokenised_query_does_not_match_unrelated_code():
+    from entroly.server import _selection_matches_query
+
+    frags = [{"source": "file:billing.py",
+              "content": "def charge_card(customer, amount): ..."}]
+    assert _selection_matches_query("parse_manifest decode_manifest", frags) is False

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -215,14 +215,35 @@ def test_mcp_registry_identity_is_canonical_and_non_squattable() -> None:
     assert actual == expected
 
 
-def test_native_engine_is_optional_for_first_time_install() -> None:
+def test_native_engine_ships_with_first_time_install() -> None:
+    """A first-time `pip install entroly` must include the native engine.
+
+    This assertion used to read `not any(dep.startswith("entroly-core") ...)`.
+    Shipping the engine as an extra meant the command in the README, the
+    quickstart, and every integration doc produced an install where
+    query-conditioned selection (QCCR) never runs: it is gated on the native
+    module in `EntrolyEngine.optimize_context`, and its candidate set comes
+    from `self._rust.export_fragments()`, which has no pure-Python equivalent.
+
+    Measured consequence: three unrelated queries, including the nonsense
+    control "banana bicycle weather forecast tuna sandwich", returned a
+    byte-identical 23 fragments / 7,588 tokens and the same "76.29% saved",
+    because that figure is baseline-minus-budget arithmetic that nothing about
+    the query can move. Every accuracy benchmark in this repo measures the QCCR
+    path, so the default install did not run the code that was benchmarked.
+
+    The `native` and `full` extras are retained as compatibility aliases for
+    install instructions already in the wild; they now resolve to the same
+    thing as a plain install. See also
+    test_memory_package_metadata.test_root_pyproject_requires_native_engine.
+    """
     for path in ("pyproject.toml", "entroly/pyproject.toml"):
         project = _read_project_metadata(path)
         hard_deps = project["dependencies"]
         native_deps = project["optional-dependencies"]["native"]
         full_deps = project["optional-dependencies"]["full"]
 
-        assert not any(dep.startswith("entroly-core") for dep in hard_deps)
+        assert f"entroly-core>={RELEASE_VERSION},<2" in hard_deps
         assert f"entroly-core>={RELEASE_VERSION},<2" in native_deps
         assert f"entroly-core>={RELEASE_VERSION},<2" in full_deps
 

--- a/tests/test_session_protection_visibility.py
+++ b/tests/test_session_protection_visibility.py
@@ -1,0 +1,317 @@
+"""Which runaway-session protection is in force, and on which surface.
+
+`entroly/session_rescue.py` compacts an append-only agent conversation before
+it crosses the provider context limit: it defers while a warm provider cache
+would be sacrificed, freezes compacted bytes so later turns do not rewrite the
+prefix, and persists every omitted span before mutating the outbound copy.
+
+`SessionRescueController` is pure policy -- it imports nothing HTTP-aware -- so
+it was never proxy-*coupled*, only proxy-*exposed*, because the proxy happened
+to be its first caller. `entroly.rescue_session` is the surface-neutral entry
+point that pip, npm-via-Python, SDK and provider-SDK callers use to run the same
+policy on their own conversations.
+
+What remains proxy-only is being automatic: rescue rewrites the outbound
+provider request, and the proxy is the only surface Entroly owns that sees one.
+MCP tools (`remember_fragment`, `entroly_retrieve`, `optimize_context`,
+`get_stats`, `analyze_codebase_health`, `smart_read`) are invoked with their own
+arguments and never receive the host's transcript, so an MCP host that wants
+rescue has to pass the conversation in.
+
+Two failure modes these tests exist to prevent: a user running long sessions
+over MCP who believes automatic protection is running, and a pip or SDK user
+told they lack a capability their install has always contained.
+
+These tests do NOT assert that rescue happens automatically under MCP. It
+cannot, and a test demanding it would be demanding a lie.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.runtime_capabilities import (
+    render_capabilities_text,
+    runtime_capabilities,
+)
+
+
+# ── capability report ────────────────────────────────────────────────────────
+
+def test_session_protection_separates_automatic_from_available() -> None:
+    """The distinction is automatic vs callable, not proxy vs nothing.
+
+    Reporting `active_modes: ["proxy"]` alone would tell a pip or SDK user they
+    do not have a capability their install has always contained.
+    """
+    session = runtime_capabilities()["session_protection"]
+
+    assert session["implemented"] is True
+    assert session["automatic_modes"] == ["proxy"]
+    assert "sdk" in session["callable_from"]
+    assert session["entry_point"] == "entroly.rescue_session"
+    assert session["enable_with"] == "entroly proxy"
+
+
+def test_report_explains_why_only_the_proxy_is_automatic() -> None:
+    """A boundary without a reason reads as an oversight and invites a "fix"."""
+    session = runtime_capabilities()["session_protection"]
+
+    reason = session["reason_not_automatic_elsewhere"].lower()
+    assert "outbound" in reason
+    assert "conversation" in reason
+
+
+def test_report_keeps_the_two_properties_that_distinguish_it_from_compaction() -> None:
+    """Recoverability and prefix stability are the whole differentiation.
+
+    Summarizing compaction is lossy and rewrites the prefix, which throws away
+    the warm provider cache. Losing either property in a refactor would remove
+    the reason to prefer this over the harness's own compaction.
+    """
+    session = runtime_capabilities()["session_protection"]
+
+    assert session["omissions_recoverable"] is True
+    assert session["prefix_cache_stable"] is True
+
+
+def test_human_output_names_both_the_automatic_mode_and_the_call() -> None:
+    text = render_capabilities_text(runtime_capabilities())
+
+    assert "Runaway-session rescue" in text
+    assert "entroly proxy" in text
+    assert "entroly.rescue_session" in text
+
+
+def test_added_block_stays_privacy_safe() -> None:
+    """The report must not gain path/error keys as it grows (see
+    test_runtime_capabilities.test_report_is_stable_conservative_and_privacy_safe).
+    """
+    session = runtime_capabilities()["session_protection"]
+
+    forbidden = {"path", "error", "exception", "traceback"}
+    assert not any(str(key).casefold() in forbidden for key in session)
+
+
+def test_render_tolerates_a_report_without_the_block() -> None:
+    """Older callers may hold a report produced before this block existed."""
+    report = runtime_capabilities()
+    report.pop("session_protection")
+
+    text = render_capabilities_text(report)
+
+    assert "Runaway-session rescue" not in text
+    assert "Engine:" in text
+
+
+# ── MCP startup notice ───────────────────────────────────────────────────────
+
+def _announce(monkeypatch: pytest.MonkeyPatch) -> None:
+    from entroly import server
+
+    monkeypatch.setattr(server, "_SESSION_PROTECTION_ANNOUNCED", False)
+    server._announce_session_protection_mode()
+
+
+def test_mcp_startup_states_the_mode_and_the_remedy(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.delenv("ENTROLY_SESSION_RESCUE", raising=False)
+
+    _announce(monkeypatch)
+
+    err = capsys.readouterr().err
+    assert "not automatic on the MCP surface" in err
+    assert "entroly proxy" in err
+
+
+def test_startup_notice_never_writes_to_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """The MCP server speaks JSON-RPC on stdout; one stray line desyncs it."""
+    monkeypatch.delenv("ENTROLY_SESSION_RESCUE", raising=False)
+
+    _announce(monkeypatch)
+
+    captured = capsys.readouterr()
+    assert captured.out == "", (
+        f"MCP stdout must carry protocol only, got: {captured.out!r}"
+    )
+    assert captured.err
+
+
+def test_notice_is_printed_once_per_process(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    from entroly import server
+
+    monkeypatch.delenv("ENTROLY_SESSION_RESCUE", raising=False)
+    monkeypatch.setattr(server, "_SESSION_PROTECTION_ANNOUNCED", False)
+
+    server._announce_session_protection_mode()
+    server._announce_session_protection_mode()
+
+    assert capsys.readouterr().err.count("not automatic on the MCP surface") == 1
+
+
+def test_operator_who_disabled_rescue_is_not_nagged(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Telling someone how to enable what they switched off is noise."""
+    monkeypatch.setenv("ENTROLY_SESSION_RESCUE", "0")
+
+    _announce(monkeypatch)
+
+    assert capsys.readouterr().err == ""
+
+
+# ── the capability itself, off the proxy ─────────────────────────────────────
+
+def _controller(tmp_path):
+    from entroly.compression_retrieval_store_secure import CompressionRetrievalStore
+    from entroly.session_rescue import SessionRescueController
+
+    return SessionRescueController(
+        recovery_store=CompressionRetrievalStore(tmp_path / "recovery.json")
+    )
+
+
+def _runaway(turns: int = 40) -> list[dict[str, str]]:
+    """An append-only agent loop: short asks, bulky tool output.
+
+    Tool output is what compacts -- see `rescue_session`. A fixture built from
+    prose would return `pressure-observed` and prove nothing about the policy.
+    """
+    messages = [{"role": "system", "content": "You are a coding agent."}]
+    for turn in range(turns):
+        messages.append({"role": "user", "content": f"run step {turn}"})
+        messages.append(
+            {
+                "role": "tool",
+                "content": "\n".join(
+                    f"[INFO] compiled crate_{i} v0.1.{i} in {i}ms" for i in range(300)
+                ),
+            }
+        )
+    return messages
+
+
+def _over_watermark(messages) -> int:
+    from entroly.session_rescue import estimate_message_tokens
+
+    return max(1, int(estimate_message_tokens(messages) / 0.95))
+
+
+def test_sdk_caller_gets_the_same_rescue_the_proxy_gets(tmp_path) -> None:
+    """A pip/SDK user must reach the real policy, not a lesser reimplementation."""
+    from entroly.session_rescue import estimate_message_tokens, rescue_session
+
+    messages = _runaway()
+    before = estimate_message_tokens(messages)
+
+    result = rescue_session(
+        "sdk-session",
+        messages,
+        context_window=_over_watermark(messages),
+        controller=_controller(tmp_path),
+    )
+
+    assert result.action == "emergency-rescue"
+    assert result.tokens_saved > 0
+    assert estimate_message_tokens(result.messages) < before
+
+
+def test_every_omission_is_receipted_before_the_copy_changes(tmp_path) -> None:
+    """Recoverability is the property that separates this from summarizing."""
+    from entroly.session_rescue import rescue_session
+
+    messages = _runaway()
+
+    result = rescue_session(
+        "receipted-session",
+        messages,
+        context_window=_over_watermark(messages),
+        controller=_controller(tmp_path),
+    )
+
+    assert result.tokens_saved > 0
+    assert result.recovery_receipts
+
+
+def test_prose_over_the_watermark_reports_instead_of_paraphrasing(tmp_path) -> None:
+    """Nothing safely compressible found is an answer, not a malfunction.
+
+    The compactor does not summarise reasoning. A caller must be able to tell
+    "I compacted nothing" from "I compacted something", which is why `action`
+    exists and why a silent zero would be the wrong contract.
+    """
+    from entroly.session_rescue import rescue_session
+
+    messages = [{"role": "system", "content": "You are a coding agent."}]
+    for turn in range(60):
+        messages.append({"role": "user", "content": f"step {turn}: " + "detail " * 400})
+        messages.append(
+            {"role": "assistant", "content": f"result {turn}: " + "output " * 400}
+        )
+
+    result = rescue_session(
+        "prose-session",
+        messages,
+        context_window=_over_watermark(messages),
+        controller=_controller(tmp_path),
+    )
+
+    assert result.action == "pressure-observed"
+    assert result.tokens_saved == 0
+
+
+def test_below_the_watermark_the_conversation_is_untouched(tmp_path) -> None:
+    """Safe to call every turn -- and calling every turn is how it sees growth."""
+    from entroly.session_rescue import rescue_session
+
+    messages = [{"role": "user", "content": "small"}]
+
+    result = rescue_session(
+        "quiet-session",
+        messages,
+        context_window=200_000,
+        controller=_controller(tmp_path),
+    )
+
+    assert result.messages == messages
+
+
+def test_caller_list_is_never_mutated(tmp_path) -> None:
+    """The caller keeps its own transcript; only the outbound copy changes."""
+    from entroly.session_rescue import estimate_message_tokens, rescue_session
+
+    messages = _runaway()
+    snapshot = [dict(message) for message in messages]
+
+    rescue_session(
+        "immutable-session",
+        messages,
+        context_window=max(1, int(estimate_message_tokens(messages) / 0.95)),
+        controller=_controller(tmp_path),
+    )
+
+    assert messages == snapshot
+
+
+def test_default_controller_is_shared_so_frozen_bytes_survive_turns() -> None:
+    """Per-call controllers would recompress the prefix and void the cache.
+
+    The freeze that keeps the prompt prefix byte-stable lives in per-conversation
+    controller state, so the process-wide instance is load-bearing rather than a
+    convenience.
+    """
+    from entroly.session_rescue import default_controller
+
+    assert default_controller() is default_controller()
+
+
+def test_rescue_session_is_importable_from_the_package_root() -> None:
+    """`from entroly import rescue_session` is the documented SDK path."""
+    import entroly
+
+    assert hasattr(entroly, "rescue_session")

--- a/tests/test_simulate_degraded_engine.py
+++ b/tests/test_simulate_degraded_engine.py
@@ -1,0 +1,268 @@
+"""What `entroly simulate` reports when the native engine is missing.
+
+Query-conditioned selection (QCCR) is gated on the native engine: its candidate
+set comes from `self._rust.export_fragments()`, which has no pure-Python
+equivalent, so `optimize_context` skips relevance ranking entirely without it.
+The optimizer still returns fragments and still fills the token budget -- it just
+never reads the query.
+
+The reported percentage is `(baseline - selected_tokens) / baseline` with
+`baseline = min(total_tokens, 32_000)`, so it is decided by the budget before
+selection happens. Measured on this repo with the engine absent, three unrelated
+questions -- including the nonsense control "banana bicycle weather forecast tuna
+sandwich" -- produced a byte-identical 23 fragments / 7,588 tokens and the same
+"76.29% saved".
+
+Normally nobody sees this: `_auto_repair_before_measuring` installs the engine
+first. These tests cover the paths where repair cannot run -- offline, CI,
+PEP 668, `ENTROLY_NO_SELF_HEAL=1`.
+
+The contract is **label, do not withhold**. An earlier version suppressed the
+number entirely. That was honest and useless: a first run that reports nothing
+gives the user no reason to continue. So the figure is printed, and the caveat
+is printed in the same block, because a claim and its caveat have to travel
+together or the caveat does not exist.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import pytest
+
+from entroly import self_heal
+from entroly.cli import _print_local_simulation
+
+
+def _report(*, query_conditioned: bool) -> dict:
+    limitations = ["No LLM call was made; quality is not judged here."]
+    if not query_conditioned:
+        limitations.append(
+            "The native engine is unavailable, so selection did not read the "
+            "query: these figures are budget arithmetic and are NOT a measured "
+            'saving. Install it with: pip install -U "entroly[native]"'
+        )
+    return {
+        "files_indexed": 140,
+        "repo_tokens_indexed": 604_158,
+        "baseline_tokens_per_query": 32_000,
+        "budget": 8_000,
+        "budget_narrowed_to_demonstrate": False,
+        "average_reduction_pct": 76.29,
+        "total_tokens_saved": 24_412,
+        "query_conditioned_selection": query_conditioned,
+        "selection_engine": "qccr-native" if query_conditioned else "python-fallback-unranked",
+        "queries": [
+            {
+                "query": "why did this project stop growing",
+                "selected_fragments": 23,
+                "selected_tokens": 7_588,
+                "reduction_pct": 76.29,
+                "tokens_saved": 24_412,
+                "latency_ms": 15.96,
+                "top_sources": ["file:pkg/rare.py", "file:src/qccr.rs"],
+            }
+        ],
+        "latency_ms": {"min": 15.96, "p95": 15.96, "max": 15.96},
+        "limitations": limitations,
+    }
+
+
+def _render(report: dict) -> str:
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        _print_local_simulation(report, title="Entroly Simulate", include_perf=False)
+    return buf.getvalue()
+
+
+# ── degraded output ──────────────────────────────────────────────────────────
+
+def test_degraded_run_still_shows_the_number() -> None:
+    """Withholding the figure leaves a first-time user with nothing."""
+    out = _render(_report(query_conditioned=False))
+
+    assert "76.3%" in out
+    assert "24,412" in out
+
+
+def test_degraded_number_is_labelled_unearned_in_the_same_block() -> None:
+    """The caveat must not be somewhere else on the page.
+
+    Printing "76.3%" and burying the qualification in a trailing limitations
+    line is how an unearned number ends up quoted on its own.
+    """
+    out = _render(_report(query_conditioned=False))
+
+    assert "unearned" in out
+    headline = next(
+        line for line in out.splitlines() if "Average reduction" in line
+    )
+    assert "unearned" in headline, (
+        f"the caveat must be on the headline itself, got: {headline!r}"
+    )
+    assert "not a measured saving" in headline
+
+
+def test_degraded_run_says_why_and_how_to_fix() -> None:
+    out = _render(_report(query_conditioned=False))
+
+    assert "Relevance ranking is OFF" in out
+    assert "did not read your query" in out
+    assert 'pip install -U "entroly[native]"' in out
+
+
+def test_healthy_run_carries_no_caveat() -> None:
+    """The warning must not leak into a correctly-installed run."""
+    out = _render(_report(query_conditioned=True))
+
+    assert "Average reduction: 76.3%" in out
+    assert "24,412 tokens saved" in out
+    assert "Relevance ranking is OFF" not in out
+    assert "unearned" not in out
+    assert "entroly[native]" not in out
+
+
+def test_report_exposes_selection_mode_for_machine_consumers() -> None:
+    """`--json` consumers must be able to tell the two modes apart."""
+    degraded = _report(query_conditioned=False)
+    healthy = _report(query_conditioned=True)
+
+    assert degraded["query_conditioned_selection"] is False
+    assert degraded["selection_engine"] == "python-fallback-unranked"
+    assert any("NOT a measured saving" in line for line in degraded["limitations"])
+
+    assert healthy["query_conditioned_selection"] is True
+    assert healthy["selection_engine"] == "qccr-native"
+    assert not any("NOT a measured saving" in line for line in healthy["limitations"])
+
+
+# ── self-heal gating ─────────────────────────────────────────────────────────
+
+def test_repair_is_disabled_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Locked, audited, and air-gapped environments need a hard off switch."""
+    monkeypatch.setenv(self_heal.ENV_DISABLE, "1")
+    monkeypatch.setattr(self_heal, "native_engine_ready", lambda: False)
+
+    outcome = self_heal.repair_native()
+
+    assert outcome.attempted is False
+    assert outcome.blocked is True
+    assert self_heal.ENV_DISABLE in outcome.blocked_reason
+
+
+def test_repair_does_not_recurse_after_reexec(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The re-executed process must not try to repair again.
+
+    Without this guard a repair that installs successfully but still fails the
+    readiness check would re-exec forever.
+    """
+    monkeypatch.setenv(self_heal.ENV_GUARD, "1")
+    monkeypatch.setattr(self_heal, "native_engine_ready", lambda: False)
+
+    outcome = self_heal.repair_native()
+
+    assert outcome.attempted is False
+    assert outcome.blocked is True
+
+
+def test_repair_is_a_noop_when_the_engine_is_already_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(self_heal, "native_engine_ready", lambda: True)
+
+    outcome = self_heal.repair_native()
+
+    assert outcome.healed is True
+    assert outcome.attempted is False
+    assert outcome.needs_reexec is False
+
+
+def test_externally_managed_python_is_never_written_to(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PEP 668 refusal must degrade to a labelled report, not an exception.
+
+    Debian/Ubuntu and Homebrew system Pythons ship an EXTERNALLY-MANAGED marker.
+    Installing there needs --break-system-packages, which Entroly must never
+    pass on a user's behalf.
+    """
+    monkeypatch.setattr(self_heal, "_externally_managed", lambda: True)
+
+    assert self_heal._installer_command() is None
+
+    ok, detail = self_heal.install_native_engine()
+    assert ok is False
+    assert "externally managed" in detail
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param("server", id="mcp-server"),
+        pytest.param("proxy", id="proxy"),
+    ],
+)
+def test_services_warn_when_repair_is_switched_off(
+    call: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Disabling repair must not make a degraded service silent.
+
+    Caught by hand: the first version short-circuited on `disabled()` before
+    printing anything, so an operator who set ENTROLY_NO_SELF_HEAL got a server
+    that returned query-independent context indefinitely with no indication why.
+    A one-shot CLI run has the labelled report to fall back on; a long-lived
+    service has nothing.
+    """
+    monkeypatch.setenv(self_heal.ENV_DISABLE, "1")
+    monkeypatch.setattr(self_heal, "native_engine_ready", lambda: False)
+
+    if call == "server":
+        from entroly.server import _repair_native_engine_at_startup
+
+        _repair_native_engine_at_startup()
+    else:
+        from entroly.cli import _auto_repair_for_service
+
+        assert _auto_repair_for_service("proxy") is None
+
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "will not read the query" in err
+    assert self_heal.ENV_DISABLE in err
+
+
+def test_service_repair_never_writes_to_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """The MCP server speaks JSON-RPC on stdout.
+
+    One stray progress line there desynchronises the client, so every repair
+    message on a service path must go to stderr.
+    """
+    monkeypatch.setenv(self_heal.ENV_DISABLE, "1")
+    monkeypatch.setattr(self_heal, "native_engine_ready", lambda: False)
+
+    from entroly.server import _repair_native_engine_at_startup
+
+    _repair_native_engine_at_startup()
+
+    captured = capsys.readouterr()
+    assert captured.out == "", (
+        f"MCP stdout must carry protocol only, got: {captured.out!r}"
+    )
+    assert captured.err
+
+
+def test_importing_entroly_does_not_install_anything() -> None:
+    """An import must never shell out to pip.
+
+    Installing mid-import risks re-entrant imports, partially initialised state,
+    and multiprocessing deadlock, so the SDK exposes `entroly.repair()` instead
+    of healing implicitly.
+    """
+    import entroly
+
+    assert hasattr(entroly, "repair")
+    assert hasattr(entroly, "native_engine_ready")
+    assert self_heal._attempted_in_this_process is False


### PR DESCRIPTION
## The bug

`pip install -U entroly` did not install the engine. PyPI metadata listed `entroly-core` only under `extra == "full"` and `extra == "native"`, so the plain install — the command in the README, the quickstart, and every integration doc — produced the pure-Python fallback.

Query-conditioned selection is gated on the native module: its candidate set comes from `self._rust.export_fragments()`, which has no pure-Python equivalent, so `optimize_context` never read the query.

**Measured.** Three unrelated questions, including the control `"banana bicycle weather forecast tuna sandwich"`, returned a byte-identical **23 fragments / 7,588 tokens** and the same **"76.29% saved"** — that figure is `(baseline − selected) / baseline` and nothing about the query can move it. With the engine present the same three returned 12/5,386, 11/3,180 and 12/4,827.

Every accuracy benchmark in this repo measures the QCCR path, so the default install did not run the code that was benchmarked.

## Changes

**Packaging.** `entroly-core` becomes a hard dependency in both manifests, with musllinux wheels so that is satisfiable on Alpine. `native` and `full` remain as compatibility aliases for install lines already published.

**Self-heal.** `entroly/self_heal.py` restores a missing engine and re-execs, hooked at the CLI, `server.main()` (where every MCP entry path converges, including bare `entroly` under an MCP host) and the proxy. `ENTROLY_NO_SELF_HEAL=1` disables it; it never runs from an import path — SDK users call `entroly.repair()`. When repair is blocked, the figure is reported labelled `[unearned]` rather than withheld, with the caveat on the headline line itself. README, PRIVACY, CLAUDE, show-hn and docs/DETAILS disclose the outbound install.

**Session rescue reaches every surface.** `SessionRescueController` was pure policy — it imports nothing HTTP-aware — but only the proxy called it, leaving pip, SDK and provider-SDK users without a capability their install already contained. `entroly.rescue_session` is the surface-neutral entry point. The proxy stays the only surface that applies it *automatically*, because it is the only one that sees the outbound request; `entroly capabilities` now reports that per mode rather than as a bare boolean.

**The no-match contract now runs on every selection path.** It lived only in the MCP tool handler nested inside `create_mcp_server` — not on `EntrolyEngine.optimize_context`, the method the CLI, SDK and proxy all call — so a query matching nothing returned confident unrelated files everywhere except MCP. Extracted to `apply_no_match_contract` and applied at the engine method, the fast-path early return, and the CLI's QCCR branch, which hand-builds its own result.

## Invariants this establishes

- **Relevance is three-valued.** `_evidence_signal` separates *scored zero* from *never scored*. A replayed fast-path recipe carries no relevance, and reading absent as zero would discard a selection promoted because its fitness was measured — the same discipline as the sufficiency certificate reporting `boundary_exposure_measured=False` instead of a zero it cannot compute.
- **The guard judges a choice, not a non-decision.** When the selection contains every candidate, nothing was displaced. A 47-token corpus under an 8,000-token budget must not be wiped over a vocabulary gap.
- **Query and haystack share one tokenizer.** Substring containment failed on plurals (`cards` vs `card`), past tense (`charged` vs `charge`), and snake_case identifiers (`parse_manifest` vs the file defining it).

## Testing

**3,935 passed, 32 skipped, 3 xfailed, 0 failed** (20m46s), `pytest tests/ --timeout=300`. `ruff` clean.

`test_no_match_honesty.py` gains behaviour tests, AST wiring tests for all three call sites, and morphology coverage in both directions. The file previously tested every predicate in isolation and nothing that called them — which is exactly how an unwired guard survived. New files: `test_simulate_degraded_engine.py`, `test_session_protection_visibility.py`.

## Note on commit shape

This is one commit rather than three. The changes are interdependent — `cli.py` imports `apply_no_match_contract` from `server.py`, `__init__.py` exports `rescue_session` — and the same files carry hunks from all three concerns, so splitting would produce intermediate commits that do not import cleanly.
