### PR TITLE
fix(verifier): make verify-code usable — 99.2% → 15.8% false positives

### DIFF
--- a/entroly/verifiers/symbol_resolution.py
+++ b/entroly/verifiers/symbol_resolution.py
@@ -226,6 +226,19 @@ def _collect_stdlib_modules() -> set[str]:
         except Exception:
             pass
 
+    # `from __future__ import annotations` opens nearly every modern Python
+    # file in this repository, and `annotations` is not a module, a builtin,
+    # or anything the AST pass collects -- so every such file contributed a
+    # guaranteed unresolved symbol. These are language features, enumerated by
+    # the interpreter rather than hardcoded, so the set tracks the running
+    # Python instead of drifting.
+    try:
+        import __future__ as _future
+
+        out.update(_future.all_feature_names)
+    except Exception:
+        pass
+
     return out
 
 

--- a/entroly/verifiers/symbol_resolution.py
+++ b/entroly/verifiers/symbol_resolution.py
@@ -80,6 +80,31 @@ logger = logging.getLogger("entroly.verifiers.symbol_resolution")
 # Conservative default: surprisal must exceed ~ ln(P)+λ before flagging.
 DEFAULT_LAMBDA = 6.5
 
+# log ρ, where ρ = P(a fabricated name collides with the manifest).
+#
+# Resolving against the manifest is evidence, not merely a gate. The original
+# derivation used it as a hard gate for σ ∉ M and then discarded it for σ ∈ M,
+# scoring a symbol the codebase demonstrably contains purely on how unusual its
+# spelling looks. Because the aggregate is a noisy-OR, those residual
+# probabilities compounded with symbol count: ten real stdlib imports, nothing
+# fabricated and nothing unresolved, scored 0.694, and five scored 0.558 --
+# past the 0.5 failure threshold. h_score measured how much code was written
+# rather than whether it was true.
+#
+# Adding log ρ to the logit is the missing likelihood-ratio update. ρ is
+# measured, not chosen: 3000 fabricated identifiers built by recombining real
+# morphemes (fetch_lattice, quantize_canonical_receipt, slurpDigest) -- the way
+# a model actually invents an API, rather than random strings that would
+# collide at zero and flatter the estimate -- produced 1 collision against a
+# 66,914-symbol manifest. A rule-of-three floor is applied so a near-zero draw
+# from a finite sample does not imply unbounded confidence.
+#
+#     ρ̂ = 1/3000 = 3.33e-4  →  floored to 1e-3  →  log ρ = -6.91
+#
+# Fail-closed is untouched: σ ∉ M still returns 1.0. This only bounds how much
+# doubt a symbol that *is* present can contribute.
+MANIFEST_EVIDENCE_LOG_ODDS = -6.9078
+
 # Per-symbol importance weights in the aggregate score.
 WEIGHT_FUNCTION_CALL = 1.0      # foo(...) — high signal
 WEIGHT_ATTRIBUTE_ACCESS = 1.0   # obj.attr — high signal
@@ -384,6 +409,24 @@ def _extract_python_top_level(path: Path, out: set[str]) -> None:
                 ):
                     out.add(target.attr)
 
+    # Class-body bindings: dataclass fields, class constants, and annotated
+    # class attributes. `@dataclass class Diff: files_added: list[str]` defines
+    # `files_added` for every instance, but it is an AnnAssign in a class body
+    # rather than a module-level one or a `self.` assignment, so neither pass
+    # above reaches it. Dataclasses are common enough here that this was a
+    # visible share of the remaining false positives.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for item in node.body:
+            if isinstance(item, ast.AnnAssign):
+                if isinstance(item.target, ast.Name):
+                    out.add(item.target.id)
+            elif isinstance(item, ast.Assign):
+                for target in item.targets:
+                    if isinstance(target, ast.Name):
+                        out.add(target.id)
+
 
 # ── Symbol Extraction from generated code ────────────────────────────
 
@@ -685,8 +728,11 @@ class SymbolVerifier:
             return 0.0  # No surprisal signal → trust the manifest
 
         surp = self.ngram_model.surprisal(name)
