### PR TITLE
test(snapshot): pin the non-UTF-8 source byte failure (PR #367 blocker)

### DIFF
--- a/tests/test_work_context_snapshot_source_bytes.py
+++ b/tests/test_work_context_snapshot_source_bytes.py
@@ -1,0 +1,106 @@
+"""Source bytes that are not valid UTF-8 must not break snapshot persistence.
+
+The repository intelligence input path decodes source with
+``errors="surrogateescape"`` (``parsers.py``, ``lsp_orchestrator.py``,
+``interprocedural_flow.py``, ``adaptive_program_graph.py``). A file carrying a
+single non-UTF-8 byte -- a latin-1 name in a string literal is the ordinary
+case -- therefore yields Python text containing lone surrogates.
+
+``json.dumps`` serialises those as ``\\udcXX``. The bytes stay pure ASCII, so
+they pass every byte-level check the cross-runtime parity test makes, but a
+lone surrogate is not valid JSON under RFC 8259. ``serde_json`` rejects it, so
+the Rust verifier that owns commitment validity cannot read what Python wrote.
+
+Python files are accidentally shielded: ``ast.parse`` raises
+``UnicodeEncodeError`` first and the file is recorded with a ``parse_error`` and
+no symbols. Languages that do not go through ``ast`` have no such gate, which is
+why the fixture below is JavaScript.
+
+Marked ``xfail(strict=True)``: the defect is real and unfixed, and strict mode
+turns the test into a failure the moment the behaviour changes, so a fix cannot
+land silently.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from entroly.repository_intelligence import RepositoryIntelligenceService
+from entroly.work_context_snapshot_store import WorkContextSnapshotStore
+from entroly.work_graph_store import WorkGraphStore
+
+
+# Written as a bytes literal on purpose: the whole point is a byte sequence that
+# is not valid UTF-8, which no str literal can express.
+_LEGACY_JS = (
+    b"function parseLegacy(value) {\n"
+    b"  const author = 'Bj\xf6rn';\n"
+    b"  return value.trim() + author;\n"
+    b"}\n"
+    b"module.exports = { parseLegacy };\n"
+)
+
+_CALLER_JS = (
+    "const { parseLegacy } = require('./legacy');\n\n"
+    "function go(value) {\n  return parseLegacy(value);\n}\n"
+)
+
+_SURROGATE_ESCAPE = "\\udc"
+
+
+def _build_payload(repo: Path) -> dict:
+    (repo / "src").mkdir(parents=True, exist_ok=True)
+    (repo / "src" / "legacy.js").write_bytes(_LEGACY_JS)
+    (repo / "src" / "caller.js").write_text(_CALLER_JS, encoding="utf-8")
+
+    service = RepositoryIntelligenceService(repo)
+    index, _digest, _generation = service._snapshot()
+
+    # The file indexes cleanly -- nothing warns the caller that its bytes will
+    # later be unrepresentable.
+    assert index.files["src/legacy.js"].parse_error is None
+    target = next(
+        symbol for symbol in index.symbols.values() if symbol.name == "parseLegacy"
+    )
+    return service.context(
+        "legacy parsing author",
+        token_budget=512,
+        max_hops=1,
+        proposal_scores=[{"symbol_id": target.symbol_id, "score": 1.0}],
+        proposal_provider="source-byte-regression",
+    )
+
+
+def test_non_utf8_source_byte_reaches_the_payload(tmp_path: Path) -> None:
+    """Guards the premise: the surrogate really does survive into the payload.
+
+    Kept separate from the xfail below so a change that merely stops the
+    surrogate reaching the payload cannot be mistaken for a snapshot fix.
+    """
+    payload = _build_payload(tmp_path / "repo")
+    assert _SURROGATE_ESCAPE in json.dumps(payload, ensure_ascii=True)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "A non-UTF-8 byte inside a non-Python symbol body makes the snapshot "
+        "unpersistable: Python emits a lone surrogate and the Rust verifier "
+        "rejects it as invalid JSON. Fixing this is a commitment-format "
+        "decision, so it is tracked rather than papered over."
+    ),
+)
+def test_snapshot_survives_non_utf8_source_bytes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    payload = _build_payload(repo)
+
+    store = WorkContextSnapshotStore(
+        WorkGraphStore("repo:source-byte-regression", root=tmp_path / "state")
+    )
+    token = store.put_json(payload)
+
+    restored = store.get_json(token)
+    assert restored == payload


### PR DESCRIPTION
Closes handoff item 3 by **finding the defect it predicted**, rather than confirming the path was safe.

> "Add/verify unusual filesystem/source-byte handling (especially Python surrogate-escape edge cases) rather than assuming UTF-8 behavior matches across runtimes."

That instinct was right. There is a reachable failure.

## The defect

A repository carrying **one non-UTF-8 byte inside a non-Python symbol body** cannot persist a context snapshot.

The repository intelligence input path decodes source with `errors="surrogateescape"` — `parsers.py:227`, `lsp_orchestrator.py:267`, `interprocedural_flow.py:96`, `adaptive_program_graph.py:73`. Such a file yields Python text containing lone surrogates. `json.dumps` serialises those as `\udcXX`.

The bytes stay **pure ASCII**, so they satisfy every byte-level assertion the existing cross-runtime parity test makes — including `raw == raw.decode("ascii").encode("ascii")`. But a lone surrogate is not valid JSON under RFC 8259. `serde_json` rejects it, so the Rust verifier that *owns commitment validity* cannot read what Python just wrote.

## Reproduction (end-to-end, real product path)

A JavaScript file with a latin-1 byte in a string literal:

```
indexed: True | parse_error: None          <- indexes cleanly, no warning
surrogate in payload: True                 <- reaches the context payload
put_json: FAILED -> WorkContextSnapshotError
          context snapshot is not valid JSON:
          lone leading surrogate in hex escape at line 1 column 83
```

Confirmed against the raw binding too:

```
RUST VERIFIER: REJECTED -> lone leading surrogate in hex escape
```

## Why nobody hit this yet

Python sources are shielded **by accident**. `ast.parse` raises `UnicodeEncodeError` first, so the file is recorded with a `parse_error` and no symbols — inspectable and honest. Languages that do not route through `ast` have no such gate, which is why the fixture is JavaScript.

The byte also has to land *inside* a symbol's span. The same byte in a file-level comment is outside the selected range and the snapshot succeeds — which is why a casual probe reports everything fine.

## What this PR does

Adds tests only. No behaviour change.

- `test_non_utf8_source_byte_reaches_the_payload` — **passes**. Pins the premise, so a change that merely stops the surrogate reaching the payload cannot be mistaken for a snapshot fix.
- `test_snapshot_survives_non_utf8_source_bytes` — **`xfail(strict=True)`**. Strict mode keeps CI green today and turns into a failure the moment behaviour changes, so a fix cannot land silently.

```
1 passed, 1 xfailed
```

## Why I did not just fix it

Repairing this means deciding how the commitment format represents bytes that are not valid UTF-8, and the options are not equivalent:

1. **Lossless encoding** (e.g. base64 with a flag) for spans that are not valid UTF-8 — faithful, but changes the schema and needs Python, Rust, and Node to agree.
2. **U+FFFD replacement in the rendered text**, relying on byte offsets plus SHA-256 for exact recovery — no schema change, but it is a lossy rendering and the receipt-honesty invariant requires it be flagged as such.

Option 2 touches "preserve the cross-backend byte-fidelity contract" directly. That is a deliberate trust decision and belongs to whoever owns the commitment format, not to a drive-by fix at the end of a session.

## Recommendation

**PR #367 should not merge until this is resolved.** The handoff's own standard applies — final certification has to prove exact recovery and cross-runtime snapshot recovery, and this is a case where both fail on legitimate input.