### PR TITLE
ci: let superseded runs cancel themselves instead of starving the queue

### DIFF
--- a/.github/workflows/agent-integration-contracts.yml
+++ b/.github/workflows/agent-integration-contracts.yml
@@ -36,6 +36,24 @@ on:
 permissions:
   contents: read
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: agent-integration-contracts-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   contracts:
     name: Python ${{ matrix.python-version }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,6 +44,24 @@ permissions:
 env:
   EVIDENCE_TIKTOKEN_VERSION: "0.9.0"
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: benchmark-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,24 @@ env:
   PIP_TIMEOUT: 120
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Python Lint (ruff)

--- a/.github/workflows/cloudflare-community-savings.yml
+++ b/.github/workflows/cloudflare-community-savings.yml
@@ -14,6 +14,24 @@ on:
 permissions:
   contents: read
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: cloudflare-community-savings-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-intelligence.yml
+++ b/.github/workflows/code-intelligence.yml
@@ -6,6 +6,24 @@ on:
   push:
     branches: [main]
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: code-intelligence-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   parser-extra:
     name: Parser Extra (explicit acquisition + offline reuse)

--- a/.github/workflows/commit-identity-guard.yml
+++ b/.github/workflows/commit-identity-guard.yml
@@ -9,6 +9,24 @@ on:
 permissions:
   contents: read
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: commit-identity-guard-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   commit-identity:
     name: Commit Identity Guard

--- a/.github/workflows/native-dogfood-diagnostic.yml
+++ b/.github/workflows/native-dogfood-diagnostic.yml
@@ -12,6 +12,24 @@ env:
   PIP_TIMEOUT: 120
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: native-dogfood-diagnostic-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   diagnose:
     if: github.event.pull_request.head.ref == 'dogfood/deep-runtime-20260727'

--- a/.github/workflows/public-trust.yml
+++ b/.github/workflows/public-trust.yml
@@ -53,6 +53,24 @@ on:
 permissions:
   contents: read
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: public-trust-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   offline-contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/qccr-signature-completion-gate.yml
+++ b/.github/workflows/qccr-signature-completion-gate.yml
@@ -22,6 +22,24 @@ on:
 permissions:
   contents: read
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: qccr-signature-completion-gate-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   exact-head-regression:
     runs-on: ubuntu-latest

--- a/.github/workflows/round7-runtime-repair.yml
+++ b/.github/workflows/round7-runtime-repair.yml
@@ -16,6 +16,24 @@ on:
 permissions:
   contents: write
 
+# Superseded runs cancel themselves.
+#
+# Four pushes to one draft branch inside three minutes queued 26 duplicate runs
+# and starved every other pull request of ubuntu runners for over an hour, while
+# macOS and Windows -- separate runner pools -- finished in a minute. The older
+# runs were validating commits that had already been replaced, so the queue was
+# spent on answers nobody could use.
+#
+# Keyed on the pull request number so concurrent pull requests never cancel each
+# other; `github.ref` is the fallback for push and dispatch events.
+concurrency:
+  group: round7-runtime-repair-${{ github.event.pull_request.number || github.ref }}
+  # Only pull-request runs cancel. A push to main can be the run that publishes,
+  # tags, or syncs a release surface, and cancelling one of those mid-flight
+  # leaves partial state behind -- exactly the "release automation stays boring"
+  # rule in CLAUDE.md.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     name: Validate (${{ matrix.os }})


### PR DESCRIPTION
## The problem

Four pushes to one draft branch inside three minutes queued **26 duplicate workflow runs** — four each of CI, Agent Integration Contracts, Commit Identity Guard, QCCR Dependency Evidence Gate, Code Intelligence Optional Extra, and the Competitive Benchmark.

They consumed the ubuntu runner pool, and every other pull request sat `Queued — Waiting to run this check...` behind them for over an hour. macOS and Windows jobs, which draw from separate runner pools, finished in about a minute — which is what makes the cause legible: nothing was broken, the queue was simply full.

The older duplicates were validating commits that later pushes had already replaced. The queue was spent computing answers nobody could act on, and the cost landed on unrelated pull requests.

## The change

Adds a concurrency group to the ten pull-request workflows that lacked one:

`agent-integration-contracts` · `benchmark` · `ci` · `cloudflare-community-savings` · `code-intelligence` · `commit-identity-guard` · `native-dogfood-diagnostic` · `public-trust` · `qccr-signature-completion-gate` · `round7-runtime-repair`

```yaml
concurrency:
  group: <workflow>-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Keyed on the pull-request number so concurrent PRs never cancel each other, falling back to `github.ref` for push and dispatch events.

## Why the guarded `cancel-in-progress`

Only pull-request runs cancel. A push to `main` can be the run that publishes, tags, or syncs a release surface, and cancelling one mid-flight leaves partial state behind — the "release automation stays boring" rule in `CLAUDE.md`.

The publish workflows already encode exactly this by pinning `cancel-in-progress: false` (`entroly-publish`, `publish-mcp-registry`, `publish-openclaw-clawhub`, `sync-homebrew-formula`, `sync-release-version`). This change keeps that property for `main` without giving up cancellation where it is safe.

`release-binary.yml` and `publish-core-wheels.yml` are deliberately untouched: neither runs on `pull_request`, and both are release paths.

## Testing

Every workflow in `.github/workflows` parses under `yaml.safe_load`, and each resulting concurrency block was read back from the **parsed document** rather than the source text, so the assertion is about what GitHub will see rather than about the string I inserted.

## Note

`deep-dogfood.yml` and `onboarding-self-dogfood.yml` already have concurrency groups with an unconditional `cancel-in-progress: true`. Those would cancel a push-to-main run too. Left as-is here to keep this change to one concern, but worth a follow-up.
