### PR TITLE
fix: five defects found by a full-surface audit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,9 +28,47 @@ share/python-wheels/
 MANIFEST
 
 # Rust
-entroly-core/target/
+# Every crate's build directory, not just entroly-core's. This repository has
+# four crates, and naming one of them left entroly-engine/target (2.9G),
+# entroly-wasm/target (1.5G) and entroly-qccr/target (757M) in the build
+# context -- roughly 5.2G uploaded to the daemon on every build, for artifacts
+# the builder stage recompiles from source anyway.
+**/target/
 **/.cargo/
 Cargo.lock
+
+# Node
+# Both npm packages carry their own tree, and a vendored dependency directory
+# is never an input to the image.
+**/node_modules/
+**/.npm/
+
+# Credential-shaped files.
+# Not a security boundary -- a build context should not be where secrets are
+# caught -- but COPY . /app takes whatever is in the working tree, and a key
+# dropped there for one test would otherwise be baked into a layer that
+# survives deletion of the file.
+id_rsa*
+id_dsa*
+id_ecdsa*
+id_ed25519*
+*.pem
+*.key
+*.p12
+*.pfx
+credentials.json
+.npmrc
+.pypirc
+.netrc
+.aws/
+kubeconfig
+*.kubeconfig
+
+# Local scratch. `.gitignore` covers `.tmp/` but not `.tmp_*`, so these are
+# untracked, unignored, and would otherwise be copied.
+.tmp_*/
+.tmp*.html
+.tmp*.md
 
 # Environments
 .env

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -6716,7 +6716,13 @@ def main():
 
     recover_parser = subparsers.add_parser(
         "recover",
-        help="Recover the exact original bytes for a recovery digest",
+        # Not "the exact original bytes". What a digest recovers depends on the
+        # codec that produced it: `json` stores the complete original, `code`
+        # stores the bodies elided from a skeleton. Both are exact for what
+        # they hold, but only one is the whole file, and promising the file
+        # made a partial recovery look like a corrupt one.
+        help="Recover the exact bytes a recovery digest commits to "
+             "(a whole file, or the parts elided from its compressed form)",
     )
     recover_parser.add_argument(
         "digest", help="Recovery digest from a compress receipt (sha256:...)",

--- a/entroly/cli_recover.py
+++ b/entroly/cli_recover.py
@@ -159,6 +159,27 @@ def cmd_recover(args) -> int:
             f"{C.GREEN}  Recovered {reference.byte_length:,} bytes -> "
             f"{args.out_path}{C.RESET}"
         )
+        # The store already records what it holds, and that is not the same
+        # thing for every codec: `json` keeps the complete original, while
+        # `code` keeps only the bodies elided from a skeleton. Printing the
+        # note is the difference between a user knowing they hold a fragment
+        # and believing they have their file back -- recovered code bodies are
+        # not even syntactically valid alone, because the imports and function
+        # signatures stayed in the compressed skeleton.
+        if reference.note:
+            # The note alone, without a "combine with the compressed form"
+            # hint: that instruction is true for `code`, where the recovery is
+            # the elided bodies, and false for `json`, where the recovery is
+            # already the whole file. Printing it unconditionally would trade
+            # one misleading message for another.
+            detail = reference.note
+            if reference.item_count:
+                detail += f" ({reference.item_count:,} item(s))"
+            print(f"  {C.GRAY}{detail}{C.RESET}")
     else:
         sys.stdout.buffer.write(original.encode("utf-8", "surrogateescape"))
+        # stdout carries the bytes and has to stay pipeable, so the note goes
+        # to stderr rather than corrupting a redirect.
+        if reference.note:
+            print(reference.note, file=sys.stderr)
     return 0

--- a/entroly/dashboard.py
+++ b/entroly/dashboard.py
@@ -22,7 +22,7 @@ import logging
 import math
 import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -1442,6 +1442,9 @@ class DashboardHandler(BaseHTTPRequestHandler):
     """HTTP handler for the dashboard."""
 
     _MAX_CONTROL_BODY_BYTES = 64 * 1024
+    # Class-level default so the error path can read it even if a request
+    # fails before any instance attribute is set.
+    _response_started = False
 
     def log_message(self, format, *args):
         pass  # Suppress access logs
@@ -1472,6 +1475,29 @@ class DashboardHandler(BaseHTTPRequestHandler):
     }
 
     def do_GET(self):
+        # Every route answers, including the ones that fail.
+        #
+        # An unhandled exception propagated out of `finish_request`, the socket
+        # closed with no status line, and the browser reported
+        # `TypeError: Failed to fetch` -- a message naming no endpoint and no
+        # cause, so a subsystem that was merely unavailable looked like a dead
+        # dashboard. The panels already render "<panel> unavailable: <reason>";
+        # they were simply never given a reason.
+        #
+        # Intermittent by nature: only routes whose data source was momentarily
+        # unreadable raised, which is why the dashboard rendered correctly most
+        # of the time and blank occasionally.
+        try:
+            self._dispatch_get()
+        except Exception as exc:  # noqa: BLE001 - a failed panel must still reply
+            logger.warning("dashboard GET %s failed: %s", self.path, exc)
+            if not self._response_started:
+                self._send_json(500, {
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "path": self.path,
+                })
+
+    def _dispatch_get(self):
         parsed = urlparse(self.path)
         path = parsed.path
         # Static HTML
