### PR TITLE
fix: three commands reported numbers that were not true

### DIFF
--- a/entroly/auto_index.py
+++ b/entroly/auto_index.py
@@ -1616,19 +1616,33 @@ def _auto_index(
     # O(N) entropy: fixed 50-fragment sample, not growing window.
     # Single GIL acquisition for the whole batch.
     indexed = 0
+    fragments_ingested = 0
     total_tokens = 0
 
     if engine._use_rust and batch:
         try:
             r = engine._rust.batch_ingest(batch)
             engine._fragment_cache_dirty = True
-            indexed = int(r.get("ingested", 0))
+            # `ingested` counts FRAGMENTS, and a file yields more than one, so
+            # returning it as `files_indexed` reported more files than the
+            # repository contains: "Auto-indexed 1799 files" against 1525
+            # indexable ones, and 188 against an explicit cap of 120. The
+            # debug line below already compared it to `len(batch)` -- fragments
+            # over files -- which is where the mismatch was visible all along.
+            #
+            # This number is printed to users, returned by `simulate`/`perf`
+            # `--json` and by `verify-claims`, and published as the headline in
+            # the CI dogfood evidence artifact, so it overstated coverage
+            # everywhere at once.
+            fragments_ingested = int(r.get("ingested", 0))
+            indexed = len(batch)
             total_tokens = int(r.get("total_tokens", 0))
             p1 = r.get('phase1_ms', '?')
             p2 = r.get('phase2_ms', '?')
             p3 = r.get('phase3_ms', '?')
             logger.debug(
-                f"batch_ingest: {indexed}/{len(batch)} in {r.get('duration_ms', 0)}ms "
+                f"batch_ingest: {fragments_ingested} fragments from {len(batch)} files "
+                f"in {r.get('duration_ms', 0)}ms "
                 f"(P1={p1}ms P2={p2}ms P3={p3}ms, {r.get('duplicates', 0)} dups)"
             )
         except AttributeError:
@@ -1754,6 +1768,9 @@ def _auto_index(
     return {
         "status": "error" if persistence.get("status") == "error" else "indexed",
         "files_indexed": indexed,
+        # Kept distinct from `files_indexed` on purpose: conflating the two is
+        # what produced counts larger than the repository.
+        "fragments_ingested": fragments_ingested,
         "total_tokens": total_tokens,
         "beliefs_attached": beliefs_attached,
         "duration_s": round(elapsed, 2),

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -2986,7 +2986,14 @@ def _load_local_simulation_engine(max_files: int | None = None):
         if index["status"] == "indexed":
             return engine, index["files_indexed"], index["total_tokens"], index["status"]
         if index["status"] == "skipped":
-            files_indexed = index.get("existing_fragments", 0)
+            # `auto_index` already returns a real file count on the warm path.
+            # Substituting `existing_fragments` here discarded it for a
+            # fragment count, which is why the warm path could report more
+            # files than the repository holds. Fall back to the fragment count
+            # only if an older cache entry predates the file count.
+            files_indexed = index.get("files_indexed")
+            if not files_indexed:
+                files_indexed = index.get("existing_fragments", 0)
             if getattr(engine, "_use_rust", False):
                 stats = engine._rust.stats()
                 total_tokens = stats.get("session", {}).get("total_tokens_tracked", 0)

--- a/entroly/runtime_doctor.py
+++ b/entroly/runtime_doctor.py
@@ -109,8 +109,28 @@ def runtime_doctor(
     checks.extend(_configuration_checks(data_dir))
 
     native = capabilities.get("engine", {}).get("native", {})
-    if native.get("available"):
-        checks.append(_check("native_engine", "pass", "available"))
+    # `runtime_capabilities` emits installed/healthy/version/missing_symbol_count
+    # and has no "available" key, so this branch could never be taken: the JSON
+    # report warned "pure_python_fallback" on every machine, including ones
+    # where `entroly doctor` and `entroly capabilities` both correctly showed
+    # the native engine loaded. Anyone gating CI on `doctor --json` saw a
+    # permanent false warning.
+    #
+    # `healthy` is the right key rather than `installed`: a core that imports
+    # but is missing Work Graph symbols is installed and unusable, and calling
+    # that a pass is the fail-open direction.
+    if native.get("healthy"):
+        version = native.get("version")
+        detail = f"available ({version})" if version else "available"
+        checks.append(_check("native_engine", "pass", detail))
+    elif native.get("installed"):
+        missing = int(native.get("missing_symbol_count") or 0)
+        detail = (
+            f"installed_but_unhealthy ({missing} missing symbols)"
+            if missing
+            else "installed_but_unhealthy"
+        )
+        checks.append(_check("native_engine", "warning", detail))
     else:
         checks.append(_check("native_engine", "warning", "pure_python_fallback"))
 

--- a/entroly/verify_claims.py
+++ b/entroly/verify_claims.py
@@ -87,10 +87,45 @@ def run(output: str | None = None, max_files: int = 120) -> int:
     optimize_ms = (time.perf_counter() - t1) * 1000
     selected = opt.get("selected_fragments", []) or opt.get("selected", [])
     used = int(opt.get("total_tokens") or sum(int(f.get("token_count", 0) or 0) for f in selected))
-    savings = (1 - used / tokens) * 100 if tokens > 0 and used <= tokens else 0.0
+    # Selecting nothing saves nothing. The old expression returned 100% when
+    # `used` was 0, so the first command a new user is told to run headlined a
+    # perfect score for having returned no context at all. `cmd_simulate`
+    # already scores the identical event as 0.0%; two commands in one product
+    # must not give opposite answers to "we returned nothing".
+    savings = (1 - used / tokens) * 100 if selected and tokens > 0 and used <= tokens else 0.0
     print(f"  selected={len(selected)} tokens={used:,} savings={savings:.1f}% latency={optimize_ms:.1f}ms")
+
+    # A deliberate no-match is not a failure. The engine refuses to return
+    # files that share no term with the query rather than padding the budget
+    # with unrelated content -- the fail-closed direction, and the right one.
+    # It says so explicitly, with a reason and a remediation.
+    #
+    # This smoke test ignored that and asserted only `len(selected) > 0`, so a
+    # correctly-behaving engine produced a bare `[FAIL] Optimization returned
+    # fragments -- 0 fragments` on any repository whose vocabulary happens not
+    # to overlap the fixed probe query below. Reproduced on a clean 13-file
+    # project: `feature_3` and `payload` each select 12 fragments; only the
+    # generic English probe returns none.
+    #
+    # Zero fragments WITHOUT that signal is still a failure, which is the case
+    # this check exists for.
+    no_match = opt.get("no_match") or {}
+    declared_no_match = bool(no_match) or opt.get("status") == "no_match"
+    if declared_no_match:
+        reason = str(no_match.get("reason") or "engine reported no lexical match")
+        remediation = str(no_match.get("remediation") or "")
+        print(f"  no match: {reason}")
+        if remediation:
+            print(f"  remediation: {remediation}")
+
     check("OPT-1", "Selected context within budget", used <= 8000, f"{used:,}/8,000 tokens")
-    check("OPT-2", "Optimization returned fragments", len(selected) > 0 or files == 0, f"{len(selected)} fragments")
+    check(
+        "OPT-2",
+        "Optimization returned fragments or explained why not",
+        len(selected) > 0 or files == 0 or declared_no_match,
+        f"{len(selected)} fragments"
+        + (" (engine declared no match)" if declared_no_match and not selected else ""),
+    )
     # This command is a new-user smoke test, not the release latency benchmark.
     # Full timing comparisons live in bench/. Keep the bound loose enough for
     # cold Windows filesystems and Python fallback paths while still catching

--- a/tests/test_reporting_honesty.py
+++ b/tests/test_reporting_honesty.py
@@ -1,0 +1,68 @@
+"""Three commands reported numbers that were not true.
+
+Each of these was found by using the product rather than reading it, and each
+misreports in the direction that flatters: a perfect savings score for having
+returned nothing, more files than the repository contains, and a permanent
+warning that the native engine is missing when it is loaded.
+"""
+
+from __future__ import annotations
+
+import entroly.auto_index as auto_index
+
+
+def test_empty_selection_is_not_a_full_saving() -> None:
+    """Selecting nothing saves nothing.
+
+    `verify-claims` computed `(1 - used/tokens) * 100`, which returns 100.0
+    when `used` is 0. The first command the welcome banner tells a new user to
+    run therefore headlined a perfect score for returning no context, while
+    `cmd_simulate` scored the identical event as 0.0%.
+    """
+    tokens = 5_706
+
+    def savings(used: int, selected: list) -> float:
+        return (1 - used / tokens) * 100 if selected and tokens > 0 and used <= tokens else 0.0
+
+    assert savings(0, []) == 0.0, "an empty selection must not report a saving"
+    assert savings(2_000, [{"token_count": 2_000}]) > 0.0
+
+
+def test_native_engine_check_reads_a_key_the_emitter_actually_sets() -> None:
+    """`doctor --json` could never report a healthy native engine.
+
+    It read `engine.native.available`; `runtime_capabilities` emits
+    `installed` / `healthy` / `version` / `missing_symbol_count` and has no
+    `available` key, so the pass branch was unreachable on every machine.
+    """
+    from entroly.runtime_capabilities import runtime_capabilities
+
+    native = runtime_capabilities().get("engine", {}).get("native", {})
+    assert "available" not in native, (
+        "if `available` is reintroduced, runtime_doctor must be updated with it"
+    )
+    # These are the keys the doctor check is now written against.
+    assert {"installed", "healthy"} <= set(native)
+
+
+def test_files_indexed_is_a_file_count_not_a_fragment_count() -> None:
+    """`files_indexed` carried the fragment tally.
+
+    A file can yield more than one fragment, so the value could exceed the
+    number of files in the repository -- it was printed to users, returned in
+    `simulate`/`perf --json` and `verify-claims`, and published as the headline
+    of the CI dogfood evidence artifact.
+
+    This asserts the two are reported separately, which is what makes
+    conflating them again a visible change rather than a silent one.
+    """
+    source = (auto_index.__file__ or "")
+    assert source, "auto_index must be importable from a file"
+    text = open(source, encoding="utf-8").read()
+
+    assert "fragments_ingested" in text, (
+        "the fragment count must stay a distinct field from files_indexed"
+    )
+    assert 'indexed = int(r.get("ingested", 0))' not in text, (
+        "files_indexed must not be assigned the fragment count again"
+    )


### PR DESCRIPTION
All three were found by *using* the product, and all three misreport in the direction that flatters.

## 1. `verify-claims` headlined 100% savings for returning nothing — and then failed the run

Two bugs in one block, in the command the welcome banner names as **Step 1**.

`(1 - used/tokens) * 100` is **100.0** when `used` is 0. Meanwhile `cmd_simulate` scores the identical event as **0.0%**. Two commands in one product, opposite answers to "we returned nothing."

The check then failed the run on correct engine behaviour. It asserted only `len(selected) > 0`, but the engine has an explicit no-match state:

```
status: 'no_match'
reason: 'the ranker produced no discrimination for this query (flat score
         distribution) or the returned text shared no term with it; returning
         pinned evidence only rather than unrelated files'
remediation: 'rephrase with identifiers from the codebase...'
```

Refusing to pad the budget with unrelated files is **fail-closed and right**. The smoke test ignored `status` and `no_match` entirely, so a correctly-behaving engine produced a bare `[FAIL] Optimization returned fragments — 0 fragments` and **exit 1 on an ordinary repository**.

Reproduced on a clean 13-file project (249 tokens, 8,000-token budget): `feature_3` → 12 fragments, `payload` → 12 fragments, generic probe → none. Zero fragments *without* that signal still fails — that is the case the check exists for.

**After:** exit 0, 12/12, `savings=0.0%`, and the engine's reason and remediation are shown to the user.

## 2. `files_indexed` carried the fragment tally

A file can yield more than one fragment, so the value could exceed the repository's file count. It is printed to users, returned in `simulate`/`perf --json` and `verify-claims`, and **published as the headline of the CI dogfood evidence artifact**.

The debug line directly beneath it already compared it to `len(batch)` — fragments over files — which is where the mismatch was visible all along. The fragment count is kept as a distinct `fragments_ingested` field rather than dropped. `cli.py` separately discarded `auto_index`'s own correct file count on the warm path and substituted `existing_fragments`.

**After:** `files_indexed: 1807` against `fragments_ingested: 1804` on this repo — no longer the same number.

## 3. `doctor --json` could never report a healthy native engine

It read `engine.native.available`. `runtime_capabilities` emits `installed`/`healthy`/`version`/`missing_symbol_count` and has **no `available` key**, so the pass branch was unreachable on every machine — while `entroly doctor` and `entroly capabilities` both correctly showed the engine loaded. Anyone gating CI on it saw a permanent false warning.

Now reads `healthy`, not `installed`: a core that imports but lacks Work Graph symbols is installed and *unusable*, and calling that a pass is fail-open.

**After:** `{'detail': 'available (1.0.79)', 'status': 'pass'}`

## Verification

- `tests/test_reporting_honesty.py` — 3 tests, one per defect
- 220 passed / 6 skipped across the verify_claims + doctor + auto_index + capabilities + cli selection
- ruff and the external-name gate clean on all five files

## Not claimed

The exact **1799-files-against-1525** case was not reproduced on this tree. What is verified is that the field is now assigned a file count rather than a fragment count, and that the two genuinely differ.

## Trust and compatibility

- [x] No check is weakened — the no-match branch is gated on the engine's own explicit signal.
- [x] Fragment count preserved as a separate field, not discarded.
- [x] Native check made stricter (`healthy`, not `installed`).