### PR TITLE
integration: add #349 passive-dedupe validation to combined Work Graph branch

### DIFF
--- a/.github/workflows/apply-workgraph-content-digests.yml
+++ b/.github/workflows/apply-workgraph-content-digests.yml
@@ -1,0 +1,133 @@
+name: Apply Work Graph Content Digests
+
+on:
+  push:
+    branches: [audit/workgraph-passive-dedupe-20260817]
+    paths: [.github/workflows/apply-workgraph-content-digests.yml]
+
+permissions:
+  contents: write
+
+jobs:
+  validate-and-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feat/ai-work-graph-v1
+          fetch-depth: 0
+
+      - name: Add bounded content-complete digests to Python and Node observers
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          py = Path('entroly/work_graph_repo.py')
+          text = py.read_text(encoding='utf-8')
+          if '_worktree_content_digest(' not in text:
+              text = text.replace('import os\nimport subprocess\n', 'import os\nimport stat\nimport subprocess\n', 1)
+              text = text.replace('_MAX_COMMITS = 20\n', '_MAX_COMMITS = 20\n_MAX_DIGEST_FILE_BYTES = 16 * 1024 * 1024\n', 1)
+              anchor = '\ndef _branch_commits(\n'
+              helper = '''\ndef _worktree_content_digest(root: Path, change: dict[str, Any]) -> str:\n    # Dedupe is fail-closed: only bounded regular files whose exact worktree\n    # bytes can be hashed qualify. Staged/conflicted/special/oversized paths\n    # remain auditable as distinct observations.\n    if change.get("staged") or change.get("conflicted"):\n        return ""\n    if change.get("kind") == "deleted":\n        return "worktree:deleted"\n    relative = str(change.get("path", ""))\n    if not relative:\n        return ""\n    candidate = root / relative\n    try:\n        info = candidate.lstat()\n    except OSError:\n        return ""\n    if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_DIGEST_FILE_BYTES:\n        return ""\n    digest = _try_git(root, "hash-object", "--no-filters", "--", relative)\n    if len(digest) not in {40, 64} or any(ch not in "0123456789abcdefABCDEF" for ch in digest):\n        return ""\n    return f"git-blob:{digest.lower()}"\n\n'''
+              if anchor not in text:
+                  raise SystemExit('Python digest helper anchor changed')
+              text = text.replace(anchor, helper + anchor, 1)
+              old = '    changes = _parse_status(root)\n    commits = _branch_commits(root, base, ahead, int(max_commits))\n'
+              new = '    changes = _parse_status(root)\n    for change in changes:\n        change["content_digest"] = _worktree_content_digest(root, change)\n    commits = _branch_commits(root, base, ahead, int(max_commits))\n'
+              if old not in text:
+                  raise SystemExit('Python observation anchor changed')
+              text = text.replace(old, new, 1)
+              py.write_text(text, encoding='utf-8')
+
+          js = Path('entroly-wasm/js/work_graph_repo.js')
+          text = js.read_text(encoding='utf-8')
+          if 'function worktreeContentDigest(' not in text:
+              text = text.replace('const MAX_COMMITS = 20;\n', 'const MAX_COMMITS = 20;\nconst MAX_DIGEST_FILE_BYTES = 16 * 1024 * 1024;\n', 1)
+              anchor = '\nfunction branchCommits(root, base, ahead, maxCommits) {'
+              helper = '''\nfunction worktreeContentDigest(root, change) {\n  // Dedupe is fail-closed: do not follow symlinks or hash special/large files.\n  if (change.staged || change.conflicted) return '';\n  if (change.kind === 'deleted') return 'worktree:deleted';\n  const relative = String(change.path || '');\n  if (!relative) return '';\n  const candidate = path.join(root, relative);\n  let info;\n  try { info = fs.lstatSync(candidate); } catch (_) { return ''; }\n  if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_DIGEST_FILE_BYTES) return '';\n  const digest = tryGit(root, ['hash-object', '--no-filters', '--', relative]);\n  if (!/^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/.test(digest)) return '';\n  return `git-blob:${digest.toLowerCase()}`;\n}\n'''
+              if anchor not in text:
+                  raise SystemExit('Node digest helper anchor changed')
+              text = text.replace(anchor, helper + anchor, 1)
+              old = '  const changes = parseStatus(root);\n  const maxCommits = options.maxCommits == null ? MAX_COMMITS : options.maxCommits;\n'
+              new = '  const changes = parseStatus(root);\n  for (const change of changes) change.content_digest = worktreeContentDigest(root, change);\n  const maxCommits = options.maxCommits == null ? MAX_COMMITS : options.maxCommits;\n'
+              if old not in text:
+                  raise SystemExit('Node observation anchor changed')
+              text = text.replace(old, new, 1)
+              js.write_text(text, encoding='utf-8')
+          PY
+
+      - name: Add cross-surface digest contract tests
+        shell: bash
+        run: |
+          cat > tests/test_work_graph_content_digest.py <<'PY'
+          from __future__ import annotations
+          import subprocess
+          from pathlib import Path
+          from entroly.work_graph_repo import discover_repository_observation
+
+          def git(repo: Path, *args: str) -> None:
+              subprocess.run(['git', '-C', str(repo), *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+          def test_worktree_digest_tracks_bytes_and_deletion(tmp_path: Path) -> None:
+              repo = tmp_path / 'repo'; repo.mkdir(); git(repo, 'init', '-b', 'main')
+              git(repo, 'config', 'user.email', 'test@example.com'); git(repo, 'config', 'user.name', 'Test')
+              target = repo / 'a.txt'; target.write_text('one\n'); git(repo, 'add', 'a.txt'); git(repo, 'commit', '-m', 'initial')
+              target.write_text('two\n')
+              first = discover_repository_observation(repo, include_checkpoint=False, observed_at_ms=1)
+              change = next(x for x in first['changes'] if x['path'] == 'a.txt')
+              assert change['content_digest'].startswith('git-blob:')
+              digest = change['content_digest']
+              target.write_text('three\n')
+              second = discover_repository_observation(repo, include_checkpoint=False, observed_at_ms=2)
+              assert next(x for x in second['changes'] if x['path'] == 'a.txt')['content_digest'] != digest
+              target.unlink()
+              third = discover_repository_observation(repo, include_checkpoint=False, observed_at_ms=3)
+              assert next(x for x in third['changes'] if x['path'] == 'a.txt')['content_digest'] == 'worktree:deleted'
+          PY
+          cat > entroly-wasm/test_work_graph_content_digest.js <<'JS'
+          'use strict';
+          const assert = require('assert');
+          const fs = require('fs'); const os = require('os'); const path = require('path');
+          const { execFileSync } = require('child_process');
+          const { discoverRepositoryObservation } = require('./js/work_graph_repo');
+          const root = fs.mkdtempSync(path.join(os.tmpdir(), 'entroly-wg-digest-'));
+          const git = (...args) => execFileSync('git', ['-C', root, ...args], { stdio: 'ignore' });
+          git('init', '-b', 'main'); git('config', 'user.email', 'test@example.com'); git('config', 'user.name', 'Test');
+          fs.writeFileSync(path.join(root, 'a.txt'), 'one\n'); git('add', 'a.txt'); git('commit', '-m', 'initial');
+          fs.writeFileSync(path.join(root, 'a.txt'), 'two\n');
+          const one = discoverRepositoryObservation(root, { includeCheckpoint: false, observedAtMs: 1 });
+          const d1 = one.changes.find(x => x.path === 'a.txt').content_digest; assert.match(d1, /^git-blob:[0-9a-f]{40,64}$/);
+          fs.writeFileSync(path.join(root, 'a.txt'), 'three\n');
+          const two = discoverRepositoryObservation(root, { includeCheckpoint: false, observedAtMs: 2 });
+          assert.notStrictEqual(two.changes.find(x => x.path === 'a.txt').content_digest, d1);
+          fs.unlinkSync(path.join(root, 'a.txt'));
+          const three = discoverRepositoryObservation(root, { includeCheckpoint: false, observedAtMs: 3 });
+          assert.strictEqual(three.changes.find(x => x.path === 'a.txt').content_digest, 'worktree:deleted');
+          fs.rmSync(root, { recursive: true, force: true });
+          JS
+
+      - name: Validate adapter contracts
+        run: |
+          python -m pytest -q tests/test_work_graph_repo.py tests/test_work_graph_content_digest.py
+          node entroly-wasm/test_work_graph_repo.js
+          node entroly-wasm/test_work_graph_content_digest.js
+          python -m py_compile entroly/work_graph_repo.py tests/test_work_graph_content_digest.py
+          node --check entroly-wasm/js/work_graph_repo.js
+          node --check entroly-wasm/test_work_graph_content_digest.js
+
+      - name: Refuse branch races and commit only validated product/test files
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin feat/ai-work-graph-v1
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/feat/ai-work-graph-v1)"
+          changed="$(git diff --name-only | sort)"
+          expected="$(printf '%s\n' entroly-wasm/js/work_graph_repo.js entroly-wasm/test_work_graph_content_digest.js entroly/work_graph_repo.py tests/test_work_graph_content_digest.py | sort)"
+          test "$changed" = "$expected"
+          git config user.name 'entroly-workgraph-bot'
+          git config user.email '208309368+juyterman1000@users.noreply.github.com'
+          git add $changed
+          git commit -m 'fix(work-graph): add content-complete passive snapshot digests'
+          git push origin HEAD:feat/ai-work-graph-v1

--- a/.github/workflows/apply-workgraph-passive-dedupe-v2.yml
+++ b/.github/workflows/apply-workgraph-passive-dedupe-v2.yml
@@ -1,3 +1,4 @@
+# Retriggered after PR #348 concurrency hardening landed on main.
 name: Apply Work Graph Passive Snapshot Dedupe v2
 
 on:

--- a/.github/workflows/apply-workgraph-passive-dedupe-v2.yml
+++ b/.github/workflows/apply-workgraph-passive-dedupe-v2.yml
@@ -1,0 +1,76 @@
+name: Apply Work Graph Passive Snapshot Dedupe v2
+
+on:
+  push:
+    branches:
+      - audit/workgraph-passive-dedupe-20260817
+    paths:
+      - .github/workflows/apply-workgraph-passive-dedupe-v2.yml
+      - scripts/apply_workgraph_passive_dedupe_v2.py
+
+permissions:
+  contents: write
+
+jobs:
+  validate-and-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out exact feature branch
+        uses: actions/checkout@v4
+        with:
+          ref: feat/ai-work-graph-v1
+          fetch-depth: 0
+
+      - name: Require audited Rust and hardened fingerprint adapters
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git hash-object entroly-engine/src/work_graph.rs)" = "4cfa2d84123b53bc8d6a4b68e5d5431da9ac3a30"
+          grep -q 'O_NOFOLLOW' entroly/work_graph_content_digest.py
+          grep -q 'st_ino' entroly/work_graph_content_digest.py
+          grep -q 'MAX_HASH_FILE_BYTES' entroly/work_graph_content_digest.py
+          grep -q 'O_NOFOLLOW' entroly-wasm/js/work_graph_content_digest.js
+          grep -q 'mtimeNs' entroly-wasm/js/work_graph_content_digest.js
+          grep -q 'MAX_HASH_FILE_BYTES' entroly-wasm/js/work_graph_content_digest.js
+          git rev-parse HEAD > /tmp/workgraph-passive-start-head
+
+      - name: Recover and apply corrected exact-anchor patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin audit/workgraph-passive-dedupe-20260817:audit-passive
+          git show audit-passive:scripts/apply_workgraph_passive_dedupe_v2.py > /tmp/apply_workgraph_passive_dedupe_v2.py
+          python /tmp/apply_workgraph_passive_dedupe_v2.py
+          test "$(git diff --name-only)" = "entroly-engine/src/work_graph.rs"
+          git diff --check
+          grep -q 'fn passive_repository_snapshot_fingerprint' entroly-engine/src/work_graph.rs
+          grep -q 'identical_content_complete_passive_snapshots_do_not_grow_history' entroly-engine/src/work_graph.rs
+          grep -q 'repeated_active_verification_is_never_collapsed' entroly-engine/src/work_graph.rs
+          grep -q 'repeated_model_execution_is_never_collapsed' entroly-engine/src/work_graph.rs
+
+      - name: Install Rust validation toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Validate shared Rust semantics
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo fmt --manifest-path entroly-engine/Cargo.toml
+          cargo test --manifest-path entroly-engine/Cargo.toml --lib
+          cargo clippy --manifest-path entroly-engine/Cargo.toml --all-targets -- -D warnings
+          test "$(git diff --name-only)" = "entroly-engine/src/work_graph.rs"
+
+      - name: Refuse feature-branch races and push one Rust-only commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin feat/ai-work-graph-v1
+          test "$(cat /tmp/workgraph-passive-start-head)" = "$(git rev-parse origin/feat/ai-work-graph-v1)"
+          test "$(git diff --name-only)" = "entroly-engine/src/work_graph.rs"
+          git config user.name "entroly-workgraph-bot"
+          git config user.email "208309368+juyterman1000@users.noreply.github.com"
+          git add entroly-engine/src/work_graph.rs
+          git commit -m "fix(work-graph): dedupe content-complete passive snapshots"
+          git push origin HEAD:feat/ai-work-graph-v1

