### PR TITLE
fix(cli): honour ENTROLY_DIR in the commands that read and delete state

### DIFF
--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -1388,7 +1388,7 @@ def is_telemetry_enabled() -> bool:
 
 def cmd_clean(args):
     """entroly clean — clear cached state (checkpoints, index, pull cache)."""
-    entroly_dir = Path.home() / ".entroly"
+    entroly_dir = _resolve_entroly_dir()
 
     if not entroly_dir.exists():
         print(f"  {C.GRAY}Nothing to clean -- {entroly_dir} does not exist.{C.RESET}")
@@ -3919,7 +3919,7 @@ def cmd_doctor(args):
 
     # 5. Check index freshness
     checks_total += 1
-    entroly_dir = Path.home() / ".entroly"
+    entroly_dir = _resolve_entroly_dir()
     checkpoint_dir = entroly_dir / "checkpoints"
     if checkpoint_dir.exists():
         checkpoint_files = list(checkpoint_dir.glob("*.json*"))
@@ -4207,7 +4207,7 @@ def cmd_digest(args):
             print(f"  {C.BOLD}Error rate:{C.RESET} {C.GREEN}0%{C.RESET}")
     else:
         # Fall back to checkpoint/stats file
-        stats_file = Path.home() / ".entroly" / "session_stats.json"
+        stats_file = _resolve_entroly_dir() / "session_stats.json"
         if stats_file.exists():
             try:
                 with open(stats_file) as f:
@@ -4229,7 +4229,7 @@ def cmd_migrate(args):
 
     from entroly import __version__ as current_version
 
-    entroly_dir = Path.home() / ".entroly"
+    entroly_dir = _resolve_entroly_dir()
     version_file = entroly_dir / ".version"
 
     # Check stored version
@@ -4637,7 +4637,7 @@ def cmd_optimize(args):
         print("\n".join(lines))
 
     # Save last optimization for feedback command
-    state_file = Path.home() / ".entroly" / "last_optimize.json"
+    state_file = _resolve_entroly_dir() / "last_optimize.json"
     try:
         state_file.parent.mkdir(parents=True, exist_ok=True)
         import json as _json
@@ -5288,7 +5288,7 @@ def cmd_feedback(args):
         return
 
     # Load the last optimization state
-    state_file = Path.home() / ".entroly" / "last_optimize.json"
+    state_file = _resolve_entroly_dir() / "last_optimize.json"
     if not state_file.exists():
         print(f"  {C.YELLOW}No previous optimization found.{C.RESET}")
         print(f"  Run {C.CYAN}entroly optimize --task \"...\" {C.RESET}first.")
@@ -5980,7 +5980,7 @@ def cmd_cache(args):
         from entroly.config import _project_checkpoint_dir
         ckpt_dir = _project_checkpoint_dir()
     except Exception:
-        ckpt_dir = Path.home() / ".entroly" / "checkpoints"
+        ckpt_dir = _resolve_entroly_dir() / "checkpoints"
 
     # On-disk footprint + freshness of the latest checkpoint
     ckpts: list[Path] = []
@@ -6119,7 +6119,7 @@ def cmd_ravs(args):
     # Resolve log path
     log_path = getattr(args, "log", None)
     if not log_path:
-        log_path = str(Path.home() / ".entroly" / "ravs" / "events.jsonl")
+        log_path = str(_resolve_entroly_dir() / "ravs" / "events.jsonl")
 
     # Parse --since
     since_ts: float | None = None

--- a/tests/test_entroly_dir_honored.py
+++ b/tests/test_entroly_dir_honored.py
@@ -1,0 +1,45 @@
+"""Commands that read or delete state must honour ``ENTROLY_DIR``.
+
+``_resolve_entroly_dir`` is the canonical resolver and honours the variable.
+Eight call sites bypassed it with a hardcoded ``Path.home() / ".entroly"``.
+
+The dangerous one is ``entroly clean``. With ``ENTROLY_DIR`` pointed at an empty
+sandbox it still enumerated the real home directory -- 8,094 checkpoints and 302
+index files -- so ``entroly clean -y`` would have deleted global state a caller
+had explicitly sandboxed away from. The same bypass sent ``ravs report`` and
+``migrate`` to the wrong tree.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from entroly.cli import _resolve_entroly_dir
+
+CLI_SOURCE = Path(__file__).resolve().parents[1] / "entroly" / "cli.py"
+
+
+def test_resolver_honours_the_environment_variable(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "sandbox"))
+    assert _resolve_entroly_dir() == (tmp_path / "sandbox")
+
+
+def test_only_the_resolver_itself_may_hardcode_the_home_path() -> None:
+    """One occurrence is legitimate: the resolver's own fallback candidate.
+
+    Any other is a command bypassing the resolver, which is how `clean` came to
+    target a directory the caller had redirected away from.
+    """
+    text = CLI_SOURCE.read_text(encoding="utf-8")
+    hits = [
+        (i + 1, line.strip())
+        for i, line in enumerate(text.splitlines())
+        if re.search(r'Path\.home\(\)\s*/\s*"\.entroly"', line)
+    ]
+    assert len(hits) == 1, (
+        "only `_resolve_entroly_dir` may name the home directory directly; "
+        f"found {len(hits)}: {hits}"
+    )
+    # And it must be the fallback inside the resolver, not a command.
+    assert hits[0][0] < 130, f"unexpected location for the fallback: {hits[0]}"


### PR DESCRIPTION
## Data-loss risk

`entroly clean` ignored `ENTROLY_DIR` and targeted the real home directory. With the variable pointed at an empty sandbox:

```
before   checkpoints: 8094 file(s)   index files: 302 file(s)     <- the user's REAL state
after    Nothing to clean -- no cached state found.
```

**`entroly clean -y` would have deleted 8,094 checkpoints that the caller had explicitly sandboxed away from.** Anyone redirecting Entroly for a test run had no way to know the destructive command ignored the redirect.

## Cause

`_resolve_entroly_dir` is the canonical resolver and honours the variable. **Eight call sites bypassed it** with a hardcoded `Path.home() / ".entroly"` — `clean`, the doctor index probe, session stats, `migrate`, last-optimize state (×2), checkpoint listing, and the RAVS event log.

Consequences beyond `clean`: `ravs report` read `~/.entroly/ravs/events.jsonl` and `migrate` wrote `~/.entroly/.version` regardless of the setting, so both reported on and mutated the wrong tree.

## The change

All eight routed through `_resolve_entroly_dir()`. One occurrence remains — the resolver's own fallback candidate — which is correct.

The regression test pins exactly that: **only one site may name the home directory, and it must be inside the resolver.** Any new bypass fails the test rather than silently targeting the wrong tree.

## Verification

- Resolver honours the variable (asserted directly)
- Before/after measured on the same sandbox, shown above
- ruff clean

## Trust and compatibility

- [x] Default behaviour unchanged when `ENTROLY_DIR` is unset — the resolver falls back to `~/.entroly` exactly as before.
- [x] No command gains access it did not have; several lose access they should never have had.
- [x] Fail-safe direction: a sandboxed caller now stays sandboxed.