### PR TITLE
fix(work-graph): withhold secret-shaped names and vendored trees from recovery

### DIFF
--- a/entroly/work_graph_content_digest.py
+++ b/entroly/work_graph_content_digest.py
@@ -8,8 +8,11 @@ Security and honesty rules:
 - never follow symlinks or read special files;
 - never read outside the repository root;
 - bound every file read;
-- staged/conflicted paths remain non-dedupeable because one worktree digest
-  cannot represent both index and worktree state;
+- staged/conflicted paths remain non-dedupeable via ``content_digest``, because
+  one worktree digest cannot represent both index and worktree state -- but
+  they are no longer left unbound: ``index_digest`` and ``worktree_digest``
+  commit to each state separately, and a conflicted path additionally records
+  its base/ours/theirs stage digests;
 - detect path/file races before and after reading and fail closed;
 - preserve Git's SHA-1/SHA-256 blob identity exactly.
 """
@@ -169,6 +172,44 @@ def _git_blob_digest(root: Path, repo_rel: str, algorithm: str) -> str:
             pass
 
 
+_CONFLICT_STAGE_NAMES = {"1": "base", "2": "ours", "3": "theirs"}
+
+
+def _index_entries(root: Path, repo_rel: str) -> dict[str, str]:
+    """Blob identities Git already holds in its index, keyed by stage name.
+
+    Read from the index rather than recomputed from disk. For a staged path the
+    index is the only place the staged bytes exist -- the worktree may have
+    moved on since ``git add`` -- and for a conflicted path the three stages
+    have no on-disk representation at all: what is in the worktree is merged
+    text with markers, which is not any of them.
+
+    ``ls-files -s`` reports ``<mode> <sha> <stage>\\t<path>``. Stage 0 is an
+    ordinary index entry; 1/2/3 are base/ours/theirs of an unresolved merge.
+    """
+    if not repo_rel or repo_rel.startswith("sensitive:"):
+        return {}
+    raw = _git_text(root, "ls-files", "-s", "-z", "--", repo_rel)
+    entries: dict[str, str] = {}
+    for record in raw.split("\0"):
+        if not record or "\t" not in record:
+            continue
+        meta, _, path = record.partition("\t")
+        if path.replace("\\", "/") != repo_rel:
+            continue
+        fields = meta.split()
+        if len(fields) < 3:
+            continue
+        _mode, sha, stage = fields[0], fields[1], fields[2]
+        if not sha or set(sha) <= {"0"}:
+            continue
+        # Same ``git-blob:`` prefix the worktree digests carry. These are the
+        # same kind of thing -- a Git blob identity -- and a caller comparing
+        # index against worktree should not have to strip one side first.
+        entries[_CONFLICT_STAGE_NAMES.get(stage, "index")] = f"git-blob:{sha}"
+    return entries
+
+
 def enrich_worktree_content_digests(
     repo_path: str | os.PathLike[str], observation: dict[str, Any]
 ) -> dict[str, Any]:
@@ -189,16 +230,44 @@ def enrich_worktree_content_digests(
         if not isinstance(raw, dict):
             continue
         raw["content_digest"] = ""
-        if raw.get("staged") or raw.get("conflicted"):
+        raw["index_digest"] = ""
+        raw["worktree_digest"] = ""
+
+        # A withheld path carries an opaque id, not a filename, so there is
+        # nothing to hash and nothing that should be hashed: a content digest
+        # of a short credential file is a confirmation oracle for a guessed
+        # value.
+        if raw.get("redacted"):
             continue
-        kind = str(raw.get("kind", ""))
-        if kind == "deleted":
-            raw["content_digest"] = "worktree:deleted"
-            continue
-        if algorithm is None:
-            continue
+
         repo_rel = str(raw.get("path", ""))
-        raw["content_digest"] = _git_blob_digest(root, repo_rel, algorithm)
+        kind = str(raw.get("kind", ""))
+        staged = bool(raw.get("staged"))
+        conflicted = bool(raw.get("conflicted"))
+
+        if kind == "deleted":
+            raw["worktree_digest"] = "worktree:deleted"
+            if not (staged or conflicted):
+                raw["content_digest"] = "worktree:deleted"
+        elif algorithm is not None:
+            worktree = _git_blob_digest(root, repo_rel, algorithm)
+            raw["worktree_digest"] = worktree
+            # content_digest keeps its original meaning -- a single identity
+            # that stands for the whole path -- so it stays empty exactly when
+            # one digest cannot honestly represent the path's state. Rust's
+            # dedup semantics are unchanged by this commit.
+            if not (staged or conflicted):
+                raw["content_digest"] = worktree
+
+        if staged or conflicted:
+            entries = _index_entries(root, repo_rel)
+            if "index" in entries:
+                raw["index_digest"] = entries["index"]
+            stages = {
+                name: sha for name, sha in entries.items() if name != "index"
+            }
+            if stages:
+                raw["conflict_stage_digests"] = stages
     return observation
 
 

--- a/entroly/work_graph_mcp.py
+++ b/entroly/work_graph_mcp.py
@@ -30,6 +30,13 @@ from .work_graph import (
     verify_recovery_handle,
 )
 from .work_graph_content_digest import enrich_worktree_content_digests
+from .work_graph_recovery_ack import (
+    RecoveryAcknowledgementRequired,
+    acknowledge as recovery_acknowledge,
+    arm as recovery_arm,
+    recovery_token,
+    require_acknowledged as recovery_require_acknowledged,
+)
 from .work_graph_repo import discover_repository_identity, discover_repository_observation
 from .work_graph_store import (
     continuation_outstanding_refs,
@@ -67,6 +74,23 @@ def _project_path(project: str = "") -> Path:
 def _store_for_path(path: Path) -> WorkGraphStore:
     identity = discover_repository_identity(path)
     return WorkGraphStore(identity["repo_id"])
+
+
+def _recovery_unknowns(view: Any) -> list[str]:
+    """What the reconstruction could not establish, for the agent to accept.
+
+    Intent is always unknown: the Work Graph observes durable Git and
+    checkpoint facts and deliberately never infers purpose from filenames,
+    commit prose, or branch names. Anything the view already records as unknown
+    is carried through rather than restated here, so the list stays honest if
+    the reconstruction learns to establish more.
+    """
+    unknowns = {"unknown:previous-agent-intent"}
+    if isinstance(view, dict):
+        recorded = view.get("unknowns")
+        if isinstance(recorded, list):
+            unknowns.update(str(item) for item in recorded if isinstance(item, str))
+    return sorted(unknowns)
 
 
 def _passive_observation(path: Path) -> dict[str, Any]:
@@ -386,6 +410,11 @@ def work_claim(
         ttl = _ttl_ms(ttl_seconds)
         path = _project_path(project)
         store = _store_for_path(path)
+        # Claiming work is the first act that binds this agent to a task. If a
+        # recovery is outstanding, the agent would be acting on reconstructed
+        # state it never accepted, which is exactly what the trust label warns
+        # about and previously did nothing to prevent.
+        recovery_require_acknowledged(store.repo_dir)
         now_ms = int(time.time() * 1000)
         lease_id = uuid.uuid4().hex
         observation = discover_repository_observation(
@@ -456,6 +485,13 @@ def work_resume(
         )
         view = store.resume(selected_workstream or None, max_evidence=max_evidence)
         payload: dict[str, Any] = {"resume": view}
+
+        # Arm the trust gate. Everything below this point is reconstructed, not
+        # observed, and the agent may not mutate work until it says so.
+        token = recovery_token(view)
+        payload["acknowledgement"] = recovery_arm(
+            store.repo_dir, token, _recovery_unknowns(view)
+        )
         if target_agent:
             payload["continuation_proof"] = store.reconstructed_continuation_proof(
                 str(view["selected_workstream"]["node_id"]),
@@ -467,6 +503,35 @@ def work_resume(
     except Exception as exc:
         return _error("work_resume", exc)
 
+
+
+def work_acknowledge_recovery(
+    *,
+    token: str,
+    project: str = "",
+) -> dict[str, Any]:
+    """Accept responsibility for reconstructed work state so acting is allowed.
+
+    ``work_resume`` returns state that was inferred from durable evidence, not
+    observed. Until an agent acknowledges the specific state it was shown,
+    ``work_claim`` refuses. The token is a digest of that state, so if the
+    worktree moved in between, the acknowledgement is rejected and the agent is
+    sent back to resume again rather than acting on a stale picture.
+    """
+    try:
+        supplied = str(token).strip()
+        if not supplied:
+            raise ValueError("token must not be empty")
+        if len(supplied) > _MAX_ID_CHARS or chr(0) in supplied:
+            raise ValueError(
+                f"token may not exceed {_MAX_ID_CHARS} characters or contain NUL"
+            )
+        path = _project_path(project)
+        store = _store_for_path(path)
+        result = recovery_acknowledge(store.repo_dir, supplied)
+        return {"status": "ok", "kind": "work_acknowledge_recovery", **result}
+    except Exception as exc:
+        return _error("work_acknowledge_recovery", exc)
 
 def work_handoff(
     *,

--- a/entroly/work_graph_mcp_server.py
+++ b/entroly/work_graph_mcp_server.py
@@ -23,6 +23,25 @@ def _json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
 
+def _takeover(project: str = "") -> None:
+    """Run automatic takeover once, on the first thing the agent actually does.
+
+    Not at ``create_mcp_server`` time. Constructing a server must stay instant
+    and side-effect-free -- warm-start already learned that a blocking cold
+    start makes the server look hung, and observing a repository because a
+    server object was built also means merely importing or listing tools
+    touches the user's worktree.
+
+    First tool call is still fully automatic from the agent's side: it never
+    calls ``work_resume``, and if there was unfinished work the trust gate is
+    armed before that first call is answered. ``start_session`` is idempotent
+    per process and repository, so this costs one dictionary lookup thereafter.
+    """
+    from .work_graph_session import start_session
+
+    start_session(project)
+
+
 def register_work_graph_tools(mcp: Any) -> Any:
     """Register the vendor-neutral continuity tools on an existing MCP server.
 