--- a/.github/workflows/apply-workgraph-passive-dedupe.yml
+++ b/.github/workflows/apply-workgraph-passive-dedupe.yml
@@ -1,0 +1,356 @@
+name: Apply Work Graph Passive Snapshot Dedupe
+
+on:
+  push:
+    branches:
+      - audit/workgraph-passive-dedupe-20260817
+    paths:
+      - .github/workflows/apply-workgraph-passive-dedupe.yml
+
+permissions:
+  contents: write
+
+jobs:
+  validate-and-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out exact feature branch
+        uses: actions/checkout@v4
+        with:
+          ref: feat/ai-work-graph-v1
+          fetch-depth: 0
+
+      - name: Require audited Rust base blob
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git hash-object entroly-engine/src/work_graph.rs)" = "4cfa2d84123b53bc8d6a4b68e5d5431da9ac3a30"
+
+      - name: Apply narrow semantic patch and kill tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('entroly-engine/src/work_graph.rs')
+          text = path.read_text(encoding='utf-8')
+          assert 'fn passive_repository_snapshot_fingerprint(' not in text
+
+          old_observe = '''    pub fn observe_repository(
+                  &mut self,
+                  observation: RepositoryObservation,
+              ) -> Result<String, WorkGraphError> {
+                  if observation.repo_id != self.repo_id {
+                      return Err(WorkGraphError::RepoMismatch {
+                          expected: self.repo_id.clone(),
+                          actual: observation.repo_id,
+                      });
+                  }
+                  let event = observation_to_event(observation)?;
+                  self.apply_event(event)
+              }
+          '''
+          new_observe = '''    pub fn observe_repository(
+                  &mut self,
+                  observation: RepositoryObservation,
+              ) -> Result<String, WorkGraphError> {
+                  if observation.repo_id != self.repo_id {
+                      return Err(WorkGraphError::RepoMismatch {
+                          expected: self.repo_id.clone(),
+                          actual: observation.repo_id.clone(),
+                      });
+                  }
+                  let passive_fingerprint = passive_repository_snapshot_fingerprint(&observation)?;
+                  let mut event = observation_to_event(observation)?;
+                  if let Some(fingerprint) = passive_fingerprint {
+                      let source_ref = format!("repo-snapshot:{fingerprint}");
+                      if let Some(last) = self.events.last() {
+                          if last.source_kind == EvidenceKind::RepositoryFact
+                              && last.source_ref == source_ref
+                          {
+                              return Ok(last.event_id.clone());
+                          }
+                      }
+                      event.source_ref = source_ref;
+                  }
+                  self.apply_event(event)
+              }
+          '''
+          if old_observe not in text:
+              raise SystemExit('observe_repository anchor changed; refusing patch')
+          text = text.replace(old_observe, new_observe, 1)
+
+          sort_start = text.index('    observation.changes.sort_by(|a, b| {', text.index('fn observation_to_event('))
+          sort_end_marker = '    observation.leases.sort_by(|a, b| a.lease_id.cmp(&b.lease_id));\n'
+          sort_end = text.index(sort_end_marker, sort_start) + len(sort_end_marker)
+          sort_block = text[sort_start:sort_end]
+          text = text[:sort_start] + '    canonicalize_repository_observation(&mut observation);\n' + text[sort_end:]
+
+          helper = '''fn canonicalize_repository_observation(observation: &mut RepositoryObservation) {
+          ''' + sort_block + '''}
+
+          fn valid_passive_content_digest(change: &FileChangeObservation) -> bool {
+              if change.staged || change.conflicted {
+                  return false;
+              }
+              if change.kind == FileChangeKind::Deleted {
+                  return change.content_digest == "worktree:deleted";
+              }
+              let Some(hex) = change.content_digest.strip_prefix("git-blob:") else {
+                  return false;
+              };
+              matches!(hex.len(), 40 | 64) && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+          }
+
+          fn passive_repository_snapshot_fingerprint(
+              observation: &RepositoryObservation,
+          ) -> Result<Option<String>, WorkGraphError> {
+              if !observation.agent_id.is_empty()
+                  || !observation.session_id.is_empty()
+                  || !observation.verifications.is_empty()
+                  || !observation.claims.is_empty()
+                  || !observation.leases.is_empty()
+                  || !observation.model_executions.is_empty()
+              {
+                  return Ok(None);
+              }
+              if observation
+                  .task_hint
+                  .as_ref()
+                  .is_some_and(|task| task.source_kind != EvidenceKind::Checkpoint)
+              {
+                  return Ok(None);
+              }
+              if observation
+                  .decisions
+                  .iter()
+                  .any(|decision| decision.source_kind != EvidenceKind::Checkpoint)
+              {
+                  return Ok(None);
+              }
+              if observation
+                  .changes
+                  .iter()
+                  .any(|change| !valid_passive_content_digest(change))
+              {
+                  return Ok(None);
+              }
+
+              let mut semantic = observation.clone();
+              semantic.observed_at_ms = 0;
+              canonicalize_repository_observation(&mut semantic);
+              Ok(Some(sha256_json(&semantic)?))
+          }
+
+          '''
+          observation_anchor = 'fn observation_to_event('
+          insert_at = text.index(observation_anchor)
+          text = text[:insert_at] + helper + text[insert_at:]
+
+          test_helper_anchor = '    #[test]\n    fn clean_repo_is_null_control()'
+          test_helper = '''    fn passive_dirty_observation(digest: &str, observed_at_ms: i64) -> RepositoryObservation {
+                  let mut obs = clean_observation();
+                  obs.observed_at_ms = observed_at_ms;
+                  obs.branch.name = "feature/passive".to_string();
+                  obs.changes.push(FileChangeObservation {
+                      path: "src/auth.rs".to_string(),
+                      kind: FileChangeKind::Modified,
+                      staged: false,
+                      conflicted: false,
+                      old_path: String::new(),
+                      content_digest: digest.to_string(),
+                  });
+                  obs
+              }
+
+          '''
+          if test_helper_anchor not in text:
+              raise SystemExit('test helper anchor changed; refusing patch')
+          text = text.replace(test_helper_anchor, test_helper + test_helper_anchor, 1)
+
+          tests_anchor = '    #[test]\n    fn explicit_task_without_durable_changes_is_planned()'
+          tests = '''    #[test]
+              fn passive_snapshot_same_content_different_timestamp_dedupes() {
+                  let mut graph = WorkGraph::new("repo-1").unwrap();
+                  let one = passive_dirty_observation(
+                      "git-blob:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      1_000,
+                  );
+                  let mut two = one.clone();
+                  two.observed_at_ms = 2_000;
+                  let first_id = graph.observe_repository(one).unwrap();
+                  let second_id = graph.observe_repository(two).unwrap();
+                  assert_eq!(first_id, second_id);
+                  assert_eq!(graph.event_count(), 1);
+              }
+
+              #[test]
+              fn passive_snapshot_changed_bytes_remain_auditable() {
+                  let mut graph = WorkGraph::new("repo-1").unwrap();
+                  graph
+                      .observe_repository(passive_dirty_observation(
+                          "git-blob:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                          1_000,
+                      ))
+                      .unwrap();
+                  graph
+                      .observe_repository(passive_dirty_observation(
+                          "git-blob:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                          2_000,
+                      ))
+                      .unwrap();
+                  assert_eq!(graph.event_count(), 2);
+              }
+
+              #[test]
+              fn passive_snapshot_refuses_incomplete_or_active_identity() {
+                  let mut missing = WorkGraph::new("repo-1").unwrap();
+                  missing
+                      .observe_repository(passive_dirty_observation("", 1_000))
+                      .unwrap();
+                  missing
+                      .observe_repository(passive_dirty_observation("", 2_000))
+                      .unwrap();
+                  assert_eq!(missing.event_count(), 2);
+
+                  let mut invalid = WorkGraph::new("repo-1").unwrap();
+                  invalid
+                      .observe_repository(passive_dirty_observation("not-a-git-object", 1_000))
+                      .unwrap();
+                  invalid
+                      .observe_repository(passive_dirty_observation("not-a-git-object", 2_000))
+                      .unwrap();
+                  assert_eq!(invalid.event_count(), 2);
+
+                  let mut staged = WorkGraph::new("repo-1").unwrap();
+                  let mut staged_one = passive_dirty_observation(
+                      "git-blob:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      1_000,
+                  );
+                  staged_one.changes[0].staged = true;
+                  let mut staged_two = staged_one.clone();
+                  staged_two.observed_at_ms = 2_000;
+                  staged.observe_repository(staged_one).unwrap();
+                  staged.observe_repository(staged_two).unwrap();
+                  assert_eq!(staged.event_count(), 2);
+
+                  let mut active = WorkGraph::new("repo-1").unwrap();
+                  let mut active_one = passive_dirty_observation(
+                      "git-blob:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      1_000,
+                  );
+                  active_one.agent_id = "claude".to_string();
+                  let mut active_two = active_one.clone();
+                  active_two.observed_at_ms = 2_000;
+                  active.observe_repository(active_one).unwrap();
+                  active.observe_repository(active_two).unwrap();
+                  assert_eq!(active.event_count(), 2);
+              }
+
+              #[test]
+              fn passive_snapshot_change_away_and_back_is_not_erased() {
+                  let mut graph = WorkGraph::new("repo-1").unwrap();
+                  graph
+                      .observe_repository(passive_dirty_observation(
+                          "git-blob:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                          1_000,
+                      ))
+                      .unwrap();
+                  graph
+                      .observe_repository(passive_dirty_observation(
+                          "git-blob:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                          2_000,
+                      ))
+                      .unwrap();
+                  graph
+                      .observe_repository(passive_dirty_observation(
+                          "git-blob:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                          3_000,
+                      ))
+                      .unwrap();
+                  assert_eq!(graph.event_count(), 3);
+              }
+
+              #[test]
+              fn deleted_passive_snapshot_accepts_only_terminal_marker() {
+                  let mut graph = WorkGraph::new("repo-1").unwrap();
+                  let mut one = clean_observation();
+                  one.branch.name = "feature/delete".to_string();
+                  one.changes.push(FileChangeObservation {
+                      path: "old.txt".to_string(),
+                      kind: FileChangeKind::Deleted,
+                      staged: false,
+                      conflicted: false,
+                      old_path: String::new(),
+                      content_digest: "worktree:deleted".to_string(),
+                  });
+                  let mut two = one.clone();
+                  two.observed_at_ms += 1;
+                  graph.observe_repository(one).unwrap();
+                  graph.observe_repository(two).unwrap();
+                  assert_eq!(graph.event_count(), 1);
+
+                  let mut wrong = WorkGraph::new("repo-1").unwrap();
+                  let mut bad = clean_observation();
+                  bad.branch.name = "feature/delete".to_string();
+                  bad.changes.push(FileChangeObservation {
+                      path: "old.txt".to_string(),
+                      kind: FileChangeKind::Deleted,
+                      staged: false,
+                      conflicted: false,
+                      old_path: String::new(),
+                      content_digest: "git-blob:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+                  });
+                  let mut bad_two = bad.clone();
+                  bad_two.observed_at_ms += 1;
+                  wrong.observe_repository(bad).unwrap();
+                  wrong.observe_repository(bad_two).unwrap();
+                  assert_eq!(wrong.event_count(), 2);
+              }
+
+          '''
+          if tests_anchor not in text:
+              raise SystemExit('test insertion anchor changed; refusing patch')
+          text = text.replace(tests_anchor, tests + tests_anchor, 1)
+          path.write_text(text, encoding='utf-8')
+          PY
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Format exact patch
+        run: cargo fmt --manifest-path entroly-engine/Cargo.toml
+
+      - name: Test shared Rust engine
+        run: cargo test --manifest-path entroly-engine/Cargo.toml --lib
+
+      - name: Clippy shared Rust engine
+        run: cargo clippy --manifest-path entroly-engine/Cargo.toml --all-targets -- -D warnings
+
+      - name: Restrict product diff to Work Graph core
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed="$(git diff --name-only)"
+          test "$changed" = "entroly-engine/src/work_graph.rs"
+
+      - name: Refuse branch races
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin feat/ai-work-graph-v1
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/feat/ai-work-graph-v1)"
+          test "$(git show HEAD:entroly-engine/src/work_graph.rs | git hash-object --stdin)" = "4cfa2d84123b53bc8d6a4b68e5d5431da9ac3a30"
+
+      - name: Commit validated Rust patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "entroly-workgraph-bot"
+          git config user.email "208309368+juyterman1000@users.noreply.github.com"
+          git add entroly-engine/src/work_graph.rs
+          git commit -m "fix(work-graph): dedupe content-complete passive snapshots"
+          git push origin HEAD:feat/ai-work-graph-v1

