### PR TITLE
fix(ravs,vault): stop three surfaces presenting unverified state as verified

### DIFF
--- a/entroly/ravs/router.py
+++ b/entroly/ravs/router.py
@@ -535,6 +535,24 @@ def _load_cells_from_log(log_path: str) -> dict[str, dict[str, Any]]:
                 if evt_type not in ("test", "build", "lint", "typecheck", "format",
                                     "other", "test_result", "ci_result", "command_exit"):
                     continue
+                # Invariant 1 in `events.py`: `include_in_default_training=False`
+                # marks an event whose value is unverified self-report -- the
+                # canonical case being an agent reporting its own success. Such
+                # events are recorded for completeness and excluded from default
+                # labeling.
+                #
+                # This loader never read the flag, so the exclusion existed only
+                # on the `derive_label` path and not on the one that actually
+                # builds the posterior. Twelve self-reported passes carried a
+                # cell to ci_lo 0.951 and authorised routing to the cheapest
+                # model: an agent could mint the evidence that downgraded its
+                # own review. `derive_label` returns "unknown" for the identical
+                # event, so the guard was already correct and simply bypassed.
+                #
+                # An absent flag means an event predating it, treated as
+                # admissible; only an explicit False excludes.
+                if evt.get("include_in_default_training") is False:
+                    continue
                 cell_key = f"{evt_type}/{tool}" if tool != evt_type else evt_type
                 cell = counts.setdefault(cell_key, {"pass": 0, "fail": 0})
                 if value in success_vals:
@@ -545,12 +563,22 @@ def _load_cells_from_log(log_path: str) -> dict[str, dict[str, Any]]:
         logger.warning("Failed to load RAVS cells: %s", e)
         return {}
 
-    total_pass = sum(c["pass"] for c in counts.values())
-    total_fail = sum(c["fail"] for c in counts.values())
-    total_obs = total_pass + total_fail
-    global_mean = total_pass / max(total_obs, 1)
-    alpha_0 = max(global_mean * 2.0, 0.1)
-    beta_0 = max((1 - global_mean) * 2.0, 0.1)
+    # Jeffreys prior, Beta(1/2, 1/2): the standard uninformative choice for a
+    # proportion, and independent of the data it is applied to.
+    #
+    # The prior here was estimated from the same log it then scored, and
+    # collapsed under exactly the case that should be treated most carefully.
+    # With no failures anywhere, `global_mean` is 1.0, so `beta_0` fell to its
+    # 0.1 floor while `alpha_0` was 2.0 -- a prior mean of 0.952 before a single
+    # observation. Two passes were then enough to clear a `ci_threshold` of
+    # 0.80, which made the threshold decorative and left `min_samples` as the
+    # only real gate. Under Jeffreys the same crossing needs eight.
+    #
+    # A confidence bound whose prior is fitted to the evidence is not a
+    # confidence bound, and this one failed open: it routed to the cheapest
+    # model on the thinnest possible record.
+    alpha_0 = 0.5
+    beta_0 = 0.5
 
     cells: dict[str, dict[str, Any]] = {}
     for key, c in counts.items():

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -305,10 +305,20 @@ class BeliefArtifact:
         # is untrusted input: an entity of "x\nclaim_id: FORGED" rewrote the
         # claim_id -- the identifier the append-only ledger is cross-referenced
         # by. Every scalar is flattened to one line before it is written.
