### PR TITLE
fix(release): keep a release a draft until its binaries are attached

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -767,6 +767,39 @@ jobs:
     with:
       tag: ${{ needs.release-metadata.outputs.tag }}
 
+  # The release stays a draft until every platform archive is attached, so the
+  # visible release is either complete or absent -- never a Latest tag that
+  # resolves to an empty download page.
+  #
+  # Deliberately NOT `if: always()`. The matrix runs fail-fast:false so one bad
+  # target does not cancel the others, but a release missing a platform is still
+  # a broken release: needing publish-binaries means any target failing leaves
+  # the draft unpublished for a human to inspect.
+  finalize-release:
+    needs: [release-metadata, github-release, publish-binaries]
+    if: needs.release-metadata.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish the release once its binaries exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.release-metadata.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Re-assert the contract rather than trusting the upstream job: this is
+          # the last gate before the release becomes user-visible.
+          asset_count="$(gh release view "${RELEASE_TAG}" --json assets \
+            --jq '.assets | length')"
+          if [[ "$asset_count" -eq 0 ]]; then
+            echo "Refusing to publish ${RELEASE_TAG}: it carries no assets." >&2
+            exit 1
+          fi
+          echo "${RELEASE_TAG} carries ${asset_count} asset(s); publishing."
+          gh release edit "${RELEASE_TAG}" --draft=false --latest
+
   # Create a release only after the source and native implementation pass.
   # External registries remain independently retryable and idempotent.
   github-release:
@@ -798,7 +831,17 @@ jobs:
           if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
             echo "Release ${RELEASE_TAG} already exists at verified source ${RELEASE_SHA}; skipping."
           else
+            # Created as a draft on purpose. A draft is invisible to users and
+            # never becomes "Latest", so a run that dies between here and the
+            # binary upload leaves nothing for a user to find. `finalize-release`
+            # publishes it only once every platform archive is attached.
+            #
+            # v1.0.79 is what this prevents: the run was cancelled after this
+            # job succeeded and before publish-binaries uploaded anything, which
+            # left a published Latest release carrying zero assets while the
+            # previous release still had all eight.
             gh release create "${RELEASE_TAG}" \