--- a/.github/workflows/retrigger-workgraph-passive-dedupe.yml
+++ b/.github/workflows/retrigger-workgraph-passive-dedupe.yml
@@ -1,5 +1,6 @@
 name: Retrigger Work Graph Passive Dedupe
 
+# Retrigger marker: hardened worktree fingerprint readers v2.
 on:
   push:
     branches:

--- a/.github/workflows/retrigger-workgraph-passive-dedupe.yml
+++ b/.github/workflows/retrigger-workgraph-passive-dedupe.yml
@@ -1,0 +1,76 @@
+name: Retrigger Work Graph Passive Dedupe
+
+on:
+  push:
+    branches:
+      - audit/workgraph-passive-dedupe-20260817
+    paths:
+      - .github/workflows/retrigger-workgraph-passive-dedupe.yml
+
+permissions:
+  contents: write
+
+jobs:
+  apply-audited-patch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out feature branch
+        uses: actions/checkout@v4
+        with:
+          ref: feat/ai-work-graph-v1
+          fetch-depth: 0
+
+      - name: Recover audited patch script
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin audit/workgraph-passive-dedupe-20260817:audit-passive
+          git show audit-passive:.github/workflows/apply-workgraph-passive-dedupe.yml > /tmp/source.yml
+          python - <<'PY'
+          from pathlib import Path
+          text = Path('/tmp/source.yml').read_text(encoding='utf-8')
+          start_marker = "          python - <<'PY'\n"
+          end_marker = "\n          PY\n"
+          start = text.index(start_marker) + len(start_marker)
+          end = text.index(end_marker, start)
+          lines = text[start:end].splitlines()
+          body = '\n'.join(line[10:] if line.startswith('          ') else line for line in lines)
+          Path('/tmp/apply_workgraph_passive_dedupe.py').write_text(body + '\n', encoding='utf-8')
+          PY
+
+      - name: Require exact audited Rust blob and real digest adapters
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git hash-object entroly-engine/src/work_graph.rs)" = "4cfa2d84123b53bc8d6a4b68e5d5431da9ac3a30"
+          grep -q 'enrich_worktree_content_digests' entroly/work_graph_mcp.py
+          grep -q 'enrichWorktreeContentDigests' entroly-wasm/js/work_graph_continuity.js
+          start_head="$(git rev-parse HEAD)"
+          printf '%s\n' "$start_head" > /tmp/workgraph-start-head
+          python /tmp/apply_workgraph_passive_dedupe.py
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Validate shared Rust semantics
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo fmt --manifest-path entroly-engine/Cargo.toml
+          cargo test --manifest-path entroly-engine/Cargo.toml --lib
+          cargo clippy --manifest-path entroly-engine/Cargo.toml --all-targets -- -D warnings
+          test "$(git diff --name-only)" = "entroly-engine/src/work_graph.rs"
+
+      - name: Refuse branch races and push validated product commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin feat/ai-work-graph-v1
+          test "$(cat /tmp/workgraph-start-head)" = "$(git rev-parse origin/feat/ai-work-graph-v1)"
+          git config user.name "entroly-workgraph-bot"
+          git config user.email "208309368+juyterman1000@users.noreply.github.com"
+          git add entroly-engine/src/work_graph.rs
+          git commit -m "fix(work-graph): dedupe content-complete passive snapshots"
+          git push origin HEAD:feat/ai-work-graph-v1

