### PR TITLE
fix(core): make warm-start selection identical to cold-start

### DIFF
--- a/entroly-core/src/lib.rs
+++ b/entroly-core/src/lib.rs
@@ -4127,10 +4127,38 @@ impl EntrolyEngine {
         self.total_duplicates_caught = snapshot.total_duplicates_caught;
         self.gradient_temperature = snapshot.gradient_temperature;
         self.gradient_norm_ema = snapshot.gradient_norm_ema;
-        // Rebuild dedup index from loaded fragments
-        for frag in self.fragments.values() {
+
+        // The persisted JSON owns canonical fragment + slot state only. Rebuild
+        // every derived selection structure from those canonical values so a
+        // warm process cannot select differently from the cold process that
+        // wrote the snapshot. Stubs are excluded from content-similarity indexes.
+        let dedup_threshold = self.dedup_index.hamming_threshold();
+        self.dedup_index = DedupIndex::new(dedup_threshold);
+        for frag in self
+            .fragments
+            .values()
+            .filter(|fragment| fragment.has_simhash)
+        {
             self.dedup_index.insert(&frag.fragment_id, &frag.content);
         }
+
+        let slot_ids_are_complete = self.fragment_slot_ids.len() == self.fragments.len()
+            && self.fragment_slot_ids.iter().collect::<HashSet<_>>().len()
+                == self.fragment_slot_ids.len()
+            && self
+                .fragment_slot_ids
+                .iter()
+                .all(|id| self.fragments.contains_key(id));
+        if slot_ids_are_complete {
+            self.rebuild_lsh_from_slot_ids();
+        } else {
+            // Backward-compatible repair for an old/incomplete slot snapshot.
+            self.rebuild_lsh_index();
+        }
+        self.rebuild_dependency_graph();
+        self.last_optimization = None;
+        self.last_cache_feedback_eligible = false;
+        self.egsc_cache.clear();
         Ok(n)
     }
 
@@ -5223,21 +5251,40 @@ impl EntrolyEngine {
 // ═══════════════════════════════════════════════════════════════════
 
 impl EntrolyEngine {
+    /// Populate LSH tables from the current persisted slot order.
+    ///
+    /// `fragment_slot_ids` is part of the persisted index contract: LSH entries
+    /// refer to these slots, so a warm load must preserve the cold engine's slot
+    /// identity exactly. Dependency stubs deliberately have `has_simhash=false`
+    /// and must never enter LSH.
+    fn rebuild_lsh_from_slot_ids(&mut self) {
+        let entries: Vec<(u64, usize)> = self
+            .fragment_slot_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(slot, id)| {
+                self.fragments
+                    .get(id)
+                    .filter(|fragment| fragment.has_simhash)
+                    .map(|fragment| (fragment.simhash, slot))
+            })
+            .collect();
+        self.lsh_index.clear();
+        for (fingerprint, slot) in entries {
+            self.lsh_index.insert(fingerprint, slot);
+        }
+    }
+
     /// Rebuild the LSH index and slot list from the current fragment map.
     ///
-    /// Called after batch eviction in advance_turn(). O(N) but infrequent.
+    /// Called after mutations that invalidate slot identity. New slot assignment
+    /// is sorted by fragment ID for deterministic reconstruction; stubs remain in
+    /// the slot list but are excluded from LSH exactly as they are during ingest.
     fn rebuild_lsh_index(&mut self) {
-        self.lsh_index.clear();
-        self.fragment_slot_ids.clear();
-        // Sort by fragment_id for deterministic slot assignment
         let mut ids: Vec<String> = self.fragments.keys().cloned().collect();
         ids.sort_unstable();
-        for (slot, id) in ids.iter().enumerate() {
-            if let Some(frag) = self.fragments.get(id) {
-                self.lsh_index.insert(frag.simhash, slot);
-            }
-            self.fragment_slot_ids.push(id.clone());
-        }
+        self.fragment_slot_ids = ids;
+        self.rebuild_lsh_from_slot_ids();
     }
 
     /// Rebuild dependency and symbol state from the live fragment set.

--- a/tests/test_warm_start.py
+++ b/tests/test_warm_start.py
@@ -58,6 +58,47 @@ def test_persistent_engine_constructs_fast_and_warm_restores_index(tmp_path: Pat
     assert e2._rust.fragment_count() == n
 
 
+def test_persisted_index_roundtrip_preserves_native_selection(tmp_path: Path):
+    """Cold and warm native engines must select identically from one snapshot."""
+    cfg = EntrolyConfig(checkpoint_dir=tmp_path, use_persistent_index=True)
+    cold = EntrolyEngine(cfg)
+    _needs_rust(cold)
+    cold._rust.set_exploration_rate(0.0)
+
+    for i in range(96):
+        cold.ingest_fragment(
+            f"def helper_{i}(value):\n    return value + {i}  # generic pipeline helper",
+            source=f"src/helpers/module_{i:03d}.py",
+        )
+    cold.ingest_fragment(
+        "def refresh_access_token(token, expiry):\n"
+        "    if expiry <= now():\n"
+        "        return rotate_refresh_token(token)\n"
+        "    return token",
+        source="src/auth/token_refresh.py",
+    )
+
+    index_path = Path(tmp_path) / "index.json.gz"
+    cold._rust.persist_index(str(index_path))
+    query = "refresh access token expiry rotate token"
+    cold_recall = [dict(item) for item in cold._rust.recall(query, 12)]
+    cold_optimized = dict(cold._rust.optimize(700, query))
+
+    warm = EntrolyEngine(cfg)
+    _needs_rust(warm)
+    warm._rust.set_exploration_rate(0.0)
+    assert warm.wait_until_warm() is True
+    warm_recall = [dict(item) for item in warm._rust.recall(query, 12)]
+    warm_optimized = dict(warm._rust.optimize(700, query))
+
+    assert warm._rust.fragment_count() == cold._rust.fragment_count()
+    assert warm_recall == cold_recall
+    assert warm_optimized.get("total_tokens") == cold_optimized.get("total_tokens")
+    assert [dict(item) for item in warm_optimized.get("selected", [])] == [
+        dict(item) for item in cold_optimized.get("selected", [])
+    ]
+
+
 def test_missing_index_loads_clean_no_crash(tmp_path: Path):
     # Empty checkpoint dir → first use finds no index, proceeds cleanly.
     e = EntrolyEngine(EntrolyConfig(checkpoint_dir=tmp_path, use_persistent_index=True))


### PR DESCRIPTION
## The bug

`load_index` restored canonical fragment and slot state but left every derived selection structure stale. A warm process could therefore rank and select **different fragments** than the cold process that wrote the snapshot.

The same query against the same index returned different evidence depending on process age. That makes a receipt non-reproducible, which violates the receipt-honesty invariant in CLAUDE.md.

This surfaced in CI as the intermittent onboarding assertion:

```
simulate/perf disagree on canonical field total_tokens_saved:
simulate=85436 perf=85437
```

The one-token gap was where it happened to show, not the size of the defect.

## The fix

Rebuild every derived structure from the persisted canonical values:

- dedup index rebuilt only from fragments that carry a fingerprint, so dependency stubs stay out of content similarity exactly as they are at ingest
- LSH rebuilt from the persisted slot order, preserving the slot identity that LSH entries refer to
- dependency graph rebuilt
- stale per-turn caches cleared

An incomplete or older slot snapshot falls back to sorted reassignment, so previously written indexes still load.

## Evidence

The regression test asserts cold and warm agree on recall, `total_tokens`, and the selected fragment list, with exploration zeroed.

Verified in both directions on a native build:

| | Result |
|---|---|
| Without the rebuild | `1 failed` |
| With the rebuild | `5 passed` |

The failure is a genuine selection divergence, not a rounding artifact:

```
At index 3 diff:
  warm: src/helpers/module_086.py  relevance 0.6355
  cold: src/helpers/module_041.py  relevance 0.6214
```

Also run locally against the native engine:

- `cargo test --lib` — 112 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` — clean
- `ruff check entroly/` — clean
- 45 index / selection / recall / determinism tests — passed

## Provenance

Cherry-picked from `6966739d` on `pr367-context-snapshot-parity`, where it was certified but stranded. This lands it on `main` independently of PR #367.