+        # An unsourced belief must not be rendered as though it cited a source
+        # named "unknown". A reader -- human or machine -- cannot tell that
+        # apart from a real citation, so a belief carrying `status: verified`
+        # and `confidence: 0.99` was stored looking sourced when nothing backed
+        # it. CLAUDE.md requires every write to carry sources; inventing one is
+        # the fail-open direction.
+        #
+        # An explicit empty list says the same thing truthfully. Frontmatter
+        # parsing is unaffected: `_parse_frontmatter` skips list-item lines, so
+        # these entries were never read back into the parsed mapping anyway.
         sources_yaml = (
             "\n".join(f"  - {_yaml_scalar(s)}" for s in self.sources)
             if self.sources
-            else "  - unknown"
+            else "  []"
         )
         derived_yaml = (
             "\n".join(f"  - {_yaml_scalar(d)}" for d in self.derived_from)

--- a/tests/test_ravs_vault_fail_closed.py
+++ b/tests/test_ravs_vault_fail_closed.py
@@ -1,0 +1,90 @@
+"""Three surfaces presented unverified state as verified.
+
+Each was found by driving the code rather than reading it, and each fails in
+the direction that lets weaker evidence pass for stronger.
+"""
+
+from __future__ import annotations
+
+import json
+
+from entroly.ravs.router import _load_cells_from_log
+from entroly.vault import BeliefArtifact
+
+
+def _log(tmp_path, events):
+    p = tmp_path / "events.jsonl"
+    p.write_text("".join(json.dumps(e) + "\n" for e in events), encoding="utf-8")
+    return str(p)
+
+
+def test_self_reported_outcomes_do_not_move_the_posterior(tmp_path) -> None:
+    """Invariant 1 of `ravs/events.py`, enforced where it actually matters.
+
+    `include_in_default_training=False` marks an unverified self-report. The
+    cell loader that builds the posterior never read the flag, so twelve
+    self-reported passes carried a cell to ci_lo 0.951 and authorised routing
+    to the cheapest model -- an agent could mint the evidence that downgraded
+    its own review. `derive_label` already returned "unknown" for the same
+    event, so the guard existed and was simply bypassed.
+    """
+    events = [
+        {
+            "kind": "outcome",
+            "event_type": "test",
+            "tool": "pytest",
+            "value": "pass",
+            "strength": "weak",
+            "source": "agent_self_report",
+            "include_in_default_training": False,
+        }
+        for _ in range(12)
+    ]
+    assert _load_cells_from_log(_log(tmp_path, events)) == {}
+
+
+def test_events_without_the_flag_are_still_counted(tmp_path) -> None:
+    """Only an explicit False excludes; older events predate the field."""
+    events = [
+        {"kind": "outcome", "event_type": "test", "tool": "pytest", "value": "pass"}
+        for _ in range(4)
+    ]
+    cells = _load_cells_from_log(_log(tmp_path, events))
+    assert cells["test/pytest"]["passes"] == 4
+
+
+def test_prior_is_not_fitted_to_the_evidence_it_scores(tmp_path) -> None:
+    """The prior was estimated from the same log it then scored.
+
+    With no failures anywhere `global_mean` was 1.0, so beta collapsed to a 0.1
+    floor against alpha 2.0 -- a prior mean of 0.952 before any observation, and
+    two passes were enough to clear a 0.80 confidence threshold. That made the
+    threshold decorative. Jeffreys Beta(1/2, 1/2) is independent of the data.
+    """
+    events = [
+        {"kind": "outcome", "event_type": "test", "tool": "pytest", "value": "pass"}
+        for _ in range(10)
+    ]
+    cell = _load_cells_from_log(_log(tmp_path, events))["test/pytest"]
+
+    # alpha = prior + passes, beta = prior + failures.
+    assert cell["alpha"] == 0.5 + 10
+    assert cell["beta"] == 0.5, "a run with no failures must not collapse the prior"
+
+
+def test_unsourced_belief_is_not_rendered_as_though_it_had_a_source() -> None:
+    """An empty source list rendered as `- unknown`.
+
+    A reader cannot tell that apart from a real citation, so a belief carrying
+    `status: verified` and `confidence: 0.99` was stored looking sourced when
+    nothing backed it.
+    """
+    unsourced = BeliefArtifact(
+        entity="auth.verify_token", status="verified", confidence=0.99, sources=[]
+    ).to_markdown()
+
+    assert "- unknown" not in unsourced, "an absent source must not be invented"
+    assert "sources:" in unsourced
+
+    sourced = BeliefArtifact(entity="auth", sources=["src/auth.py:10"]).to_markdown()
+    assert "  - src/auth.py:10" in sourced, "real citations must still render"


### PR DESCRIPTION
Found by driving these surfaces rather than reading them. All three fail in the direction that lets weaker evidence pass for stronger — the inversion of this product's stated contract.

## 1. An agent could authorise its own downgrade

`ravs/events.py` invariant 1: `include_in_default_training=False` marks an unverified self-report, "excluded by default labeling rules."

`_load_cells_from_log` — the function that actually builds the routing posterior — **never read the flag**.

```
12 events: strength='weak', include_in_default_training=False, source='agent_self_report'
  -> cells: {"test/pytest": {"n":12,"passes":12,"alpha":14.0,"beta":0.1}}
  -> DECISION: use_original=False -> claude-3-5-haiku  (ci=0.951)
```

`derive_label` returns `'unknown'` for the identical event — so the guard was already correct and simply bypassed on the path that mattered. Any agent that can write an outcome event could mint the evidence downgrading its own review.

**After:** those 12 events yield `{}`. Only an explicit `False` excludes; events predating the field stay admissible.

## 2. The confidence bound was fitted to the evidence it scored

`alpha_0` and `beta_0` were estimated from the same log they were then applied to. With no failures anywhere, `global_mean` is 1.0, so beta collapsed to its 0.1 floor against alpha 2.0 — **a prior mean of 0.952 before a single observation.**

```
n=10 passes, 0 failures, threshold 0.80
  fitted prior  Beta(2.0, 0.1) -> ci_lo=0.9427  ROUTES
  Jeffreys      Beta(0.5, 0.5) -> ci_lo≈0.77    does not route
  passes needed to cross 0.80:  fitted 2   Jeffreys 8
```

That made `ci_threshold` decorative and left `min_samples` as the only real gate. Jeffreys Beta(½, ½) is the standard uninformative prior for a proportion and does not depend on the data.

## 3. An unsourced belief was written as though it cited a source

Empty `sources` rendered as `- unknown`. No reader — human or machine — can tell that apart from a real citation, so a belief carrying `status: verified` and `confidence: 0.99` was stored **looking sourced when nothing backed it**. CLAUDE.md requires every write to carry sources; inventing one is fail-open.

Now renders an explicit empty list. Frontmatter parsing is unaffected — `_parse_frontmatter` skips list-item lines, so these entries were never read back anyway.

## Verification

- 4 regression tests; **each fails when its fix is reverted** (verified)
- 234 passed / 4 skipped across the vault + ravs + router selection
- ruff and the external-name gate clean

## Scope note

The Bayesian router is gated behind `ENTROLY_RAVS_ROUTER=1` (default off), which limits today's blast radius for 1 and 2 — but every guard *inside* the router was defeatable, and the vault issue is on the default path.

## Not fixed here, recorded for follow-up

- `capture_from_args` accepts `command` and `exit_code` as unverified caller assertions and stamps them `strength=strong, source=ci` — cargo was never invoked in the probe that produced one
- Cell keys are `{category}/{tool}` but archetypes are `{category}/{verb}`, so `_find_best_cell` almost always falls back to category and can use "pytest passed" as proof a cheap model can *write* a test
- EICV returns `hallucinated` for a true claim outside the evidence, and scores a true and a false claim identically at φ=0.4427
- Unknown `gpt-*` ids fuzzy-match to flagship tier and book savings against a cost never paid

## Trust and compatibility

- [x] Fail-closed direction in all three cases.
- [x] No existing verified evidence is discarded — only unverified self-report is excluded.
- [x] Real citations still render unchanged.