### PR TITLE
fix(ci): pin the grammar pack that the coverage artifact was measured under

### DIFF
--- a/.github/workflows/code-intelligence.yml
+++ b/.github/workflows/code-intelligence.yml
@@ -43,6 +43,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[code-intelligence,test]"
+          # `benchmarks/results/language_symbol_coverage.json` is a byte-exact
+          # record of ONE grammar pack: it embeds
+          # `environment.tree_sitter_language_pack`, and the verify step below
+          # regenerates the whole payload and compares it byte for byte. The
+          # extra deliberately floats (`>=1.14.3,<2`) so users pick up grammar
+          # fixes, which means every upstream release silently invalidates the
+          # published artifact. 1.15.8 shipped on 2026-08-23 and turned main red
+          # on the very next push — a dependency bump that had nothing to do
+          # with parsing — because the gate resolved 1.15.8 against an artifact
+          # recorded under 1.14.3.
+          #
+          # So pin the *verification* environment, not the user-facing range.
+          # The artifact says results "must be regenerated and reviewed for a
+          # different grammar pack": moving it changes published coverage
+          # claims (C3, F#, Groovy, Nim and OCaml are recorded gaps), so that is
+          # a reviewed decision, not something CI absorbs on upstream's
+          # schedule. Bump this pin in the same commit that regenerates the
+          # artifact.
+          python -m pip install "tree-sitter-language-pack==1.14.3"
 
       - name: Warm required grammars with explicit acquisition
         env:


### PR DESCRIPTION
## What broke

`Code Intelligence Optional Extra` was green on `51357eca` (2026-08-18) and red on `b38a4b8a` — the sentence-transformers dev-dependency bump (#358). That bump has nothing to do with parsing.

## Why

`benchmarks/results/language_symbol_coverage.json` embeds `environment.tree_sitter_language_pack: "1.14.3"`, and the verify step regenerates the whole payload and compares it **byte for byte**. The extra floats (`tree-sitter-language-pack>=1.14.3,<2` at `pyproject.toml:66,77`) so users pick up grammar fixes — which means any upstream release invalidates the published artifact with no change to this repository.

**tree-sitter-language-pack 1.15.8 was published 2026-08-23 23:29 UTC.** Main was green since 08-18 only because nothing had been pushed in between. The next push — whatever it contained — was going to fail this gate.

## The change

Pin the **verification environment** to the version the artifact documents; leave the user-facing range floating.

The artifact itself says results "must be regenerated and reviewed for a different grammar pack", and regenerating moves published coverage claims (C3, F#, Groovy, Nim and OCaml are recorded declaration gaps). That stays a reviewed decision rather than one upstream makes on its own schedule. Bump the pin in the same commit that regenerates the artifact.

## Trust and compatibility

- [x] No user-facing dependency range is narrowed — only the CI verification environment.
- [x] Benchmark honesty preserved: the artifact keeps meaning exactly what it claims.
- [x] `tests/test_parser_compatibility.py` asserts a *minimum* (`>=1.14.3`), which `==1.14.3` satisfies.