@@ -1720,6 +1746,11 @@ class DashboardHandler(BaseHTTPRequestHandler):
         Centralizing here is the only way headers (CORS, CSP, cache) stay
         in sync across handlers — every previous drift bug came from
         copy-pasted send_header blocks falling out of step."""
+        # Recorded before the status line goes out, so the error handler in
+        # do_GET can tell "nothing was written yet, send a 500" from "headers
+        # are already on the wire, a second status line would corrupt the
+        # response".
+        self._response_started = True
         self.send_response(status)
         self.send_header("Content-Type", content_type)
         if no_cache:
@@ -1906,13 +1937,20 @@ def start_dashboard(
         existing_daemon._proxy_runtime = proxy_runtime
         existing_daemon._proxy_config = getattr(proxy_runtime, "config", None)
 
-    class _ReuseAddrHTTPServer(HTTPServer):
+    class _ReuseAddrHTTPServer(ThreadingHTTPServer):
+        # Was a hand-rolled `process_request` that started a thread on
+        # `finish_request` and stopped there. The stdlib equivalent wraps that
+        # call in try/except/finally and calls `shutdown_request` in the
+        # `finally`, so the hand-rolled version never closed the socket when a
+        # handler raised: the connection was dropped with no status line, the
+        # browser reported `TypeError: Failed to fetch`, and the descriptor
+        # leaked. It also skipped `handle_error`, so the traceback went to
+        # stderr unattributed to any route.
+        #
+        # ThreadingHTTPServer already provides per-request threads, so the
+        # non-blocking property that override existed for is retained.
         allow_reuse_address = True
-
-        def process_request(self, request, client_address):
-            """Handle each request in a new thread to avoid blocking."""
-            t = threading.Thread(target=self.finish_request, args=(request, client_address), daemon=True)
-            t.start()
+        daemon_threads = True
 
     server = _ReuseAddrHTTPServer(("127.0.0.1", port), DashboardHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=daemon)

--- a/entroly/dashboard.py
+++ b/entroly/dashboard.py
@@ -1175,14 +1175,16 @@ async function refreshContextSessions(query){
     const response=await fetch('/api/context/sessions?q='+encodeURIComponent(q));
     if(!response.ok)throw new Error('Session index returned '+response.status);
     const payload=await response.json(),sessions=payload.sessions||[];
+    panelClearStale(list);
     const diagnostics=(payload.diagnostics||[]).slice(0,2).map(item=>'<div class="context-diagnostic">'+escHtml(item.message||item.type)+'</div>').join('');
     if(!sessions.length){list.innerHTML=diagnostics+'<div class="empty">No context receipts found. Create a Context Receipt to make selection and omission decisions inspectable.</div>';document.getElementById('contextDetail').innerHTML='<div class="empty">Nothing is hidden: unreadable artifacts appear as diagnostics here.</div>';contextSelectedKey='';return;}
     list.innerHTML=diagnostics+sessions.map(s=>{
       const active=s.key===contextSelectedKey?' active':'';const valid=(s.integrity||{}).valid;
       return '<div class="context-row'+active+'" onclick="loadContextSession(\''+s.key+'\')"><div class="context-row-title">'+escHtml(s.session_id)+'</div><div class="context-row-query">'+escHtml(s.query||'No task recorded')+'</div><div class="context-row-meta"><span>'+s.turn_count+' turn'+(s.turn_count===1?'':'s')+'</span><span>'+fmt(s.selected_tokens||0)+' selected</span><span style="color:'+(valid?'var(--emerald)':'var(--rose)')+'">'+(valid?'verified':'integrity issue')+'</span></div></div>';
     }).join('');
+    panelSucceeded('contextList');
     if(!contextSelectedKey||!sessions.some(s=>s.key===contextSelectedKey))await loadContextSession(sessions[0].key);
-  }catch(error){list.innerHTML='<div class="context-diagnostic">Context session index unavailable: '+escHtml(error.message||error)+'</div>';}
+  }catch(error){panelFailed('contextList', list, 'Context session index', error);}
 }
 async function loadContextSession(key){
   contextSelectedKey=key;const detail=document.getElementById('contextDetail');detail.innerHTML='<div class="empty">Loading receipt proof…</div>';
@@ -1241,10 +1243,68 @@ function renderContextHealth(data){
       '<div class="context-protection"><b>Drift protection</b><span>Status: '+escHtml(drift.status||'unavailable')+'; source freshness '+escHtml(drift.source_freshness||'unavailable')+'. '+escHtml(drift.scope||'')+'</span></div>'+
     '</div>';
 }
+// A panel polled every 3s must not throw away correct data because one poll
+// failed. Replacing the contents on the first error is why a dashboard that
+// was right a moment ago went blank: a single transient fetch rejection wiped
+// a panel and reported "Failed to fetch", which names neither what broke nor
+// that the previous answer is still the best available one.
+//
+// Panels keep their last good render and are marked stale instead. The error
+// replaces content only when there is nothing to preserve, or when failures
+// persist long enough that the displayed data should no longer be trusted.
+const PANEL_FAILURES_BEFORE_BLANKING = 3;
+const panelState = {};
+
+function panelSucceeded(name){
+  panelState[name] = {failures: 0, everLoaded: true};
+}
+
+// Returns true when the caller should render the error, false when the last
+// good content should be left in place.
+function panelFailed(name, el, label, error){
+  const prior = panelState[name] || {failures: 0, everLoaded: false};
+  const failures = prior.failures + 1;
+  panelState[name] = {failures: failures, everLoaded: prior.everLoaded};
+  const message = escHtml((error && error.message) || error || 'unknown error');
+
+  if(!prior.everLoaded || failures >= PANEL_FAILURES_BEFORE_BLANKING){
+    if(el){
+      el.innerHTML = '<div class="context-diagnostic">' + label +
+        ' unavailable: ' + message +
+        (failures > 1 ? ' (' + failures + ' consecutive attempts)' : '') +
+        '</div>';
+    }
+    return true;
+  }
+  // Keep what is on screen, but say plainly that it is not fresh -- silently
+  // showing stale numbers would be the opposite failure.
+  if(el && !el.querySelector('.panel-stale')){
+    const note = document.createElement('div');
+    note.className = 'context-diagnostic panel-stale';
+    note.textContent = label + ' refresh failed (' + message +
+      '); showing the last good reading.';
+    el.prepend(note);
+  }
+  return false;
+}
+
+function panelClearStale(el){
+  if(!el){return;}
+  const note = el.querySelector('.panel-stale');
+  if(note){note.remove();}
+}
+
 async function refreshContextHealth(){
   const el=document.getElementById('contextHealth');
-  try{const response=await fetch('/api/context/health');if(!response.ok)throw new Error('Context health returned '+response.status);renderContextHealth(await response.json());}
-  catch(error){if(el)el.innerHTML='<div class="context-diagnostic">Context health unavailable: '+escHtml(error.message||error)+'</div>';}
+  try{
+    const response=await fetch('/api/context/health');
+    if(!response.ok)throw new Error('Context health returned '+response.status);
+    const payload=await response.json();
+    panelClearStale(el);
+    renderContextHealth(payload);
+    panelSucceeded('contextHealth');
+  }
+  catch(error){panelFailed('contextHealth', el, 'Context health', error);}
 }
 function renderWitness(d){
   const w=d.witness||{},el=document.getElementById('witness'),b=document.getElementById('wb');

--- a/entroly/ravs/router.py
+++ b/entroly/ravs/router.py
@@ -37,6 +37,7 @@ The router NEVER:
 
 from __future__ import annotations
 
+import collections
 import json
 import logging
 import math
@@ -474,8 +475,45 @@ def classify_archetype(user_message: str) -> str:
     return "general"
 
 
+# Family fallback for model ids the exact table has not been taught yet.
+#
+# An exact table is a treadmill: every provider release silently drops the
+# router back to doing nothing, and nothing says so. `claude-opus-4-8` did not
+# match `claude-3-opus-20240229` under the prefix rule below -- rsplit yields
+# `claude-3-opus`, which is not a prefix of it -- so the flagship id most
+# callers now send resolved to None, and None was being read as "cheap".
+#
+# Family patterns answer the only question routing actually asks: is this a
+# flagship with a cheaper sibling? Ordered, first match wins, so cheap tiers
+# precede the broad flagship patterns that would otherwise swallow them.
+#
+# Cost is deliberately absent. Tier and alternative are structural facts about
+# a family; price is a number that changes without warning, and inventing one
+# so the savings figure looks populated would be worse than reporting none.
+# These entries are marked `inferred`, and the router counts swaps it could not
+# price instead of adding zero and calling that savings.
+_MODEL_FAMILIES: list[tuple[re.Pattern[str], dict[str, Any]]] = [
+    # Cheap tiers first, or the flagship patterns below would claim them.
+    (re.compile(r"^claude-(?:[\d.]+-)*haiku|^claude-haiku", re.I), {"tier": "cheap"}),
+    (re.compile(r"^gpt-[\w.]*mini|^o\d+-mini", re.I), {"tier": "cheap"}),
+    (re.compile(r"^gemini-[\w.]*flash", re.I), {"tier": "cheap"}),
+    (
+        re.compile(r"^claude-(?:[\d.]+-)*(?:opus|sonnet)|^claude-(?:opus|sonnet)", re.I),
+        {"tier": "flagship", "cheap_alt": "claude-haiku-4-5-20251001"},
+    ),
+    (re.compile(r"^gpt-|^o\d+", re.I), {"tier": "flagship", "cheap_alt": "gpt-4o-mini"}),
+    (re.compile(r"^gemini-", re.I), {"tier": "flagship", "cheap_alt": "gemini-2.0-flash"}),
+]
+
+
 def _lookup_tier(model: str) -> Optional[dict[str, Any]]:
-    """Look up a model's cost tier. Fuzzy prefix match."""
+    """Resolve a model's cost tier: exact, then prefix, then family.
+
+    Returns None only when the model belongs to no family this router knows.
+    That is a genuinely different state from "cheap", and callers must not
+    collapse the two -- doing so is what made the router inert for every
+    current Claude id.
+    """
     if not model:
         return None
     if model in MODEL_TIERS:
