### PR TITLE
fix(mcp): contain create_context_receipt_from_path to the project root

### DIFF
--- a/entroly/server.py
+++ b/entroly/server.py
@@ -1767,8 +1767,39 @@ def create_mcp_server(
         try:
             from .sdk import context_receipt_from_path as _context_receipt_from_path
 
+            # Containment, matching `prepare_proof_guided_context` below.
+            #
+            # This tool passed `path` straight through, while every other
+            # path-taking tool on this server -- smart_read,
+            # export_training_data, coverage_gaps, compile_docs,
+            # prefetch_related, prepare_proof_guided_context -- rejects escapes.
+            # `../secret.txt`, `../../` and a bare `..` each read files outside
+            # the project root, and the directory form made that a bulk read
+            # ranked by an attacker-chosen query.
+            #
+            # It is reachable from the default MCP server and from the
+            # `receipts` attach scope, whose name reads as audit-oriented.
+            #
+            # The ingester's extension allowlist bounds what can be read, but an
+            # allowlist is not a path guard: it was never meant to be the
+            # boundary, and it says nothing about directories the tool should
+            # not have been pointed at in the first place.
+            project_root = Path(
+                os.environ.get("ENTROLY_SOURCE", os.getcwd())
+            ).resolve()
+            candidate = Path(path).expanduser()
+            if not candidate.is_absolute():
+                candidate = project_root / candidate
+            candidate = candidate.resolve()
+            try:
+                candidate.relative_to(project_root)
+            except ValueError as exc:
+                raise ValueError(
+                    f"path must remain within the project root: {path}"
+                ) from exc
+
             receipt = _context_receipt_from_path(
-                path,
+                str(candidate),
                 query=query,
                 budget=token_budget,
                 chunk_tokens=chunk_tokens,

--- a/tests/test_receipt_path_containment.py
+++ b/tests/test_receipt_path_containment.py
@@ -1,0 +1,71 @@
+"""`create_context_receipt_from_path` must not read outside the project root.
+
+Every other path-taking tool on the MCP server rejects escapes -- smart_read,
+export_training_data, coverage_gaps, compile_docs, prefetch_related and
+prepare_proof_guided_context all return "must remain within the project root".
+This one passed `path` straight to the ingester, so `../secret.md`, `../../` and
+a bare `..` each read files outside the root, and the directory form turned that
+into a bulk read ranked by an attacker-chosen query.
+
+It is reachable from the default MCP server and from the `receipts` attach
+scope, whose name reads as audit-oriented.
+
+The ingester's extension allowlist bounds what is readable, but an allowlist is
+not a path guard: it was never meant to be the boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from entroly.server import create_mcp_server
+
+CANARY = "AWS_CANARY_hunter2"
+
+
+def _tool(name: str):
+    built = create_mcp_server()
+    server = next(x for x in built if hasattr(x, "_tool_manager"))
+    return server._tool_manager._tools.get(name)
+
+
+def _run(tool, path: str, query: str) -> str:
+    out = asyncio.run(tool.run({"path": path, "query": query}))
+    return out if isinstance(out, str) else json.dumps(out, default=str)
+
+
+@pytest.fixture
+def rooted(tmp_path, monkeypatch):
+    outside = tmp_path / "OUTSIDE_SECRET.md"
+    outside.write_text(f"{CANARY}\n", encoding="utf-8")
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "README.md").write_text("# inside\nordinary project documentation\n", encoding="utf-8")
+    monkeypatch.setenv("ENTROLY_SOURCE", str(root))
+    monkeypatch.chdir(root)
+    return root
+
+
+@pytest.mark.parametrize("escape", ["../OUTSIDE_SECRET.md", "..", "../../"])
+def test_paths_outside_the_root_are_refused(rooted, escape) -> None:
+    tool = _tool("create_context_receipt_from_path")
+    assert tool is not None, "tool must be registered"
+
+    # The query deliberately avoids the canary string so a match can only come
+    # from file content, never from the query being echoed back in the receipt.
+    result = _run(tool, escape, "summarise the documentation")
+
+    assert CANARY not in result, f"{escape} leaked content from outside the project root"
+    assert "must remain within the project root" in result
+
+
+def test_a_path_inside_the_root_still_works(rooted) -> None:
+    """Containment must not break the legitimate case."""
+    tool = _tool("create_context_receipt_from_path")
+    result = _run(tool, "README.md", "summarise the documentation")
+
+    assert "must remain within the project root" not in result
+    assert CANARY not in result


### PR DESCRIPTION
## Security defect: arbitrary file read via MCP

`create_context_receipt_from_path` passed `path` straight to the receipt ingester with no containment check.

```
{"path":"../OUTSIDE_SECRET.txt","query":"secret key"}   -> CANARY FOUND: hunter2
{"path":"../../ESCAPED_TWO_LEVELS.txt",...}              -> CANARY FOUND: AKIA_NEVER_LEAK_ME
{"path":"..","query":"secret key aws"}                  -> 4 files ingested from outside the project root
```

The directory form is the serious one: it is a **bulk read of an arbitrary tree, ranked by an attacker-chosen query**.

## Why it is a plain omission

Every other path-taking tool on this server already refuses the same inputs — `smart_read`, `export_training_data`, `coverage_gaps`, `compile_docs`, `prefetch_related`, `prepare_proof_guided_context`. `path_safety` is imported at the top of the module and was never applied here. The fix is the same resolve-then-`relative_to` check used by the sibling proof-guided tool immediately below it.

## Exposure

Reachable from the **default 66-tool MCP server**, and from the **`receipts` attach scope** — a scope whose name reads as audit-oriented and read-only.

The ingester's extension allowlist (`.txt/.md/.rst` plus ~40 source extensions) bounds what can be read, which is why this is not worse: `.env`, `.pem` and `.ini` are not reachable. But an allowlist is not a path guard. It was never intended to be the boundary, and it says nothing about directories the tool should never have been pointed at. Source trees and documentation outside the root were readable.

## Verification

```
'../OUTSIDE_SECRET.md'   blocked=True   canary_leaked=False
'..'                     blocked=True   canary_leaked=False
'README.md'              allowed        (legitimate case still works)
```

- 4 regression tests; **3 fail when the guard is removed** (verified by reverting)
- The test query deliberately avoids the canary string, so a match can only come from file content and never from the query being echoed back in the receipt
- ruff and the external-name gate clean

## Trust and compatibility

- [x] Fail-closed: paths outside the root now raise rather than read.
- [x] Legitimate in-root paths, relative and absolute, are unaffected.
- [x] Matches the containment pattern already used by six sibling tools.