@@ -34,6 +53,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
     @mcp.tool()
     def work_state(project: str = "", now_ms: int = 0) -> str:
         """Inspect persisted shared work state without appending a polling event."""
+        _takeover(project)
         return _json(_work.work_state(project=project, now_ms=now_ms or None))
 
     @mcp.tool()
@@ -48,6 +68,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
         ttl_seconds: float = 900.0,
     ) -> str:
         """Record explicit agent work plus a bounded advisory scope lease."""
+        _takeover(project)
         return _json(
             _work.work_claim(
                 agent_id=agent_id,
@@ -69,6 +90,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
         to_agent: str = "",
     ) -> str:
         """Recover unfinished work and optionally seal a no-handoff proof."""
+        _takeover(project)
         return _json(
             _work.work_resume(
                 project=project,
@@ -86,6 +108,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
         project: str = "",
     ) -> str:
         """Create a graph-bound handoff receipt and complete continuation proof."""
+        _takeover(project)
         return _json(
             _work.work_handoff(
                 from_agent=from_agent,
@@ -103,6 +126,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
         session_id: str = "",
     ) -> str:
         """Attach a canonical ContextReceipt to its exact WorkScope."""
+        _takeover(project)
         return _json(
             _work.work_record_context(
                 receipt=receipt,
@@ -124,6 +148,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
         max_fragments: int = 24,
     ) -> str:
         """Compile verified code context and record its Work Graph receipt."""
+        _takeover(project)
         return _json(
             _work.work_compile_context(
                 query=query,
@@ -149,6 +174,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
         token_budget: int | None = None,
     ) -> str:
         """Fault exact omitted code from a context token or verified context object."""
+        _takeover(project)
         return _json(
             _work.work_context_fault(
                 context=context,
@@ -170,6 +196,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
         superseded_ids: list[str] | None = None,
     ) -> str:
         """Attach provenance-bearing memory without trusting raw model prose."""
+        _takeover(project)
         return _json(
             _work.work_record_memory(
                 memory=memory,
@@ -188,6 +215,7 @@ def register_work_graph_tools(mcp: Any) -> Any:
         invalidated_commitments: list[str] | None = None,
     ) -> str:
         """Atomically record route, observable execution and exact-head verification."""
+        _takeover(project)
         return _json(
             _work.work_record_execution(
                 route=route,
@@ -197,6 +225,59 @@ def register_work_graph_tools(mcp: Any) -> Any:
                 invalidated_commitments=invalidated_commitments,
             )
         )
+
+
+    @mcp.tool()
+    def work_session_status(project: str = "") -> str:
+        """Report the automatic takeover performed when this server started."""
+        _takeover(project)
+        from .work_graph_session import session_state, session_watcher
+
+        state = session_state(project)
+        payload = {
+            "status": "ok",
+            "kind": "work_session_status",
+            "session": state if state is not None else {"attempted": False},
+        }
+        watcher = session_watcher(project)
+        if watcher is not None:
+            payload["watcher"] = watcher.status()
+        return _json(payload)
+
+    @mcp.tool()
+    def work_modifications(project: str = "", drain: bool = False) -> str:
+        """Modifications recorded between observations by the workspace watcher.
+
+        A point-in-time refresh shows what a file looks like now. This shows
+        that it changed at 14:02 and again at 14:07, which a refresh cannot.
+        Empty when the watcher is disabled.
+        """
+        _takeover(project)
+        from .work_graph_session import session_watcher
+
+        watcher = session_watcher(project)
+        if watcher is None:
+            return _json({
+                "status": "ok",
+                "kind": "work_modifications",
+                "watching": False,
+                "reason": "workspace watcher disabled; set ENTROLY_WORK_GRAPH_WATCH=1",
+                "modifications": [],
+            })
+        records = watcher.drain() if drain else watcher.modifications()
+        return _json({
+            "status": "ok",
+            "kind": "work_modifications",
+            "watching": True,
+            "modifications": records,
+            "watcher": watcher.status(),
+        })
+
+    @mcp.tool()
+    def work_acknowledge_recovery(token: str, project: str = "") -> str:
+        """Accept responsibility for recovered work state so acting is allowed."""
+        _takeover(project)
+        return _json(_work.work_acknowledge_recovery(token=token, project=project))
 
     return mcp
 
@@ -225,6 +306,7 @@ def create_mcp_server():
         mcp._mcp_server.version = package_version
     except (AttributeError, ImportError):
         pass
+
     return register_work_graph_tools(mcp)
 
 

--- a/entroly/work_graph_path_policy.py
+++ b/entroly/work_graph_path_policy.py
@@ -1,0 +1,166 @@
+"""Classification of worktree paths before they become recoverable evidence.
+
+``git status --porcelain`` already omits git-ignored files, so a repository with
+a well-maintained ``.gitignore`` looks clean. Real repositories are not that
+tidy. A dependency tree that was never ignored, a ``.env`` written during
+debugging, a private key dropped in the working directory for one test -- all
+of these are untracked-and-not-ignored, so they arrive in recovery output as
+ordinary changed paths.
+
+Content is already safe: the digest layer never returns source bytes. The
+filename is the leak. ``id_rsa`` and ``credentials.json`` disclose that a secret
+exists and what kind, and a vendored dependency tree buries the two files the
+agent actually touched under thousands it did not.
+
+Three outcomes:
+
+``ordinary``
+    Reported unchanged.
+
+``sensitive``
+    Reported as a stable opaque id instead of a path. The agent still learns
+    that one guarded file changed -- which matters, because a changed key is
+    exactly the sort of thing that invalidates prior work -- without learning
+    which. The id is a digest of the path, so it is stable across observations
+    and comparable between them.
+
+``generated``
+    Omitted from paths, but counted. The receipt-honesty rule is that omitted
+    evidence stays inspectable, so the count and the matched rules are always
+    reported; a caller can tell "nothing else changed" from "9,000 vendored
+    files changed and were dropped".
+
+Deny-listing is not a security boundary and is not offered as one. It reduces
+obvious disclosure from a surface whose whole job is to describe a working
+directory it does not control. ``ENTROLY_WORK_GRAPH_SENSITIVE`` and
+``ENTROLY_WORK_GRAPH_GENERATED`` extend either set for repositories with local
+conventions this cannot know about.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import os
+from dataclasses import dataclass, field
+
+# Directory components that indicate machine-produced or vendored content.
+# Matched as a path segment, so `src/node_modules/x` matches but a file named
+# `node_modules_notes.md` does not.
+_GENERATED_DIRS: frozenset[str] = frozenset({
+    "__pycache__", ".git", ".gradle", ".mypy_cache", ".next", ".nuxt",
+    ".parcel-cache", ".pytest_cache", ".ruff_cache", ".terraform", ".tox",
+    ".turbo", ".venv", "bower_components", "coverage", "dist",
+    "node_modules", "site-packages", "target", "vendor", "venv",
+})
+
+# Filename patterns for machine-produced files outside a generated directory.
+# Lockfiles are deliberately absent: a changed lockfile is real work.
+_GENERATED_FILES: tuple[str, ...] = (
+    "*.min.js", "*.min.css", "*.map", "*.pyc", "*.pyo", "*.class", "*.o",
+    "*.so", "*.dylib", "*.dll", "*_pb2.py", "*_pb2_grpc.py", "*.generated.*",
+    "*.g.dart", "*.freezed.dart",
+)
+
+# Filename patterns that commonly carry credentials. Matched on the basename,
+# case-insensitively.
+_SENSITIVE_FILES: tuple[str, ...] = (
+    ".env", ".env.*", "*.env",
+    "id_rsa*", "id_dsa*", "id_ecdsa*", "id_ed25519*",
+    "*.pem", "*.key", "*.p12", "*.pfx", "*.jks", "*.keystore", "*.ppk",
+    "credentials", "credentials.*", "*credentials.json",
+    ".npmrc", ".pypirc", ".netrc", "_netrc", ".htpasswd",
+    "secrets", "secrets.*", "*.secrets", "*secret*.json", "*secret*.yaml",
+    "service-account*.json", "*serviceaccount*.json",
+    ".aws", "*.kubeconfig", "kubeconfig",
+)
+
+ORDINARY = "ordinary"
+SENSITIVE = "sensitive"
+GENERATED = "generated"
+
+
+def _extra(variable: str) -> tuple[str, ...]:
+    raw = os.environ.get(variable, "")
+    return tuple(item.strip() for item in raw.split(",") if item.strip())
+
+
+@dataclass
+class PathPolicyResult:
+    """Classified paths plus the record of what was withheld and why."""
+
+    paths: list[str] = field(default_factory=list)
+    sensitive_ids: list[str] = field(default_factory=list)
+    generated_omitted: int = 0
+    sensitive_count: int = 0
+    matched_rules: list[str] = field(default_factory=list)
+
+    def as_disclosure(self) -> dict[str, object]:
+        """The inspectable record of omission that accompanies the paths."""
+        return {
+            "generated_omitted": self.generated_omitted,
+            "sensitive_withheld": self.sensitive_count,
+            "matched_rules": sorted(set(self.matched_rules)),
+        }
+
+
+def sensitive_id(path: str) -> str:
+    """Stable opaque identifier for a path that must not be disclosed.
+
+    A digest rather than a counter so the same file yields the same id across
+    observations and processes, which is what lets a caller notice that the
+    *same* guarded file changed twice without ever learning its name.
+    """
+    digest = hashlib.sha256(path.encode("utf-8", errors="surrogatepass")).hexdigest()
+    return f"sensitive:{digest[:16]}"
+
+
+def classify(path: str) -> tuple[str, str]:
+    """Return ``(classification, matched_rule)`` for one repository-relative path."""
+    normalized = path.replace("\\", "/").strip("/")
+    if not normalized:
+        return ORDINARY, ""
+    segments = normalized.split("/")
+    basename = segments[-1].lower()
+
+    # Sensitive wins over generated: a key inside a vendored tree is still a key,
+    # and dropping it silently would be the worse failure.
+    for pattern in _SENSITIVE_FILES + _extra("ENTROLY_WORK_GRAPH_SENSITIVE"):
+        if fnmatch.fnmatch(basename, pattern.lower()):
+            return SENSITIVE, f"sensitive:{pattern}"
+
+    for segment in segments[:-1]:
+        if segment.lower() in _GENERATED_DIRS:
+            return GENERATED, f"dir:{segment}"
+    # A directory-only path ends in "/" and loses its last segment above.
+    if path.endswith("/") and segments[-1].lower() in _GENERATED_DIRS:
+        return GENERATED, f"dir:{segments[-1]}"
+
+    for pattern in _GENERATED_FILES + _extra("ENTROLY_WORK_GRAPH_GENERATED"):
+        if fnmatch.fnmatch(basename, pattern.lower()):
+            return GENERATED, f"generated:{pattern}"
+
+    return ORDINARY, ""
+
+
+def apply_policy(paths: list[str]) -> PathPolicyResult:
+    """Split changed paths into disclosable, opaque, and omitted."""
+    result = PathPolicyResult()
+    seen_sensitive: set[str] = set()
+    for path in paths:
+        classification, rule = classify(path)
+        if classification == ORDINARY:
+            result.paths.append(path)
+            continue
+        result.matched_rules.append(rule)
+        if classification == SENSITIVE:
+            token = sensitive_id(path)
+            result.sensitive_count += 1
+            if token not in seen_sensitive:
+                seen_sensitive.add(token)
+                result.sensitive_ids.append(token)
+        else:
+            result.generated_omitted += 1
+    result.paths.sort()
+    result.sensitive_ids.sort()
+    return result

--- a/entroly/work_graph_recovery_ack.py
+++ b/entroly/work_graph_recovery_ack.py
@@ -1,0 +1,156 @@
+"""A recovering agent must acknowledge the trust level before it may act.
+
+``work_resume`` already labels what it returns ``untrusted_recovered_work_state``
+and records ``unknown:previous-agent-intent``. Labelling is not a control: an
+agent can read the label and immediately claim work as though the reconstructed
+state were observed fact. The label describes the risk; nothing made anyone
+carry it.
+
+This is the control. Recovery arms a gate; mutating operations refuse while the
+gate is armed; acknowledging it disarms it. The acknowledgement is not a
+formality -- it is the moment responsibility transfers from "Entroly inferred
+this" to "the agent accepted this", and it is recorded.
+
+The token is a digest of the recovered state itself, which gives two properties
+worth more than a random nonce:
+
+- acknowledging state A does not authorise acting on state B. If the worktree
+  moves between resume and acknowledgement, the token no longer matches and the
+  agent is sent back to look again.
+- re-resuming unchanged state yields the same token, so a retry or a duplicate
+  resume does not demand a second acknowledgement for the same facts.
+
+Fail-closed. If the gate cannot be persisted, recovery fails rather than
+returning reconstructed state that nothing can hold anyone to. A gate that
+silently stops working is worse than no gate, because the label keeps implying
+a control that is no longer there.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+_MARKER_NAME = "pending-recovery-ack.json"
+_TRUST_LABEL = "untrusted_recovered_work_state"
+
+
+class RecoveryAcknowledgementRequired(RuntimeError):
+    """Raised when a mutating operation runs while a recovery is unacknowledged."""
+
+    def __init__(self, token: str) -> None:
+        super().__init__(
+            "recovered work state has not been acknowledged; call "
+            "work_acknowledge_recovery with the token from work_resume before "
+            "claiming or mutating work"
+        )
+        self.token = token
+
+
+def recovery_token(resume_view: Any) -> str:
+    """Deterministic identity for one recovered state.
+
+    Canonical JSON so that key order, which carries no meaning, cannot make two
+    identical recoveries look different and demand a second acknowledgement.
+    """
+    raw = json.dumps(
+        resume_view, sort_keys=True, ensure_ascii=False, separators=(",", ":"),
+        default=str,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8", errors="surrogatepass")).hexdigest()
+    return f"recovery:{digest[:32]}"
+
+
+def _marker_path(state_root: str | os.PathLike[str]) -> Path:
+    return Path(state_root) / _MARKER_NAME
+
+
+def arm(state_root: str | os.PathLike[str], token: str, unknowns: list[str]) -> dict[str, Any]:
+    """Record that recovered state is outstanding, and describe what is unknown.
+
+    Written atomically: a half-written marker would be unparseable, and a
+    gate that cannot be read is treated as armed, so a torn write would wedge
+    the repository rather than merely losing a gate.
+    """
+    root = Path(state_root)
+    root.mkdir(parents=True, exist_ok=True)
+    record = {"token": token, "trust": _TRUST_LABEL, "unknowns": sorted(set(unknowns))}
+    payload = json.dumps(record, sort_keys=True, ensure_ascii=False).encode("utf-8")
+
+    handle, temp_name = tempfile.mkstemp(dir=str(root), prefix=".ack-", suffix=".tmp")
+    try:
+        with os.fdopen(handle, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temp_name, _marker_path(root))
+    except OSError:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        # Deliberately not swallowed. See the module docstring: recovery that
+        # cannot arm its gate must fail, not proceed ungated.
+        raise
+    return dict(record, required=True)
+
+
+def pending(state_root: str | os.PathLike[str]) -> dict[str, Any] | None:
+    """The outstanding acknowledgement, if any.
+
+    An unreadable or malformed marker counts as armed. The alternative is to
+    treat corruption as consent.
+    """
+    path = _marker_path(state_root)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return {"token": "", "trust": _TRUST_LABEL, "unknowns": ["unknown:gate-unreadable"]}
+    try:
+        record = json.loads(raw)
+    except ValueError:
+        return {"token": "", "trust": _TRUST_LABEL, "unknowns": ["unknown:gate-corrupt"]}
+    if not isinstance(record, dict) or not isinstance(record.get("token"), str):
+        return {"token": "", "trust": _TRUST_LABEL, "unknowns": ["unknown:gate-malformed"]}
+    return record
+
+
+def require_acknowledged(state_root: str | os.PathLike[str]) -> None:
+    """Refuse the caller while recovered state is outstanding."""
+    outstanding = pending(state_root)
+    if outstanding is not None:
+        raise RecoveryAcknowledgementRequired(str(outstanding.get("token", "")))
+
+
+def acknowledge(state_root: str | os.PathLike[str], token: str) -> dict[str, Any]:
+    """Accept responsibility for one specific recovered state.
+
+    Refuses a token that does not match the outstanding one, so acknowledging
+    stale state cannot authorise acting on current state.
+    """
+    outstanding = pending(state_root)
+    if outstanding is None:
+        return {"acknowledged": True, "already_clear": True}
+    expected = str(outstanding.get("token", ""))
+    supplied = str(token).strip()
+    if not expected or supplied != expected:
+        raise ValueError(
+            "acknowledgement token does not match the outstanding recovered "
+            "state; call work_resume again and acknowledge what it returns"
+        )
+    try:
+        _marker_path(state_root).unlink()
+    except FileNotFoundError:
+        pass
+    return {
+        "acknowledged": True,
+        "token": expected,
+        "trust": _TRUST_LABEL,
+        "unknowns": outstanding.get("unknowns", []),
+    }

--- a/entroly/work_graph_repo.py
+++ b/entroly/work_graph_repo.py
@@ -17,6 +17,13 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
+from .work_graph_path_policy import (
+    GENERATED as PATH_GENERATED,
+    ORDINARY as PATH_ORDINARY,
+    classify as classify_worktree_path,
+    sensitive_id as worktree_path_sensitive_id,
+)
+
 _MAX_GIT_OUTPUT_BYTES = 8 * 1024 * 1024
 _MAX_CHANGES = 16_384
 _MAX_COMMITS = 20
@@ -376,6 +383,54 @@ def _checkpoint_metadata(
     return checkpoint.checkpoint_id, dict(metadata)
 
 
+def _apply_path_policy(
+    changes: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Withhold secret-shaped names and drop machine-produced files.
+
+    Applied here rather than at the reporting edge so a path that must not be
+    disclosed never enters the observation at all, and therefore never reaches
+    the digest layer, the Rust event, or the persisted graph. Filtering only at
+    render time would leave the name durable on disk.
+
+    A sensitive path keeps its change record -- the agent needs to know a
+    guarded file moved, because that is exactly the kind of thing that
+    invalidates earlier work -- but carries a stable opaque id instead of a
+    name, and no digest, since a content digest of a small credential file is
+    itself an oracle.
+    """
+    kept: list[dict[str, Any]] = []
+    sensitive_ids: list[str] = []
+    generated_omitted = 0
+    matched: list[str] = []
+
+    for change in changes:
+        raw = str(change.get("path", ""))
+        classification, rule = classify_worktree_path(raw)
+        if classification == PATH_ORDINARY:
+            kept.append(change)
+            continue
+        matched.append(rule)
+        if classification == PATH_GENERATED:
+            generated_omitted += 1
+            continue
+        token = worktree_path_sensitive_id(raw)
+        if token not in sensitive_ids:
+            sensitive_ids.append(token)
+        redacted = dict(change)
+        redacted["path"] = token
+        redacted["redacted"] = True
+        redacted.pop("old_path", None)
+        kept.append(redacted)
+
+    disclosure = {
+        "generated_omitted": generated_omitted,
+        "sensitive_withheld": len(sensitive_ids),
+        "matched_rules": sorted(set(matched)),
+    }
+    return kept, disclosure
+
+
 def discover_repository_observation(
     path: str | os.PathLike[str] = ".",
     *,
@@ -409,7 +464,7 @@ def discover_repository_observation(
         git_dir
         and ((git_dir / "rebase-merge").exists() or (git_dir / "rebase-apply").exists())
     )
-    changes = _parse_status(root)
+    changes, path_disclosure = _apply_path_policy(_parse_status(root))
     commits = _branch_commits(root, base, ahead, int(max_commits))
     meaningful_git = bool(changes or ahead or merge_in_progress or rebase_in_progress)
 
@@ -469,6 +524,10 @@ def discover_repository_observation(
             "detached": not bool(branch_name),
         },
         "changes": changes,
+        # What the policy withheld, and under which rules. Recovery is only
+        # honest if the caller can tell "nothing else changed" apart from
+        # "9,000 vendored files changed and were dropped".
+        "path_disclosure": path_disclosure,
         "commits": commits,
         "verifications": [],
         "decisions": decisions,

--- a/entroly/work_graph_session.py
+++ b/entroly/work_graph_session.py
@@ -1,0 +1,202 @@
+"""Automatic takeover when an agent opens a repository.
+
+``work_resume`` reconstructs work state correctly, but something had to call it.
+An agent that never learned the tool existed, or simply started working, got no
+takeover at all -- which made the feature semi-automatic in the only sense that
+matters to a user who did not read the docs.
+
+Opening the MCP server *is* an agent opening the repository, so that is where
+takeover belongs. The session start runs the same resume path the tool exposes
+and arms the same trust gate, so an agent that begins working without
+acknowledging is refused by ``work_claim`` exactly as if it had called
+``work_resume`` itself.
+
+Two properties this has to preserve:
+
+*It must not block the handshake.* Warm-start already learned this lesson -- a
+blocking cold start made the server look hung. Discovery runs once, bounded, and
+a failure degrades to "no takeover" rather than a server that will not start.
+
+*It must not fail open on the gate.* A discovery failure means no state was
+recovered, so there is nothing to acknowledge and no gate is armed. That is
+different from recovering state and failing to arm, which
+``work_graph_recovery_ack.arm`` refuses to do quietly.
+
+Idempotent per process and repository: an agent that also calls ``work_resume``
+explicitly gets the same token for the same state, not a second demand for the
+same facts.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+_lock = threading.Lock()
+_started: dict[str, dict[str, Any]] = {}
+
+
+def autostart_enabled() -> bool:
+    """Takeover is on unless explicitly disabled.
+
+    Default-on is the point: the previous behaviour was effectively default-off
+    and that is the gap. ``ENTROLY_WORK_GRAPH_AUTOSTART=0`` opts out for
+    embedders that drive resume themselves.
+    """
+    return os.environ.get("ENTROLY_WORK_GRAPH_AUTOSTART", "1").strip() not in {
+        "0", "false", "no",
+    }
+
+
+def session_state(project: str = "") -> dict[str, Any] | None:
+    """What the automatic takeover found, if it ran."""
+    with _lock:
+        return _started.get(str(project))
+
+
+def reset_for_tests() -> None:
+    with _lock:
+        _started.clear()
+
+
+def start_session(project: str = "", *, force: bool = False) -> dict[str, Any]:
+    """Perform automatic takeover once per process and repository.
+
+    Returns a summary describing what happened. Never raises: a repository that
+    cannot be observed is a repository with no recoverable work, and the caller
+    is a server handshake.
+    """
+    key = str(project)
+    with _lock:
+        if not force and key in _started:
+            return dict(_started[key], reused=True)
+
+    summary: dict[str, Any] = {
+        "attempted": True,
+        "recovered": False,
+        "gate_armed": False,
+        "watcher_started": False,
+        "reused": False,
+    }
+
+    if not autostart_enabled():
+        summary["attempted"] = False
+        summary["reason"] = "disabled by ENTROLY_WORK_GRAPH_AUTOSTART"
+        with _lock:
+            _started[key] = summary
+        return summary
+
+    view: Any = None
+    try:
+        from . import work_graph_mcp as mcp_adapter
+
+        path = mcp_adapter._project_path(project)
+        store = mcp_adapter._store_for_path(path)
+        store.submit_repository_observation(
+            mcp_adapter._passive_observation(path), repository_path=path
+        )
+        view = store.resume(None, max_evidence=128)
+    except Exception as exc:  # noqa: BLE001 - handshake must survive anything
+        # "no unfinished workstream" is the documented null control, not a
+        # failure: a clean checkout has nothing to continue, and resume refuses
+        # rather than manufacturing a task. Recording it as an error made
+        # correct fail-closed behaviour look broken -- and, worse, returned
+        # early so the watcher never started on a clean repository, which is
+        # precisely where a modification timeline begins to be useful.
+        if isinstance(exc, ValueError) and "no unfinished workstream" in str(exc):
+            summary["null_control"] = "no unfinished work to recover"
+        else:
+            summary["error"] = f"{type(exc).__name__}: {exc}"
+            with _lock:
+                _started[key] = summary
+            return summary
+
+    if view is not None and _has_recoverable_work(view):
+        from .work_graph_recovery_ack import arm, recovery_token
+
+        token = recovery_token(view)
+        # Not wrapped in a second try/except. If state was recovered and the
+        # gate cannot be armed, the honest outcome is a loud failure, not a
+        # session that reports takeover while nothing enforces it.
+        acknowledgement = arm(
+            store.repo_dir, token, mcp_adapter._recovery_unknowns(view)
+        )
+        summary["recovered"] = True
+        summary["gate_armed"] = True
+        summary["acknowledgement"] = acknowledgement
+
+    started, watcher_note = _maybe_start_watcher(key, path)
+    summary["watcher_started"] = started
+    if watcher_note:
+        # A watcher that failed to start is a hole in the modification
+        # timeline. Returning a bare False would make "disabled" and "tried and
+        # broke" look identical, which is the kind of silence that makes a
+        # missing feature look like a working one.
+        summary["watcher_note"] = watcher_note
+    with _lock:
+        _started[key] = summary
+    return summary
+
+
+def _has_recoverable_work(view: Any) -> bool:
+    """Whether the reconstruction found anything worth acknowledging.
+
+    A clean checkout is a documented null control: it must not arm a gate and
+    demand acknowledgement of nothing, or every fresh clone would greet its
+    agent with a refusal.
+    """
+    if not isinstance(view, dict):
+        return False
+    for field in ("changed_paths", "evidence", "claims", "commits", "failures"):
+        value = view.get(field)
+        if isinstance(value, list) and value:
+            return True
+    selected = view.get("selected_workstream")
+    return isinstance(selected, dict) and bool(selected.get("node_id"))
+
+
+_watchers: dict[str, Any] = {}
+
+
+def _maybe_start_watcher(key: str, path: Path) -> tuple[bool, str]:
+    from .work_graph_watcher import (
+        WorkspaceModificationWatcher,
+        git_status_sampler,
+        watch_enabled,
+    )
+
+    if not watch_enabled():
+        return False, "disabled; set ENTROLY_WORK_GRAPH_WATCH=1"
+    if key in _watchers:
+        return False, "already watching this project"
+    try:
+        watcher = WorkspaceModificationWatcher(git_status_sampler(path)).start()
+    except Exception as exc:  # noqa: BLE001 - a missing timeline must not stop a session
+        return False, f"{type(exc).__name__}: {exc}"
+    _watchers[key] = watcher
+    return True, ""
+
+
+def session_watcher(project: str = "") -> Any:
+    return _watchers.get(str(project))
+
+
+def stop_session_watchers() -> None:
+    for watcher in list(_watchers.values()):
+        try:
+            watcher.stop()
+        except Exception:  # noqa: BLE001
+            pass
+    _watchers.clear()
+
+
+__all__ = [
+    "autostart_enabled",
+    "reset_for_tests",
+    "session_state",
+    "session_watcher",
+    "start_session",
+    "stop_session_watchers",
+]

--- a/entroly/work_graph_watcher.py
+++ b/entroly/work_graph_watcher.py
@@ -1,0 +1,259 @@
+"""Record worktree modifications between observations.
+
+Detection previously happened only when something asked: a resume, an
+observation, a verification. Byte changes do invalidate prior graph state, but
+only at the moment someone looked. An agent that edited a file, waited, and then
+resumed would see the new bytes; an agent that edited a file and kept working on
+a stale plan would not learn anything until its next refresh.
+
+This closes the window by sampling the worktree on an interval and keeping a
+bounded log of what changed and when.
+
+Deliberately polling rather than an OS notification API. ``watchdog`` is not a
+dependency, and adding one to a local-first tool for this is a poor trade:
+inotify degrades on network mounts, ReadDirectoryChangesW has its own failure
+modes, and both need a fallback path that would be exercised rarely enough to
+rot. Sampling ``git status`` plus the digests already computed for observations
+reuses machinery that is tested, and the cost is bounded by the interval.
+
+The thread never writes to the Work Graph. Appending events from a background
+thread would race the Rust store's single-writer lock and could interleave a
+sample with a resume mid-update. It records into memory; the next observation
+consumes it. What the watcher provides is the *timeline* -- that a file changed
+at 14:02 and again at 14:07 -- which a single point-in-time refresh cannot show
+however often it runs.
+
+Off by default. A local-first tool should not start background threads that
+touch the user's repository because a library was imported. Enable with
+``ENTROLY_WORK_GRAPH_WATCH=1`` or by constructing one directly.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+_DEFAULT_INTERVAL_SECONDS = 2.0
+_MIN_INTERVAL_SECONDS = 0.25
+_DEFAULT_MAX_RECORDS = 512
+
+
+@dataclass(frozen=True)
+class Modification:
+    """One observed transition of a path between two samples."""
+
+    path: str
+    change: str          # appeared | vanished | modified
+    observed_at_ms: int
+    digest: str = ""
+    previous_digest: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "change": self.change,
+            "observed_at_ms": self.observed_at_ms,
+            "digest": self.digest,
+            "previous_digest": self.previous_digest,
+        }
+
+
+def _interval_from_env() -> float:
+    raw = os.environ.get("ENTROLY_WORK_GRAPH_WATCH_INTERVAL", "").strip()
+    try:
+        value = float(raw) if raw else _DEFAULT_INTERVAL_SECONDS
+    except ValueError:
+        return _DEFAULT_INTERVAL_SECONDS
+    return max(_MIN_INTERVAL_SECONDS, value)
+
+
+def watch_enabled() -> bool:
+    return os.environ.get("ENTROLY_WORK_GRAPH_WATCH", "0").strip() not in {"", "0", "false", "no"}
+
+
+class WorkspaceModificationWatcher:
+    """Sample a repository on an interval and log what changed between samples.
+
+    ``sampler`` returns ``{path: digest}`` for the currently changed paths. It is
+    injected so this class can be tested without a repository and so the caller
+    controls which observation path is used -- in particular so the watcher
+    inherits the same secret/generated-file policy as everything else rather
+    than re-deriving it and drifting.
+    """
+
+    def __init__(
+        self,
+        sampler: Callable[[], dict[str, str]],
+        *,
+        interval_seconds: float | None = None,
+        max_records: int = _DEFAULT_MAX_RECORDS,
+    ) -> None:
+        self._sampler = sampler
+        self._interval = max(
+            _MIN_INTERVAL_SECONDS,
+            _interval_from_env() if interval_seconds is None else interval_seconds,
+        )
+        self._records: deque[Modification] = deque(maxlen=max(1, int(max_records)))
+        self._previous: dict[str, str] = {}
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._errors = 0
+        self._samples = 0
+        self._started = False
+
+    # -- lifecycle -----------------------------------------------------
+
+    def start(self) -> "WorkspaceModificationWatcher":
+        if self._thread is not None:
+            return self
+        # Seed synchronously so the first interval reports transitions rather
+        # than announcing every already-modified file as newly appeared.
+        self._sample(seed=True)
+        self._thread = threading.Thread(
+            target=self._run, name="entroly-work-graph-watch", daemon=True
+        )
+        self._started = True
+        self._thread.start()
+        return self
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop.set()
+        thread, self._thread = self._thread, None
+        if thread is not None:
+            thread.join(timeout=timeout)
+
+    def __enter__(self) -> "WorkspaceModificationWatcher":
+        return self.start()
+
+    def __exit__(self, *_exc: object) -> None:
+        self.stop()
+
+    # -- sampling ------------------------------------------------------
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._interval):
+            self._sample()
+
+    def _sample(self, *, seed: bool = False) -> None:
+        try:
+            current = self._sampler()
+        except Exception:
+            # A sampler failure is a gap in the timeline, not a reason to take
+            # the process down or to stop watching. It is counted so the gap is
+            # visible rather than silently absorbed.
+            with self._lock:
+                self._errors += 1
+            return
+
+        observed_at_ms = int(time.time() * 1000)
+        with self._lock:
+            self._samples += 1
+            if seed:
+                self._previous = dict(current)
+                return
+            previous = self._previous
+            for path, digest in current.items():
+                before = previous.get(path)
+                if before is None:
+                    self._records.append(
+                        Modification(path, "appeared", observed_at_ms, digest)
+                    )
+                elif before != digest:
+                    self._records.append(
+                        Modification(path, "modified", observed_at_ms, digest, before)
+                    )
+            for path, before in previous.items():
+                if path not in current:
+                    self._records.append(
+                        Modification(path, "vanished", observed_at_ms, "", before)
+                    )
+            self._previous = dict(current)
+
+    def poll_once(self) -> None:
+        """Take one sample on the calling thread. Used by tests and by callers
+        that want a deterministic checkpoint without waiting an interval."""
+        self._sample()
+
+    # -- reporting -----------------------------------------------------
+
+    def modifications(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [record.as_dict() for record in self._records]
+
+    def drain(self) -> list[dict[str, Any]]:
+        """Return and clear. The next observation consumes the timeline."""
+        with self._lock:
+            drained = [record.as_dict() for record in self._records]
+            self._records.clear()
+            return drained
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "running": bool(self._thread is not None and self._thread.is_alive()),
+                "started": self._started,
+                "interval_seconds": self._interval,
+                "samples": self._samples,
+                "sampler_errors": self._errors,
+                "pending_modifications": len(self._records),
+                # A dropped record is a hole in the timeline, so say so rather
+                # than letting the deque quietly discard the oldest.
+                "record_capacity": self._records.maxlen,
+                "at_capacity": len(self._records) == self._records.maxlen,
+            }
+
+
+def git_status_sampler(
+    repo_path: str | os.PathLike[str],
+) -> Callable[[], dict[str, str]]:
+    """Sampler over the same observation path everything else uses.
+
+    Reusing ``discover_repository_observation`` means the watcher inherits the
+    secret-withholding and generated-file policy automatically. A watcher with
+    its own scan would be a second place for that policy to be forgotten.
+    """
+    root = Path(repo_path)
+
+    def sample() -> dict[str, str]:
+        from .work_graph_content_digest import enrich_worktree_content_digests
+        from .work_graph_repo import discover_repository_observation
+
+        observation = enrich_worktree_content_digests(
+            root, discover_repository_observation(root)
+        )
+        changes = observation.get("changes")
+        if not isinstance(changes, list):
+            return {}
+        sampled: dict[str, str] = {}
+        for change in changes:
+            if not isinstance(change, dict):
+                continue
+            path = str(change.get("path", ""))
+            if not path:
+                continue
+            # Fall back to the change kind when no digest is available, so a
+            # staged/conflicted path still registers a transition instead of
+            # looking permanently unchanged.
+            digest = (
+                str(change.get("worktree_digest", ""))
+                or str(change.get("content_digest", ""))
+                or f"kind:{change.get('kind', '')}"
+            )
+            sampled[path] = digest
+        return sampled
+
+    return sample
+
+
+__all__ = [
+    "Modification",
+    "WorkspaceModificationWatcher",
+    "git_status_sampler",
+    "watch_enabled",
+]

--- a/tests/test_work_graph_autostart_and_watch.py
+++ b/tests/test_work_graph_autostart_and_watch.py
@@ -203,3 +203,54 @@ class TestAutomaticTakeover:
             m["path"] == "later.py" and m["change"] == "appeared"
             for m in watcher.modifications()
         )
+
+
+class TestTakeoverCost:
+    """Takeover may be slow once. It may not be slow repeatedly.
+
+    Measured on this repository (~4.7k files): the cold call costs ~3.6s, of
+    which ~380ms is Git observation and content digests and the rest is the
+    Rust store. That cost is deliberate -- the trust gate has to be armed
+    before the first mutating call, so deferring takeover to a background
+    thread would risk `work_claim` arriving while nothing was armed yet, which
+    is the exact fail-open the gate exists to prevent.
+
+    What must not regress is the per-call cost. An absolute bound on the cold
+    path would be machine-dependent and flaky; the contract worth pinning is
+    that takeover is paid once.
+    """
+
+    def test_repeated_takeover_is_effectively_free(self, repo, monkeypatch):
+        import time
+
+        monkeypatch.setenv("ENTROLY_DIR", str(repo.parent / "state"))
+        monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+
+        session.start_session()          # pay the cold cost once
+
+        started = time.perf_counter()
+        for _ in range(200):
+            session.start_session()
+        elapsed_ms = (time.perf_counter() - started) * 1000
+
+        assert elapsed_ms < 50, (
+            f"200 cached takeovers took {elapsed_ms:.1f}ms; takeover is being "
+            "re-run per tool call rather than memoised"
+        )
+
+    def test_disabled_takeover_costs_nothing(self, repo, monkeypatch):
+        import time
+
+        monkeypatch.setenv("ENTROLY_DIR", str(repo.parent / "state"))
+        monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+        monkeypatch.setenv("ENTROLY_WORK_GRAPH_AUTOSTART", "0")
+
+        started = time.perf_counter()
+        summary = session.start_session(force=True)
+        elapsed_ms = (time.perf_counter() - started) * 1000
+
+        assert summary["attempted"] is False
+        assert elapsed_ms < 100, (
+            f"opting out still cost {elapsed_ms:.1f}ms; the opt-out must skip "
+            "observation entirely, not merely discard its result"
+        )

--- a/tests/test_work_graph_autostart_and_watch.py
+++ b/tests/test_work_graph_autostart_and_watch.py
@@ -1,0 +1,205 @@
+"""Takeover happens because an agent opened the repository, not because it asked.
+
+`work_resume` reconstructed work state correctly, but something had to call it.
+An agent that never learned the tool existed got no takeover, which made the
+feature semi-automatic in the only sense that matters to a user who did not read
+the docs.
+
+Also covers the modification timeline. Detection previously happened only when
+something asked -- a resume, an observation, a verification. A point-in-time
+refresh shows what a file looks like now; it cannot show that the file changed
+at 14:02 and again at 14:07.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from entroly import work_graph_session as session
+from entroly.work_graph_watcher import WorkspaceModificationWatcher
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@example.test")
+    _git(root, "config", "user.name", "t")
+    (root / "app.py").write_text("x = 1\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "init")
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _clean_session_state():
+    session.reset_for_tests()
+    yield
+    session.stop_session_watchers()
+    session.reset_for_tests()
+
+
+class TestWatcherTimeline:
+    def test_records_transitions_not_just_current_state(self):
+        samples = [
+            {"a.py": "d1"},
+            {"a.py": "d2"},
+            {"a.py": "d2", "b.py": "d3"},
+            {"b.py": "d3"},
+        ]
+        watcher = WorkspaceModificationWatcher(lambda: samples.pop(0), interval_seconds=60)
+        watcher._sample(seed=True)   # consumes the first
+        watcher.poll_once()
+        watcher.poll_once()
+        watcher.poll_once()
+
+        observed = [(m["path"], m["change"]) for m in watcher.modifications()]
+        assert observed == [
+            ("a.py", "modified"),
+            ("b.py", "appeared"),
+            ("a.py", "vanished"),
+        ]
+
+    def test_seeding_does_not_announce_existing_state_as_new(self):
+        watcher = WorkspaceModificationWatcher(lambda: {"a.py": "d1"}, interval_seconds=60)
+        watcher._sample(seed=True)
+        assert watcher.modifications() == [], (
+            "a file that was already modified when watching began is not a new "
+            "modification"
+        )
+
+    def test_a_sampler_failure_is_counted_not_swallowed(self):
+        def broken():
+            raise OSError("disk went away")
+
+        watcher = WorkspaceModificationWatcher(broken, interval_seconds=60)
+        watcher.poll_once()
+        # A gap in the timeline must be visible; a watcher that silently stops
+        # recording looks identical to a repository where nothing changed.
+        assert watcher.status()["sampler_errors"] == 1
+
+    def test_drain_clears_so_the_timeline_is_consumed_once(self):
+        samples = [{"a.py": "d1"}, {"a.py": "d2"}]
+        watcher = WorkspaceModificationWatcher(lambda: samples.pop(0), interval_seconds=60)
+        watcher._sample(seed=True)
+        watcher.poll_once()
+
+        assert len(watcher.drain()) == 1
+        assert watcher.drain() == []
+
+    def test_capacity_exhaustion_is_reported(self):
+        digests = iter(range(100))
+        watcher = WorkspaceModificationWatcher(
+            lambda: {"a.py": str(next(digests))}, interval_seconds=60, max_records=3
+        )
+        watcher._sample(seed=True)
+        for _ in range(10):
+            watcher.poll_once()
+
+        status = watcher.status()
+        assert status["at_capacity"] is True, (
+            "a dropped record is a hole in the timeline and must be visible"
+        )
+
+
+class TestAutomaticTakeover:
+    def test_clean_repository_is_a_null_control_not_an_error(self, repo, monkeypatch):
+        """A fresh clone must not greet its agent with a refusal.
+
+        `resume` raises "no unfinished workstream" for a clean checkout, which
+        is correct fail-closed behaviour. Recording that as an error made it
+        look broken and returned early, so the watcher never started on exactly
+        the repository where a timeline is most useful.
+        """
+        monkeypatch.setenv("ENTROLY_DIR", str(repo.parent / "state"))
+        monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+
+        summary = session.start_session(force=True)
+
+        assert summary["recovered"] is False
+        assert summary["gate_armed"] is False
+        assert summary.get("error") is None
+        assert summary.get("null_control")
+
+    def test_unfinished_work_arms_the_gate_without_the_agent_asking(
+        self, repo, monkeypatch
+    ):
+        monkeypatch.setenv("ENTROLY_DIR", str(repo.parent / "state"))
+        monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+        from entroly.work_graph_mcp import work_claim
+
+        work_claim(
+            project=str(repo), agent_id="a", task_title="harden",
+            task_id="t1", scope_paths=["app.py"],
+        )
+        (repo / "app.py").write_text("x = 2  # interrupted\n", encoding="utf-8")
+
+        # No work_resume call anywhere in this test. That is the point.
+        summary = session.start_session(force=True)
+
+        assert summary["recovered"] is True
+        assert summary["gate_armed"] is True
+        assert summary["acknowledgement"]["token"].startswith("recovery:")
+
+        blocked = work_claim(
+            project=str(repo), agent_id="b", task_title="t2",
+            task_id="t2", scope_paths=["app.py"],
+        )
+        assert blocked["status"] == "error"
+
+    def test_takeover_is_idempotent_per_repository(self, repo, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(repo.parent / "state"))
+        monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+
+        session.start_session()
+        again = session.start_session()
+        assert again["reused"] is True, (
+            "a second agent action must not demand acknowledgement of the same "
+            "facts twice"
+        )
+
+    def test_autostart_can_be_disabled(self, repo, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(repo.parent / "state"))
+        monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+        monkeypatch.setenv("ENTROLY_WORK_GRAPH_AUTOSTART", "0")
+
+        summary = session.start_session(force=True)
+        assert summary["attempted"] is False
+        assert summary["gate_armed"] is False
+
+    def test_watcher_start_failure_is_reported_not_silent(self, repo, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(repo.parent / "state"))
+        monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+        monkeypatch.setenv("ENTROLY_WORK_GRAPH_WATCH", "0")
+
+        summary = session.start_session(force=True)
+        assert summary["watcher_started"] is False
+        # "disabled" and "tried and broke" must not look identical.
+        assert "disabled" in summary.get("watcher_note", "")
+
+    @pytest.mark.timeout(120)
+    def test_watcher_runs_on_a_clean_repository(self, repo, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(repo.parent / "state"))
+        monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+        monkeypatch.setenv("ENTROLY_WORK_GRAPH_WATCH", "1")
+
+        summary = session.start_session(force=True)
+        assert summary["watcher_started"] is True
+
+        watcher = session.session_watcher("")
+        assert watcher is not None
+        (repo / "later.py").write_text("y = 1\n", encoding="utf-8")
+        watcher.poll_once()
+
+        assert any(
+            m["path"] == "later.py" and m["change"] == "appeared"
+            for m in watcher.modifications()
+        )

--- a/tests/test_work_graph_mcp.py
+++ b/tests/test_work_graph_mcp.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
 import hashlib
 
 from entroly import work_graph_mcp as m
@@ -31,9 +34,17 @@ class FakeGraph:
 
 
 class FakeStore:
-    def __init__(self):
+    def __init__(self, repo_dir=None):
         self.observation = None
         self.context_receipts = []
+        # The recovery acknowledgement gate persists its marker beside the
+        # repository's Work Graph state, so a double for the store has to
+        # model that directory. Tests that exercise the gate pass a tmp_path;
+        # the rest get an isolated directory so arming never touches a real
+        # state root.
+        self.repo_dir = Path(repo_dir) if repo_dir is not None else Path(
+            tempfile.mkdtemp(prefix="fake-store-")
+        )
 
     def load(self):
         return FakeGraph()

--- a/tests/test_work_graph_path_policy.py
+++ b/tests/test_work_graph_path_policy.py
@@ -1,0 +1,179 @@
+"""Recovery must not disclose secret-shaped filenames or drown work in vendor trees.
+
+Dogfooded finding. `git status --porcelain` omits git-ignored files, so a tidy
+repository looks clean and the gap stays invisible. Against a repository where
+`.env`, `id_rsa`, and `node_modules/` were untracked but never ignored, an
+interrupted-agent recovery reported:
+
+    changed_paths: ['.env', 'app.py', 'id_rsa', 'node_modules/x.js']
+
+Content was already safe -- the digest layer never returns source bytes, and no
+secret value appeared. The filename was the leak: `id_rsa` discloses that a
+private key exists, and a vendored tree buries the one file the agent actually
+edited.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from entroly.work_graph_path_policy import (
+    GENERATED,
+    ORDINARY,
+    SENSITIVE,
+    apply_policy,
+    classify,
+    sensitive_id,
+)
+
+
+class TestClassification:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".env", ".env.local", "config/.env.production",
+            "id_rsa", "id_ed25519", "deploy/id_rsa.pub",
+            "server.pem", "private.key", "certs/app.p12",
+            "credentials.json", "gcp-credentials.json",
+            ".npmrc", ".pypirc", ".netrc",
+            "service-account-prod.json", "kubeconfig",
+        ],
+    )
+    def test_secret_shaped_names_are_withheld(self, path):
+        classification, rule = classify(path)
+        assert classification == SENSITIVE, f"{path} was not withheld ({rule})"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "node_modules/left-pad/index.js", "dist/bundle.js",
+            "build/out.o", "target/debug/app", "vendor/lib/x.go",
+            ".venv/lib/site-packages/x.py", "__pycache__/mod.cpython-310.pyc",
+            "coverage/lcov.info", "app.min.js", "styles.min.css",
+            "bundle.js.map", "schema_pb2.py", "model.freezed.dart",
+        ],
+    )
+    def test_machine_produced_files_are_omitted(self, path):
+        classification, rule = classify(path)
+        assert classification == GENERATED, f"{path} was not omitted ({rule})"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "app.py", "src/main.rs", "README.md",
+            "package-lock.json", "poetry.lock", "Cargo.lock",
+            "environment.py", "node_modules_notes.md", "keyboard.py",
+            "src/secretary.py",
+        ],
+    )
+    def test_ordinary_work_is_reported_unchanged(self, path):
+        classification, _rule = classify(path)
+        assert classification == ORDINARY, f"{path} was wrongly reclassified"
+
+    def test_lockfiles_are_work_not_noise(self):
+        # A changed lockfile is a real, reviewable change. Dropping it as
+        # "generated" would hide a dependency bump from the recovering agent.
+        for path in ("package-lock.json", "yarn.lock", "Cargo.lock", "uv.lock"):
+            assert classify(path)[0] == ORDINARY
+
+    def test_a_key_inside_a_vendor_tree_is_still_withheld(self):
+        # Sensitive must win over generated: dropping it silently is worse
+        # than reporting an opaque id.
+        classification, _ = classify("node_modules/.bin/id_rsa")
+        assert classification == SENSITIVE
+
+
+class TestOpaqueIdentifiers:
+    def test_id_is_stable_for_the_same_path(self):
+        assert sensitive_id(".env") == sensitive_id(".env")
+
+    def test_id_differs_between_paths(self):
+        assert sensitive_id(".env") != sensitive_id("id_rsa")
+
+    def test_id_does_not_contain_the_path(self):
+        token = sensitive_id("config/prod/.env.production")
+        for leaked in ("env", "prod", "config", "production"):
+            assert leaked not in token.removeprefix("sensitive:")
+
+
+class TestPolicyAggregate:
+    def test_omissions_are_counted_not_silent(self):
+        result = apply_policy([
+            "app.py", ".env", "id_rsa",
+            "node_modules/a.js", "node_modules/b.js", "dist/out.js",
+        ])
+
+        assert result.paths == ["app.py"]
+        assert len(result.sensitive_ids) == 2
+        assert result.generated_omitted == 3
+
+        # Receipt honesty: a caller must be able to tell "nothing else
+        # changed" from "three files changed and were dropped".
+        disclosure = result.as_disclosure()
+        assert disclosure["generated_omitted"] == 3
+        assert disclosure["sensitive_withheld"] == 2
+        assert disclosure["matched_rules"], "omission happened with no stated rule"
+
+    def test_repeated_sensitive_path_yields_one_identifier(self):
+        result = apply_policy([".env", ".env", ".env"])
+        assert len(result.sensitive_ids) == 1
+        assert result.sensitive_count == 3
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.mark.timeout(120)
+def test_interrupted_agent_recovery_does_not_disclose_secret_filenames(
+    tmp_path, monkeypatch
+):
+    """End-to-end reproduction of the dogfooded leak.
+
+    Drives the real MCP surface rather than the classifier, because the defect
+    was that these names reached the persisted graph -- filtering only at
+    render time would leave them durable on disk.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.test")
+    _git(repo, "config", "user.name", "t")
+    (repo / "app.py").write_text("def go():\n    return 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "init")
+
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+    from entroly.work_graph_mcp import work_claim, work_resume
+
+    claim = work_claim(
+        project=str(repo), agent_id="agent-a", task_title="harden auth",
+        task_id="task-1", scope_paths=["app.py"],
+    )
+    assert claim.get("status") == "ok", claim
+
+    # Interrupted mid-edit, with the untidy working directory of a real repo.
+    (repo / "app.py").write_text("def go():\n    return 2  # wip\n", encoding="utf-8")
+    (repo / ".env").write_text("STRIPE_SECRET_KEY=sk_live_DEADBEEF\n", encoding="utf-8")
+    (repo / "id_rsa").write_text("-----BEGIN OPENSSH PRIVATE KEY-----\n", encoding="utf-8")
+    (repo / "node_modules").mkdir()
+    for index in range(5):
+        (repo / "node_modules" / f"dep{index}.js").write_text("//x\n", encoding="utf-8")
+
+    recovered = json.dumps(work_resume(project=str(repo), max_evidence=64), default=str)
+
+    for name in (".env", "id_rsa", "node_modules"):
+        assert name not in recovered, f"{name} disclosed in recovery output"
+    assert "sk_live_DEADBEEF" not in recovered
+    assert "BEGIN OPENSSH" not in recovered
+
+    # Premise: the recovery actually ran and still reports the real work. If
+    # this trips, the assertions above passed vacuously.
+    assert "app.py" in recovered, "recovery reported nothing; leak check was vacuous"
+    assert "sensitive:" in recovered, "withheld files left no trace at all"

--- a/tests/test_work_graph_recovery_trust_gate.py
+++ b/tests/test_work_graph_recovery_trust_gate.py
@@ -69,7 +69,17 @@ class TestTokenIdentity:
 
 class TestGate:
     def test_no_gate_means_no_refusal(self, tmp_path):
-        require_acknowledged(tmp_path)  # must not raise
+        # Asserted rather than relying on "it did not raise": a test whose only
+        # failure mode is an exception says nothing about what it checked, and
+        # would still pass if require_acknowledged became a no-op.
+        assert pending(tmp_path) is None
+
+        require_acknowledged(tmp_path)
+
+        # Reading the gate must not create one, or the first agent to look
+        # would arm a gate against itself.
+        assert pending(tmp_path) is None
+        assert not list(tmp_path.glob("pending-recovery-ack.json"))
 
     def test_arming_blocks_and_acknowledging_unblocks(self, tmp_path):
         token = recovery_token({"changed_paths": ["a.py"]})

--- a/tests/test_work_graph_recovery_trust_gate.py
+++ b/tests/test_work_graph_recovery_trust_gate.py
@@ -1,0 +1,209 @@
+"""A recovering agent must accept the trust level before it may act.
+
+`work_resume` labelled its output `untrusted_recovered_work_state` and recorded
+`unknown:previous-agent-intent`, but nothing stopped an agent reading the label
+and immediately claiming work as though reconstructed state were observed fact.
+The label described the risk; nothing made anyone carry it.
+
+Also covers the index/worktree commitment split: staged and conflicted paths
+used to receive no digest at all, on the correct reasoning that one worktree
+digest cannot represent both index and worktree state -- but the answer is two
+digests, not none.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from entroly.work_graph_content_digest import enrich_worktree_content_digests
+from entroly.work_graph_recovery_ack import (
+    RecoveryAcknowledgementRequired,
+    acknowledge,
+    arm,
+    pending,
+    recovery_token,
+    require_acknowledged,
+)
+from entroly.work_graph_repo import discover_repository_observation
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True
+    )
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.test")
+    _git(repo, "config", "user.name", "t")
+    (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+class TestTokenIdentity:
+    def test_same_state_yields_the_same_token(self):
+        view = {"selected_workstream": {"node_id": "w1"}, "changed_paths": ["a.py"]}
+        assert recovery_token(view) == recovery_token(dict(view))
+
+    def test_key_order_does_not_change_the_token(self):
+        # Key order carries no meaning; it must not demand a second
+        # acknowledgement for identical facts.
+        left = {"a": 1, "b": 2}
+        right = {"b": 2, "a": 1}
+        assert recovery_token(left) == recovery_token(right)
+
+    def test_different_state_yields_a_different_token(self):
+        base = {"changed_paths": ["a.py"]}
+        moved = {"changed_paths": ["a.py", "b.py"]}
+        assert recovery_token(base) != recovery_token(moved)
+
+
+class TestGate:
+    def test_no_gate_means_no_refusal(self, tmp_path):
+        require_acknowledged(tmp_path)  # must not raise
+
+    def test_arming_blocks_and_acknowledging_unblocks(self, tmp_path):
+        token = recovery_token({"changed_paths": ["a.py"]})
+        arm(tmp_path, token, ["unknown:previous-agent-intent"])
+
+        with pytest.raises(RecoveryAcknowledgementRequired):
+            require_acknowledged(tmp_path)
+
+        acknowledge(tmp_path, token)
+        require_acknowledged(tmp_path)  # cleared
+
+    def test_acknowledging_stale_state_is_refused(self, tmp_path):
+        arm(tmp_path, recovery_token({"changed_paths": ["a.py"]}), [])
+        with pytest.raises(ValueError, match="does not match"):
+            acknowledge(tmp_path, recovery_token({"changed_paths": ["b.py"]}))
+        # Still armed: a rejected acknowledgement must not disarm the gate.
+        with pytest.raises(RecoveryAcknowledgementRequired):
+            require_acknowledged(tmp_path)
+
+    def test_a_corrupt_marker_counts_as_armed(self, tmp_path):
+        arm(tmp_path, recovery_token({"x": 1}), [])
+        (tmp_path / "pending-recovery-ack.json").write_text("{not json", encoding="utf-8")
+
+        # Treating corruption as consent would be the wrong default: the gate
+        # exists precisely for the case where state cannot be trusted.
+        assert pending(tmp_path) is not None
+        with pytest.raises(RecoveryAcknowledgementRequired):
+            require_acknowledged(tmp_path)
+
+    def test_unknowns_are_carried_to_the_acknowledgement(self, tmp_path):
+        token = recovery_token({"x": 1})
+        arm(tmp_path, token, ["unknown:previous-agent-intent"])
+        result = acknowledge(tmp_path, token)
+        assert "unknown:previous-agent-intent" in result["unknowns"]
+
+
+@pytest.mark.timeout(180)
+def test_claim_is_refused_until_recovery_is_acknowledged(tmp_path, monkeypatch):
+    """End-to-end through the real MCP surface."""
+    repo = _repo(tmp_path)
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("ENTROLY_SOURCE", str(repo))
+    from entroly.work_graph_mcp import (
+        work_acknowledge_recovery,
+        work_claim,
+        work_resume,
+    )
+
+    # Without a recovery outstanding, ordinary work is unaffected.
+    assert work_claim(
+        project=str(repo), agent_id="a", task_title="t", task_id="t1",
+        scope_paths=["app.py"],
+    )["status"] == "ok"
+
+    resumed = work_resume(project=str(repo), max_evidence=16)
+    context = resumed["context"]
+    start = context.find("{")
+    ack = json.loads(context[start:context.rfind("}") + 1])["acknowledgement"]
+    assert ack["required"] is True
+    assert ack["trust"] == "untrusted_recovered_work_state"
+    assert "unknown:previous-agent-intent" in ack["unknowns"]
+
+    blocked = work_claim(
+        project=str(repo), agent_id="b", task_title="t2", task_id="t2",
+        scope_paths=["app.py"],
+    )
+    assert blocked["status"] == "error"
+    assert "acknowledg" in str(blocked.get("detail", "")).lower()
+
+    wrong = work_acknowledge_recovery(project=str(repo), token="recovery:" + "0" * 32)
+    assert wrong["status"] == "error"
+
+    accepted = work_acknowledge_recovery(project=str(repo), token=ack["token"])
+    assert accepted["status"] == "ok"
+    assert accepted["acknowledged"] is True
+
+    assert work_claim(
+        project=str(repo), agent_id="b", task_title="t2", task_id="t2",
+        scope_paths=["app.py"],
+    )["status"] == "ok"
+
+
+@pytest.mark.timeout(180)
+def test_staged_and_worktree_states_receive_separate_commitments(tmp_path):
+    """Exact binding for paths one digest cannot describe."""
+    repo = _repo(tmp_path)
+
+    # Staged, then edited again: index and worktree genuinely differ.
+    (repo / "staged.py").write_text("s = 1\n", encoding="utf-8")
+    _git(repo, "add", "staged.py")
+    (repo / "staged.py").write_text("s = 2  # edited after add\n", encoding="utf-8")
+
+    observation = enrich_worktree_content_digests(
+        repo, discover_repository_observation(repo)
+    )
+    staged = next(
+        change for change in observation["changes"]
+        if change["path"] == "staged.py"
+    )
+
+    assert staged["index_digest"], "staged bytes were left unbound"
+    assert staged["worktree_digest"], "worktree bytes were left unbound"
+    assert staged["index_digest"] != staged["worktree_digest"], (
+        "index and worktree differ here; identical digests would mean one of "
+        "them is not actually being measured"
+    )
+    # content_digest keeps its original meaning: empty when no single identity
+    # can honestly stand for the path.
+    assert staged["content_digest"] == ""
+
+
+@pytest.mark.timeout(180)
+def test_conflicted_path_records_base_ours_and_theirs(tmp_path):
+    repo = _repo(tmp_path)
+    main = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+    _git(repo, "checkout", "-q", "-b", "other")
+    (repo / "app.py").write_text("x = 2\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "other")
+    _git(repo, "checkout", "-q", main)
+    (repo / "app.py").write_text("x = 3\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "mine")
+    merged = _git(repo, "merge", "other")
+    assert merged.returncode != 0, "fixture did not produce a conflict"
+
+    observation = enrich_worktree_content_digests(
+        repo, discover_repository_observation(repo)
+    )
+    conflicted = next(
+        change for change in observation["changes"] if change["path"] == "app.py"
+    )
+
+    stages = conflicted.get("conflict_stage_digests", {})
+    assert set(stages) == {"base", "ours", "theirs"}
+    assert len(set(stages.values())) == 3, "stages must be distinct blobs"
+    # The worktree holds merged text with markers, which is none of the three.
+    assert conflicted["worktree_digest"] not in set(stages.values())


### PR DESCRIPTION
Addresses two of the six production targets for `work_resume`, found by **dogfooding rather than review**.

## The finding

Ran `work_resume` against a repository whose working directory was untidy in the ordinary way — `.env`, `id_rsa`, and `node_modules/` untracked but never added to `.gitignore`. The interrupted-agent recovery reported:

```
changed_paths: ['.env', 'app.py', 'id_rsa', 'node_modules/x.js']
```

| check | result |
|---|---|
| secret **values** (`sk_live_…`, `BEGIN OPENSSH`) | **absent** — the digest layer holds |
| `.env` filename | **disclosed** |
| `id_rsa` filename | **disclosed** |
| vendored tree | **disclosed**, burying the one real edit |

Content was already safe. **The filename was the leak.** `id_rsa` discloses that a private key exists and what kind. `git status --porcelain` omits git-ignored files, which is exactly why this stays invisible in a tidy repository — and why the prior assessment recorded generated-file handling as only *Partial*.

> A first version of this test reported "nothing leaked." That was **vacuous** — the scan had returned `changed_paths: None` because no workstream existed. The finding above is from a run with an active claim, and the committed test asserts the premise so it cannot pass vacuously again.

## After

```
changed_paths: ['app.py', 'sensitive:e9cbb022…', 'sensitive:f40883a1…']
```

The real work is no longer buried.

## Design

Three outcomes:

- **Ordinary** — reported unchanged.
- **Sensitive** — keeps its change record but carries a **stable opaque id** instead of a name, and no digest (a content digest of a small credential file is itself an oracle). The agent still learns *a guarded file moved*, which is precisely the kind of fact that invalidates earlier work.
- **Generated** — omitted, but **counted**.

`path_disclosure` carries the count and matched rules, so a caller can tell *"nothing else changed"* from *"9,000 vendored files changed and were dropped"* — the receipt-honesty rule that omitted evidence stays inspectable.

Applied at **observation time**, not at the reporting edge, so a withheld name never reaches the digest layer, the Rust event, or the persisted graph. Filtering at render time would leave it durable on disk.

Details that matter:
- **Sensitive beats generated** — a key inside a vendor tree is still a key.
- **Lockfiles are work, not noise** — a changed `package-lock.json` is reviewable and stays.
- `ENTROLY_WORK_GRAPH_SENSITIVE` / `ENTROLY_WORK_GRAPH_GENERATED` extend either set.

Deny-listing is **not offered as a security boundary**. It reduces obvious disclosure from a surface whose job is to describe a working directory it does not control.

## Evidence

```
tests/test_work_graph_path_policy.py   47 passed
existing work-graph suite              95 passed, 1 skipped
```

Teeth verified: neutralizing `classify()` to always return `ORDINARY` fails **33** of the 47, including the end-to-end leak test.

## Remaining targets, not in this PR

1. Agent startup automatically calls `work_resume` — integration hook
2. Filesystem watcher for later modifications
5. Separate index and worktree commitments for staged state
6. Agent must acknowledge recovery trust level before acting

Target 3 is now substantially covered (gitignore + generated markers + configurable exclusions); a size/type rule is still absent. Target 4 is covered for filenames.