-        # Sigmoid in nats: sigmoid(surp − λ)
-        x = surp - self.lambda_
+        # Sigmoid in nats, with manifest membership carried as evidence rather
+        # than discarded once the hard gate is passed:
+        #     sigmoid(surp − λ + log ρ)
+        # See MANIFEST_EVIDENCE_LOG_ODDS for how ρ was measured.
+        x = surp - self.lambda_ + MANIFEST_EVIDENCE_LOG_ODDS
         # Numerically stable sigmoid
         if x >= 0:
             return 1.0 / (1.0 + math.exp(-x))
@@ -748,9 +794,14 @@ class SymbolVerifier:
             h_score=h_score,
             n_resolved=sum(1 for j in judgments if j.resolved),
             n_unresolved=sum(1 for j in judgments if not j.resolved),
+            # Reported on the uncorrected surprisal. Once membership is
+            # carried as evidence a resolved symbol almost never exceeds 0.5,
+            # so keying this off p_hallucinated would silently zero the
+            # "resolved but oddly named" signal. It stays observable here
+            # without being allowed to drive h_score.
             n_suspicious=sum(
                 1 for j in judgments
-                if j.resolved and j.p_hallucinated > 0.5
+                if j.resolved and j.surprisal > self.lambda_
             ),
             manifest_size=self.manifest.size(),
         )

--- a/entroly/verifiers/symbol_resolution.py
+++ b/entroly/verifiers/symbol_resolution.py
@@ -279,8 +279,30 @@ def _collect_repo_symbols(
         if path is None:
             continue
         files_seen += 1
+        _record_module_identity(root, path, out)
         _extract_python_top_level(path, out)
     return out
+
+
+def _record_module_identity(root: Path, path: Path, out: set[str]) -> None:
+    """Add the importable names the repository's own layout defines.
+
+    `from ledger.accounts import Account` references two names the codebase
+    really does define -- `ledger` because a directory of that name holds an
+    `__init__.py`, and `accounts` because `accounts.py` exists. Neither is a
+    def, a class, or a module-level assignment, so the AST pass never saw
+    them and every intra-repo import scored as hallucinated.
+
+    This is not the case the "imports are not definitions" rule guards
+    against. That rule stops `from torch.nn import HyperbolicAttention`
+    grounding a name that only an external package could define. Here the
+    filesystem is the evidence: the name is grounded because a file or
+    package of that name is present in this repository.
+    """
+    if path.stem != "__init__":
+        out.add(path.stem)
+    for parent in path.parent.relative_to(root).parts:
+        out.add(parent)
 
 
 def _extract_python_top_level(path: Path, out: set[str]) -> None:
@@ -327,6 +349,27 @@ def _extract_python_top_level(path: Path, out: set[str]) -> None:
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             out.add(node.name)
+        # `self.entries = {}` defines an attribute just as much as a `def`
+        # does. Without it every `account.entries` read scored as
+        # hallucinated, which is most of what real code does with objects.
+        #
+        # Attribute names are collected repository-wide rather than per
+        # class because the manifest is name-based and carries no type
+        # information -- the same reason `Class.method` is already grounded
+        # for every receiver. That admits a fictional attribute if some
+        # unrelated class happens to define the same name, which is a real
+        # cost, but it is bounded by "some file in this repository assigns
+        # it" and is the difference between the verifier discriminating at
+        # all and rejecting every correct program.
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                ):
+                    out.add(target.attr)
 
 
 # ── Symbol Extraction from generated code ────────────────────────────

--- a/tests/test_symbol_verifier.py
+++ b/tests/test_symbol_verifier.py
@@ -316,3 +316,67 @@ class TestPerformance:
             verifier.verify(code)
         avg_ms = (time.perf_counter() - t0) * 100  # /10 then *1000
         assert avg_ms < 100, f"verify avg {avg_ms:.1f}ms > 100ms budget"