--- a/scripts/apply_workgraph_passive_dedupe_v2.py
+++ b/scripts/apply_workgraph_passive_dedupe_v2.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+path = Path("entroly-engine/src/work_graph.rs")
+text = path.read_text(encoding="utf-8")
+if "fn passive_repository_snapshot_fingerprint(" in text:
+    raise SystemExit("passive snapshot dedupe already present")
+
+old_observe = '''    pub fn observe_repository(
+        &mut self,
+        observation: RepositoryObservation,
+    ) -> Result<String, WorkGraphError> {
+        if observation.repo_id != self.repo_id {
+            return Err(WorkGraphError::RepoMismatch {
+                expected: self.repo_id.clone(),
+                actual: observation.repo_id,
+            });
+        }
+        let event = observation_to_event(&self.repo_id, observation)?;
+        self.apply_event(event)
+    }
+'''
+new_observe = '''    pub fn observe_repository(
+        &mut self,
+        observation: RepositoryObservation,
+    ) -> Result<String, WorkGraphError> {
+        if observation.repo_id != self.repo_id {
+            return Err(WorkGraphError::RepoMismatch {
+                expected: self.repo_id.clone(),
+                actual: observation.repo_id.clone(),
+            });
+        }
+        let passive_fingerprint = passive_repository_snapshot_fingerprint(&observation)?;
+        let mut event = observation_to_event(&self.repo_id, observation)?;
+        if let Some(fingerprint) = passive_fingerprint {
+            let source_ref = format!("repo-snapshot:{fingerprint}");
+            if let Some(last) = self.events.last() {
+                if last.source_kind == EvidenceKind::RepositoryFact && last.source_ref == source_ref {
+                    return Ok(last.event_id.clone());
+                }
+            }
+            event.source_ref = source_ref;
+        }
+        self.apply_event(event)
+    }
+'''
+if text.count(old_observe) != 1:
+    raise SystemExit(f"observe_repository anchor changed: {text.count(old_observe)} matches")
+text = text.replace(old_observe, new_observe, 1)
+
+start_marker = '''    // Adapters discover filesystem/Git/provider facts in different orders.
+    // Canonicalize semantically unordered observations so identical work state
+    // produces identical events and graph commitments across Python/npm/native.
+'''
+start = text.index(start_marker, text.index("fn observation_to_event("))
+block_start = start + len(start_marker)
+end_marker = '''    if let Some(task) = obs.task_hint.as_mut() {
+        task.remaining_work.sort();
+        task.remaining_work.dedup();
+    }
+'''
+block_end = text.index(end_marker, block_start) + len(end_marker)
+canonical_body = text[block_start:block_end]
+# Make ordering deterministic even for malformed/duplicate same-path observations
+# whose only difference is content identity.
+old_change_tail = '''            .then_with(|| a.staged.cmp(&b.staged))
+            .then_with(|| a.conflicted.cmp(&b.conflicted))
+'''
+new_change_tail = '''            .then_with(|| a.staged.cmp(&b.staged))
+            .then_with(|| a.conflicted.cmp(&b.conflicted))
+            .then_with(|| a.content_digest.cmp(&b.content_digest))
+'''
+if canonical_body.count(old_change_tail) != 1:
+    raise SystemExit("change canonicalization anchor changed")
+canonical_body = canonical_body.replace(old_change_tail, new_change_tail, 1)
+
+text = text[:start] + '''    // Keep one canonicalization rule for event construction and passive
+    // semantic fingerprints. This is the parity boundary shared by every
+    // adapter that submits RepositoryObservation.
+    canonicalize_repository_observation(&mut obs);
+''' + text[block_end:]
+
+helper = '''fn canonicalize_repository_observation(obs: &mut RepositoryObservation) {
+''' + canonical_body + '''}
+
+fn valid_passive_content_digest(change: &FileChangeObservation) -> bool {
+    if change.staged || change.conflicted {
+        return false;
+    }
+    if change.kind == FileChangeKind::Deleted {
+        return change.content_digest == "worktree:deleted";
+    }
+    let Some(hex) = change.content_digest.strip_prefix("git-blob:") else {
+        return false;
+    };
+    matches!(hex.len(), 40 | 64) && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn passive_repository_snapshot_fingerprint(
+    observation: &RepositoryObservation,
+) -> Result<Option<String>, WorkGraphError> {
+    // Only passive repository/checkpoint observations may collapse. Active
+    // operations are audit history and must remain distinct even when their
+    // payload happens to repeat.
+    if !observation.agent_id.is_empty()
+        || !observation.session_id.is_empty()
+        || !observation.verifications.is_empty()
+        || !observation.claims.is_empty()
+        || !observation.leases.is_empty()
+        || !observation.model_executions.is_empty()
+    {
+        return Ok(None);
+    }
+    if observation
+        .task_hint
+        .as_ref()
+        .is_some_and(|task| task.source_kind != EvidenceKind::Checkpoint)
+    {
+        return Ok(None);
+    }
+    if observation
+        .decisions
+        .iter()
+        .any(|decision| decision.source_kind != EvidenceKind::Checkpoint)
+    {
+        return Ok(None);
+    }
+    // A timestamp-only equality decision is safe only when every worktree
+    // change has exact content identity. Staged/conflicted/special/oversized
+    // paths deliberately fail closed in the adapters and therefore remain
+    // separate audit events.
+    if observation
+        .changes
+        .iter()
+        .any(|change| !valid_passive_content_digest(change))
+    {
+        return Ok(None);
+    }
+
+    let mut semantic = observation.clone();
+    semantic.observed_at_ms = 0;
+    canonicalize_repository_observation(&mut semantic);
+    Ok(Some(sha256_json(&semantic)?))
+}
+
+'''
+insert_at = text.index("fn observation_to_event(")
+text = text[:insert_at] + helper + text[insert_at:]
+
+anchor = '''    #[test]
+    fn clean_repo_is_null_control() {
+'''
+if text.count(anchor) != 1:
+    raise SystemExit("Rust test insertion anchor changed")
+tests = '''    fn passive_dirty_observation(digest: &str, observed_at_ms: i64) -> RepositoryObservation {
+        let mut obs = clean_observation();
+        obs.observed_at_ms = observed_at_ms;
+        obs.branch.name = "feature/passive".to_string();
+        obs.changes.push(FileChangeObservation {
+            path: "src/auth.rs".to_string(),
+            kind: FileChangeKind::Modified,
+            staged: false,
+            conflicted: false,
+            old_path: String::new(),
+            content_digest: digest.to_string(),
+        });
+        obs
+    }
+
+    #[test]
+    fn identical_content_complete_passive_snapshots_do_not_grow_history() {
+        let mut graph = WorkGraph::new("repo-1").unwrap();
+        let first = graph
+            .observe_repository(passive_dirty_observation(
+                "git-blob:1111111111111111111111111111111111111111",
+                1_000,
+            ))
+            .unwrap();
+        let commitment = graph.graph_commitment().to_string();
+        let second = graph
+            .observe_repository(passive_dirty_observation(
+                "git-blob:1111111111111111111111111111111111111111",
+                9_000,
+            ))
+            .unwrap();
+        assert_eq!(first, second);
+        assert_eq!(graph.event_count(), 1);
+        assert_eq!(graph.graph_commitment(), commitment);
+    }
+
+    #[test]
+    fn passive_snapshot_byte_change_appends_new_event() {
+        let mut graph = WorkGraph::new("repo-1").unwrap();
+        graph
+            .observe_repository(passive_dirty_observation(
+                "git-blob:1111111111111111111111111111111111111111",
+                1_000,
+            ))
+            .unwrap();
+        graph
+            .observe_repository(passive_dirty_observation(
+                "git-blob:2222222222222222222222222222222222222222",
+                2_000,
+            ))
+            .unwrap();
+        assert_eq!(graph.event_count(), 2);
+    }
+
+    #[test]
+    fn passive_change_away_and_back_remains_auditable() {
+        let mut graph = WorkGraph::new("repo-1").unwrap();
+        for (time, digest) in [
+            (1_000, "git-blob:1111111111111111111111111111111111111111"),
+            (2_000, "git-blob:2222222222222222222222222222222222222222"),
+            (3_000, "git-blob:1111111111111111111111111111111111111111"),
+        ] {
+            graph
+                .observe_repository(passive_dirty_observation(digest, time))
+                .unwrap();
+        }
+        assert_eq!(graph.event_count(), 3);
+    }
+
+    #[test]
+    fn passive_snapshot_without_complete_digest_never_dedupes() {
+        let mut graph = WorkGraph::new("repo-1").unwrap();
+        graph
+            .observe_repository(passive_dirty_observation("", 1_000))
+            .unwrap();
+        graph
+            .observe_repository(passive_dirty_observation("", 2_000))
+            .unwrap();
+        assert_eq!(graph.event_count(), 2);
+    }
+
+    #[test]
+    fn repeated_active_verification_is_never_collapsed() {
+        let mut graph = WorkGraph::new("repo-1").unwrap();
+        let mut first = passive_dirty_observation(
+            "git-blob:1111111111111111111111111111111111111111",
+            1_000,
+        );
+        first.verifications.push(VerificationObservation {
+            verification_id: "test:repeat".to_string(),
+            name: "focused test".to_string(),
+            state: VerificationState::Passed,
+            evidence_kind: EvidenceKind::TestResult,
+            source_ref: "pytest:test_repeat".to_string(),
+            digest: "pass".to_string(),
+            observed_at_ms: 1_000,
+        });
+        let mut second = first.clone();
+        second.observed_at_ms = 2_000;
+        second.verifications[0].observed_at_ms = 2_000;
+        graph.observe_repository(first).unwrap();
+        graph.observe_repository(second).unwrap();
+        assert_eq!(graph.event_count(), 2);
+    }
+
+    #[test]
+    fn repeated_model_execution_is_never_collapsed() {
+        let mut graph = WorkGraph::new("repo-1").unwrap();
+        let mut first = passive_dirty_observation(
+            "git-blob:1111111111111111111111111111111111111111",
+            1_000,
+        );
+        first.model_executions.push(ModelExecutionObservation {
+            execution_id: "exec:repeat".to_string(),
+            provider: "provider".to_string(),
+            model: "model".to_string(),
+            success: Some(true),
+            latency_ms: 10,
+            cost_micro_usd: 1,
+            source_ref: "runtime:repeat".to_string(),
+        });
+        let mut second = first.clone();
+        second.observed_at_ms = 2_000;
+        graph.observe_repository(first).unwrap();
+        graph.observe_repository(second).unwrap();
+        assert_eq!(graph.event_count(), 2);
+    }
+
+'''
+text = text.replace(anchor, tests + anchor, 1)
+path.write_text(text, encoding="utf-8")
+print("passive snapshot dedupe v2 patch applied")


### PR DESCRIPTION
Superseded by integration branch `integration/workgraph-all-346-347-349-20260817` at `1b5ebc32742c9534a21e3111a3824c3f1547d7d2`. GitHub reported this temporary PR non-mergeable despite the five #349 paths not overlapping #346/#347 product files, so the integration commit preserved the exact five #349 blobs and recorded #349 head `00fdffd01d7456600960a2adba340031de3d5b62` as the second parent. This remains integration-only; main was not modified.