+              --draft \
               --title "v${RELEASE_VERSION}" \
               --target "${GITHUB_SHA}" \
               --generate-notes

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -94,3 +94,9 @@ jobs:
         with:
           tag_name: ${{ steps.release.outputs.tag }}
           files: dist/*
+          # This action PATCHes the release with whatever it is given, and its
+          # `draft` input defaults to false. Omitting it would publish the draft
+          # from whichever matrix target finished first, re-exposing the empty
+          # release this draft-first flow exists to prevent. The caller's
+          # finalize-release job owns the transition to published.
+          draft: true

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -34,3 +34,67 @@ def test_docker_quality_gate_exposes_installed_console_scripts() -> None:
     path_export = 'echo "$PWD/.venv/bin" >> "$GITHUB_PATH"'
     assert path_export in body
     assert body.index(path_export) < body.index(".venv/bin/pytest tests/")
+
+
+def test_github_release_is_created_as_a_draft() -> None:
+    """A release must not be user-visible before its binaries are attached.
+
+    v1.0.79 shipped as Latest with zero assets: the publish run was cancelled
+    after github-release succeeded and before publish-binaries uploaded
+    anything, so the download page for the current version was empty while the
+    previous release still carried all eight archives. Creating the release as
+    a draft makes that intermediate state invisible instead of broken.
+    """
+    workflow = (ROOT / ".github/workflows/entroly-publish.yml").read_text(
+        encoding="utf-8"
+    )
+    create = re.search(
+        r"(?ms)^\s+gh release create \"\$\{RELEASE_TAG\}\"(?P<flags>.*?)\n\s*fi$",
+        workflow,
+    )
+
+    assert create is not None, "gh release create invocation not found"
+    assert "--draft" in create.group("flags"), (
+        "gh release create must pass --draft; finalize-release publishes it "
+        "only once every platform archive is attached"
+    )
+
+
+def test_finalize_release_publishes_only_after_binaries() -> None:
+    workflow = (ROOT / ".github/workflows/entroly-publish.yml").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(
+        r"(?ms)^  finalize-release:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)",
+        workflow,
+    )
+
+    assert match is not None, "finalize-release job is missing"
+    body = match.group("body")
+    # Gating on publish-binaries is the whole contract: without it the job would
+    # publish a release whose upload never ran.
+    assert "publish-binaries" in body
+    assert "--draft=false" in body
+    # `always()` would publish regardless of the upload outcome.
+    assert "always()" not in body
+
+
+def test_binary_upload_does_not_publish_the_draft() -> None:
+    """softprops/action-gh-release defaults `draft` to false.
+
+    The action PATCHes the release with whatever it is given, so omitting the
+    input would let whichever matrix target finished first flip the draft to
+    published -- re-exposing the empty release the draft-first flow prevents.
+    """
+    workflow = (ROOT / ".github/workflows/release-binary.yml").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(
+        r"(?ms)^      - name: Attach to release\n(?P<body>.*?)(?=^      - |\Z)",
+        workflow,
+    )
+
+    assert match is not None, "Attach to release step not found"
+    assert re.search(r"(?m)^\s+draft:\s*true\s*$", match.group("body")), (
+        "the upload step must set draft: true so only finalize-release publishes"
+    )


### PR DESCRIPTION
## The bug

`github-release` created a **published** release, and `publish-binaries` attached the archives afterwards. The release was therefore user-visible before a single asset existed, and any interruption between the two steps left a `Latest` tag whose download page was empty.

This is not hypothetical. **`entroly-v1.0.79` is in exactly that state right now:**

| Release | Assets |
|---|---|
| `entroly-v1.0.79` (Latest) | **0** |
| `entroly-v1.0.78` | 8 |

Its publish run (`32953915415`) was cancelled to stop a defective PyPI publish. The job graph shows the split precisely:

```
success      github-release              <- release created, published, Latest
cancelled    publish-binaries / x86_64-unknown-linux-gnu
cancelled    publish-binaries / x86_64-apple-darwin
cancelled    publish-binaries / aarch64-apple-darwin
cancelled    publish-binaries / x86_64-pc-windows-msvc
```

Stopping a bad release was correct. Being left with a published, asset-less `Latest` was not — that is the automation failing open.

## The fix

- `gh release create` now passes `--draft`. A draft is invisible to users and never becomes `Latest`, so an interrupted run leaves *nothing* rather than something broken.
- New `finalize-release` job publishes the release only after every platform archive is attached. It **re-counts the assets** before flipping the flag rather than trusting the upstream job, and refuses to publish a zero-asset release.
- It deliberately does **not** use `always()`. The matrix is `fail-fast: false`, so one bad target does not cancel the others — but a release missing a platform is still broken, so any target failing leaves the draft unpublished for a human to inspect.
- The upload step pins `draft: true`. `softprops/action-gh-release` defaults that input to `false` and PATCHes the release with whatever it is given, so omitting it would let whichever matrix target finished first publish the draft and reintroduce the same gap.

## Evidence

Three guards pin the contract so it cannot silently revert. Each was verified to fail when its property is removed:

- `test_github_release_is_created_as_a_draft`
- `test_finalize_release_publishes_only_after_binaries`
- `test_binary_upload_does_not_publish_the_draft`

```
tests/test_workflow_guards.py + tests/test_release_surface.py
27 passed
```

Both workflow files parse as valid YAML and the job graph has no dangling `needs`.

## Not addressed here — needs a human decision

This prevents recurrence but does **not** repair the existing `entroly-v1.0.79` release, which is still Latest with 0 assets. Repairing it means either re-running the binary build for that tag or converting it back to a draft. Both are outward-facing actions on a published release, so I have deliberately left that decision alone.