+
+
+# ── Manifest completeness ────────────────────────────────────────────
+
+
+class TestManifestCoversRepositoryLayout:
+    """Names the repository's own layout defines must resolve.
+
+    `from ledger.accounts import Account` names a package and a module, and
+    `self.entries = {}` names an attribute. None of these is a def, a class,
+    or a module-level assignment, so the AST pass never collected them and
+    ordinary intra-repository code scored as unresolved.
+
+    This is distinct from the "imports are not definitions" rule, which stops
+    `from torch.nn import HyperbolicAttention` grounding a name only an
+    external package could define. Here the filesystem is the evidence.
+    """
+
+    @staticmethod
+    def _repo(tmp_path):
+        pkg = tmp_path / "ledger"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "accounts.py").write_text(
+            "class Account:\n"
+            "    def __init__(self, name):\n"
+            "        self.name = name\n"
+            "        self.entries = {}\n",
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_package_module_and_attribute_names_resolve(self, tmp_path):
+        from entroly.verifiers.symbol_resolution import verify_code
+
+        code = (
+            "from ledger.accounts import Account\n\n"
+            "def summarize(accounts):\n"
+            "    totals = {}\n"
+            "    for acct in accounts:\n"
+            "        for key, value in acct.entries.items():\n"
+            "            totals[key] = totals.get(key, 0) + value\n"
+            "    return totals\n"
+        )
+        result = verify_code(code, repo_root=str(self._repo(tmp_path)))
+
+        # `ledger` is a package directory, `entries` is a self-assigned
+        # attribute. Both are defined by this repository.
+        assert result.unresolved_symbols() == []
+
+    def test_a_fabricated_symbol_still_fails_closed(self, tmp_path):
+        from entroly.verifiers.symbol_resolution import verify_code
+
+        code = (
+            "from ledger.accounts import Account\n\n"
+            "def summarize(accounts):\n"
+            "    return quantum_reconcile(accounts)\n"
+        )
+        result = verify_code(code, repo_root=str(self._repo(tmp_path)))
+
+        # Widening the manifest must not ground something the repository
+        # never defines.
+        assert "quantum_reconcile" in result.unresolved_symbols()
+        assert not result.passed()

--- a/tests/test_symbol_verifier.py
+++ b/tests/test_symbol_verifier.py
@@ -172,16 +172,37 @@ class TestPosteriorMath:
         p = verifier.posterior_hallucinated(ref)
         assert p < 0.1, f"P_halu={p} for legitimate 'compress' too high"
 
-    def test_resolved_high_surprisal_is_suspicious(self, verifier):
-        """Symbol in manifest BUT unusual character distribution → suspicious."""
-        # Add a high-surprisal name to the manifest to force the mixed case
+    def test_resolved_high_surprisal_is_reported_but_does_not_drive_the_score(
+        self, verifier
+    ):
+        """Odd spelling is observability, not evidence of fabrication.
+
+        This assertion used to require p > 0.3 for a symbol that is present in
+        the manifest but spelled unusually. Because the aggregate is a
+        noisy-OR, residual probabilities on symbols the codebase demonstrably
+        contains compounded with symbol count: ten real stdlib imports scored
+        0.694 and five scored 0.558, past the failure threshold, with nothing
+        fabricated and nothing unresolved.
+
+        The suspicion signal is not discarded -- it moves to `n_suspicious`,
+        which is keyed off raw surprisal. Both halves are pinned here so
+        neither can be lost.
+        """
         verifier.manifest.repo.add("zxqyvtbprwklm")
         from entroly.verifiers.symbol_resolution import SymbolReference
         ref = SymbolReference(
             name="zxqyvtbprwklm", kind="call", line=1, weight=1.0,
         )
+
         p = verifier.posterior_hallucinated(ref)
-        assert p > 0.3, f"P_halu={p} for high-surprisal symbol too low"
+        assert p < 0.1, (
+            f"P_halu={p}: a symbol the manifest contains must not carry the "
+            "doubt of one it does not"
+        )
+
+        # ...but the oddity is still surfaced.
+        result = verifier.verify("zxqyvtbprwklm()\n")
+        assert result.n_suspicious >= 1, "suspicion signal was lost, not moved"
 
     def test_dunder_methods_always_pass(self, verifier):
         from entroly.verifiers.symbol_resolution import SymbolReference
@@ -401,3 +422,56 @@ class TestFutureFeatureNames:
         result = verify_code(code, repo_root=str(tmp_path))
 
         assert "annotations" not in result.unresolved_symbols()
+
+
+class TestScoreDoesNotTrackCodeLength:
+    """h_score must answer "is anything fabricated", not "how much was written".
+
+    The aggregate is a noisy-OR over distinct symbols. While symbols the
+    manifest contains retained a residual probability, that product grew with
+    symbol count: five real stdlib imports scored 0.558 and ten scored 0.694,
+    both past the 0.5 failure threshold, with nothing fabricated and nothing
+    unresolved. Any sufficiently long correct program failed.
+    """
+
+    # Every name here is in the `small_manifest` fixture, so the only thing
+    # varying across the cases below is how many distinct symbols appear.
+    IMPORTS = [
+        "import json", "import math", "import os", "import sys", "import re",
+        "import numpy", "import requests", "import torch", "import pandas",
+        "import entroly",
+    ]
+
+    def _code(self, count: int) -> str:
+        return "\n".join(self.IMPORTS[:count]) + "\ndef handle(value):\n    return value\n"
+
+    def test_grounded_imports_do_not_accumulate_into_a_failure(self, verifier):
+        scores = {}
+        for count in (1, 2, 5, 10):
+            result = verifier.verify(self._code(count))
+            # Premise: nothing here is fabricated. If this trips, the fixture
+            # drifted and the length claim below would be measuring something
+            # else entirely.
+            assert result.unresolved_symbols() == [], (
+                f"fixture is not fully grounded at {count} imports: "
+                f"{result.unresolved_symbols()}"
+            )
+            scores[count] = result.h_score
+
+        assert all(score < 0.5 for score in scores.values()), (
+            f"grounded code failed verification purely on length: {scores}"
+        )
+        # Ten grounded imports must not cost meaningfully more than one.
+        assert scores[10] - scores[1] < 0.1, f"score still tracks length: {scores}"
+
+    def test_a_single_fabricated_symbol_still_fails_closed(self, verifier):
+        code = self._code(10).replace(
+            "return value", "return quantum_reconcile_ledger(value)"
+        )
+        result = verifier.verify(code)
+
+        assert "quantum_reconcile_ledger" in result.unresolved_symbols()
+        # Not exactly 1.0: the aggregate clamps each p to 1 - 1e-12 so the
+        # log term stays finite.
+        assert result.h_score > 0.999
+        assert not result.passed()

--- a/tests/test_symbol_verifier.py
+++ b/tests/test_symbol_verifier.py
@@ -380,3 +380,24 @@ class TestManifestCoversRepositoryLayout:
         # never defines.
         assert "quantum_reconcile" in result.unresolved_symbols()
         assert not result.passed()
+
+
+class TestFutureFeatureNames:
+    def test_future_import_names_resolve(self, tmp_path):
+        """`from __future__ import annotations` opens most modern Python files.
+
+        `annotations` is not a module, not a builtin, and not anything the AST
+        pass collects, so before this every such file contributed a guaranteed
+        unresolved symbol -- one per file, repository-wide.
+        """
+        from entroly.verifiers.symbol_resolution import verify_code
+
+        (tmp_path / "mod.py").write_text("VALUE = 1\n", encoding="utf-8")
+        code = (
+            "from __future__ import annotations\n\n"
+            "def widen(value: str | None) -> str:\n"
+            "    return value or ''\n"
+        )
+        result = verify_code(code, repo_root=str(tmp_path))
+
+        assert "annotations" not in result.unresolved_symbols()

--- a/tests/test_verifier_service_concurrency.py
+++ b/tests/test_verifier_service_concurrency.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
 
+import math
+
+import pytest
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 from entroly.verifiers.scope_analyzer import ReverseIndex
 from entroly.verifiers.service import VerifierService, _ServiceInstance
-from entroly.verifiers.symbol_resolution import SymbolManifest, SymbolVerifier
+from entroly.verifiers.symbol_resolution import (
+    MANIFEST_EVIDENCE_LOG_ODDS,
+    SymbolManifest,
+    SymbolVerifier,
+)
+
+
+def _expected_posterior(surprisal: float, lambda_used: float) -> float:
+    """The posterior this configuration should produce, derived not guessed.
+
+    Pinning the formula rather than a literal keeps the test meaningful when
+    the calibration constants move: it still fails if per-archetype lambda
+    stops being applied, which is what this test exists to guard.
+    """
+    x = surprisal - lambda_used + MANIFEST_EVIDENCE_LOG_ODDS
+    return 1.0 / (1.0 + math.exp(-x)) if x >= 0 else math.exp(x) / (1.0 + math.exp(x))
 
 
 class _FixedSurprisal:
@@ -60,13 +78,24 @@ def test_concurrent_archetypes_do_not_mutate_shared_lambda(
         outcomes = list(pool.map(run, archetypes))
 
     assert base_verifier.lambda_ == 42.0
+    strict_seen: list[float] = []
+    permissive_seen: list[float] = []
     for archetype, lambda_used, probability in outcomes:
         if archetype == "strict":
             assert lambda_used == 0.0
-            assert probability > 0.99
+            assert probability == pytest.approx(
+                _expected_posterior(7.0, 0.0), rel=1e-9
+            )
+            strict_seen.append(probability)
         else:
             assert lambda_used == 100.0
             assert probability < 0.01
+            permissive_seen.append(probability)
+
+    # The point of the two archetypes is that lambda actually reaches the
+    # posterior. Assert the separation directly rather than trusting a literal
+    # threshold, which previously encoded the pre-correction absolute value.
+    assert min(strict_seen) > max(permissive_seen) * 1000
 
 
 def test_snapshot_survives_invalidation_without_none_state(


### PR DESCRIPTION
`entroly verify-code` rejected **119 of 120** real, committed, working functions from this repository. This makes it usable.

> **Corrections.** Two earlier measurements in this PR were wrong and are discarded: a 2-file fixture (undertrained n-gram model), and a 99.2% figure measured against a **different repository checkout** — a script run from a scratchpad puts its own directory on `sys.path[0]`, not the cwd. Everything below is from controlled runs with `PYTHONPATH` pinned to this checkout.

## Results

120 real committed functions, `h_score >= 0.5` is a false positive by construction:

| | mean | median | false positives |
|---|---|---|---|
| original | 0.9940 | 1.0000 | **119/120 (99.2%)** |
| + manifest & `__future__` | 0.6143 | 0.5810 | 80/120 (66.7%) |
| **+ evidence correction** | **0.1590** | **0.0009** | **19/120 (15.8%)** |

Tie-corrected AUROC on the labelled set holds at **1.0000**, with the margin widening sharply — real code's max falls from 0.4431 to **0.0002** while fabricated code stays at 1.0000.

## The core defect

`h_score` measured **how much code you wrote**, not whether it was true:

| grounded stdlib imports | before | after |
|---|---|---|
| 1 | 0.0426 | 0.0000 |
| 2 | 0.1032 | 0.0001 |
| 5 | **0.5577 FAIL** | **0.0009 pass** |
| 10 | 0.6940 FAIL | 0.0013 pass |

Nothing fabricated, `unresolved=[]` in every row. The posterior used manifest membership as a hard gate for σ ∉ M and then **discarded it** for σ ∈ M, scoring a symbol the codebase demonstrably contains purely on how unusual its spelling looks. Since the aggregate is a noisy-OR over distinct symbols, those residuals compounded with symbol count.

## The correction, with ρ measured not chosen

Adding `log ρ` to the logit is the missing likelihood-ratio update, where ρ = P(a fabricated name collides with the manifest).

ρ was **measured**: 3000 fabricated identifiers built by recombining real morphemes — `fetch_lattice`, `quantize_canonical_receipt`, `slurpDigest`, the way a model actually invents an API rather than random strings that would collide at zero and flatter the estimate. Result: **1 collision** against a 66,914-symbol manifest. With a rule-of-three floor, `log ρ = −6.91`.

## Fail-closed is untouched

- σ ∉ M still returns exactly `1.0`
- One fabricated name among ten grounded imports still scores **> 0.999**
- Widening the manifest still does not ground a symbol the repository never defines

## The suspicion signal moved, it was not dropped

`n_suspicious` now keys off raw surprisal, so "resolved but oddly named" stays observable without driving the score. The posterior test that required `p > 0.3` for that case was **rewritten to pin both halves** of the new contract, not deleted.

## Also fixed

- **Package/module names** — `path_safety`, `metrics`, `verifiers` now resolve with `provenance=repo`
- **`self.x` attributes** — `self.entries = {}` defines an attribute
- **`__future__` feature names** — `annotations` was unresolved in nearly every file, and an unresolved symbol is a hard `1.0`
- **Class-body bindings** — dataclass fields are `AnnAssign` in a class body, reached by neither prior pass

## Tests

```
tests/test_symbol_verifier.py — 30 passed
```

Verified to have teeth: neutralizing `MANIFEST_EVIDENCE_LOG_ODDS` to `0.0` fails exactly the two tests that pin this behaviour.

## Known remainder

The residual 15.8% is **manifest breadth, not aggregation** — `hexdigest` is a hash *object* method and `contextmanager` isn't in the expanded stdlib list. A different, separately addressable defect.