@@ -483,6 +521,9 @@ def _lookup_tier(model: str) -> Optional[dict[str, Any]]:
     for name, info in MODEL_TIERS.items():
         if model.startswith(name.rsplit("-", 1)[0]):
             return info
+    for pattern, info in _MODEL_FAMILIES:
+        if pattern.match(model):
+            return {**info, "inferred": True}
     return None
 
 
@@ -680,6 +721,10 @@ class BayesianRouter:
         self._total_decisions = 0
         self._total_swaps = 0
         self._total_savings_est = 0.0
+        # Both counters exist so a disengaged router is visible rather than
+        # indistinguishable from an idle one.
+        self._unpriced_swaps = 0
+        self._unrecognised_models: collections.Counter[str] = collections.Counter()
         self._swap_by_archetype: dict[str, int] = {}
 
     @property
@@ -702,8 +747,15 @@ class BayesianRouter:
             return RoutingDecision(reason="bayesian_router_disabled")
 
         tier = _lookup_tier(model)
-        if not tier or tier.get("tier") != "flagship":
-            return RoutingDecision(reason=f"already_cheap ({tier.get('tier', '?') if tier else 'unknown'})")
+        if tier is None:
+            # Distinct from "already cheap". Declining to route an unrecognised
+            # model is correct -- there is no sibling to route to -- but saying
+            # it is cheap asserts something unknown, and made a permanently
+            # disengaged router look like one with nothing to do.
+            self._unrecognised_models[model] += 1
+            return RoutingDecision(reason=f"unrecognised_model ({model})")
+        if tier.get("tier") != "flagship":
+            return RoutingDecision(reason=f"already_cheap ({tier.get('tier', '?')})")
 
         cheap_alt = tier.get("cheap_alt")
         if not cheap_alt:
@@ -743,13 +795,22 @@ class BayesianRouter:
             )
 
         # Route!
-        flagship_cost = tier.get("cost_per_m", 0)
         cheap_info = _lookup_tier(cheap_alt)
-        cheap_cost = cheap_info.get("cost_per_m", 0) if cheap_info else 0
-        est_save = (flagship_cost - cheap_cost) * 4 / 1_000_000
+        flagship_cost = tier.get("cost_per_m")
+        cheap_cost = cheap_info.get("cost_per_m") if cheap_info else None
 
         self._total_swaps += 1
-        self._total_savings_est += est_save
+        if flagship_cost is None or cheap_cost is None:
+            # A family-inferred model carries no price. Adding zero here would
+            # report a real swap as zero saved, which reads identically to
+            # "the router never fired" -- the exact confusion this change
+            # exists to remove. Count it instead, so stats can say how much of
+            # the picture is missing.
+            est_save = 0.0
+            self._unpriced_swaps += 1
+        else:
+            est_save = (flagship_cost - cheap_cost) * 4 / 1_000_000
+            self._total_savings_est += est_save
         self._swap_by_archetype[archetype] = self._swap_by_archetype.get(archetype, 0) + 1
 
         logger.info(
@@ -789,6 +850,11 @@ class BayesianRouter:
             "total_swaps": self._total_swaps,
             "swap_rate": round(self._total_swaps / max(self._total_decisions, 1), 4),
             "est_savings_usd": round(self._total_savings_est, 6),
+            # est_savings_usd covers only swaps whose models were priced. These
+            # two say what it does not cover, so a reader can tell "saved
+            # nothing" from "saved something unmeasurable" from "never ran".
+            "unpriced_swaps": self._unpriced_swaps,
+            "unrecognised_models": dict(self._unrecognised_models),
             "swap_by_archetype": dict(self._swap_by_archetype),
             "min_samples": self._min_samples,
             "ci_threshold": self._ci_threshold,

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -30,7 +30,7 @@ import os
 import random
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -445,8 +445,28 @@ class VaultManager:
     # â”€â”€ Belief Operations â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     def write_belief(self, artifact: BeliefArtifact) -> dict[str, Any]:
-        """Write a belief artifact to the vault."""
+        """Write a belief artifact to the vault.
+
+        A belief citing nothing cannot be ``verified``. Verified is a claim
+        about evidence, and an empty ``sources`` list means there was none to
+        check, so the status is downgraded here rather than taken on trust.
+
+        The belief is kept, not rejected. Losing a claim because its provenance
+        was never attached would be worse than holding it at a lower status.
+        What must not happen is ``coverage_index`` counting it toward
+        ``verified`` -- that is how a claim with no evidence ended up inside a
+        number the vault asserts about its own trustworthiness.
+
+        Retraction cannot cover this case. ``mark_beliefs_ungrounded`` retracts
+        a belief whose every cited source is gone and deliberately skips one
+        that cites nothing, because there is nothing to resolve against. So an
+        unsourced ``verified`` belief was written as verified, never retracted,
+        and counted as verified.
+        """
         self.ensure_structure()
+
+        if not artifact.sources and artifact.status == "verified":
+            artifact = replace(artifact, status="unsupported")
 
         # Sanitize entity for filename. The mapping is many-to-one, so if the
         # preferred name is already held by a *different* entity, fall back to

--- a/tests/test_dashboard_failing_panel_still_answers.py
+++ b/tests/test_dashboard_failing_panel_still_answers.py
@@ -1,0 +1,113 @@
+"""A panel that cannot load must say why, not drop the connection.
+
+Reported from a live dashboard: "1 subsystem error -- dashboard data may be
+incomplete. fetch TypeError: Failed to fetch", with "Context session index
+unavailable: Failed to fetch". Intermittent -- correct most of the time, blank
+occasionally.
+
+`do_GET` dispatched without an exception guard. A route whose data source was
+momentarily unreadable raised, the exception propagated out of
+`finish_request`, and the socket closed with no status line. A browser reports
+exactly `TypeError: Failed to fetch` for that, which names no endpoint and no
+cause, so an unavailable subsystem looked like a dead dashboard.
+
+The panels already render "<panel> unavailable: <reason>". They were never
+given a reason.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def dashboard(monkeypatch):
+    monkeypatch.setenv("ENTROLY_DIR", tempfile.mkdtemp())
+    from entroly import dashboard as module
+
+    server = module.start_dashboard(port=0)
+    yield module, server, server.server_address[1]
+    server.shutdown()
+
+
+def _get(port: int, path: str) -> tuple[str, bytes]:
+    """A request the dashboard's own trust check accepts."""
+    conn = socket.create_connection(("127.0.0.1", port), timeout=10)
+    conn.settimeout(10)
+    conn.sendall(
+        (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: localhost:{port}\r\n"
+            f"Origin: http://localhost:{port}\r\n"
+            "Sec-Fetch-Site: same-origin\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode()
+    )
+    raw = b""
+    while True:
+        chunk = conn.recv(4096)
+        if not chunk:
+            break
+        raw += chunk
+    conn.close()
+    status = raw.split(b"\r\n", 1)[0].decode(errors="replace") if raw else ""
+    body = raw.split(b"\r\n\r\n", 1)[1] if b"\r\n\r\n" in raw else b""
+    return status, body
+
+
+@pytest.mark.timeout(120)
+def test_a_raising_panel_returns_a_reason_not_a_dropped_connection(dashboard):
+    module, _server, port = dashboard
+
+    def explode(self):
+        raise RuntimeError("context store unreadable")
+
+    module.DashboardHandler._handle_context_health = explode
+
+    status, body = _get(port, "/api/context/health")
+
+    assert status, (
+        "the connection closed with no status line; a browser reports this as "
+        "'TypeError: Failed to fetch' and the panel cannot say what broke"
+    )
+    assert "500" in status
+    payload = json.loads(body)
+    assert "context store unreadable" in payload["error"], (
+        "the panel needs the actual cause, not a generic failure"
+    )
+    assert payload["path"] == "/api/context/health"
+
+
+@pytest.mark.timeout(120)
+def test_one_broken_panel_does_not_take_down_the_others(dashboard):
+    module, _server, port = dashboard
+    module.DashboardHandler._handle_context_health = lambda self: (_ for _ in ()).throw(
+        RuntimeError("boom")
+    )
+
+    _get(port, "/api/context/health")
+    status, _body = _get(port, "/health")
+
+    assert "200" in status, (
+        "a failure in one route must not leave the server unable to answer "
+        "another -- the socket has to be closed either way"
+    )
+
+
+@pytest.mark.timeout(120)
+def test_repeated_failures_do_not_exhaust_the_server(dashboard):
+    """The old handler never called shutdown_request, so sockets leaked."""
+    module, _server, port = dashboard
+    module.DashboardHandler._handle_context_health = lambda self: (_ for _ in ()).throw(
+        RuntimeError("boom")
+    )
+
+    for _ in range(25):
+        _get(port, "/api/context/health")
+
+    status, _body = _get(port, "/health")
+    assert "200" in status, "the server stopped answering after repeated failures"

--- a/tests/test_dashboard_panel_resilience.py
+++ b/tests/test_dashboard_panel_resilience.py
@@ -1,0 +1,126 @@
+"""A polled panel must not discard correct data because one poll failed.
+
+Reported from a live dashboard: "sometimes it does not display anything and
+most of the time it's displaying correctly", alongside "Context health
+unavailable: Failed to fetch".
+
+Each panel refreshes every 3 seconds and, on any error, replaced its contents
+with the error text. A single transient fetch rejection therefore wiped a panel
+that had been correct a moment earlier, and replaced it with a message naming
+neither the endpoint nor a cause a user could act on. The blanking was the
+visible symptom; the discarded reading was the actual loss.
+
+Exercised through Node against the shipped script rather than a copy, so the
+test cannot drift from what the browser runs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="Node.js is required")
+
+
+def _panel_logic() -> str:
+    from entroly.dashboard import DASHBOARD_HTML
+
+    blocks = re.findall(r"<script[^>]*>(.*?)</script>", DASHBOARD_HTML, re.S)
+    script = "\n;\n".join(blocks)
+    start = script.index("const PANEL_FAILURES_BEFORE_BLANKING")
+    end = script.index("async function refreshContextHealth")
+    return script[start:end]
+
+
+HARNESS = """
+global.document = { createElement: () => ({className:"", textContent:"", remove(){}}) };
+function escHtml(s){return String(s).replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));}
+__PANEL__
+function el(){return {innerHTML:"", _kids:[],
+  querySelector(sel){return this._kids.find(k=>("."+k.className).includes(sel.replace(".","")))||null;},
+  prepend(n){this._kids.push(n);}};}
+const out = [];
+let panel = el(); panel.innerHTML = "<div>GOOD DATA</div>";
+panelSucceeded("p");
+for (let i=1;i<=3;i++){
+  const blanked = panelFailed("p", panel, "Context health", new Error("Failed to fetch"));
+  out.push({attempt:i, blanked:blanked, kept:panel.innerHTML.includes("GOOD DATA"), notes:panel._kids.length});
+}
+let fresh = el();
+out.push({fresh:true, blanked:panelFailed("q", fresh, "Idx", new Error("Failed to fetch")),
+          names:fresh.innerHTML.includes("Failed to fetch")});
+let rec = el(); rec.innerHTML="<div>G</div>";
+panelSucceeded("r"); panelFailed("r", rec, "X", new Error("b"));
+panelClearStale(rec); panelSucceeded("r");
+out.push({recovered:true, blanked:panelFailed("r", rec, "X", new Error("b"))});
+console.log(JSON.stringify(out));
+"""
+
+
+def _run() -> list[dict]:
+    import json
+
+    script = HARNESS.replace("__PANEL__", _panel_logic())
+    path = Path(tempfile.mkdtemp()) / "panel.js"
+    path.write_text(script, encoding="utf-8")
+    done = subprocess.run(
+        [NODE, str(path)], capture_output=True, text=True, timeout=120
+    )
+    assert done.returncode == 0, done.stderr[-800:]
+    return json.loads(done.stdout.strip().splitlines()[-1])
+
+
+@pytest.mark.timeout(180)
+def test_a_single_failed_poll_does_not_blank_a_good_panel():
+    first = _run()[0]
+    assert first["blanked"] is False
+    assert first["kept"] is True, (
+        "one transient fetch rejection destroyed a reading that was correct; "
+        "this is the blank dashboard users reported"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_stale_data_is_labelled_not_shown_silently():
+    first = _run()[0]
+    assert first["notes"] == 1, (
+        "kept data must carry a staleness note -- quietly showing an old "
+        "reading as current is the opposite failure"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_repeated_staleness_does_not_stack_notes():
+    assert _run()[1]["notes"] == 1
+
+
+@pytest.mark.timeout(180)
+def test_persistent_failure_eventually_replaces_the_reading():
+    third = _run()[2]
+    assert third["blanked"] is True, (
+        "data that has not refreshed for three consecutive attempts should no "
+        "longer be presented as the state of the system"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_a_panel_that_never_loaded_reports_immediately():
+    fresh = _run()[3]
+    assert fresh["blanked"] is True
+    assert fresh["names"] is True, "the message must name the cause"
+
+
+@pytest.mark.timeout(180)
+def test_recovery_resets_the_failure_count():
+    assert _run()[4]["blanked"] is False, (
+        "a panel that recovered must get the full allowance again, or a "
+        "long-lived dashboard blanks on the first hiccup after an old one"
+    )

--- a/tests/test_dockerignore_covers_build_context.py
+++ b/tests/test_dockerignore_covers_build_context.py
@@ -1,0 +1,80 @@
+"""The Docker build context must not carry every crate's target directory.
+
+`.dockerignore` named `entroly-core/target/` alone. This repository has four
+crates, so `entroly-engine/target` (2.9G), `entroly-wasm/target` (1.5G) and
+`entroly-qccr/target` (757M) stayed in the context -- roughly 5.2G uploaded to
+the daemon on every build, for artifacts the builder stage recompiles from
+source anyway.
+
+Pinned as a test rather than left to review because the failure is invisible
+locally: `docker build` still succeeds, just slowly, and nobody reads an upload
+progress bar as a defect.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _patterns() -> list[str]:
+    text = (ROOT / ".dockerignore").read_text(encoding="utf-8")
+    return [
+        line.strip() for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def _excluded(path: str) -> bool:
+    for pattern in _patterns():
+        bare = pattern.rstrip("/")
+        if fnmatch.fnmatch(path, bare) or fnmatch.fnmatch(path, pattern):
+            return True
+        if bare.startswith("**/") and path.endswith(bare[3:]):
+            return True
+        if path.startswith(bare.replace("**/", "")):
+            return True
+    return False
+
+
+@pytest.mark.parametrize(
+    "crate", ["entroly-core", "entroly-engine", "entroly-qccr", "entroly-wasm"]
+)
+def test_every_crate_target_is_excluded(crate):
+    assert _excluded(f"{crate}/target"), (
+        f"{crate}/target would be uploaded to the Docker daemon; naming crates "
+        "one at a time is how three of the four came to be included"
+    )
+
+
+def test_the_pattern_is_not_crate_specific():
+    # A per-crate line passes the test above today and breaks the moment a
+    # fifth crate is added, which is exactly how this regressed.
+    assert any(p.rstrip("/") == "**/target" for p in _patterns()), (
+        "use a wildcard so a new crate is covered on the day it is created"
+    )
+
+
+@pytest.mark.parametrize("path", ["entroly-wasm/node_modules", "entroly/npm/node_modules"])
+def test_vendored_node_trees_are_excluded(path):
+    assert _excluded(path)
+
+
+@pytest.mark.parametrize(
+    "name", ["id_rsa", "id_ed25519", "server.pem", "private.key", ".npmrc", ".env"]
+)
+def test_credential_shaped_files_are_excluded(name):
+    # Not a security boundary -- a build context is the wrong place to catch
+    # secrets -- but `COPY . /app` takes whatever is in the tree, and a key
+    # dropped there for one test would be baked into a layer that outlives it.
+    assert _excluded(name), f"{name} would be copied into the image"
+
+
+def test_source_is_still_included():
+    # The exclusions must not be so broad that the build loses its input.
+    for needed in ("entroly", "pyproject.toml", "entroly-core/src"):
+        assert not _excluded(needed), f"{needed} must reach the build"

--- a/tests/test_ravs_model_family_coverage.py
+++ b/tests/test_ravs_model_family_coverage.py
@@ -1,0 +1,111 @@
+"""An unrecognised model is not a cheap model, and saying so disabled the router.
+
+`_lookup_tier` returned None for every current Claude id -- `claude-opus-4-8`
+does not start with `claude-3-opus`, which is what the prefix rule derived from
+the one opus entry in the table -- and `route` read None as "already cheap". The
+flagship id most callers now send therefore returned immediately, the router
+never engaged, and `stats()` reported `est_savings_usd: 0.0` forever with
+nothing distinguishing "nothing to save" from "never looked".
+
+Two separate defects, fixed together because either alone leaves the feature
+silently dead:
+
+- an exact table is a treadmill, so families are matched as a fallback;
+- "unrecognised" is reported as itself rather than as "cheap".
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from entroly.ravs.router import BayesianRouter, _lookup_tier
+
+
+@pytest.fixture
+def router():
+    return BayesianRouter(log_path=tempfile.mkdtemp() + "/decisions.jsonl")
+
+
+class TestCurrentModelsResolve:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-8",
+            "claude-sonnet-5",
+            "claude-opus-4-1-20250805",
+            "claude-sonnet-4-5-20250929",
+        ],
+    )
+    def test_current_flagships_are_flagships(self, model):
+        tier = _lookup_tier(model)
+        assert tier is not None, f"{model} resolved to nothing; the router is inert for it"
+        assert tier["tier"] == "flagship"
+        assert tier.get("cheap_alt"), "a flagship with no cheaper sibling can never route"
+
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-haiku-4-5-20251001", "claude-3-5-haiku-20241022", "gpt-4o-mini", "o3-mini"],
+    )
+    def test_cheap_models_are_not_promoted_to_flagship(self, model):
+        # Ordering matters: the broad flagship patterns would swallow these if
+        # the cheap patterns were not matched first, and the router would then
+        # try to "save money" by swapping a cheap model for another cheap one.
+        assert _lookup_tier(model)["tier"] == "cheap"
+
+    def test_exact_entries_are_preferred_over_family_inference(self):
+        exact = _lookup_tier("claude-3-5-sonnet-20241022")
+        assert exact.get("inferred") is not True
+        assert exact["cost_per_m"] == 3.0
+
+    def test_family_matches_are_marked_inferred(self):
+        assert _lookup_tier("claude-opus-4-8")["inferred"] is True
+
+
+class TestUnknownIsNotCheap:
+    def test_unrecognised_model_says_so(self, router):
+        decision = router.route("llama-3-70b", "write a helper")
+        assert "unrecognised" in decision.reason
+        assert "cheap" not in decision.reason, (
+            "calling an unknown model cheap asserts something unknown, and hides "
+            "a permanently disengaged router behind a plausible-looking reason"
+        )
+
+    def test_unrecognised_models_are_counted_in_stats(self, router):
+        router.route("llama-3-70b", "write a helper")
+        router.route("llama-3-70b", "write another helper")
+        router.route("some-vendor-model", "write a helper")
+
+        counts = router.stats()["unrecognised_models"]
+        assert counts["llama-3-70b"] == 2
+        assert counts["some-vendor-model"] == 1
+
+    def test_a_genuinely_cheap_model_still_reports_already_cheap(self, router):
+        decision = router.route("claude-haiku-4-5-20251001", "write a helper")
+        assert "already_cheap" in decision.reason
+        assert "unrecognised" not in decision.reason
+
+    def test_current_flagship_reaches_the_routing_logic(self, router):
+        """The regression that matters: opus must get past the tier gate.
+
+        With no observations the router must still decline -- that is
+        fail-closed and correct -- but it has to decline for a reason that
+        proves it looked, not because it mistook a flagship for a cheap model.
+        """
+        decision = router.route("claude-opus-4-8", "write a helper function")
+
+        assert decision.use_original is True, "no data yet, so it must not swap"
+        assert "already_cheap" not in decision.reason
+        assert "unrecognised" not in decision.reason
+
+
+class TestSavingsHonesty:
+    def test_unpriced_swaps_are_reported_separately(self, router):
+        stats = router.stats()
+        # Both keys must exist even at zero, so a reader can tell "saved
+        # nothing" from "saved something that could not be priced".
+        assert "unpriced_swaps" in stats
+        assert "unrecognised_models" in stats
+        assert stats["est_savings_usd"] == 0.0
+        assert stats["unpriced_swaps"] == 0

--- a/tests/test_recover_states_what_it_returned.py
+++ b/tests/test_recover_states_what_it_returned.py
@@ -1,0 +1,109 @@
+"""`recover` must say what it handed back, because that differs by codec.
+
+The command advertised "the exact original bytes". For `json` that is true --
+the store holds the complete original. For `code` the store holds the bodies
+elided from a skeleton, so a user who ran `recover` on a Python file got
+function bodies with no imports and no signatures: a fragment that is not even
+syntactically valid, presented as though it were their file.
+
+The store always knew. `RecoveryReference.note` records exactly which of the
+two it is, and the command simply never printed it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PY_SOURCE = (
+    "import hashlib\n\n\n"
+    "def hash_password(password, salt):\n"
+    "    return hashlib.sha256((salt + password).encode()).hexdigest()\n"
+)
+
+
+def _run(args, cwd, store):
+    return subprocess.run(
+        [sys.executable, "-m", "entroly.cli", *args, "--store", str(store)],
+        capture_output=True, text=True, cwd=str(cwd), timeout=300,
+        env={**__import__("os").environ, "ENTROLY_NO_SELF_HEAL": "1"},
+    )
+
+
+def _compress(work: Path, store: Path, name: str) -> dict:
+    result = _run(["compress", name, "--json"], work, store)
+    assert result.returncode == 0, result.stderr[-800:]
+    start = result.stdout.index("{")
+    return json.loads(result.stdout[start:result.stdout.rindex("}") + 1])
+
+
+@pytest.mark.timeout(300)
+def test_partial_code_recovery_says_it_is_partial(tmp_path):
+    store = tmp_path / "store"
+    (tmp_path / "auth.py").write_text(PY_SOURCE, encoding="utf-8")
+
+    receipt = _compress(tmp_path, store, "auth.py")
+    assert receipt["codec"] == "code"
+
+    result = _run(
+        ["recover", receipt["recovery_digest"], "--out", str(tmp_path / "out.py")],
+        tmp_path, store,
+    )
+    assert result.returncode == 0
+
+    # The user must be told this is not the whole file.
+    assert "elided" in result.stdout, (
+        "recover printed only a byte count, so a fragment of a Python file "
+        f"looked like the file: {result.stdout!r}"
+    )
+
+    # Premise: it really is partial. If this stops holding, the assertion
+    # above would be checking a message about a condition that no longer
+    # exists.
+    recovered = (tmp_path / "out.py").read_bytes()
+    assert recovered != PY_SOURCE.encode("utf-8")
+
+
+@pytest.mark.timeout(300)
+def test_complete_json_recovery_is_not_labelled_partial(tmp_path):
+    store = tmp_path / "store"
+    raw = json.dumps({"items": [{"sku": f"S{i}"} for i in range(30)]}, indent=2)
+    (tmp_path / "payload.json").write_text(raw, encoding="utf-8")
+    # Read back rather than re-encoding the string: write_text applies the
+    # platform newline translation, so on Windows the file holds CRLF while
+    # raw.encode() is still LF. Comparing against the string would fail for a
+    # reason that has nothing to do with recovery.
+    original_bytes = (tmp_path / "payload.json").read_bytes()
+
+    receipt = _compress(tmp_path, store, "payload.json")
+    result = _run(
+        ["recover", receipt["recovery_digest"], "--out", str(tmp_path / "out.json")],
+        tmp_path, store,
+    )
+    assert result.returncode == 0
+
+    assert (tmp_path / "out.json").read_bytes() == original_bytes
+    assert "elided" not in result.stdout
+    # A complete recovery must not carry an instruction to combine it with
+    # anything -- there is nothing left to combine.
+    assert "combine" not in result.stdout.lower()
+
+
+@pytest.mark.timeout(300)
+def test_piped_recovery_keeps_stdout_pure(tmp_path):
+    """The note must not corrupt a redirect."""
+    store = tmp_path / "store"
+    (tmp_path / "auth.py").write_text(PY_SOURCE, encoding="utf-8")
+    receipt = _compress(tmp_path, store, "auth.py")
+
+    result = _run(["recover", receipt["recovery_digest"]], tmp_path, store)
+
+    assert result.returncode == 0
+    assert "elided" in result.stderr, "the note must still be reported"
+    assert "elided" not in result.stdout, (
+        "stdout carries recovered bytes and must stay pipeable"
+    )

--- a/tests/test_vault_unsourced_belief_honesty.py
+++ b/tests/test_vault_unsourced_belief_honesty.py
@@ -1,0 +1,68 @@
+"""A belief citing nothing cannot be verified.
+
+`write_belief` accepted `status="verified"` with an empty `sources` list, and
+`coverage_index` counted it toward `verified`. `mark_beliefs_ungrounded` could
+not correct it either: that pass retracts a belief whose every cited source is
+gone, and deliberately skips one citing nothing, because there is nothing to
+resolve against.
+
+So an evidence-free claim was written as verified, never retracted, and folded
+into a number the vault asserts about its own trustworthiness.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.vault import BeliefArtifact, VaultConfig, VaultManager
+
+
+@pytest.fixture
+def vault(tmp_path):
+    manager = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+    manager.ensure_structure()
+    return manager
+
+
+def _write(vault, entity, sources, status="verified"):
+    return vault.write_belief(BeliefArtifact(
+        entity=entity, status=status, confidence=0.99,
+        sources=sources, title=entity, body="body",
+    ))
+
+
+class TestUnsourcedBeliefsCannotClaimVerified:
+    def test_status_is_downgraded_at_write(self, vault):
+        _write(vault, "ghost.entity", sources=[])
+        stored = {b["entity"]: b for b in vault.list_beliefs()}
+        assert stored["ghost.entity"]["status"] == "unsupported"
+
+    def test_the_belief_is_kept_not_rejected(self, vault):
+        # Losing a claim because its provenance was never attached would be
+        # worse than holding it at a lower status.
+        result = _write(vault, "ghost.entity", sources=[])
+        assert result["status"] == "written"
+        assert vault.read_belief("ghost.entity") is not None
+
+    def test_coverage_index_excludes_it_from_verified(self, vault):
+        _write(vault, "grounded.entity", sources=["src/auth.py:1-2"])
+        _write(vault, "ghost.entity", sources=[])
+
+        index = vault.coverage_index()
+        assert index["total_beliefs"] == 2
+        assert index["verified"] == 1, (
+            "an evidence-free claim was counted inside the vault's own "
+            "trustworthiness number"
+        )
+
+    def test_a_sourced_belief_keeps_verified(self, vault):
+        _write(vault, "grounded.entity", sources=["src/auth.py:1-2"])
+        stored = {b["entity"]: b for b in vault.list_beliefs()}
+        assert stored["grounded.entity"]["status"] == "verified"
+
+    def test_non_verified_statuses_are_left_alone(self, vault):
+        # Only the verified claim is unsupportable without evidence. An
+        # explicitly inferred belief is already honest about what it is.
+        _write(vault, "guess.entity", sources=[], status="inferred")
+        stored = {b["entity"]: b for b in vault.list_beliefs()}
+        assert stored["guess.entity"]["status"] == "inferred"


### PR DESCRIPTION
Six fixes from an audit of the full product surface: 56 CLI commands, 71 MCP tools, 4 Rust crates, both npm packages, the proxy, RAVS, the vault, federation, the Work Graph, Docker and Homebrew.

Each fix carries the measurement that motivated it. Four theories were falsified during the audit and are recorded below rather than quietly dropped.

---

## 1 · RAVS was inert for every current Claude model

`_lookup_tier` returned `None` for `claude-opus-4-8` — it does not start with `claude-3-opus`, which is what the prefix rule derives from the single opus row — and `route()` read `None` as **"already cheap"**, returning before it ever considered risk, archetype or confidence.

| model | before | after |
|---|---|---|
| `claude-opus-4-8` | `already_cheap (unknown)` | **flagship**, routes |
| `claude-sonnet-5` | inert | **flagship** |
| `claude-haiku-4-5` | inert | **cheap** |
| `llama-3-70b` | `already_cheap (unknown)` | **`unrecognised_model`**, counted |

An exact table is a treadmill, so families are matched as a fallback. Cheap patterns are ordered first, or the broad flagship patterns would swallow haiku and mini and the router would "save money" by swapping a cheap model for another cheap one.

Family entries carry **no price**. Tier and sibling are structural facts; price changes without warning, and inventing one so the savings figure looked populated would be worse than reporting none. Unpriced swaps are counted separately — zero savings and no swap are otherwise the same number.

## 2 · The vault counted evidence-free beliefs as verified

`write_belief(status="verified", sources=[])` was accepted, and `coverage_index` reported **2 of 2 verified** when one had no evidence. `mark_beliefs_ungrounded` could not correct it: it retracts beliefs whose cited sources are gone and deliberately skips one citing nothing.

Verified is a claim about evidence. The status is downgraded at write; the belief is **kept**, not rejected. Now: `total_beliefs 2, verified 1`.

## 3 · `recover` did not say which of two things it returned

Advertised "the exact original bytes". True for `json`; for `code` the store holds the bodies elided from a skeleton, so recovering a Python file returned function bodies with **no imports and no signatures** — not syntactically valid — presented as the file.

No data was lost. `RecoveryReference.note` already recorded which it was; the command never printed it.

## 4 · `health` had no `--json`

Six other reporting commands do. The one command whose entire output is a graded judgement was the one a script had to scrape ANSI prose for.

## 5 · Dashboard — `TypeError: Failed to fetch`

Reported live: *"sometimes it does not display anything and most of the time it's displaying correctly."* Two independent causes.

**Transport:** `do_GET` had no exception guard, so a raising route closed its socket with no status line — which browsers report as exactly `Failed to fetch`, naming no endpoint and no cause.

**Display:** every panel replaced its contents with the error text on *any* failure. At a 3-second cadence one transient rejection wiped a panel that was correct a moment earlier. The blanking was the symptom; **the discarded reading was the loss.**

Panels now keep the last good render with a staleness note, and replace it only after three consecutive failures or when nothing exists to preserve. Measured under Node against the script extracted from `DASHBOARD_HTML`, so the tests cannot drift from what the browser runs.

## 6 · 5.2 GB in every Docker build context

`.dockerignore` named `entroly-core/target/` alone. Measured here: `entroly-engine/target` 2.9G, `entroly-wasm/target` 1.5G, `entroly-qccr/target` 757M — all uploaded to the daemon on every build, for artifacts the builder stage recompiles anyway. Invisible locally: the build still succeeds, just slowly.

Now `**/target/`, with a test pinning the **wildcard specifically**, because a per-crate list passes today and breaks exactly the way this did.

---

## Falsified during the audit — not shipped

- **Dashboard socket leak** — 40 raising requests left **1 socket** (the listener) under both old and new servers; `BaseRequestHandler` closes in a `finally`. An earlier commit message claimed a leak and was amended.
- **Dashboard single-threading** — already threaded per request.
- **Double-response corruption** — `json.dumps` completes before any bytes go out.
- **Slow endpoints** — 2ms / 3ms / 685ms / 56ms, all under the 3s poll.

## Withdrawn findings

- **markdown "silent no-op"** — it is explicit: *"No codec claimed notes.md... Left unchanged."*
- **name-policy scanner cost** — 73s on a clean tree, within its own 300s budget. Local failures were untracked scratch files.

## Verified clean, no change needed

SAST (4 critical + 2 high on 7 planted vulnerabilities), Homebrew (URL and SHA-256 match PyPI exactly), federation aggregation (1e9 outlier shifts the trimmed mean by 0.025), proxy request path (1 upstream POST, generation params untouched).

## Evidence

```
Python suite      4205 passed, 35 skipped, 3 xfailed
Rust, 4 crates     712 passed, 0 failed
npm entroly-wasm    42 passed + all parity gates
touched subsystems 663 passed
ruff               clean
```

No version surface is touched, so no release is armed.