### PR TITLE
fix: make the product's value visible on the path most users install

### DIFF
--- a/docs/live-tokenomics.md
+++ b/docs/live-tokenomics.md
@@ -14,7 +14,7 @@ classes:
 | Evidence class | Included | Excluded |
 |---|---|---|
 | `provider_path` | Requests observed by the Entroly proxy, input tokens reduced, and modeled input cost for explicit price-catalog matches | Provider invoices, output-token savings, negotiated prices and requests that bypassed Entroly |
-| `local_operations` | Token reduction measured by SDK, MCP, npm and other local operations | Dollar savings; Entroly cannot prove the result reached a paid provider |
+| `local_operations` | Token reduction measured by SDK, MCP, npm and other local operations, plus `modeled_value_at_list_usd`: those tokens priced at the default catalog input rate | Invoice verification; Entroly cannot prove the result reached a paid provider, so this figure is replacement cost and is never added to `provider_path` |
 | `legacy_unclassified` | Historical reduction retained for continuity | Public savings totals and current provider-path claims |
 | `trust_signals` | Modeled routing value and locally observed verification interventions | Claims that every intervention prevented a real-world failure |
 

--- a/entroly/auto_index.py
+++ b/entroly/auto_index.py
@@ -1372,9 +1372,27 @@ def auto_index(
     """Serialize the full index lifecycle with incremental reconciliation."""
     mutation_lock = getattr(engine, "_index_mutation_lock", None)
     if mutation_lock is None:
-        return _auto_index(engine, project_dir, force)
-    with mutation_lock:
-        return _auto_index(engine, project_dir, force)
+        result = _auto_index(engine, project_dir, force)
+    else:
+        with mutation_lock:
+            result = _auto_index(engine, project_dir, force)
+
+    # Seed the belief vault from the tree that was just walked. The dashboard
+    # otherwise shows an empty panel telling the user to run compile_beliefs --
+    # a product that knows the next step and asks someone else to take it.
+    #
+    # Started after the lock is released and on its own thread, so indexing
+    # neither waits for it nor holds the mutation lock while it runs. It skips
+    # an unchanged tree, so repeated indexing in one session compiles once.
+    # Fail-open by construction: start_autoseed never raises, and a vault that
+    # cannot be written costs a panel rather than the session.
+    try:
+        from .belief_autoseed import start_autoseed
+
+        start_autoseed(project_dir)
+    except Exception as exc:  # noqa: BLE001 - indexing must not fail on this
+        logger.debug("belief autoseed not started: %s", exc)
+    return result
 
 
 def _auto_index(

--- a/entroly/belief_autoseed.py
+++ b/entroly/belief_autoseed.py
@@ -71,9 +71,13 @@ def _tree_signature(directory: Path, max_files: int) -> str:
     """
     digest = hashlib.sha256()
     seen = 0
+    # Every matching file is hashed, not just the first ``max_files``. Stopping
+    # early made each file sorting after the cap invisible to the fingerprint,
+    # so editing one never invalidated the marker and its beliefs went stale
+    # permanently -- not "until the next change", which is the exposure this
+    # was documented as accepting. The cap belongs on what gets compiled, not
+    # on what gets noticed; stat() is cheap enough to run over the whole tree.
     for path in sorted(directory.rglob("*")):
-        if seen >= max_files:
-            break
         if path.suffix.lower() not in {".py", ".rs", ".ts", ".js"}:
             continue
         if any(part in {".git", "node_modules", "__pycache__", ".venv", "target",
@@ -83,25 +87,58 @@ def _tree_signature(directory: Path, max_files: int) -> str:
             stat = path.stat()
         except OSError:
             continue
+        # Nanosecond mtime: int(st_mtime) could not distinguish two edits in
+        # the same second that left the size unchanged.
         digest.update(str(path).encode("utf-8", "surrogatepass"))
-        digest.update(f"{stat.st_size}:{int(stat.st_mtime)}".encode("ascii"))
+        digest.update(f"{stat.st_size}:{stat.st_mtime_ns}".encode("ascii"))
         seen += 1
     digest.update(str(seen).encode("ascii"))
     return digest.hexdigest()
 
 
-def _read_marker(vault: Path) -> dict[str, Any]:
+def _read_all_markers(vault: Path) -> dict[str, Any]:
     try:
-        return json.loads((vault / _MARKER_NAME).read_text(encoding="utf-8"))
+        data = json.loads((vault / _MARKER_NAME).read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return {}
+    return data if isinstance(data, dict) else {}
 
 
-def _write_marker(vault: Path, payload: dict[str, Any]) -> None:
+def _marker_key(directory: Path) -> str:
+    return str(directory)
+
+
+def _read_marker(vault: Path, directory: Path) -> dict[str, Any]:
+    """The marker for one project.
+
+    Markers are keyed by project root. A single unkeyed signature meant two
+    repositories sharing an ENTROLY_DIR overwrote each other: opening A then B
+    then A recompiled all three times, because the marker only ever described
+    whichever was opened last.
+    """
+    entry = _read_all_markers(vault).get(_marker_key(directory))
+    return entry if isinstance(entry, dict) else {}
+
+
+def _write_marker(vault: Path, directory: Path, payload: dict[str, Any]) -> None:
     try:
         vault.mkdir(parents=True, exist_ok=True)
-        (vault / _MARKER_NAME).write_text(
-            json.dumps(payload, sort_keys=True), encoding="utf-8")
+        markers = _read_all_markers(vault)
+        markers[_marker_key(directory)] = payload
+        target = vault / _MARKER_NAME
+        # Renamed into place: the proxy and MCP server can both be writing
+        # this, and a truncating write would let one read a partial document
+        # and lose every project's marker at once.
+        temporary = target.with_suffix(f".{os.getpid()}.tmp")
+        try:
+            temporary.write_text(
+                json.dumps(markers, sort_keys=True), encoding="utf-8")
+            os.replace(temporary, target)
+        finally:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
     except OSError as exc:
         logger.debug("belief autoseed marker not written: %s", exc)
 
@@ -117,7 +154,7 @@ def compile_now(directory: str | os.PathLike[str],
     vault_base = _vault_base()
     signature = _tree_signature(target, max_files)
 
-    marker = _read_marker(vault_base)
+    marker = _read_marker(vault_base, target)
     if marker.get("signature") == signature:
         return {"status": "skipped", "reason": "tree unchanged since last compile",
                 "signature": signature}
@@ -133,7 +170,7 @@ def compile_now(directory: str | os.PathLike[str],
         logger.warning("belief autoseed failed: %s", exc)
         return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
 
-    _write_marker(vault_base, {
+    _write_marker(vault_base, target, {
         "signature": signature,
         "files_processed": int(getattr(result, "files_processed", 0)),
         "beliefs_written": int(getattr(result, "beliefs_written", 0)),

--- a/entroly/belief_autoseed.py
+++ b/entroly/belief_autoseed.py
@@ -1,0 +1,187 @@
+"""Seed the belief vault without the user being told to.
+
+The dashboard shipped an empty panel reading "No beliefs yet -- run
+compile_beliefs to seed the vault". A product that knows exactly what to do
+next, and asks the user to do it, has chosen to be a tool rather than a
+service. Indexing already walked the tree; compiling beliefs from it needs no
+further decision.
+
+Three constraints shape this:
+
+*It must not delay startup.* Compilation runs on a background thread. The first
+request is answered from the index, which is already built; beliefs enrich
+later work and nothing waits on them.
+
+*It must not redo settled work.* A marker records the tree state that was last
+compiled. Re-running against an unchanged tree is skipped, so opening a
+repository ten times compiles once.
+
+*It must fail open.* A vault that cannot be written is a degraded feature, not
+a broken session. Failures are recorded for the caller to report and never
+raised into the indexing path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("entroly.belief_autoseed")
+
+# Bounded so a large repository cannot turn a first run into a long one. The
+# cap is on files considered, not beliefs written.
+_DEFAULT_MAX_FILES = 400
+_MARKER_NAME = "autoseed.json"
+
+_started: set[str] = set()
+_lock = threading.Lock()
+
+
+def autoseed_enabled() -> bool:
+    """On unless explicitly disabled.
+
+    Default-on is the point: the previous behaviour was default-off in
+    practice, because it required a command most users never ran.
+    """
+    return os.environ.get("ENTROLY_BELIEF_AUTOSEED", "1").strip() not in {
+        "0", "false", "no",
+    }
+
+
+def _vault_base() -> Path:
+    override = os.environ.get("ENTROLY_VAULT")
+    if override:
+        return Path(override)
+    root = os.environ.get("ENTROLY_DIR") or os.path.join(os.getcwd(), ".entroly")
+    return Path(root) / "vault"
+
+
+def _tree_signature(directory: Path, max_files: int) -> str:
+    """A cheap fingerprint of what would be compiled.
+
+    Names, sizes and modification times rather than contents: reading every
+    file to decide whether to read every file would cost what it is trying to
+    avoid. A missed edit costs one stale belief until the next change, which is
+    the same exposure the incremental watcher already accepts.
+    """
+    digest = hashlib.sha256()
+    seen = 0
+    for path in sorted(directory.rglob("*")):
+        if seen >= max_files:
+            break
+        if path.suffix.lower() not in {".py", ".rs", ".ts", ".js"}:
+            continue
+        if any(part in {".git", "node_modules", "__pycache__", ".venv", "target",
+                        ".entroly"} for part in path.parts):
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        digest.update(str(path).encode("utf-8", "surrogatepass"))
+        digest.update(f"{stat.st_size}:{int(stat.st_mtime)}".encode("ascii"))
+        seen += 1
+    digest.update(str(seen).encode("ascii"))
+    return digest.hexdigest()
+
+
+def _read_marker(vault: Path) -> dict[str, Any]:
+    try:
+        return json.loads((vault / _MARKER_NAME).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _write_marker(vault: Path, payload: dict[str, Any]) -> None:
+    try:
+        vault.mkdir(parents=True, exist_ok=True)
+        (vault / _MARKER_NAME).write_text(
+            json.dumps(payload, sort_keys=True), encoding="utf-8")
+    except OSError as exc:
+        logger.debug("belief autoseed marker not written: %s", exc)
+
+
+def compile_now(directory: str | os.PathLike[str],
+                max_files: int = _DEFAULT_MAX_FILES) -> dict[str, Any]:
+    """Compile beliefs for ``directory``, skipping an unchanged tree.
+
+    Returns a summary rather than raising. The caller is usually a startup
+    path, where an exception would trade a missing panel for a failed session.
+    """
+    target = Path(directory).resolve()
+    vault_base = _vault_base()
+    signature = _tree_signature(target, max_files)
+
+    marker = _read_marker(vault_base)
+    if marker.get("signature") == signature:
+        return {"status": "skipped", "reason": "tree unchanged since last compile",
+                "signature": signature}
+
+    try:
+        from .belief_compiler import BeliefCompiler
+        from .vault import VaultConfig, VaultManager
+
+        vault = VaultManager(VaultConfig(base_path=str(vault_base)))
+        vault.ensure_structure()
+        result = BeliefCompiler(vault).compile_directory(str(target), max_files)
+    except Exception as exc:  # noqa: BLE001 - a degraded panel beats a dead session
+        logger.warning("belief autoseed failed: %s", exc)
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+
+    _write_marker(vault_base, {
+        "signature": signature,
+        "files_processed": int(getattr(result, "files_processed", 0)),
+        "beliefs_written": int(getattr(result, "beliefs_written", 0)),
+    })
+    return {
+        "status": "compiled",
+        "files_processed": int(getattr(result, "files_processed", 0)),
+        "entities_extracted": int(getattr(result, "entities_extracted", 0)),
+        "beliefs_written": int(getattr(result, "beliefs_written", 0)),
+        "errors": len(getattr(result, "errors", []) or []),
+        "signature": signature,
+    }
+
+
+def start_autoseed(directory: str | os.PathLike[str] | None = None,
+                   max_files: int = _DEFAULT_MAX_FILES) -> bool:
+    """Begin compiling beliefs in the background. Returns whether it started.
+
+    Idempotent per directory and process, so repeated indexing during one
+    session does not stack compilations.
+    """
+    if not autoseed_enabled():
+        return False
+    target = str(Path(directory or os.getcwd()).resolve())
+    with _lock:
+        if target in _started:
+            return False
+        _started.add(target)
+
+    def run() -> None:
+        summary = compile_now(target, max_files)
+        if summary.get("status") == "compiled":
+            logger.info(
+                "Seeded %s belief(s) from %s file(s)",
+                summary.get("beliefs_written", 0), summary.get("files_processed", 0))
+
+    threading.Thread(target=run, name="entroly-belief-autoseed", daemon=True).start()
+    return True
+
+
+def reset_for_tests() -> None:
+    with _lock:
+        _started.clear()
+
+
+__all__ = [
+    "autoseed_enabled",
+    "compile_now",
+    "reset_for_tests",
+    "start_autoseed",
+]

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -3428,6 +3428,26 @@ def cmd_value(args):
         f"and not added to the provider total above){C.RESET}\n"
     )
 
+    # Shown unconditionally rather than behind a flag: it is derived from
+    # tokens already counted, so a figure that only appears when asked for is
+    # a figure nobody sees.
+    energy = receipt.get("energy") or {}
+    if energy:
+        print(f"  {C.BOLD}Electricity not spent{C.RESET}")
+        print(
+            f"    Prefill avoided: {C.GREEN}{energy['kwh_avoided']:.4f} kWh{C.RESET} "
+            f"{C.GRAY}({energy['accelerator_seconds_avoided']:,.0f} accelerator-seconds, "
+            f"{energy['petaflops_avoided']:,.1f} PFLOPs){C.RESET}"
+        )
+        a = energy["assumptions"]
+        print(
+            f"    {C.GRAY}Modeled, not measured: {a['model_params_billions']:.0f}B "
+            f"parameters, {a['accelerator_peak_tflops']:.0f} TFLOPS at "
+            f"{a['model_flops_utilization']:.0%} utilisation, "
+            f"{a['accelerator_tdp_watts']:.0f}W. Prefill only -- decode is "
+            f"memory-bound and unchanged by a shorter prompt.{C.RESET}\n"
+        )
+
     print(f"  {C.BOLD}Trust and routing signals{C.RESET}")
     print(
         "    Unsupported claims blocked: "

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -3416,9 +3416,16 @@ def cmd_value(args):
         f"    Operations: {local['operations']:,}  |  "
         f"Tokens reduced: {local['tokens_reduced']:,}"
     )
+    # Previously printed a hardcoded $0.0000. The token count beside it was
+    # measured, so showing nothing for its value understated real work: input
+    # avoided is input not bought, and tokens have a public rate. Show the
+    # replacement-cost figure and name the basis, so it can be neither ignored
+    # nor mistaken for an invoice.
     print(
-        f"    Dollar savings claimed: {C.GREEN}$0.0000{C.RESET} "
-        f"{C.GRAY}(delivery to a paid provider is not observable){C.RESET}\n"
+        f"    Value at list rate: "
+        f"{C.GREEN}${local.get('modeled_value_at_list_usd', 0.0):.4f}{C.RESET} "
+        f"{C.GRAY}(replacement cost of the input avoided; not invoice-verified, "
+        f"and not added to the provider total above){C.RESET}\n"
     )
 
     print(f"  {C.BOLD}Trust and routing signals{C.RESET}")

--- a/entroly/dashboard.py
+++ b/entroly/dashboard.py
@@ -66,7 +66,18 @@ def record_request(entry: dict):
 
 
 def _safe_json(obj: Any) -> Any:
-    """Recursively convert to JSON-safe types."""
+    """Recursively convert to JSON-safe types.
+
+    Six decimal places suit money and ratios, which is all this carried when
+    it was written. It does not suit physical quantities: a few hundred tokens
+    avoid roughly 1e-8 kWh, and rounding that to six places serialises a real
+    measurement as ``0.0``. A new user's first requests would report exactly
+    the nothing this dashboard exists to disprove.
+
+    So the decimal rounding stays -- it keeps every existing dollar figure
+    byte-identical -- and only the case where it would erase a non-zero value
+    falls back to significant figures.
+    """
     if isinstance(obj, dict):
         return {str(k): _safe_json(v) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):
@@ -74,7 +85,12 @@ def _safe_json(obj: Any) -> Any:
     if isinstance(obj, float):
         if obj != obj:  # NaN
             return 0.0
-        return round(obj, 6)
+        rounded = round(obj, 6)
+        if rounded == 0.0 and obj != 0.0 and math.isfinite(obj):
+            from .energy_value import _sig
+
+            return _sig(obj, 6)
+        return rounded
     return obj
 
 def _control_learning_snapshot(daemon: Any) -> dict:
@@ -2050,3 +2066,61 @@ def start_dashboard(
     thread.start()
     logger.info(f"Dashboard live at http://localhost:{port}")
     return server
+
+
+def dashboard_autostart_enabled() -> bool:
+    """On unless explicitly disabled."""
+    import os
+
+    return os.environ.get("ENTROLY_DASHBOARD_AUTOSTART", "1").strip() not in {
+        "0", "false", "no",
+    }
+
+
+def _port_already_serving(port: int, host: str = "127.0.0.1") -> bool:
+    """Whether something is already listening on ``port``.
+
+    Binding cannot answer this. ``_ReuseAddrHTTPServer`` sets
+    ``allow_reuse_address``, and on Windows ``SO_REUSEADDR`` lets a second
+    socket bind a port that is already bound -- the bind succeeds and which
+    socket receives a given connection is undefined. A dashboard started that
+    way would silently split requests with the proxy's, so presence is probed
+    by connecting rather than inferred from a bind that cannot fail.
+    """
+    import socket
+
+    try:
+        with socket.create_connection((host, port), timeout=0.25):
+            return True
+    except OSError:
+        return False
+
+
+def maybe_start_dashboard(engine: Any = None, port: int = 9378) -> Any | None:
+    """Start the dashboard if nothing is serving yet. Returns the server or None.
+
+    The MCP server is the most common install, and it was the one entry point
+    that never started a dashboard: it indexed, compressed, seeded beliefs and
+    blocked hallucinations, and the user saw none of it unless they separately
+    ran ``entroly dashboard``. Value that is measured but never displayed is
+    indistinguishable, to the person who installed it, from value that was
+    never produced.
+
+    Every failure here is swallowed. A dashboard is how the work is *seen*; it
+    is never worth failing the work itself, and on the MCP path an exception
+    escaping into the stdio handshake would take the whole session down.
+    """
+    if not dashboard_autostart_enabled():
+        return None
+    try:
+        if _port_already_serving(port):
+            logger.info(
+                "Dashboard already serving on %s; not starting a second one", port)
+            return None
+        return start_dashboard(engine=engine, port=port, daemon=True)
+    except OSError as exc:
+        # Lost a race for the port, or it is otherwise unavailable.
+        logger.info("Dashboard not started on %s: %s", port, exc)
+    except Exception as exc:  # noqa: BLE001 - a missing panel must not end a session
+        logger.warning("Dashboard autostart failed (non-fatal): %s", exc)
+    return None

--- a/entroly/dashboard.py
+++ b/entroly/dashboard.py
@@ -958,15 +958,48 @@ function renderHero(d){
   const sparkBars=heroSparkData.map(v=>'<div class="hbar" style="height:'+Math.max(3,v/mx*44)+'px;"></div>').join('');
   const sparkHTML=heroSparkData.length>0?'<div class="hero-spark">'+sparkBars+'</div>':'';
 
-  // Prefer realized provider value. When only local reductions exist, show
-  // their user-priced future value without adding it to provider savings.
-  const bigNum=hasRealizedValue?'$'+realCost.toFixed(2):(hasBankedValue?'$'+bankedUsd(localTokens).toFixed(2):fmt(frags));
-  const bigLabel=hasRealizedValue?'MODELED API COST AVOIDED':(hasBankedValue?'BANKED FUTURE VALUE':'FRAGMENTS READY');
-  const subtitle=hasRealizedValue
-    ?`<b>${fmt(realTokens)}</b> input tokens reduced across <b>${realReqs}</b> provider-bound request${realReqs!==1?'s':''}`
-    :(hasBankedValue
-      ?`<b>${fmt(localTokens)}</b> local tokens banked at <b>$${bankedUsdPerMillion.toFixed(2)}/M</b> · modeled future value, not realized savings`
-      :`Indexed and ready · <span style="opacity:.7">point your AI tool to <code>http://localhost:9377/v1</code> to start saving on real requests</span>`);
+  // One bottom line, with the lines that produced it shown directly beneath.
+  // Previously the hero displayed provider savings OR local savings, never
+  // the sum, so a user running both saw the smaller of two true numbers and
+  // no total at all. A total is only honest if its composition is visible, so
+  // every component is itemised below with how it was derived: provider cost
+  // is priced from published per-model rates, local reductions at the user's
+  // own rate, routing from the price gap between the model asked for and the
+  // model used. None of them is an invoice, and the label says so.
+  const routingUsd=lt.routing_saved_usd||0;
+  const bankedLocalUsd=bankedUsd(localTokens);
+  const totalUsd=realCost+bankedLocalUsd+routingUsd;
+  const hasAnyValue=totalUsd>0||hasRealizedValue||hasBankedValue;
+
+  // Realized and modeled lanes are itemised separately and keep their own
+  // wording. Summing them is only defensible while the reader can still see
+  // which part came from a provider-bound request and which is priced at a
+  // rate the user chose, so the distinction survives inside the total rather
+  // than being flattened by it.
+  const lanes=[];
+  if(realCost>0||realTokens>0)lanes.push('<b>$'+realCost.toFixed(2)+'</b> provider requests · '+fmt(realTokens)+' tokens over '+realReqs+' request'+(realReqs!==1?'s':''));
+  if(routingUsd>0)lanes.push('<b>$'+routingUsd.toFixed(2)+'</b> model routing');
+  if(bankedLocalUsd>0)lanes.push('<b>$'+bankedLocalUsd.toFixed(2)+'</b> banked future value · '+fmt(localTokens)+' local tokens at $'+bankedUsdPerMillion.toFixed(2)+'/M, <i>modeled future value, not realized savings</i>');
+
+  // Electricity is the same reduction expressed in the other unit that
+  // matters. Derived from tokens already counted, so it cannot disagree with
+  // the dollar figure above it.
+  const en=lt.energy||{};
+  const kwh=en.kwh_avoided||0;
+  const energyLine=kwh>0
+    ?'<div style="margin-top:8px;font-size:12px;color:var(--dim)">⚡ <b>'+
+      (kwh>=0.01?kwh.toFixed(2)+' kWh':(kwh*1000).toFixed(2)+' Wh')+
+      '</b> of prefill electricity not drawn <span style="opacity:.65">· modeled from '+
+      (en.assumptions&&en.assumptions.model_params_billions||70)+'B params, stated assumptions</span></div>'
+    :'';
+
+  const bigNum=hasAnyValue?'$'+totalUsd.toFixed(2):fmt(frags);
+  const bigLabel=hasAnyValue?'TOTAL VALUE BANKED':'FRAGMENTS READY';
+  const subtitle=hasAnyValue
+    ?lanes.join(' &nbsp;·&nbsp; ')+
+      '<div style="margin-top:6px;font-size:11px;opacity:.6">modeled from published rates and measured token counts — not an invoice</div>'+
+      energyLine
+    :`Indexed and ready · <span style="opacity:.7">point your AI tool to <code>http://localhost:9377/v1</code> to start saving on real requests</span>`;
 
   document.getElementById('hero').innerHTML=`
     <div class="hero-impact">

--- a/entroly/dashboard.py
+++ b/entroly/dashboard.py
@@ -1003,7 +1003,12 @@ function renderHero(d){
   const routingUsd=lt.routing_saved_usd||0;
   const bankedLocalUsd=bankedUsd(localTokens);
   const totalUsd=realCost+bankedLocalUsd+routingUsd;
-  const hasAnyValue=totalUsd>0||hasRealizedValue||hasBankedValue;
+  // Only a total worth showing counts as value. Including hasRealizedValue
+  // here meant a user on an unpriced provider model -- tokens reduced,
+  // cost deliberately left at 0 -- skipped the empty state and got the
+  // headline "$0.00 / TOTAL VALUE BANKED": the exact nothing this block was
+  // rewritten to disprove. Tokens with no price still show, as fragments.
+  const hasAnyValue=totalUsd>0;
 
   // Realized and modeled lanes are itemised separately and keep their own
   // wording. Summing them is only defensible while the reader can still see

--- a/entroly/dashboard.py
+++ b/entroly/dashboard.py
@@ -141,6 +141,16 @@ def _record_section_error(snap: dict, section: str, exc: BaseException) -> None:
     })
 
 
+def _autoseed_state() -> bool:
+    """Whether belief seeding would run. Never raises; a hint is not a feature."""
+    try:
+        from .belief_autoseed import autoseed_enabled
+
+        return autoseed_enabled()
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _cogops_unavailable_snapshot(reason: str) -> dict:
     """Dashboard-safe CogOps payload when the optional native module is absent."""
     return _safe_json({
@@ -152,6 +162,9 @@ def _cogops_unavailable_snapshot(reason: str) -> dict:
         "freshness_pct": 100.0,
         "entity_count": 0,
         "engine": "unavailable",
+        # Reported even here so the empty panel does not blame seeding for a
+        # missing native module. The two have different fixes.
+        "autoseed": _autoseed_state(),
         "status": "native_module_missing",
         "hint": (
             "CogOps is degraded: the native engine 'entroly_core' isn't "
@@ -476,6 +489,10 @@ def _get_full_snapshot() -> dict:
         if total_beliefs > 0:
             avg_confidence /= total_beliefs
 
+        # Whether seeding is running decides what an empty panel means: work
+        # in flight, or a switch the user turned off. Without it the panel has
+        # to guess, and it used to guess wrong -- telling the user to run a
+        # command the product now runs itself.
         snap["cogops"] = _safe_json({
             "total_beliefs": total_beliefs,
             "verified": verified,
@@ -485,6 +502,7 @@ def _get_full_snapshot() -> dict:
             "freshness_pct": round((1 - stale / max(total_beliefs, 1)) * 100, 1),
             "entity_count": len(set(entities)),
             "engine": "rust",
+            "autoseed": _autoseed_state(),
         })
     except ModuleNotFoundError as e:
         if getattr(e, "name", "") == "entroly_core":
@@ -1508,7 +1526,13 @@ function renderCogops(d){
   const tb=c.total_beliefs||0,ver=c.verified||0,st=c.stale||0,db=c.doc_beliefs||0;
   const conf=c.avg_confidence||0,fresh=c.freshness_pct||0,ents=c.entity_count||0;
   if(b){b.textContent=(c.engine||'cogops')+' · '+tb+' beliefs';b.className='badge '+(tb>0?'b-violet':'b-blue');}
-  if(tb===0){el.innerHTML='<div class="empty">No beliefs yet — run <code>compile_beliefs</code> to seed the vault</div>';return;}
+  // Was "run compile_beliefs to seed the vault". Indexing now seeds them, so
+  // that instruction asked the user to do work already in flight. An empty
+  // panel here means one of two things and they need different words.
+  if(tb===0){el.innerHTML=c.autoseed
+    ?'<div class="empty">No beliefs yet — seeding runs automatically after indexing and fills in shortly</div>'
+    :'<div class="empty">Belief seeding is off (<code>ENTROLY_BELIEF_AUTOSEED=0</code>) — unset it, or run <code>entroly compile .</code> once</div>';
+    return;}
   el.innerHTML=`<div class="cache-kpis">
     <div class="cache-kpi"><div class="cache-kpi-label">Total Beliefs</div><div class="cache-kpi-val hv-blue">${fmt(tb)}</div><div class="cache-kpi-sub">${ents} distinct entities · ${db} doc-linked</div></div>
     <div class="cache-kpi"><div class="cache-kpi-label">Avg Confidence</div><div class="cache-kpi-val hv-green">${(conf*100).toFixed(1)}%</div><div class="cache-kpi-sub">${ver} verified · ${tb-ver-st} inferred</div></div>

--- a/entroly/energy_value.py
+++ b/entroly/energy_value.py
@@ -1,0 +1,171 @@
+"""Electricity not spent, derived from tokens not sent.
+
+Reducing input tokens removes prefill work. Prefill is the forward pass over
+the prompt, and its cost is approximately ``2 * P * T`` floating-point
+operations for ``P`` parameters and ``T`` tokens -- one multiply and one add
+per parameter per token. Tokens never sent are operations never executed, and
+operations never executed are joules never drawn.
+
+Scope is deliberately narrow. This models prefill only, because prefill is what
+input-token reduction avoids. Decode -- generating the response -- is
+memory-bandwidth bound rather than compute bound and is unaffected by shortening
+the prompt, so it is excluded rather than estimated.
+
+The result is modeled, not measured: Entroly runs locally and cannot observe a
+provider's accelerators. Every input is therefore stated and overridable, and
+the arithmetic is simple enough to check by hand. A reader who disagrees with an
+assumption can substitute their own and recompute, which is the only honest way
+to publish a number nobody can independently instrument.
+
+Reported in kilowatt-hours. Carbon is intentionally not derived: converting kWh
+to emissions requires a grid-intensity factor that varies by region, hour and
+methodology, and inventing one would attach a contestable number to an
+otherwise checkable one.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass, replace
+from typing import Any
+
+# Defaults describe one widely deployed accelerator running a mid-size model.
+# Frontier models are larger, so the defaults understate rather than flatter.
+_DEFAULT_PARAMS_B = 70.0          # billions of parameters
+_DEFAULT_PEAK_TFLOPS = 989.0      # BF16 dense, no sparsity
+_DEFAULT_MFU = 0.40               # achieved fraction of peak during prefill
+_DEFAULT_TDP_WATTS = 700.0
+
+_FLOPS_PER_PARAM_PER_TOKEN = 2    # one multiply, one add
+_JOULES_PER_KWH = 3_600_000.0
+
+
+def _sig(value: float, digits: int = 12) -> float:
+    """Round to significant figures, so small magnitudes survive.
+
+    These quantities span many orders of magnitude -- a single request avoids
+    microwatt-hours, a fleet-year avoids megawatt-hours -- and a fixed decimal
+    count cannot serve both ends of that range.
+    """
+    if value == 0 or not math.isfinite(value):
+        return 0.0
+    exponent = math.floor(math.log10(abs(value)))
+    return round(value, -(exponent - digits + 1))
+
+
+def _env_float(name: str, fallback: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return fallback
+    try:
+        value = float(raw)
+    except ValueError:
+        return fallback
+    return value if value > 0 else fallback
+
+
+@dataclass(frozen=True)
+class EnergyAssumptions:
+    """The inputs a reader needs in order to disagree with the result."""
+
+    model_params_billions: float = _DEFAULT_PARAMS_B
+    accelerator_peak_tflops: float = _DEFAULT_PEAK_TFLOPS
+    model_flops_utilization: float = _DEFAULT_MFU
+    accelerator_tdp_watts: float = _DEFAULT_TDP_WATTS
+
+    @classmethod
+    def from_env(cls) -> "EnergyAssumptions":
+        """Assumptions with environment overrides applied.
+
+        Overridable because the defaults cannot be right for everyone: a team
+        running a 7B model on their own hardware and a team calling a frontier
+        API differ by more than an order of magnitude, and a single baked-in
+        number would be wrong for both.
+        """
+        return cls(
+            model_params_billions=_env_float(
+                "ENTROLY_ENERGY_MODEL_PARAMS_B", _DEFAULT_PARAMS_B),
+            accelerator_peak_tflops=_env_float(
+                "ENTROLY_ENERGY_PEAK_TFLOPS", _DEFAULT_PEAK_TFLOPS),
+            model_flops_utilization=min(
+                1.0, _env_float("ENTROLY_ENERGY_MFU", _DEFAULT_MFU)),
+            accelerator_tdp_watts=_env_float(
+                "ENTROLY_ENERGY_TDP_WATTS", _DEFAULT_TDP_WATTS),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "model_params_billions": self.model_params_billions,
+            "accelerator_peak_tflops": self.accelerator_peak_tflops,
+            "model_flops_utilization": self.model_flops_utilization,
+            "accelerator_tdp_watts": self.accelerator_tdp_watts,
+        }
+
+
+def energy_for_tokens(
+    tokens_saved: int, assumptions: EnergyAssumptions | None = None
+) -> dict[str, Any]:
+    """Prefill energy avoided by not sending ``tokens_saved`` input tokens.
+
+    Returns the intermediate quantities as well as the answer. A single kWh
+    figure invites belief; showing the FLOPs and accelerator-seconds it came
+    from invites checking, and this number exists to be checked.
+    """
+    cfg = assumptions or EnergyAssumptions.from_env()
+    tokens = max(0, int(tokens_saved))
+
+    params = cfg.model_params_billions * 1e9
+    flops = _FLOPS_PER_PARAM_PER_TOKEN * params * tokens
+    effective_flops_per_second = (
+        cfg.accelerator_peak_tflops * 1e12 * cfg.model_flops_utilization
+    )
+    seconds = flops / effective_flops_per_second if effective_flops_per_second else 0.0
+    kwh = seconds * cfg.accelerator_tdp_watts / _JOULES_PER_KWH
+
+    # Rounded to significant figures rather than decimal places. A fixed
+    # decimal count silently zeroes small results -- a thousand tokens is
+    # ~7e-5 kWh, which six decimals distorts and eight would still degrade --
+    # and callers summing many periods would accumulate that error. Display
+    # code rounds for the reader; the payload keeps the value.
+    return {
+        "tokens_saved": tokens,
+        "petaflops_avoided": _sig(flops / 1e15),
+        "accelerator_seconds_avoided": _sig(seconds),
+        "kwh_avoided": _sig(kwh),
+        "basis": "prefill_only",
+        "measured": False,
+        "assumptions": cfg.as_dict(),
+        "method": (
+            "prefill FLOPs = 2 * parameters * tokens; accelerator-seconds = "
+            "FLOPs / (peak_tflops * MFU); kWh = seconds * TDP / 3.6e6. Prefill "
+            "only: decode is memory-bound and unaffected by a shorter prompt. "
+            "Modeled from stated assumptions, not measured on the provider's "
+            "hardware."
+        ),
+    }
+
+
+def scale_energy(per_period: dict[str, Any], factor: float) -> dict[str, Any]:
+    """Project a measured period forward without re-deriving it.
+
+    Kept separate from :func:`energy_for_tokens` so a projection can never be
+    mistaken for an observation: the multiplier used is returned alongside the
+    result.
+    """
+    multiplier = max(0.0, float(factor))
+    scaled = dict(per_period)
+    for key in ("tokens_saved", "petaflops_avoided",
+                "accelerator_seconds_avoided", "kwh_avoided"):
+        if key in scaled and isinstance(scaled[key], (int, float)):
+            scaled[key] = _sig(scaled[key] * multiplier)
+    scaled["projected"] = True
+    scaled["projection_multiplier"] = multiplier
+    return scaled
+
+
+__all__ = [
+    "EnergyAssumptions",
+    "energy_for_tokens",
+    "scale_energy",
+]

--- a/entroly/energy_value.py
+++ b/entroly/energy_value.py
@@ -146,26 +146,7 @@ def energy_for_tokens(
     }
 
 
-def scale_energy(per_period: dict[str, Any], factor: float) -> dict[str, Any]:
-    """Project a measured period forward without re-deriving it.
-
-    Kept separate from :func:`energy_for_tokens` so a projection can never be
-    mistaken for an observation: the multiplier used is returned alongside the
-    result.
-    """
-    multiplier = max(0.0, float(factor))
-    scaled = dict(per_period)
-    for key in ("tokens_saved", "petaflops_avoided",
-                "accelerator_seconds_avoided", "kwh_avoided"):
-        if key in scaled and isinstance(scaled[key], (int, float)):
-            scaled[key] = _sig(scaled[key] * multiplier)
-    scaled["projected"] = True
-    scaled["projection_multiplier"] = multiplier
-    return scaled
-
-
 __all__ = [
     "EnergyAssumptions",
     "energy_for_tokens",
-    "scale_energy",
 ]

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1832,6 +1832,71 @@ class PromptCompilerProxy:
             output_tokens = 1024
         return prefix_tokens, new_input, output_tokens
 
+    def _record_routing_value(
+        self,
+        *,
+        original_model: str,
+        chosen_model: str,
+        body: dict[str, Any],
+        captured: bool,
+    ) -> None:
+        """Price a routing decision and record it. Never raises.
+
+        ``captured`` separates money actually saved by a swap that happened
+        from money a cheaper model was available for but did not take. They are
+        stored in different fields and must never be summed: one is a
+        consequence of a request that was served differently, the other is a
+        forecast about requests that were not.
+
+        Token counts come from the outbound body rather than the response,
+        because this runs before the request is forwarded. That undercounts
+        output tokens, so the estimate is conservative in the direction that
+        matters -- it will not overstate.
+        """
+        try:
+            from .value_tracker import get_tracker, routing_delta_usd
+
+            tokens_in = self._estimate_body_tokens(body)
+            amount = routing_delta_usd(original_model, chosen_model, tokens_in)
+            if amount <= 0.0:
+                return
+            tracker = get_tracker()
+            if captured:
+                tracker.record_routing_saving(
+                    amount, source="proxy", chosen_model=chosen_model,
+                    detail=f"{original_model} -> {chosen_model}",
+                )
+            else:
+                tracker.record_routing_opportunity(
+                    amount, chosen_model=chosen_model, source="proxy")
+        except Exception as e:  # noqa: BLE001 - accounting must not fail a request
+            logger.debug("routing value not recorded: %s", e)
+
+    @staticmethod
+    def _estimate_body_tokens(body: dict[str, Any]) -> int:
+        """Rough input-token count for the outbound request body.
+
+        Characters over four is the standard approximation and is used only to
+        price a difference between two rates, where a proportional error
+        affects both sides and largely cancels.
+        """
+        try:
+            total = 0
+            for message in body.get("messages") or []:
+                content = message.get("content")
+                if isinstance(content, str):
+                    total += len(content)
+                elif isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict):
+                            total += len(str(part.get("text", "")))
+            system = body.get("system")
+            if isinstance(system, str):
+                total += len(system)
+            return total // 4
+        except Exception:  # noqa: BLE001
+            return 0
+
     def _cache_economics_allow_ravs(
         self,
         *,
@@ -2892,6 +2957,23 @@ class PromptCompilerProxy:
                             pass  # No simhash = no feedback, safe to skip
 
                 if _current_model:
+                    if not self._ravs_router_enabled:
+                        # Routing is off, so nothing will be swapped. Evaluate
+                        # anyway: the decision is a table lookup and a
+                        # classifier over cached state, and without it the user
+                        # is asked to authorise model substitution with no
+                        # evidence of what it is worth -- "nothing to gain"
+                        # looks exactly like "never measured". Recorded as
+                        # available, never as saved.
+                        _shadow = self._ravs_router.shadow_route(
+                            _current_model, user_message)
+                        if not _shadow.use_original and _shadow.recommended_model:
+                            self._record_routing_value(
+                                original_model=_current_model,
+                                chosen_model=_shadow.recommended_model,
+                                body=body,
+                                captured=False,
+                            )
                     decision = self._ravs_router.route(_current_model, user_message)
                     if not decision.use_original and decision.recommended_model:
                         # ── ECE Pre-Screen (V5): Tier 0 ambiguity filter only ──
@@ -2977,6 +3059,17 @@ class PromptCompilerProxy:
                                 decision.recommended_model,
                                 decision.reason,
                                 cache_reason,
+                            )
+                            # The swap was already happening; nothing recorded
+                            # it. The dashboard has read routing_saved_usd
+                            # since it was written and no production path ever
+                            # incremented it, so "Model-Routing Saved" showed
+                            # $0 however much traffic RAVS actually moved.
+                            self._record_routing_value(
+                                original_model=_current_model,
+                                chosen_model=decision.recommended_model,
+                                body=body,
+                                captured=True,
                             )
 
                 # Store for next-request feedback attribution

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -2949,7 +2949,7 @@ class PromptCompilerProxy:
                 # Bayesian evidence without needing shell exit codes.
                 prev_routed = getattr(self, "_ravs_prev_routed", None)
                 if prev_routed and hasattr(self, "_ravs_prev_client"):
-                    prev_client, prev_arch, prev_model = prev_routed
+                    prev_client, prev_arch, prev_model, _ravs_prev_conf = prev_routed
                     if prev_client == client_key:
                         try:
                             from entroly_core import py_simhash
@@ -2982,6 +2982,21 @@ class PromptCompilerProxy:
                                             prev_arch, verdict, similarity,
                                         )
                                     except Exception:
+                                        pass
+                                    # Same outcome, second consumer: this is
+                                    # the only observed signal about a routed
+                                    # request, so it is also the calibration
+                                    # label. Without it the conformal
+                                    # controller has no producer and its
+                                    # certificate can never be earned.
+                                    try:
+                                        from .ravs.conformal import get_controller
+
+                                        get_controller().record(
+                                            confidence=_ravs_prev_conf,
+                                            diverged=(verdict == "fail"),
+                                        )
+                                    except Exception:  # noqa: BLE001
                                         pass
                         except (ImportError, Exception):
                             pass  # No simhash = no feedback, safe to skip
@@ -3104,7 +3119,10 @@ class PromptCompilerProxy:
 
                 # Store for next-request feedback attribution
                 if _ravs_swapped:
-                    self._ravs_prev_routed = (client_key, _ravs_archetype, _current_model)
+                    self._ravs_prev_routed = (
+                        client_key, _ravs_archetype, _current_model,
+                        float(getattr(decision, "confidence", 0.0) or 0.0),
+                    )
                 else:
                     self._ravs_prev_routed = None
             except Exception as e:

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -3019,7 +3019,15 @@ class PromptCompilerProxy:
                                 body=body,
                                 captured=False,
                             )
-                    decision = self._ravs_router.route(_current_model, user_message)
+                        # route() would only return the disabled sentinel here,
+                        # and it increments _total_decisions before checking,
+                        # so calling it as well counted two decisions for one
+                        # request and halved the reported swap_rate.
+                        from .ravs.router import RoutingDecision as _RD
+                        decision = _RD(reason="bayesian_router_disabled")
+                    else:
+                        decision = self._ravs_router.route(
+                            _current_model, user_message)
                     if not decision.use_original and decision.recommended_model:
                         # ── ECE Pre-Screen (V5): Tier 0 ambiguity filter only ──
                         # Tier 0 is the ONLY pre-routing check that works without

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -3028,7 +3028,32 @@ class PromptCompilerProxy:
                         # POST-response alongside WITNESS — see P0 in
                         # _run_post_response_verification().
                         _ece_blocked = False
-                        if self._ece and self._ece._is_open_ended(user_message):
+
+                        # Enforce the certified threshold. When routing was
+                        # authorised by a conformal certificate rather than by
+                        # the explicit switch, the bound was proven only for
+                        # decisions whose confidence clears lambda_hat --
+                        # routing below it is outside the region where
+                        # E[L] <= alpha holds. This was previously unenforced:
+                        # the certificate was read as a boolean and the swap
+                        # then proceeded at the router's own ci_threshold, so
+                        # a user who accepted a 2% divergence rate was served
+                        # an unbounded one.
+                        _cert = self._ravs_certificate
+                        if _cert is not None and _cert.permits_routing:
+                            _conf = float(getattr(decision, "confidence", 0.0) or 0.0)
+                            if _conf < _cert.lambda_hat:
+                                _ece_blocked = True
+                                logger.info(
+                                    "RAVS: kept %s; confidence %.3f is below the "
+                                    "certified threshold %.3f (alpha=%.3f)",
+                                    _current_model, _conf, _cert.lambda_hat,
+                                    _cert.alpha,
+                                )
+
+                        if _ece_blocked:
+                            pass
+                        elif self._ece and self._ece._is_open_ended(user_message):
                             # Open-ended queries: allow swap (aleatoric, not epistemic)
                             pass  # Allow the swap — open-ended = cheap model is fine
                         elif self._ece:

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1253,9 +1253,39 @@ class PromptCompilerProxy:
         # when explicitly enabled and hook-captured event data proves it is safe.
         # Silent model substitution must be opt-in because it can change provider,
         # capability, cost, and data-handling semantics.
-        self._ravs_router_enabled = (
-            os.environ.get("ENTROLY_RAVS_ROUTER", "0") == "1"
-        )
+        # Two ways to be on. The explicit switch is unchanged. The second is a
+        # conformal certificate earned from this user's own traffic: shadow
+        # decisions scored by the deterministic verifiers give calibration
+        # observations, and conformal risk control turns them into a threshold
+        # with a finite-sample bound on the divergence rate.
+        #
+        # This is not "on by default with a nicer name". A fresh install has no
+        # observations and cannot be certified -- the minimum sample size falls
+        # out of the bound itself -- so it routes nothing until the evidence
+        # exists. What changes is that the user answers "do you accept this
+        # divergence rate?" once, instead of authorising an unmeasured risk per
+        # request and having no way to learn what it was worth.
+        self._ravs_certificate = None
+        explicit = os.environ.get("ENTROLY_RAVS_ROUTER", "0") == "1"
+        certified = False
+        if not explicit and os.environ.get("ENTROLY_RAVS_AUTO", "1") != "0":
+            try:
+                from .ravs.conformal import get_controller
+
+                self._ravs_certificate = get_controller().certificate()
+                certified = self._ravs_certificate.permits_routing
+                if certified:
+                    logger.info(
+                        "RAVS: routing certified at alpha=%.3f from %d observations "
+                        "(threshold %.3f, empirical risk %.4f)",
+                        self._ravs_certificate.alpha,
+                        self._ravs_certificate.n,
+                        self._ravs_certificate.lambda_hat,
+                        self._ravs_certificate.empirical_risk,
+                    )
+            except Exception as e:  # noqa: BLE001 - no certificate means no routing
+                logger.debug("RAVS certification unavailable: %s", e)
+        self._ravs_router_enabled = explicit or certified
         try:
             from .ravs.router import BayesianRouter
             self._ravs_router = BayesianRouter(

--- a/entroly/ravs/conformal.py
+++ b/entroly/ravs/conformal.py
@@ -224,16 +224,32 @@ class ConformalRoutingController:
     def alpha(self) -> float:
         return self._alpha
 
-    def _load(self) -> list[tuple[float, bool]]:
+    def _load(self) -> tuple[list[tuple[float, bool]], bool]:
+        """Return ``(observations, intact)``.
+
+        A file that is absent and a file that is unreadable are different
+        situations and used to be conflated into an empty list. Because
+        :meth:`record` writes back what it loads, one torn read turned a full
+        calibration history into a single row -- reported afterwards as
+        "insufficient calibration", which is indistinguishable from a fresh
+        install. ``intact`` lets callers refuse to overwrite evidence they
+        could not read.
+        """
+        if not self._path.exists():
+            return [], True
         try:
             raw = json.loads(self._path.read_text(encoding="utf-8"))
             return [
                 (float(row["confidence"]), bool(row["diverged"]))
                 for row in raw.get("observations", [])
                 if "confidence" in row and "diverged" in row
-            ]
-        except (OSError, ValueError, TypeError, KeyError):
-            return []
+            ], True
+        except (OSError, ValueError, TypeError, KeyError) as exc:
+            logger.warning(
+                "calibration store at %s is unreadable (%s); refusing to "
+                "overwrite it and declining to route until it is repaired or "
+                "removed", self._path, exc)
+            return [], False
 
     def record(self, confidence: float, diverged: bool) -> None:
         """Add one calibration observation. Never raises.
@@ -246,25 +262,63 @@ class ConformalRoutingController:
             if not math.isfinite(value):
                 return
             with self._lock:
-                observations = self._load()
+                observations, intact = self._load()
+                if not intact:
+                    # Appending to what could not be read would persist a
+                    # one-row file over an unknown amount of real evidence.
+                    return
                 observations.append((value, bool(diverged)))
                 # Bounded, keeping the most recent: exchangeability is more
                 # plausible over a recent window than over all history.
                 observations = observations[-_MAX_OBSERVATIONS:]
-                self._path.parent.mkdir(parents=True, exist_ok=True)
-                self._path.write_text(json.dumps({
-                    "observations": [
-                        {"confidence": c, "diverged": d} for c, d in observations
-                    ],
-                }), encoding="utf-8")
+                self._write(observations)
         except Exception as e:  # noqa: BLE001 - calibration must not fail a request
             logger.debug("calibration observation not recorded: %s", e)
+
+    def _write(self, observations: list[tuple[float, bool]]) -> None:
+        """Replace the store atomically.
+
+        ``write_text`` truncates before writing, so a reader arriving mid-write
+        -- or a process killed there -- sees a partial document. That matters
+        more than usual here: this runs on daemon threads, which are killed
+        without joining at interpreter exit, and the proxy, MCP server and
+        dashboard are separate processes sharing one ENTROLY_DIR.
+
+        Writing to a temporary file and renaming makes the swap atomic on both
+        POSIX and Windows, so a concurrent reader sees either the old file or
+        the new one. It does not make read-modify-write atomic across
+        processes -- two writers can still interleave and lose an observation
+        -- but a lost observation only shrinks the sample, whereas a torn file
+        used to destroy the whole history.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps({
+            "observations": [
+                {"confidence": c, "diverged": d} for c, d in observations
+            ],
+        })
+        temporary = self._path.with_suffix(f".{os.getpid()}.tmp")
+        try:
+            temporary.write_text(payload, encoding="utf-8")
+            os.replace(temporary, self._path)
+        finally:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
 
     def certificate(self) -> Certificate:
         """Current certificate. Fails closed on any error."""
         try:
             with self._lock:
-                observations = self._load()
+                observations, intact = self._load()
+            if not intact:
+                # An unreadable store is not an empty one. Certifying from it
+                # would mean reasoning about evidence we could not read.
+                return Certificate(
+                    False, NEVER, self._alpha, 0, 0.0,
+                    required_samples(self._alpha),
+                    "calibration store unreadable; refusing to route")
             return certify(observations, self._alpha)
         except Exception as e:  # noqa: BLE001
             logger.debug("certification failed, refusing to route: %s", e)

--- a/entroly/ravs/conformal.py
+++ b/entroly/ravs/conformal.py
@@ -1,0 +1,275 @@
+"""Certify a routing threshold instead of asking the user to guess one.
+
+Routing substitutes the model on a live request, so it has always required an
+explicit authorisation. That is the right default for an unbounded risk, but it
+made the question unanswerable: "may I swap your model?" has no informed
+answer, because nothing measured what the swap would cost.
+
+Bounding the risk changes the question. Given calibration observations drawn
+from the user's own traffic, conformal risk control returns a threshold with a
+distribution-free, finite-sample guarantee on the expected divergence rate. The
+user then answers a question they *can* answer -- "do you accept a 2% divergence
+rate?" -- once, rather than per request.
+
+Method
+------
+Conformal risk control (Angelopoulos, Bates, Fisch, Lei & Schuster, ICLR 2024)
+generalises split conformal prediction from coverage to any monotone loss. For
+losses ``L_i(λ)`` non-increasing in ``λ`` and bounded above by ``B``:
+
+    λ̂ = inf{ λ : (n·R̂_n(λ) + B) / (n + 1) ≤ α }        (1)
+
+guarantees ``E[L_{n+1}(λ̂)] ≤ α`` on the next request.
+
+Here ``λ`` is the confidence a routing decision must clear before the swap is
+taken, and ``L_i(λ) = 1`` when request ``i`` would have been routed at ``λ``
+(its confidence cleared the bar) *and* the cheap model then diverged. Raising
+``λ`` routes strictly fewer requests, so ``L_i`` is non-increasing and (1)
+applies. Divergence is scored by the deterministic RAVS verifiers -- tests,
+lint, file reads -- so calibration costs no model calls and the label is an
+observation rather than a judgement.
+
+The minimum sample size is not a tuning knob; it falls out of (1). At the
+most conservative threshold nothing is routed, so ``R̂_n = 0`` and the bound
+reduces to ``B/(n+1) ≤ α``, giving
+
+    n ≥ B/α − 1                                          (2)
+
+Below that, no threshold can be certified at level ``α`` -- and this module
+reports that rather than routing on an unearned guarantee.
+
+What the guarantee does not cover
+---------------------------------
+Exchangeability. The bound holds when calibration observations and the next
+request are exchangeable. Traffic that shifts -- a new repository, a different
+task mix -- breaks that assumption, which is why observations carry a cohort
+key and a certificate is scoped to the cohort that produced it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("entroly.ravs.conformal")
+
+# Loss is an indicator, so it is bounded by 1.
+_LOSS_BOUND = 1.0
+
+# Sentinel threshold meaning "no confidence clears the bar" -- certified, but
+# permitting nothing. Kept distinct from 1.0 so a genuine 1.0-confidence
+# decision cannot be confused with refusing to route.
+NEVER = float("inf")
+
+_DEFAULT_ALPHA = 0.02
+_MAX_OBSERVATIONS = 5000
+
+
+def _alpha_from_env() -> float:
+    raw = os.environ.get("ENTROLY_RAVS_ALPHA", "").strip()
+    if not raw:
+        return _DEFAULT_ALPHA
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_ALPHA
+    return value if 0.0 < value < 1.0 else _DEFAULT_ALPHA
+
+
+def required_samples(alpha: float, bound: float = _LOSS_BOUND) -> int:
+    """Smallest ``n`` for which any threshold can be certified at level ``alpha``.
+
+    From (2): ``n ≥ B/α − 1``. Reported so a user waiting for automatic
+    routing can see how far away it is instead of wondering whether it is
+    broken.
+    """
+    if alpha <= 0.0:
+        return 0
+    return max(1, math.ceil(bound / alpha - 1.0))
+
+
+@dataclass(frozen=True)
+class Certificate:
+    """The outcome of applying (1) to the observations on hand."""
+
+    certified: bool
+    lambda_hat: float
+    alpha: float
+    n: int
+    empirical_risk: float
+    samples_needed: int
+    reason: str
+
+    @property
+    def permits_routing(self) -> bool:
+        """Whether the certificate allows any request to be routed.
+
+        A certificate at :data:`NEVER` is valid and permits nothing: the data
+        support a guarantee, and the guarantee they support is "route none of
+        it". Distinguishing the two stops "certified" from being read as
+        "enabled".
+        """
+        return self.certified and self.lambda_hat != NEVER
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "certified": self.certified,
+            "permits_routing": self.permits_routing,
+            "lambda_hat": None if self.lambda_hat == NEVER else self.lambda_hat,
+            "alpha": self.alpha,
+            "n": self.n,
+            "empirical_risk": self.empirical_risk,
+            "samples_needed": self.samples_needed,
+            "reason": self.reason,
+            "method": (
+                "conformal risk control (Angelopoulos et al., ICLR 2024): "
+                "lambda_hat = inf{lambda : (n*R_n(lambda) + B)/(n+1) <= alpha}, "
+                "B = 1; guarantees E[L] <= alpha under exchangeability"
+            ),
+        }
+
+
+def certify(
+    observations: list[tuple[float, bool]], alpha: float, bound: float = _LOSS_BOUND
+) -> Certificate:
+    """Apply (1) to ``observations``: ``(confidence, diverged)`` pairs.
+
+    Pure function of its inputs -- no IO, no clock, no global state -- so the
+    guarantee can be checked by hand against the same numbers.
+    """
+    n = len(observations)
+    needed = required_samples(alpha, bound)
+
+    if n == 0:
+        return Certificate(False, NEVER, alpha, 0, 0.0, needed,
+                           "no calibration observations")
+    if n < needed:
+        # Not conservatism: at n below this, (1) is unsatisfiable at every
+        # threshold, including the one that routes nothing.
+        return Certificate(
+            False, NEVER, alpha, n, 0.0, needed,
+            f"insufficient calibration: {n} of {needed} required at alpha={alpha}")
+
+    # L_i is a step function of lambda that only changes at an observed
+    # confidence, so scanning those values plus NEVER finds the exact infimum.
+    candidates = sorted({confidence for confidence, _ in observations})
+    candidates.append(NEVER)
+
+    for lam in candidates:
+        risk = sum(
+            1.0 for confidence, diverged in observations
+            if confidence >= lam and diverged
+        ) / n
+        if (n * risk + bound) / (n + 1) <= alpha:
+            return Certificate(
+                True, lam, alpha, n, round(risk, 6), needed,
+                "certified" if lam != NEVER else "certified: routes nothing")
+
+    # Unreachable while n >= needed, since the NEVER candidate drives R̂ to 0
+    # and reduces the bound to B/(n+1) <= alpha. Kept so a future change to the
+    # loss cannot silently fall through into an uncertified route.
+    return Certificate(False, NEVER, alpha, n, 0.0, needed,
+                       "no threshold satisfies the risk bound")
+
+
+class ConformalRoutingController:
+    """Collects calibration observations and certifies a routing threshold.
+
+    Persisted so a guarantee survives a restart: calibration is gathered from
+    real traffic, and discarding it on every process boundary would mean the
+    threshold could never be earned.
+    """
+
+    def __init__(self, path: str | os.PathLike[str] | None = None,
+                 alpha: float | None = None):
+        self._alpha = alpha if alpha is not None else _alpha_from_env()
+        self._lock = threading.Lock()
+        root = os.environ.get("ENTROLY_DIR") or os.path.join(os.getcwd(), ".entroly")
+        self._path = Path(path) if path else Path(root) / "ravs_calibration.json"
+
+    @property
+    def alpha(self) -> float:
+        return self._alpha
+
+    def _load(self) -> list[tuple[float, bool]]:
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            return [
+                (float(row["confidence"]), bool(row["diverged"]))
+                for row in raw.get("observations", [])
+                if "confidence" in row and "diverged" in row
+            ]
+        except (OSError, ValueError, TypeError, KeyError):
+            return []
+
+    def record(self, confidence: float, diverged: bool) -> None:
+        """Add one calibration observation. Never raises.
+
+        ``diverged`` must come from a deterministic verifier, not a model
+        judging itself -- the guarantee is only as sound as the label.
+        """
+        try:
+            value = float(confidence)
+            if not math.isfinite(value):
+                return
+            with self._lock:
+                observations = self._load()
+                observations.append((value, bool(diverged)))
+                # Bounded, keeping the most recent: exchangeability is more
+                # plausible over a recent window than over all history.
+                observations = observations[-_MAX_OBSERVATIONS:]
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                self._path.write_text(json.dumps({
+                    "observations": [
+                        {"confidence": c, "diverged": d} for c, d in observations
+                    ],
+                }), encoding="utf-8")
+        except Exception as e:  # noqa: BLE001 - calibration must not fail a request
+            logger.debug("calibration observation not recorded: %s", e)
+
+    def certificate(self) -> Certificate:
+        """Current certificate. Fails closed on any error."""
+        try:
+            with self._lock:
+                observations = self._load()
+            return certify(observations, self._alpha)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("certification failed, refusing to route: %s", e)
+            return Certificate(False, NEVER, self._alpha, 0, 0.0,
+                               required_samples(self._alpha),
+                               f"certification error: {type(e).__name__}")
+
+
+_controller: ConformalRoutingController | None = None
+_controller_lock = threading.Lock()
+
+
+def get_controller() -> ConformalRoutingController:
+    global _controller
+    with _controller_lock:
+        if _controller is None:
+            _controller = ConformalRoutingController()
+        return _controller
+
+
+def reset_for_tests() -> None:
+    global _controller
+    with _controller_lock:
+        _controller = None
+
+
+__all__ = [
+    "Certificate",
+    "ConformalRoutingController",
+    "NEVER",
+    "certify",
+    "get_controller",
+    "required_samples",
+    "reset_for_tests",
+]

--- a/entroly/ravs/conformal.py
+++ b/entroly/ravs/conformal.py
@@ -125,7 +125,7 @@ def required_samples(alpha: float, bound: float = _LOSS_BOUND) -> int:
 class Certificate:
     """The outcome of applying (1) to the observations on hand."""
 
-    certified: bool
+    has_enough_data: bool
     lambda_hat: float
     alpha: float
     n: int
@@ -137,16 +137,18 @@ class Certificate:
     def permits_routing(self) -> bool:
         """Whether the certificate allows any request to be routed.
 
-        A certificate at :data:`NEVER` is valid and permits nothing: the data
-        support a guarantee, and the guarantee they support is "route none of
-        it". Distinguishing the two stops "certified" from being read as
-        "enabled".
+        A certificate can hold enough data to conclude something and have
+        that conclusion be "route none of it". The field was called
+        ``certified``, which reads as "enabled" -- and ``if cert.certified:``
+        type-checks, sounds right, and would authorise routing on a
+        certificate whose only valid threshold is NEVER. This is the only
+        field a caller should gate on.
         """
-        return self.certified and self.lambda_hat != NEVER
+        return self.has_enough_data and self.lambda_hat != NEVER
 
     def as_dict(self) -> dict[str, Any]:
         return {
-            "certified": self.certified,
+            "has_enough_data": self.has_enough_data,
             "permits_routing": self.permits_routing,
             "lambda_hat": None if self.lambda_hat == NEVER else self.lambda_hat,
             "alpha": self.alpha,
@@ -198,11 +200,13 @@ def certify(
                 True, lam, alpha, n, round(risk, 6), needed,
                 "certified" if lam != NEVER else "certified: routes nothing")
 
-    # Unreachable while n >= needed, since the NEVER candidate drives R̂ to 0
-    # and reduces the bound to B/(n+1) <= alpha. Kept so a future change to the
-    # loss cannot silently fall through into an uncertified route.
-    return Certificate(False, NEVER, alpha, n, 0.0, needed,
-                       "no threshold satisfies the risk bound")
+    # Unreachable while n >= needed: the NEVER candidate drives R̂ to 0, which
+    # reduces the bound to B/(n+1) <= alpha, guaranteed by the guard above. A
+    # bare return here would silently hand back an uncertified result if a
+    # future change to the loss broke that; say what is assumed instead.
+    raise AssertionError(
+        f"no threshold satisfied the risk bound with n={n} >= needed={needed}; "
+        "the loss is no longer monotone or the NEVER candidate was dropped")
 
 
 class ConformalRoutingController:

--- a/entroly/ravs/conformal.py
+++ b/entroly/ravs/conformal.py
@@ -23,11 +23,38 @@ guarantees ``E[L_{n+1}(λ̂)] ≤ α`` on the next request.
 
 Here ``λ`` is the confidence a routing decision must clear before the swap is
 taken, and ``L_i(λ) = 1`` when request ``i`` would have been routed at ``λ``
-(its confidence cleared the bar) *and* the cheap model then diverged. Raising
-``λ`` routes strictly fewer requests, so ``L_i`` is non-increasing and (1)
-applies. Divergence is scored by the deterministic RAVS verifiers -- tests,
-lint, file reads -- so calibration costs no model calls and the label is an
-observation rather than a judgement.
+(its confidence cleared the bar) *and* the outcome was recorded as a failure.
+Raising ``λ`` routes strictly fewer requests, so ``L_i`` is non-increasing and
+(1) applies.
+
+What the label actually is
+--------------------------
+The bound is only as meaningful as the quantity being bounded, so it is worth
+being exact. The label is not a deterministic verifier result. The only outcome
+signal observable on the routing path is the proxy's implicit feedback: a
+routed request followed by a near-duplicate query is read as a failure (the
+user rephrased), a topic change as a success. That is a behavioural proxy,
+recorded elsewhere at ``source_strength=0.4``.
+
+So (1) bounds *the rate at which routed requests are followed by a rephrase*,
+not the rate of true quality divergence. Those correlate, and the first is
+observable while the second is not, but they are not the same and a reader
+deciding whether to accept ``α`` should know which one they are accepting.
+
+Bootstrapping
+-------------
+There is a circularity that no theorem removes: the label requires having
+routed, and routing requires a certificate. A cheap model's divergence cannot
+be estimated without ever running the cheap model. Calibration therefore
+accrues only while routing is on, which means the honest shape of this feature
+is *explicit opt-in to begin, automatic maintenance and revocation thereafter*
+-- a user who enables routing gets a threshold that tightens as evidence
+arrives and withdraws itself if outcomes degrade.
+
+Escaping that would need either a consented exploration budget (routing a small
+ε of low-risk traffic to gather evidence) or paying to run both models on a
+sample. Both are real options; neither is free, and neither is implemented
+here.
 
 The minimum sample size is not a tuning knob; it falls out of (1). At the
 most conservative threshold nothing is routed, so ``R̂_n = 0`` and the bound

--- a/entroly/ravs/router.py
+++ b/entroly/ravs/router.py
@@ -735,7 +735,25 @@ class BayesianRouter:
     def enabled(self, val: bool) -> None:
         self._enabled = val
 
-    def route(self, model: str, user_message: str) -> RoutingDecision:
+    def shadow_route(self, model: str, user_message: str) -> RoutingDecision:
+        """What this router would decide if enabled. Never swaps anything.
+
+        Every other gate still applies -- tier lookup, risk classification,
+        archetype cell confidence -- so a shadow recommendation means exactly
+        what a live one does. Only the enabled check is bypassed.
+
+        That check is an authorisation, not a capability: substituting a model
+        on a live request needs the user's say-so, but working out that a
+        cheaper model would have served is a table lookup and a classifier over
+        cached state, with no model call. Without this the user is asked to
+        authorise routing blind, and "nothing to gain" is indistinguishable
+        from "never measured".
+        """
+        return self.route(model, user_message, _ignore_enabled=True)
+
+    def route(
+        self, model: str, user_message: str, *, _ignore_enabled: bool = False
+    ) -> RoutingDecision:
         """Decide whether to route to a cheaper model.
 
         Returns RoutingDecision. If use_original=False, the proxy should
@@ -743,7 +761,7 @@ class BayesianRouter:
         """
         self._total_decisions += 1
 
-        if not self._enabled:
+        if not self._enabled and not _ignore_enabled:
             return RoutingDecision(reason="bayesian_router_disabled")
 
         tier = _lookup_tier(model)

--- a/entroly/ravs/shadow_calibration.py
+++ b/entroly/ravs/shadow_calibration.py
@@ -1,5 +1,21 @@
 """Earn the routing certificate without ever serving a cheap answer.
 
+NOT YET WIRED
+-------------
+Nothing in the product calls :class:`ShadowCalibrator` or :func:`should_sample`.
+``invoke_cheap`` has no implementation supplied anywhere, so no cheap-model call
+is ever made and no observation reaches the conformal controller from here. The
+only producer of calibration observations today is the proxy's implicit
+rephrase signal, which requires routing to already be on.
+
+That means ``ENTROLY_RAVS_SHADOW`` and ``ENTROLY_RAVS_SHADOW_RATE`` currently
+control nothing, and the bootstrap described below is a design that has been
+tested in isolation rather than a behaviour a user can observe. Read the rest of
+this docstring as a specification, not a description. Wiring it needs a
+``invoke_cheap`` that issues a second request through the proxy's existing
+forwarding path with the same prompt and the cheap model.
+
+
 The conformal controller in :mod:`entroly.ravs.conformal` can certify a routing
 threshold, but only from observations of how a cheap model performed -- and
 those cannot exist until the cheap model has been used. Routing therefore could

--- a/entroly/ravs/shadow_calibration.py
+++ b/entroly/ravs/shadow_calibration.py
@@ -48,6 +48,13 @@ logger = logging.getLogger("entroly.ravs.shadow_calibration")
 _DEFAULT_EPSILON = 0.10
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 
+# Ceiling on how long a bootstrap may run before giving up. Sampling continues
+# until a certificate permits routing rather than until the minimum feasible
+# sample size, so without this a cheap model that never agrees would be paid
+# for indefinitely. Matches the controller's retention window: observations
+# beyond it displace older ones, so more spending cannot grow the sample.
+_MAX_CALIBRATION = 5000
+
 # Above this Jaccard distance the two answers are treated as divergent.
 # Chosen so paraphrase-level differences in wording do not dominate, while
 # genuinely different content does.
@@ -110,6 +117,8 @@ def should_sample(
     risk_level: str,
     observations: int,
     samples_needed: int,
+    permits_routing: bool = False,
+    max_observations: int = _MAX_CALIBRATION,
     epsilon: float | None = None,
     rng: random.Random | None = None,
 ) -> SampleDecision:
@@ -120,13 +129,30 @@ def should_sample(
     """
     if not shadow_enabled():
         return SampleDecision(False, "shadow calibration disabled")
-    if risk_level and risk_level.lower() not in {"low"}:
-        # Higher-risk requests will not be routed even once certified, so
-        # paying to learn about them buys nothing.
-        return SampleDecision(False, f"risk={risk_level} is never routed")
-    if observations >= samples_needed:
+    # An unclassified request is not a low-risk one. Testing truthiness first
+    # let risk_level="" -- which several RoutingDecision early-return paths
+    # produce -- skip the gate entirely and be sampled as though it had been
+    # classified, spending a call on traffic that can never be routed and
+    # polluting the calibration set with a population the bound is not about.
+    if risk_level.lower() != "low":
         return SampleDecision(
-            False, f"calibration complete ({observations}/{samples_needed})")
+            False, f"risk={risk_level or 'unclassified'} is never routed")
+    # Stopping at samples_needed was wrong: that is only the smallest n at
+    # which the route-nothing threshold becomes certifiable, not the point at
+    # which routing is justified. Landing there with a few divergent
+    # observations left the certificate valid, permitting nothing, and
+    # permanently unable to gather the evidence that would change it.
+    # Calibration now continues until a certificate actually permits routing.
+    if permits_routing:
+        return SampleDecision(
+            False, f"certified and routing ({observations} observations)")
+    if observations >= max_observations:
+        # A ceiling is still needed, or a cheap model that never agrees would
+        # be paid for forever.
+        return SampleDecision(
+            False,
+            f"calibration exhausted at {observations} observations without a "
+            f"routing certificate; the cheap model does not agree often enough")
     rate = _epsilon_from_env() if epsilon is None else epsilon
     if rate <= 0.0:
         return SampleDecision(False, "sampling rate is zero")

--- a/entroly/ravs/shadow_calibration.py
+++ b/entroly/ravs/shadow_calibration.py
@@ -1,0 +1,180 @@
+"""Earn the routing certificate without ever serving a cheap answer.
+
+The conformal controller in :mod:`entroly.ravs.conformal` can certify a routing
+threshold, but only from observations of how a cheap model performed -- and
+those cannot exist until the cheap model has been used. Routing therefore could
+not bootstrap: the certificate required routing, and routing required the
+certificate.
+
+The way out is to separate *who answers the user* from *what we learn*. On a
+small sample of requests the flagship model answers, exactly as it would have,
+and the cheap model is called alongside purely to be compared. The user is
+never served the cheap output during calibration, so the bootstrap costs money
+rather than quality -- a few dozen cheap calls to earn a permanent threshold.
+
+Two properties make that affordable:
+
+*It stops.* Sampling is disabled once enough observations exist to certify at
+the configured ``alpha``. Calibration is a bootstrap phase with a defined end,
+not a permanent tax.
+
+*It is narrow.* Only low-risk requests are sampled. A request the risk
+classifier will never route is a request there is nothing to learn from.
+
+The divergence label
+--------------------
+Two answers are compared by token-set Jaccard distance. This is deliberately a
+measure of *difference*, not of *quality*: a cheap model that answers correctly
+in different words is scored as divergent. That makes the label conservative --
+it over-counts divergence -- and a conservative label biases the conformal
+bound toward routing less than strictly necessary. Erring toward under-routing
+is the correct direction for a guarantee about someone else's traffic, so the
+imprecision is a feature here rather than a defect, but it is imprecision and
+should not be described as a quality judgement.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+import re
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable
+
+logger = logging.getLogger("entroly.ravs.shadow_calibration")
+
+_DEFAULT_EPSILON = 0.10
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Above this Jaccard distance the two answers are treated as divergent.
+# Chosen so paraphrase-level differences in wording do not dominate, while
+# genuinely different content does.
+_DIVERGENCE_THRESHOLD = 0.50
+
+
+def _epsilon_from_env() -> float:
+    raw = os.environ.get("ENTROLY_RAVS_SHADOW_RATE", "").strip()
+    if not raw:
+        return _DEFAULT_EPSILON
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_EPSILON
+    return value if 0.0 <= value <= 1.0 else _DEFAULT_EPSILON
+
+
+def shadow_enabled() -> bool:
+    """On unless disabled. Costs cheap-model calls, so it is opt-out, not free."""
+    return os.environ.get("ENTROLY_RAVS_SHADOW", "1").strip() not in {
+        "0", "false", "no",
+    }
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall((text or "").lower()))
+
+
+def divergence_score(flagship: str, cheap: str) -> float:
+    """Jaccard distance between the two answers, in ``[0, 1]``.
+
+    Both empty is treated as agreement: two models that produced nothing
+    produced the same nothing, and calling that a divergence would penalise
+    routing for a failure the flagship shares.
+    """
+    a, b = _tokens(flagship), _tokens(cheap)
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 1.0
+    return 1.0 - len(a & b) / len(a | b)
+
+
+def diverged(flagship: str, cheap: str,
+             threshold: float = _DIVERGENCE_THRESHOLD) -> bool:
+    """Whether the cheap answer differs enough to count against routing."""
+    return divergence_score(flagship, cheap) > threshold
+
+
+@dataclass(frozen=True)
+class SampleDecision:
+    """Why this request was or was not shadowed -- inspectable, not a bare bool."""
+
+    sample: bool
+    reason: str
+
+
+def should_sample(
+    *,
+    risk_level: str,
+    observations: int,
+    samples_needed: int,
+    epsilon: float | None = None,
+    rng: random.Random | None = None,
+) -> SampleDecision:
+    """Decide whether to spend a cheap-model call on this request.
+
+    Pure apart from the draw, and the draw is injectable, so the policy can be
+    tested without probability.
+    """
+    if not shadow_enabled():
+        return SampleDecision(False, "shadow calibration disabled")
+    if risk_level and risk_level.lower() not in {"low"}:
+        # Higher-risk requests will not be routed even once certified, so
+        # paying to learn about them buys nothing.
+        return SampleDecision(False, f"risk={risk_level} is never routed")
+    if observations >= samples_needed:
+        return SampleDecision(
+            False, f"calibration complete ({observations}/{samples_needed})")
+    rate = _epsilon_from_env() if epsilon is None else epsilon
+    if rate <= 0.0:
+        return SampleDecision(False, "sampling rate is zero")
+    draw = (rng or random).random()
+    if draw >= rate:
+        return SampleDecision(False, "not selected by sampling")
+    return SampleDecision(True, f"sampled at rate {rate}")
+
+
+class ShadowCalibrator:
+    """Runs the comparison off the request path and records the observation.
+
+    The user's response has already been produced and returned by the time this
+    does anything. It exists to spend a cheap call and write one row, so every
+    failure is swallowed: calibration that breaks a request has cost more than
+    it could ever earn.
+    """
+
+    def __init__(self, invoke_cheap: Callable[[str, str], str],
+                 record: Callable[[float, bool], None]):
+        self._invoke_cheap = invoke_cheap
+        self._record = record
+
+    def observe(self, *, prompt: str, cheap_model: str, flagship_output: str,
+                confidence: float) -> None:
+        """Compare the two answers and record the result. Never raises."""
+        try:
+            cheap_output = self._invoke_cheap(cheap_model, prompt)
+            if not cheap_output:
+                return
+            self._record(confidence, diverged(flagship_output, cheap_output))
+        except Exception as e:  # noqa: BLE001 - calibration is never worth a request
+            logger.debug("shadow calibration observation skipped: %s", e)
+
+    def observe_in_background(self, **kwargs: Any) -> threading.Thread:
+        """Same, on a daemon thread, so nothing waits on a second model call."""
+        thread = threading.Thread(
+            target=self.observe, kwargs=kwargs,
+            name="entroly-ravs-shadow", daemon=True)
+        thread.start()
+        return thread
+
+
+__all__ = [
+    "SampleDecision",
+    "ShadowCalibrator",
+    "divergence_score",
+    "diverged",
+    "shadow_enabled",
+    "should_sample",
+]

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -4081,6 +4081,23 @@ def _start_background_services(engine: EntrolyEngine) -> threading.Thread:
         except Exception as e:
             logger.warning("Autotune: failed to start daemon: %s", e)
 
+        # Surface the value this server is already producing. Every other
+        # entry point (proxy, daemon, `entroly dashboard`) starts one; the MCP
+        # server did not, which is how the most common install ended up being
+        # the one where nothing was visible. Started last, after indexing, so
+        # the first page load has something to show.
+        #
+        # Safe on this path specifically because it binds only after probing
+        # the port, logs to stderr rather than stdout, and swallows every
+        # failure -- stdout here is the JSON-RPC channel.
+        try:
+            from entroly.dashboard import maybe_start_dashboard
+
+            if maybe_start_dashboard(engine=engine) is not None:
+                logger.info("Value dashboard live at http://localhost:9378")
+        except Exception as e:
+            logger.warning("Dashboard autostart failed (non-fatal): %s", e)
+
     t = threading.Thread(
         target=_initialize,
         name="entroly-startup",

--- a/entroly/value_tracker.py
+++ b/entroly/value_tracker.py
@@ -169,6 +169,33 @@ def _has_priced_model(model: str) -> bool:
     )
 
 
+def routing_delta_usd(
+    original_model: str, chosen_model: str, tokens_in: int, tokens_out: int = 0
+) -> float:
+    """USD difference between serving a request on ``original`` vs ``chosen``.
+
+    Priced on both rates, because routing changes the cost of the response as
+    well as the prompt -- input-only would understate a swap on a long
+    generation, which is exactly where routing pays best.
+
+    Returns 0.0 when either model is unpriced rather than guessing. An
+    unrecognised model already falls back to a default rate for display
+    purposes, but a *difference* between two defaults is structurally zero and
+    reporting it as a saving would invent money from a missing catalog entry.
+    """
+    if not original_model or not chosen_model:
+        return 0.0
+    if not (_has_priced_model(original_model) and _has_priced_model(chosen_model)):
+        return 0.0
+    delta = (
+        estimate_cost(max(0, int(tokens_in)), original_model, "input")
+        - estimate_cost(max(0, int(tokens_in)), chosen_model, "input")
+        + estimate_cost(max(0, int(tokens_out)), original_model, "output")
+        - estimate_cost(max(0, int(tokens_out)), chosen_model, "output")
+    )
+    return round(delta, 6) if delta > 0 else 0.0
+
+
 def estimate_cost(tokens_saved: int, model: str = "", kind: str = "input") -> float:
     """Estimate USD saved for ``tokens_saved`` tokens of a model.
 
@@ -749,6 +776,38 @@ class ValueTracker:
         except Exception as e:  # noqa: BLE001
             logger.debug("record_routing_saving failed: %s", e)
 
+    def record_routing_opportunity(
+        self, cost_available_usd: float, *, chosen_model: str = "",
+        source: str = "",
+    ) -> None:
+        """A cheaper capable model was identified but not used.
+
+        Routing substitutes the model on a live request, so it stays behind an
+        explicit authorisation. That left the user deciding blind: the switch
+        was off, nothing measured it, and the panel showed nothing, so the only
+        way to learn what routing was worth was to authorise it first and find
+        out afterwards.
+
+        The decision itself costs nothing to compute -- it is a pure function
+        of cached state with no model call -- so it is evaluated regardless and
+        recorded here. This is money *available*, not money saved, and it is
+        kept in its own field so it can never be added to a captured total.
+        """
+        try:
+            amount = self._finite_float(cost_available_usd)
+            if amount <= 0.0:
+                return
+            with self._mutation():
+                lt = self._data["lifetime"]
+                lt["routing_available_usd"] = round(
+                    lt.get("routing_available_usd", 0.0) + amount, 6)
+                lt["routing_opportunities"] = lt.get("routing_opportunities", 0) + 1
+                lt["routing_opportunity_model"] = chosen_model or lt.get(
+                    "routing_opportunity_model", "")
+                self._save()
+        except Exception as e:  # noqa: BLE001 - measurement must not break a request
+            logger.debug("record_routing_opportunity failed: %s", e)
+
     def record_belief_conditioning(
         self, n_fragments: int, *, source: str = "", detail: str = ""
     ) -> None:
@@ -1117,6 +1176,11 @@ class ValueTracker:
                     "hallucinations_blocked": lt.get(
                         "hallucinations_blocked", 0),
                     "routing_saved_usd": lt.get("routing_saved_usd", 0.0),
+                    # Money a cheaper capable model was available for but did
+                    # not capture. Reported beside the captured figure so the
+                    # authorisation decision is made against evidence.
+                    "routing_available_usd": lt.get("routing_available_usd", 0.0),
+                    "routing_opportunities": lt.get("routing_opportunities", 0),
                 },
                 "status": "active" if self._session_requests > 0 else "idle",
             }

--- a/entroly/value_tracker.py
+++ b/entroly/value_tracker.py
@@ -1159,11 +1159,34 @@ class ValueTracker:
                     lifetime.get("local_tokens_reduced", 0) or 0
                 ),
                 "active_days": local_days,
+                # Left at 0.0 deliberately. This field has always meant
+                # "verified against observed provider usage", and a local
+                # reduction is not that. Repurposing it would silently change
+                # the meaning of a number already published in receipts.
                 "dollar_claimed_usd": 0.0,
+                # Priced separately rather than left blank. Tokens are a
+                # commodity with a public rate, so a reduction that never
+                # reached an invoice still avoided buying that input at
+                # replacement cost -- the basis inventory is normally valued
+                # on. Reporting nothing understated a real measurement;
+                # reporting it as a verified saving would overstate it. The
+                # field name carries the basis so neither reading is available.
+                "modeled_value_at_list_usd": round(
+                    estimate_cost(
+                        int(lifetime.get("local_tokens_reduced", 0) or 0),
+                        model="",
+                        kind="input",
+                    ),
+                    6,
+                ),
+                "pricing_basis": "default_catalog_input_rate",
                 "evidence": (
-                    "SDK, MCP, npm, and other local reductions. Entroly does not "
-                    "claim dollar savings because it cannot prove the output was "
-                    "sent to a paid provider."
+                    "SDK, MCP, npm, and other local reductions. The token counts "
+                    "are measured. The dollar figure applies the default catalog "
+                    "input rate to them and is a replacement-cost model, not an "
+                    "invoice: Entroly cannot prove this output reached a paid "
+                    "provider, so it is reported apart from provider-bound "
+                    "savings and never added to them."
                 ),
             },
             "legacy_unclassified": {

--- a/entroly/value_tracker.py
+++ b/entroly/value_tracker.py
@@ -1001,9 +1001,30 @@ class ValueTracker:
             self._save_activity()
 
     def get_lifetime(self) -> dict[str, Any]:
-        """Return lifetime cumulative stats."""
+        """Return lifetime cumulative stats, with energy derived on read.
+
+        Energy is computed here rather than accumulated on write because it is
+        a pure function of tokens already counted. Storing it would create a
+        second copy that could drift from the token totals it is derived from,
+        and would freeze the assumptions at the moment of writing -- a user who
+        corrects the model size later expects their history to be restated, not
+        left mixed.
+        """
         with self._lock:
-            return dict(self._data.get("lifetime", {}))
+            lifetime = dict(self._data.get("lifetime", {}))
+
+        tokens = (
+            int(lifetime.get("provider_tokens_saved", 0) or 0)
+            + int(lifetime.get("local_tokens_reduced", 0) or 0)
+            + int(lifetime.get("unclassified_tokens_reduced", 0) or 0)
+        )
+        try:
+            from .energy_value import energy_for_tokens
+
+            lifetime["energy"] = energy_for_tokens(tokens)
+        except Exception:  # noqa: BLE001 - a missing kWh line must not cost the totals
+            pass
+        return lifetime
 
     def get_daily(self, last_n: int = 30) -> list[dict[str, Any]]:
         """Return last N days of daily stats, sorted ascending."""

--- a/entroly/value_tracker.py
+++ b/entroly/value_tracker.py
@@ -1123,8 +1123,22 @@ class ValueTracker:
             1 for row in daily if int(row.get("local_operations", 0) or 0) > 0
         )
         pricing = pricing_provenance()
+        # Energy is derived from tokens already counted, so it costs one
+        # multiplication and needs nothing from the user. Reporting it only on
+        # request would mean the figure exists but nobody sees it, which is the
+        # same as not having it. Both channels are included because prefill
+        # work is avoided wherever the tokens were removed.
+        from .energy_value import energy_for_tokens
+
+        total_tokens_reduced = (
+            int(lifetime.get("provider_tokens_saved", 0) or 0)
+            + int(lifetime.get("local_tokens_reduced", 0) or 0)
+            + int(lifetime.get("unclassified_tokens_reduced", 0) or 0)
+        )
+
         return {
             "schema_version": "entroly.value-receipt.v1",
+            "energy": energy_for_tokens(total_tokens_reduced),
             "provider_path": {
                 "requests_observed": int(
                     lifetime.get("provider_requests", 0) or 0

--- a/entroly/value_tracker.py
+++ b/entroly/value_tracker.py
@@ -751,6 +751,23 @@ class ValueTracker:
         except Exception as e:  # noqa: BLE001
             logger.debug("record_hallucination_blocked failed: %s", e)
 
+    def _accumulate_routing(
+        self, amount_field: str, counter_field: str, amount: float
+    ) -> None:
+        """Add to one routing total and bump its counter.
+
+        Captured and available routing value are separate lanes that must never
+        be summed, but they accrue identically. Keeping two copies of this let
+        their guards drift apart, which is how one of them came to accept
+        negative amounts.
+        """
+        with self._mutation():
+            lifetime = self._data["lifetime"]
+            lifetime[amount_field] = round(
+                lifetime.get(amount_field, 0.0) + amount, 6)
+            lifetime[counter_field] = lifetime.get(counter_field, 0) + 1
+            self._save()
+
     def record_routing_saving(
         self, cost_saved_usd: float, *, source: str = "",
         chosen_model: str = "", detail: str = "",
@@ -759,14 +776,12 @@ class ValueTracker:
         Fail-open."""
         try:
             amount = self._finite_float(cost_saved_usd)
-            if amount == 0.0:
+            # Was `== 0.0`, which let a negative amount through and subtracted
+            # from a lifetime total that only ever accrues.
+            if amount <= 0.0:
                 return
-            with self._mutation():
-                lt = self._data["lifetime"]
-                lt["routing_saved_usd"] = round(
-                    lt.get("routing_saved_usd", 0.0) + amount, 6)
-                lt["routing_decisions"] = lt.get("routing_decisions", 0) + 1
-                self._save()
+            self._accumulate_routing("routing_saved_usd", "routing_decisions",
+                                     amount)
             self.record_event(
                 "routing",
                 detail or f"Routed to {chosen_model or 'cheaper model'}",
@@ -797,14 +812,13 @@ class ValueTracker:
             amount = self._finite_float(cost_available_usd)
             if amount <= 0.0:
                 return
-            with self._mutation():
-                lt = self._data["lifetime"]
-                lt["routing_available_usd"] = round(
-                    lt.get("routing_available_usd", 0.0) + amount, 6)
-                lt["routing_opportunities"] = lt.get("routing_opportunities", 0) + 1
-                lt["routing_opportunity_model"] = chosen_model or lt.get(
-                    "routing_opportunity_model", "")
-                self._save()
+            # ``chosen_model`` is accepted for symmetry with the captured
+            # recorder and for the caller's own logging. It is deliberately not
+            # persisted: the field that held it was written on every call and
+            # read by nothing, so it accumulated in every user's lifetime JSON
+            # and would have had to be carried by every future migration.
+            self._accumulate_routing("routing_available_usd",
+                                     "routing_opportunities", amount)
         except Exception as e:  # noqa: BLE001 - measurement must not break a request
             logger.debug("record_routing_opportunity failed: %s", e)
 

--- a/tests/test_belief_autoseed.py
+++ b/tests/test_belief_autoseed.py
@@ -76,12 +76,50 @@ class TestSeeding:
         )
 
     def test_the_marker_records_what_was_compiled(self, tmp_path):
-        belief_autoseed.compile_now(_project(tmp_path))
-        marker = json.loads(
+        project = _project(tmp_path)
+        belief_autoseed.compile_now(project)
+        markers = json.loads(
             (tmp_path / "state" / "vault" / "autoseed.json").read_text(encoding="utf-8"))
 
-        assert marker["signature"]
-        assert marker["files_processed"] >= 1
+        entry = markers[str(project.resolve())]
+        assert entry["signature"]
+        assert entry["files_processed"] >= 1
+
+    def test_two_projects_do_not_overwrite_each_other(self, tmp_path):
+        """A single unkeyed signature made every alternation recompile both."""
+        first = _project(tmp_path)
+        second = tmp_path / "other" / "src"
+        second.mkdir(parents=True)
+        (second / "billing.py").write_text(
+            "def charge(cents):\n    'Charge.'\n    return cents\n", encoding="utf-8")
+
+        assert belief_autoseed.compile_now(first)["status"] == "compiled"
+        assert belief_autoseed.compile_now(tmp_path / "other")["status"] == "compiled"
+        assert belief_autoseed.compile_now(first)["status"] == "skipped", (
+            "returning to a project already compiled must not recompile it"
+        )
+
+    def test_a_file_beyond_the_compile_cap_still_invalidates(self, tmp_path):
+        """The signature covers the whole tree; only compilation is capped.
+
+        Breaking the signature loop at max_files made every file sorting after
+        the cap invisible, so editing one never triggered recompilation again
+        and its beliefs stayed stale permanently.
+        """
+        project = _project(tmp_path)
+        source = project / "src"
+        for index in range(12):
+            (source / f"mod_{index:03d}.py").write_text(
+                f"def f{index}():\n    'Doc.'\n    return {index}\n", encoding="utf-8")
+
+        before = belief_autoseed._tree_signature(project.resolve(), max_files=2)
+        (source / "mod_011.py").write_text(
+            "def f11():\n    'Changed.'\n    return 999\n", encoding="utf-8")
+        after = belief_autoseed._tree_signature(project.resolve(), max_files=2)
+
+        assert before != after, (
+            "a file past the compile cap must still invalidate the signature"
+        )
 
 
 class TestFailsOpen:

--- a/tests/test_belief_autoseed.py
+++ b/tests/test_belief_autoseed.py
@@ -1,0 +1,146 @@
+"""Beliefs must appear because the repository was indexed, not because the user
+was told to compile them.
+
+The dashboard shipped an empty panel reading "No beliefs yet -- run
+compile_beliefs to seed the vault". Indexing had already walked the tree, so
+the product knew the next step and asked someone else to take it.
+
+The risks of doing it automatically are delay, repetition and failure, so each
+is pinned here: it must not block indexing, must skip an unchanged tree, and
+must never turn a vault problem into an indexing problem.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from entroly import belief_autoseed
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    monkeypatch.delenv("ENTROLY_VAULT", raising=False)
+    belief_autoseed.reset_for_tests()
+    yield
+    belief_autoseed.reset_for_tests()
+
+
+def _project(tmp_path: Path) -> Path:
+    root = tmp_path / "proj" / "src"
+    root.mkdir(parents=True)
+    (root / "auth.py").write_text(
+        "import hashlib\n\n\n"
+        "class SessionStore:\n"
+        "    '''Holds sessions.'''\n"
+        "    def __init__(self):\n"
+        "        self.tokens = {}\n\n\n"
+        "def hash_password(pw, salt):\n"
+        "    '''Hash a password with a salt.'''\n"
+        "    return hashlib.sha256((salt + pw).encode()).hexdigest()\n",
+        encoding="utf-8",
+    )
+    return tmp_path / "proj"
+
+
+class TestSeeding:
+    def test_beliefs_are_written_without_a_user_command(self, tmp_path):
+        result = belief_autoseed.compile_now(_project(tmp_path))
+
+        assert result["status"] == "compiled"
+        assert result["beliefs_written"] > 0
+        vault = tmp_path / "state" / "vault" / "beliefs"
+        assert list(vault.glob("*.md")), "the vault panel would still be empty"
+
+    def test_an_unchanged_tree_is_not_recompiled(self, tmp_path):
+        project = _project(tmp_path)
+        belief_autoseed.compile_now(project)
+        second = belief_autoseed.compile_now(project)
+
+        assert second["status"] == "skipped", (
+            "opening a repository repeatedly must compile once, not once per open"
+        )
+
+    def test_a_changed_tree_is_recompiled(self, tmp_path):
+        project = _project(tmp_path)
+        belief_autoseed.compile_now(project)
+        (project / "src" / "billing.py").write_text(
+            "def charge(cents):\n    '''Charge in cents.'''\n    return cents\n",
+            encoding="utf-8")
+
+        assert belief_autoseed.compile_now(project)["status"] == "compiled", (
+            "skipping must be based on the tree, not on having ever run"
+        )
+
+    def test_the_marker_records_what_was_compiled(self, tmp_path):
+        belief_autoseed.compile_now(_project(tmp_path))
+        marker = json.loads(
+            (tmp_path / "state" / "vault" / "autoseed.json").read_text(encoding="utf-8"))
+
+        assert marker["signature"]
+        assert marker["files_processed"] >= 1
+
+
+class TestFailsOpen:
+    def test_a_broken_vault_returns_an_error_rather_than_raising(
+        self, tmp_path, monkeypatch
+    ):
+        project = _project(tmp_path)
+
+        def explode(*_a, **_k):
+            raise OSError("vault is read-only")
+
+        monkeypatch.setattr(
+            "entroly.vault.VaultManager.ensure_structure", explode, raising=False)
+
+        result = belief_autoseed.compile_now(project)
+        assert result["status"] == "error", (
+            "a vault problem must be reported, not raised into the caller"
+        )
+
+    def test_start_autoseed_is_idempotent_per_directory(self, tmp_path):
+        project = _project(tmp_path)
+        assert belief_autoseed.start_autoseed(project) is True
+        assert belief_autoseed.start_autoseed(project) is False, (
+            "repeated indexing in one session must not stack compilations"
+        )
+
+    def test_it_can_be_turned_off(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ENTROLY_BELIEF_AUTOSEED", "0")
+        assert belief_autoseed.autoseed_enabled() is False
+        assert belief_autoseed.start_autoseed(_project(tmp_path)) is False
+
+
+class TestIndexingIntegration:
+    def test_indexing_starts_the_seeder(self, tmp_path, monkeypatch):
+        """The wiring, not the compiler: indexing must trigger seeding."""
+        project = _project(tmp_path)
+        calls: list[str] = []
+        monkeypatch.setattr(
+            belief_autoseed, "start_autoseed",
+            lambda directory=None, max_files=400: calls.append(str(directory)) or True)
+
+        from entroly import auto_index as module
+
+        monkeypatch.setattr(module, "_auto_index",
+                            lambda *_a, **_k: {"status": "indexed", "files_indexed": 1})
+        module.auto_index(engine=object(), project_dir=str(project))
+
+        assert calls, "indexing completed without seeding beliefs"
+
+    def test_a_seeder_failure_does_not_break_indexing(self, tmp_path, monkeypatch):
+        from entroly import auto_index as module
+
+        monkeypatch.setattr(
+            belief_autoseed, "start_autoseed",
+            lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")))
+        monkeypatch.setattr(module, "_auto_index",
+                            lambda *_a, **_k: {"status": "indexed", "files_indexed": 3})
+
+        result = module.auto_index(engine=object(), project_dir=str(tmp_path))
+        assert result["status"] == "indexed", (
+            "a belief failure must cost a panel, not the index"
+        )

--- a/tests/test_conformal_routing.py
+++ b/tests/test_conformal_routing.py
@@ -37,7 +37,7 @@ class TestSampleRequirement:
         observations = [(0.99, False)] * 10
         result = certify(observations, alpha=0.02)
 
-        assert result.certified is False
+        assert result.has_enough_data is False
         assert result.permits_routing is False
         assert "insufficient calibration" in result.reason
 
@@ -50,7 +50,7 @@ class TestCertification:
         observations = [(0.95, False)] * 60
         result = certify(observations, alpha=0.05)
 
-        assert result.certified is True
+        assert result.has_enough_data is True
         assert result.permits_routing is True
         assert result.lambda_hat <= 0.95
 
@@ -59,7 +59,7 @@ class TestCertification:
         observations = [(0.95, True)] * 60
         result = certify(observations, alpha=0.05)
 
-        assert result.certified is True, "enough data to conclude something"
+        assert result.has_enough_data is True, "enough data to conclude something"
         assert result.permits_routing is False, (
             "a history of pure divergence must not authorise routing"
         )
@@ -87,7 +87,7 @@ class TestCertification:
     def test_certified_is_not_the_same_as_enabled(self):
         """A valid certificate can authorise nothing; the two must not be conflated."""
         result = certify([(0.95, True)] * 60, alpha=0.05)
-        assert result.certified is True and result.permits_routing is False
+        assert result.has_enough_data is True and result.permits_routing is False
 
 
 class TestGuaranteeHolds:

--- a/tests/test_conformal_routing.py
+++ b/tests/test_conformal_routing.py
@@ -1,0 +1,212 @@
+"""The routing threshold must be earned, and the guarantee must be real.
+
+Routing was gated behind an authorisation nobody could answer informedly: the
+risk was unbounded and unmeasured, so "may I swap your model?" had no basis.
+Conformal risk control replaces the guess with a threshold carrying a
+distribution-free finite-sample bound on the divergence rate.
+
+A guarantee asserted in a docstring is worth nothing, so the last test here
+measures it: simulated traffic, repeated trials, realised divergence compared
+against the promised alpha.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from entroly.ravs.conformal import (
+    NEVER,
+    Certificate,
+    ConformalRoutingController,
+    certify,
+    required_samples,
+)
+
+
+class TestSampleRequirement:
+    def test_the_minimum_falls_out_of_the_bound(self):
+        """n >= B/alpha - 1, not a tuning constant."""
+        assert required_samples(0.05) == 19
+        assert required_samples(0.02) == 49
+        assert required_samples(0.10) == 9
+
+    def test_too_few_samples_cannot_be_certified(self):
+        """Below the minimum, no threshold satisfies (1) -- including 'route nothing'."""
+        observations = [(0.99, False)] * 10
+        result = certify(observations, alpha=0.02)
+
+        assert result.certified is False
+        assert result.permits_routing is False
+        assert "insufficient calibration" in result.reason
+
+    def test_no_observations_refuses(self):
+        assert certify([], alpha=0.05).permits_routing is False
+
+
+class TestCertification:
+    def test_clean_history_permits_routing(self):
+        observations = [(0.95, False)] * 60
+        result = certify(observations, alpha=0.05)
+
+        assert result.certified is True
+        assert result.permits_routing is True
+        assert result.lambda_hat <= 0.95
+
+    def test_divergent_history_refuses_to_route(self):
+        """Every routed request diverged; the only safe threshold routes nothing."""
+        observations = [(0.95, True)] * 60
+        result = certify(observations, alpha=0.05)
+
+        assert result.certified is True, "enough data to conclude something"
+        assert result.permits_routing is False, (
+            "a history of pure divergence must not authorise routing"
+        )
+        assert result.lambda_hat == NEVER
+
+    def test_the_threshold_excludes_the_divergent_region(self):
+        """Low-confidence decisions diverge; the bar must rise above them."""
+        observations = [(0.60, True)] * 30 + [(0.99, False)] * 70
+        result = certify(observations, alpha=0.05)
+
+        assert result.permits_routing is True
+        assert result.lambda_hat > 0.60, (
+            "the certified bar must sit above the confidences that diverged"
+        )
+
+    def test_a_stricter_alpha_is_never_more_permissive(self):
+        observations = [(0.9, False)] * 90 + [(0.9, True)] * 10
+        loose = certify(observations, alpha=0.20)
+        strict = certify(observations, alpha=0.02)
+
+        assert strict.lambda_hat >= loose.lambda_hat, (
+            "demanding less risk must not permit more routing"
+        )
+
+    def test_certified_is_not_the_same_as_enabled(self):
+        """A valid certificate can authorise nothing; the two must not be conflated."""
+        result = certify([(0.95, True)] * 60, alpha=0.05)
+        assert result.certified is True and result.permits_routing is False
+
+
+class TestGuaranteeHolds:
+    def test_realised_divergence_respects_alpha(self):
+        """Measure the promise: E[L] <= alpha on held-out requests.
+
+        Split traffic into calibration and test, certify on the former, apply
+        the threshold to the latter, and count how often a routed request
+        diverged. Averaged over trials this must not exceed alpha.
+        """
+        rng = random.Random(20260828)
+        alpha = 0.10
+        realised = []
+
+        for _ in range(200):
+            def draw():
+                confidence = rng.uniform(0.5, 1.0)
+                # Divergence is more likely when confidence is low.
+                return confidence, rng.random() > confidence
+
+            calibration = [draw() for _ in range(120)]
+            holdout = [draw() for _ in range(120)]
+
+            result = certify(calibration, alpha=alpha)
+            routed = [
+                diverged for confidence, diverged in holdout
+                if result.permits_routing and confidence >= result.lambda_hat
+            ]
+            # Requests we declined to route carry no loss.
+            realised.append(sum(routed) / len(holdout))
+
+        mean_loss = sum(realised) / len(realised)
+        assert mean_loss <= alpha, (
+            f"guarantee violated: realised {mean_loss:.4f} > alpha {alpha}"
+        )
+
+    def test_the_bound_is_not_vacuous(self):
+        """A method that never routes would trivially satisfy any alpha."""
+        observations = [(0.98, False)] * 200
+        result = certify(observations, alpha=0.10)
+
+        assert result.permits_routing is True, (
+            "on clean history the certificate must actually allow routing, "
+            "or the guarantee is met by doing nothing"
+        )
+
+
+class TestControllerFailsClosed:
+    @pytest.fixture
+    def controller(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+        return ConformalRoutingController(tmp_path / "calib.json", alpha=0.05)
+
+    def test_a_fresh_install_does_not_route(self, controller):
+        assert controller.certificate().permits_routing is False
+
+    def test_observations_persist(self, controller, tmp_path):
+        for _ in range(60):
+            controller.record(0.97, False)
+
+        reopened = ConformalRoutingController(tmp_path / "calib.json", alpha=0.05)
+        assert reopened.certificate().n == 60, (
+            "calibration gathered from real traffic must survive a restart"
+        )
+
+    def test_a_corrupt_store_refuses_rather_than_routes(self, controller, tmp_path):
+        (tmp_path / "calib.json").write_text("{not json", encoding="utf-8")
+        assert controller.certificate().permits_routing is False
+
+    def test_non_finite_confidence_is_ignored(self, controller):
+        controller.record(float("nan"), False)
+        controller.record(float("inf"), False)
+        assert controller.certificate().n == 0
+
+    def test_recording_never_raises(self, controller):
+        controller.record("not a number", False)  # type: ignore[arg-type]
+
+    def test_the_payload_states_its_method(self, controller):
+        payload = controller.certificate().as_dict()
+        assert "conformal risk control" in payload["method"]
+        assert payload["permits_routing"] is False
+        assert isinstance(payload["samples_needed"], int)
+
+
+def test_certificate_is_immutable():
+    """A guarantee that can be edited after issue is not a guarantee."""
+    cert = Certificate(True, 0.9, 0.05, 100, 0.0, 19, "certified")
+    with pytest.raises(Exception):
+        cert.lambda_hat = 0.1  # type: ignore[misc]
+
+
+class TestProxyGating:
+    """Certification must gate the switch, and a fresh install must not route."""
+
+    def test_the_proxy_consults_the_certificate(self):
+        import inspect
+
+        from entroly import proxy
+
+        source = inspect.getsource(proxy)
+        assert "permits_routing" in source, (
+            "the proxy must gate on the certificate, not merely compute one"
+        )
+        assert "ENTROLY_RAVS_AUTO" in source
+
+    def test_an_uncertified_install_leaves_routing_off(self, tmp_path, monkeypatch):
+        """The whole safety property in one assertion."""
+        monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+        monkeypatch.delenv("ENTROLY_RAVS_ROUTER", raising=False)
+        from entroly.ravs import conformal
+
+        conformal.reset_for_tests()
+        assert conformal.get_controller().certificate().permits_routing is False
+
+    def test_the_explicit_switch_still_works(self, monkeypatch):
+        """Certification adds a path to on; it must not remove the existing one."""
+        import inspect
+
+        from entroly import proxy
+
+        source = inspect.getsource(proxy)
+        assert 'os.environ.get("ENTROLY_RAVS_ROUTER", "0") == "1"' in source

--- a/tests/test_conformal_routing.py
+++ b/tests/test_conformal_routing.py
@@ -210,3 +210,50 @@ class TestProxyGating:
 
         source = inspect.getsource(proxy)
         assert 'os.environ.get("ENTROLY_RAVS_ROUTER", "0") == "1"' in source
+
+
+class TestTheLoopIsClosed:
+    """A certificate with no producer can never be earned.
+
+    The first version of this module shipped a consumer and no writer: nothing
+    called record(), so n stayed 0 and the feature was inert. That is the same
+    defect as a dashboard field nothing increments, and it is pinned here.
+    """
+
+    def test_the_proxy_records_calibration_observations(self):
+        import inspect
+
+        from entroly import proxy
+
+        source = inspect.getsource(proxy)
+        assert "get_controller().record(" in source, (
+            "no producer: the certificate could never be earned"
+        )
+
+    def test_the_observation_is_paired_with_its_confidence(self):
+        """A label without the confidence it was observed at cannot calibrate."""
+        import inspect
+
+        from entroly import proxy
+
+        source = inspect.getsource(proxy)
+        assert "confidence=_ravs_prev_conf" in source
+        assert "_ravs_prev_conf = prev_routed" in source, (
+            "confidence must be carried from the decision to its outcome"
+        )
+
+    def test_the_docstring_does_not_claim_a_verifier_label(self):
+        """The label is behavioural feedback; claiming otherwise oversells it."""
+        from entroly.ravs import conformal
+
+        doc = conformal.__doc__ or ""
+        assert "behavioural proxy" in doc
+        assert "not a deterministic verifier" in doc
+
+    def test_the_bootstrap_limitation_is_documented(self):
+        from entroly.ravs import conformal
+
+        doc = conformal.__doc__ or ""
+        assert "circularity" in doc, (
+            "a user must be told the certificate cannot self-start"
+        )

--- a/tests/test_conformal_routing.py
+++ b/tests/test_conformal_routing.py
@@ -257,3 +257,85 @@ class TestTheLoopIsClosed:
         assert "circularity" in doc, (
             "a user must be told the certificate cannot self-start"
         )
+
+
+class TestReviewFixes:
+    """Five defects an extra-high-recall review found in this feature."""
+
+    def test_an_unreadable_store_is_not_an_empty_one(self, tmp_path):
+        """Finding 3: one torn read used to destroy the whole history."""
+        from entroly.ravs.conformal import ConformalRoutingController
+
+        path = tmp_path / "calib.json"
+        controller = ConformalRoutingController(path, alpha=0.05)
+        for _ in range(60):
+            controller.record(0.97, False)
+        assert controller.certificate().n == 60
+
+        path.write_text('{"observations": [{"conf', encoding="utf-8")
+        controller.record(0.97, False)
+
+        assert path.read_text(encoding="utf-8").startswith('{"observations": [{"conf'), (
+            "a store that could not be read must not be overwritten"
+        )
+
+    def test_an_unreadable_store_refuses_to_route(self, tmp_path):
+        from entroly.ravs.conformal import ConformalRoutingController
+
+        path = tmp_path / "calib.json"
+        path.write_text("{ truncated", encoding="utf-8")
+        certificate = ConformalRoutingController(path, alpha=0.05).certificate()
+
+        assert certificate.permits_routing is False
+        assert "unreadable" in certificate.reason
+
+    def test_a_missing_store_is_still_a_clean_start(self, tmp_path):
+        """Absent and corrupt must stay distinguishable."""
+        from entroly.ravs.conformal import ConformalRoutingController
+
+        controller = ConformalRoutingController(tmp_path / "none.json", alpha=0.05)
+        controller.record(0.9, False)
+        assert controller.certificate().n == 1
+
+    def test_the_store_is_replaced_atomically(self, tmp_path):
+        """Finding 4: write_text truncated before writing, so readers tore."""
+        import inspect
+
+        from entroly.ravs import conformal
+
+        source = inspect.getsource(conformal.ConformalRoutingController._write)
+        assert "os.replace" in source, "the swap must be atomic for concurrent readers"
+
+    def test_no_temp_files_are_left_behind(self, tmp_path):
+        from entroly.ravs.conformal import ConformalRoutingController
+
+        controller = ConformalRoutingController(tmp_path / "calib.json", alpha=0.05)
+        for _ in range(5):
+            controller.record(0.9, False)
+
+        assert list(tmp_path.glob("*.tmp")) == []
+
+
+class TestCertifiedThresholdIsEnforced:
+    """Finding 1: the bound was proven for a rule production did not apply."""
+
+    def test_the_proxy_compares_confidence_against_lambda_hat(self):
+        import inspect
+
+        from entroly import proxy
+
+        source = inspect.getsource(proxy)
+        assert "_conf < _cert.lambda_hat" in source, (
+            "routing below the certified threshold is outside the proven region"
+        )
+
+    def test_lambda_hat_is_not_only_a_log_argument(self):
+        """It was previously reachable only from a logger.info format string."""
+        import inspect
+
+        from entroly import proxy
+
+        source = inspect.getsource(proxy)
+        before, _, after = source.partition("logger.info")
+        assert "lambda_hat" in source
+        assert "_cert.lambda_hat" in source.replace("logger.info", "", 1) or                "_conf < _cert.lambda_hat" in source

--- a/tests/test_dashboard_autostart.py
+++ b/tests/test_dashboard_autostart.py
@@ -135,3 +135,43 @@ class TestMcpWiring:
         assert "try:" in source[max(0, index - 400):index], (
             "an unguarded dashboard start can take down the stdio session"
         )
+
+
+class TestEmptyBeliefPanelTellsTheTruth:
+    """An empty panel must not ask for work the product already does.
+
+    It read "No beliefs yet -- run compile_beliefs to seed the vault". Since
+    indexing seeds them, that instruction is now false in the common case: an
+    empty panel means seeding is in flight, not that the user must act. The
+    two states have different fixes, so the panel needs to know which it is in.
+    """
+
+    def test_the_stale_instruction_is_gone(self):
+        from entroly.dashboard import DASHBOARD_HTML
+
+        assert "run <code>compile_beliefs</code> to seed the vault" not in DASHBOARD_HTML
+
+    def test_both_empty_states_are_distinguished(self):
+        from entroly.dashboard import DASHBOARD_HTML
+
+        assert "seeding runs automatically after indexing" in DASHBOARD_HTML
+        assert "ENTROLY_BELIEF_AUTOSEED=0" in DASHBOARD_HTML
+        assert "c.autoseed" in DASHBOARD_HTML, "the panel must branch on real state"
+
+    def test_the_snapshot_reports_seeding_state(self, monkeypatch):
+        from entroly.dashboard import _autoseed_state
+
+        monkeypatch.delenv("ENTROLY_BELIEF_AUTOSEED", raising=False)
+        assert _autoseed_state() is True
+        monkeypatch.setenv("ENTROLY_BELIEF_AUTOSEED", "0")
+        assert _autoseed_state() is False
+
+    def test_a_missing_native_module_does_not_read_as_seeding_off(self, monkeypatch):
+        """Different causes, different fixes -- the panel must not conflate them."""
+        monkeypatch.delenv("ENTROLY_BELIEF_AUTOSEED", raising=False)
+        from entroly.dashboard import _cogops_unavailable_snapshot
+
+        snapshot = _cogops_unavailable_snapshot("no entroly_core")
+        assert snapshot["autoseed"] is True, (
+            "a native-engine problem would be reported as a seeding switch"
+        )

--- a/tests/test_dashboard_autostart.py
+++ b/tests/test_dashboard_autostart.py
@@ -1,0 +1,137 @@
+"""The MCP server must show its work.
+
+Every other entry point starts a dashboard -- the proxy, the daemon, and
+`entroly dashboard` itself. The MCP server did not, which made the most
+common install the one where indexing, compression, belief seeding and
+hallucination blocking all ran and none of it was visible. Value that is
+measured but never displayed is indistinguishable, to the person who
+installed it, from value that was never produced.
+
+Autostart on that path is only safe under three conditions, pinned here: it
+must not bind a port something else is serving, it must not write to stdout,
+and it must not raise.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+
+import pytest
+
+from entroly import dashboard
+
+
+@pytest.fixture
+def taken_port():
+    """A port with a real listener on it."""
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    yield sock.getsockname()[1]
+    sock.close()
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class TestPortSafety:
+    def test_an_occupied_port_is_detected(self, taken_port):
+        assert dashboard._port_already_serving(taken_port) is True
+
+    def test_a_free_port_is_detected(self):
+        assert dashboard._port_already_serving(_free_port()) is False
+
+    def test_it_refuses_to_start_on_an_occupied_port(self, taken_port):
+        """SO_REUSEADDR makes bind-and-see an unreliable test on Windows.
+
+        The dashboard server sets allow_reuse_address, so a second bind to a
+        live port can succeed there and leave two servers splitting requests
+        non-deterministically. Presence must be probed, not inferred.
+        """
+        assert dashboard.maybe_start_dashboard(engine=None, port=taken_port) is None
+
+
+class TestFailsOpen:
+    def test_a_start_failure_returns_none_rather_than_raising(self, monkeypatch):
+        monkeypatch.setattr(dashboard, "_port_already_serving", lambda *_a, **_k: False)
+        monkeypatch.setattr(
+            dashboard, "start_dashboard",
+            lambda **_k: (_ for _ in ()).throw(RuntimeError("no socket")))
+
+        assert dashboard.maybe_start_dashboard(port=_free_port()) is None
+
+    def test_an_oserror_returns_none_rather_than_raising(self, monkeypatch):
+        monkeypatch.setattr(dashboard, "_port_already_serving", lambda *_a, **_k: False)
+        monkeypatch.setattr(
+            dashboard, "start_dashboard",
+            lambda **_k: (_ for _ in ()).throw(OSError("address in use")))
+
+        assert dashboard.maybe_start_dashboard(port=_free_port()) is None
+
+    def test_it_can_be_turned_off(self, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DASHBOARD_AUTOSTART", "0")
+        assert dashboard.dashboard_autostart_enabled() is False
+        assert dashboard.maybe_start_dashboard(port=_free_port()) is None
+
+    def test_it_is_on_by_default(self, monkeypatch):
+        monkeypatch.delenv("ENTROLY_DASHBOARD_AUTOSTART", raising=False)
+        assert dashboard.dashboard_autostart_enabled() is True
+
+
+class TestStdioIsNotCorrupted:
+    def test_starting_writes_nothing_to_stdout(self, capsys):
+        """stdout on the MCP path is the JSON-RPC channel.
+
+        One stray line desynchronises the client and the session dies, so the
+        dashboard must announce itself on stderr or not at all.
+        """
+        port = _free_port()
+        server = dashboard.maybe_start_dashboard(engine=None, port=port)
+        try:
+            assert capsys.readouterr().out == "", (
+                "a print() here would break every MCP client"
+            )
+        finally:
+            if server is not None:
+                server.shutdown()
+                server.server_close()
+
+    def test_the_server_actually_serves(self):
+        """Autostart that silently no-ops is the bug it was meant to fix."""
+        port = _free_port()
+        server = dashboard.maybe_start_dashboard(engine=None, port=port)
+        assert server is not None
+        try:
+            assert dashboard._port_already_serving(port) is True
+        finally:
+            server.shutdown()
+            server.server_close()
+
+
+class TestMcpWiring:
+    def test_the_mcp_startup_path_starts_a_dashboard(self):
+        """The wiring, not the server: without this call nothing is shown."""
+        import inspect
+
+        from entroly import server as server_module
+
+        source = inspect.getsource(server_module)
+        assert "maybe_start_dashboard" in source, (
+            "the MCP server would index, compress and verify invisibly again"
+        )
+
+    def test_dashboard_start_is_not_left_to_a_bare_thread(self):
+        """It must run inside the guarded startup path, not beside it."""
+        import inspect
+
+        from entroly import server as server_module
+
+        source = inspect.getsource(server_module)
+        index = source.index("maybe_start_dashboard")
+        assert "try:" in source[max(0, index - 400):index], (
+            "an unguarded dashboard start can take down the stdio session"
+        )

--- a/tests/test_dashboard_wiring.py
+++ b/tests/test_dashboard_wiring.py
@@ -385,3 +385,48 @@ def test_cross_runtime_schema_contract(fresh_dir):
     assert receipt["provider_path"]["input_tokens_reduced"] == 500
     assert receipt["local_operations"]["tokens_reduced"] == 2200
     assert receipt["local_operations"]["dollar_claimed_usd"] == 0
+
+
+class TestSerialisationPreservesSmallMeasurements:
+    """Rounding for money must not erase physics.
+
+    _safe_json rounds every float to six decimal places, which suits dollars
+    and ratios but not the quantities the energy panel reports: a few hundred
+    tokens avoid ~1e-8 kWh. Serialised at six places that is 0.0, so a new
+    user's first requests would report exactly the nothing the dashboard
+    exists to disprove.
+    """
+
+    def test_a_small_non_zero_value_does_not_serialise_to_zero(self):
+        from entroly.dashboard import _safe_json
+
+        assert _safe_json(6.88e-9) != 0.0, (
+            "the first requests a user makes would report no energy saved"
+        )
+
+    def test_dollar_figures_are_unchanged(self):
+        """The narrow fix must not move any number that already displayed."""
+        from entroly.dashboard import _safe_json
+
+        for value in (0.75, 39.136125, 117.408375, 1.0, 0.000123):
+            assert _safe_json(value) == round(value, 6)
+
+    def test_zero_and_nan_still_collapse(self):
+        from entroly.dashboard import _safe_json
+
+        assert _safe_json(0.0) == 0.0
+        assert _safe_json(float("nan")) == 0.0
+
+    def test_energy_survives_the_api_boundary(self, tmp_path, monkeypatch):
+        """End to end: a tiny reduction still reaches the client as non-zero."""
+        monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+        from entroly.dashboard import _safe_json
+        from entroly.value_tracker import ValueTracker
+
+        tracker = ValueTracker()
+        tracker.record(tokens_saved=50, source="mcp")
+        payload = _safe_json(tracker.get_lifetime())
+
+        assert payload["energy"]["kwh_avoided"] > 0.0, (
+            "measured, priced, then rounded away on the way to the browser"
+        )

--- a/tests/test_dashboard_wiring.py
+++ b/tests/test_dashboard_wiring.py
@@ -252,14 +252,45 @@ def test_modeled_banked_value_calculator(tokens, rate, expected):
 
 
 def test_dashboard_labels_banked_value_separately_from_realized_savings():
+    """Modeled value may be added to realized value, never disguised as it.
+
+    The hero shows one total, because a user running both the proxy and the
+    MCP server otherwise saw the smaller of two true numbers and no sum. That
+    is only defensible while the reader can still tell the parts apart, so the
+    modeled lane keeps its own wording and its own rate control inside the
+    total rather than being absorbed by it.
+    """
     from entroly.dashboard import DASHBOARD_HTML
 
-    assert "BANKED FUTURE VALUE" in DASHBOARD_HTML
     assert "Banked Future Value" in DASHBOARD_HTML
+    assert "banked future value" in DASHBOARD_HTML
     assert "modeled future value, not realized savings" in DASHBOARD_HTML
     assert "USD per 1M input tokens" in DASHBOARD_HTML
     assert "bankedUsdPerMillion" in DASHBOARD_HTML
     assert "if(raw===null)return 1" in DASHBOARD_HTML
+
+
+def test_dashboard_total_is_itemised_rather_than_a_bare_number():
+    """A total with no visible composition is a claim, not a report."""
+    from entroly.dashboard import DASHBOARD_HTML
+
+    assert "TOTAL VALUE BANKED" in DASHBOARD_HTML
+    for lane in ("provider requests", "model routing", "banked future value"):
+        assert lane in DASHBOARD_HTML, f"the total hides its {lane} component"
+    assert "not an invoice" in DASHBOARD_HTML, (
+        "a dollar total must say it is modeled, not billed"
+    )
+
+
+def test_dashboard_total_sums_every_priced_lane():
+    """The headline must not silently drop a lane that carries real value.
+
+    Regression: the hero showed provider savings OR local savings, so routing
+    savings never reached the headline at all no matter how large they grew.
+    """
+    from entroly.dashboard import DASHBOARD_HTML
+
+    assert "const totalUsd=realCost+bankedLocalUsd+routingUsd;" in DASHBOARD_HTML
 
 
 _NODE = shutil.which("node")

--- a/tests/test_energy_value.py
+++ b/tests/test_energy_value.py
@@ -127,3 +127,64 @@ class TestReceiptIntegration:
         # Prefill is avoided wherever the tokens were removed, so the energy
         # figure spans both channels even though their dollar treatment differs.
         assert tracker.get_value_receipt()["energy"]["tokens_saved"] == 1_000_000
+
+
+class TestEnergyReachesTheDashboard:
+    """Deriving kWh is worthless if the number never leaves the module.
+
+    The energy figure is computed on read from token totals rather than
+    accumulated on write, so these pin the two properties that choice buys:
+    it always agrees with the tokens beside it, and a failure to derive it
+    costs the kWh line rather than the dollar totals.
+    """
+
+    def _tracker(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+        from entroly.value_tracker import ValueTracker
+
+        return ValueTracker()
+
+    def test_lifetime_carries_energy(self, tmp_path, monkeypatch):
+        tracker = self._tracker(tmp_path, monkeypatch)
+        tracker.record(tokens_saved=250_000, model="claude-sonnet-4",
+                       source="provider")
+
+        energy = tracker.get_lifetime().get("energy")
+        assert energy, "the dashboard cannot render a kWh line that isn't sent"
+        assert energy["kwh_avoided"] > 0
+        assert energy["measured"] is False, "modeled figures must say so"
+
+    def test_energy_spans_every_token_lane(self, tmp_path, monkeypatch):
+        """Provider, local and unclassified tokens all avoid the same prefill."""
+        tracker = self._tracker(tmp_path, monkeypatch)
+        tracker.record(tokens_saved=100_000, model="claude-sonnet-4",
+                       source="provider")
+        tracker.record(tokens_saved=60_000, source="mcp")
+        tracker.record(tokens_saved=40_000, source="unclassified")
+
+        lifetime = tracker.get_lifetime()
+        counted = (
+            lifetime.get("provider_tokens_saved", 0)
+            + lifetime.get("local_tokens_reduced", 0)
+            + lifetime.get("unclassified_tokens_reduced", 0)
+        )
+        assert lifetime["energy"]["tokens_saved"] == counted, (
+            "energy must be derived from the same tokens shown as dollars"
+        )
+
+    def test_a_failure_to_derive_energy_does_not_lose_the_totals(
+        self, tmp_path, monkeypatch
+    ):
+        tracker = self._tracker(tmp_path, monkeypatch)
+        tracker.record(tokens_saved=250_000, model="claude-sonnet-4",
+                       source="provider")
+
+        def explode(*_a, **_k):
+            raise RuntimeError("no")
+
+        monkeypatch.setattr("entroly.energy_value.energy_for_tokens", explode)
+
+        lifetime = tracker.get_lifetime()
+        assert lifetime.get("provider_tokens_saved") == 250_000, (
+            "a missing kWh line must not take the dollar figures with it"
+        )

--- a/tests/test_energy_value.py
+++ b/tests/test_energy_value.py
@@ -1,0 +1,129 @@
+"""Electricity avoided must be derivable by hand from the numbers it reports.
+
+Token reduction removes prefill work, and prefill work is joules. The figure is
+modeled rather than measured -- Entroly runs locally and cannot instrument a
+provider's accelerators -- so its only defence is that every input is stated and
+the arithmetic is checkable. These tests recompute it independently rather than
+asserting a constant, which would pass even if the formula drifted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.energy_value import (
+    EnergyAssumptions,
+    energy_for_tokens,
+    scale_energy,
+)
+
+
+def _by_hand(tokens: int, a: EnergyAssumptions) -> float:
+    flops = 2 * a.model_params_billions * 1e9 * tokens
+    seconds = flops / (a.accelerator_peak_tflops * 1e12 * a.model_flops_utilization)
+    return seconds * a.accelerator_tdp_watts / 3_600_000.0
+
+
+class TestArithmetic:
+    @pytest.mark.parametrize("tokens", [1_000, 1_000_000, 14_065_000])
+    def test_matches_an_independent_computation(self, tokens):
+        a = EnergyAssumptions()
+        result = energy_for_tokens(tokens, a)
+        assert result["kwh_avoided"] == pytest.approx(_by_hand(tokens, a), rel=1e-6)
+
+    def test_scales_linearly_in_tokens(self):
+        one = energy_for_tokens(1_000_000)["kwh_avoided"]
+        ten = energy_for_tokens(10_000_000)["kwh_avoided"]
+        assert ten == pytest.approx(one * 10, rel=1e-9), (
+            "prefill is linear in prompt length; a non-linear result means the "
+            "model no longer describes what it claims to"
+        )
+
+    def test_zero_tokens_is_zero_energy(self):
+        assert energy_for_tokens(0)["kwh_avoided"] == 0.0
+
+    def test_negative_tokens_cannot_manufacture_energy(self):
+        assert energy_for_tokens(-5_000)["kwh_avoided"] == 0.0
+
+
+class TestHonesty:
+    def test_result_declares_it_is_not_measured(self):
+        result = energy_for_tokens(1_000_000)
+        assert result["measured"] is False
+        assert result["basis"] == "prefill_only"
+
+    def test_every_assumption_is_reported(self):
+        result = energy_for_tokens(1_000)
+        # A reader who disagrees must be able to see, and substitute, each
+        # input. Reporting kWh alone would be unfalsifiable.
+        for key in ("model_params_billions", "accelerator_peak_tflops",
+                    "model_flops_utilization", "accelerator_tdp_watts"):
+            assert key in result["assumptions"]
+
+    def test_intermediates_are_exposed_for_checking(self):
+        result = energy_for_tokens(1_000_000)
+        assert result["petaflops_avoided"] > 0
+        assert result["accelerator_seconds_avoided"] > 0
+
+    def test_no_carbon_is_derived(self):
+        # kWh is arithmetic. Emissions need a grid-intensity factor that varies
+        # by region, hour and methodology; attaching one would put a
+        # contestable number next to a checkable one.
+        result = energy_for_tokens(1_000_000)
+        assert not any("co2" in k.lower() or "carbon" in k.lower() for k in result)
+
+
+class TestOverrides:
+    def test_a_smaller_model_avoids_less_energy(self):
+        big = energy_for_tokens(1_000_000, EnergyAssumptions(model_params_billions=70))
+        small = energy_for_tokens(1_000_000, EnergyAssumptions(model_params_billions=7))
+        assert small["kwh_avoided"] == pytest.approx(big["kwh_avoided"] / 10, rel=1e-9)
+
+    def test_environment_overrides_are_honoured(self, monkeypatch):
+        monkeypatch.setenv("ENTROLY_ENERGY_MODEL_PARAMS_B", "8")
+        assert EnergyAssumptions.from_env().model_params_billions == 8.0
+
+    def test_a_nonsense_override_falls_back_rather_than_crashing(self, monkeypatch):
+        monkeypatch.setenv("ENTROLY_ENERGY_TDP_WATTS", "not-a-number")
+        assert EnergyAssumptions.from_env().accelerator_tdp_watts == 700.0
+
+    def test_zero_override_is_rejected(self, monkeypatch):
+        # A zero would divide by zero or zero out the result silently.
+        monkeypatch.setenv("ENTROLY_ENERGY_MFU", "0")
+        assert EnergyAssumptions.from_env().model_flops_utilization == 0.40
+
+
+class TestProjection:
+    def test_projection_is_labelled_as_such(self):
+        base = energy_for_tokens(1_000_000)
+        projected = scale_energy(base, 365)
+        assert projected["projected"] is True
+        assert projected["projection_multiplier"] == 365
+        assert projected["kwh_avoided"] == pytest.approx(base["kwh_avoided"] * 365, rel=1e-6)
+
+
+class TestReceiptIntegration:
+    def test_energy_appears_without_being_asked_for(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+        from entroly.value_tracker import ValueTracker
+
+        tracker = ValueTracker(data_dir=tmp_path)
+        tracker.record(tokens_saved=1_000_000, source="sdk")
+
+        receipt = tracker.get_value_receipt()
+        assert "energy" in receipt, (
+            "a figure that only appears behind a flag is a figure nobody sees"
+        )
+        assert receipt["energy"]["kwh_avoided"] > 0.0
+
+    def test_energy_counts_both_channels(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+        from entroly.value_tracker import ValueTracker
+
+        tracker = ValueTracker(data_dir=tmp_path)
+        tracker.record(tokens_saved=500_000, source="sdk")
+        tracker.record(tokens_saved=500_000, model="gpt-4o", source="proxy")
+
+        # Prefill is avoided wherever the tokens were removed, so the energy
+        # figure spans both channels even though their dollar treatment differs.
+        assert tracker.get_value_receipt()["energy"]["tokens_saved"] == 1_000_000

--- a/tests/test_energy_value.py
+++ b/tests/test_energy_value.py
@@ -14,7 +14,6 @@ import pytest
 from entroly.energy_value import (
     EnergyAssumptions,
     energy_for_tokens,
-    scale_energy,
 )
 
 
@@ -91,15 +90,6 @@ class TestOverrides:
         # A zero would divide by zero or zero out the result silently.
         monkeypatch.setenv("ENTROLY_ENERGY_MFU", "0")
         assert EnergyAssumptions.from_env().model_flops_utilization == 0.40
-
-
-class TestProjection:
-    def test_projection_is_labelled_as_such(self):
-        base = energy_for_tokens(1_000_000)
-        projected = scale_energy(base, 365)
-        assert projected["projected"] is True
-        assert projected["projection_multiplier"] == 365
-        assert projected["kwh_avoided"] == pytest.approx(base["kwh_avoided"] * 365, rel=1e-6)
 
 
 class TestReceiptIntegration:

--- a/tests/test_local_savings_are_priced.py
+++ b/tests/test_local_savings_are_priced.py
@@ -1,0 +1,86 @@
+"""Measured local token reductions must carry a value, and must not be confused
+with invoice-verified savings.
+
+The receipt printed a hardcoded `$0.0000` for local operations while displaying
+the measured token count beside it. Input avoided is input not bought, and
+tokens have a public rate, so reporting nothing understated real work: an agent
+saving ~28k tokens per request through the SDK or MCP banked nothing on any
+surface a user looks at.
+
+The opposite error is worse. Provider-bound savings are checked against
+observed usage; local ones cannot be. The two therefore stay in separate
+fields, and the local figure carries its basis in its name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.value_tracker import ValueTracker, estimate_cost
+
+
+@pytest.fixture
+def tracker(tmp_path, monkeypatch):
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+    return ValueTracker(data_dir=tmp_path)
+
+
+class TestLocalReductionsArePriced:
+    def test_measured_local_tokens_get_a_dollar_figure(self, tracker):
+        tracker.record(tokens_saved=28_130, source="sdk")
+
+        local = tracker.get_value_receipt()["local_operations"]
+        assert local["tokens_reduced"] == 28_130
+        assert local["modeled_value_at_list_usd"] > 0.0, (
+            "a measured reduction reported no value; the token count beside it "
+            "proves work was done"
+        )
+
+    def test_the_figure_matches_the_catalog_rate(self, tracker):
+        tracker.record(tokens_saved=100_000, source="mcp")
+
+        local = tracker.get_value_receipt()["local_operations"]
+        expected = round(estimate_cost(100_000, model="", kind="input"), 6)
+        assert local["modeled_value_at_list_usd"] == expected, (
+            "the local figure must be the catalog rate applied to the measured "
+            "tokens, not an independent estimate that could drift"
+        )
+
+    def test_the_basis_is_named_in_the_payload(self, tracker):
+        tracker.record(tokens_saved=1_000, source="npm")
+        local = tracker.get_value_receipt()["local_operations"]
+
+        assert local["pricing_basis"] == "default_catalog_input_rate"
+        # The evidence string is what a reader sees when they ask where the
+        # number came from, so it must state both halves: that it is priced,
+        # and that it is not an invoice.
+        assert "replacement-cost" in local["evidence"]
+        assert "not an invoice" in local["evidence"]
+        assert "measured" in local["evidence"]
+
+
+class TestVerifiedAndModelledStaySeparate:
+    def test_local_value_never_enters_the_provider_total(self, tracker):
+        tracker.record(tokens_saved=500_000, source="sdk")
+
+        receipt = tracker.get_value_receipt()
+        assert receipt["provider_path"]["modeled_input_cost_avoided_usd"] == 0.0, (
+            "local replacement-cost value leaked into the provider-bound total, "
+            "which is the number checked against observed usage"
+        )
+        assert receipt["local_operations"]["modeled_value_at_list_usd"] > 0.0
+
+    def test_dollar_claimed_stays_zero_for_local(self, tracker):
+        # This field has always meant "verified against observed provider
+        # usage". Repurposing it would silently change the meaning of a number
+        # already published in receipts.
+        tracker.record(tokens_saved=250_000, source="local")
+        assert tracker.get_value_receipt()["local_operations"]["dollar_claimed_usd"] == 0.0
+
+    def test_provider_traffic_still_prices_into_the_provider_bucket(self, tracker):
+        tracker.record(tokens_saved=10_000, model="gpt-4o", source="proxy")
+
+        receipt = tracker.get_value_receipt()
+        assert receipt["provider_path"]["input_tokens_reduced"] == 10_000
+        assert receipt["provider_path"]["modeled_input_cost_avoided_usd"] > 0.0
+        assert receipt["local_operations"]["tokens_reduced"] == 0

--- a/tests/test_routing_value_visibility.py
+++ b/tests/test_routing_value_visibility.py
@@ -1,0 +1,125 @@
+"""Routing value must be recorded, and available value must stay separate.
+
+Two defects sit behind this file. The dashboard has read `routing_saved_usd`
+since it was written -- there is a KPI card labelled "Model-Routing Saved" --
+and no production path ever incremented it, so the panel read $0 however much
+traffic RAVS moved. And because routing is off until the user authorises model
+substitution, a disabled router measured nothing at all, leaving that
+authorisation to be given blind.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.value_tracker import ValueTracker, routing_delta_usd
+
+
+@pytest.fixture
+def tracker(tmp_path, monkeypatch):
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+    return ValueTracker(tmp_path)
+
+
+class TestPricing:
+    def test_a_flagship_to_cheap_swap_is_worth_money(self):
+        assert routing_delta_usd(
+            "claude-opus-4-20250514", "claude-haiku-4-5", 100_000) > 0
+
+    def test_an_unpriced_model_yields_nothing_rather_than_a_guess(self):
+        """Two default rates differ by zero; reporting that would be invented."""
+        assert routing_delta_usd("mystery-model", "claude-haiku-4-5", 100_000) == 0.0
+        assert routing_delta_usd("claude-opus-4-20250514", "mystery", 100_000) == 0.0
+
+    def test_routing_to_a_dearer_model_is_not_a_saving(self):
+        assert routing_delta_usd(
+            "claude-haiku-4-5", "claude-opus-4-20250514", 100_000) == 0.0
+
+    def test_missing_model_names_are_not_priced(self):
+        assert routing_delta_usd("", "claude-haiku-4-5", 100_000) == 0.0
+
+
+class TestCapturedAndAvailableNeverMix:
+    def test_a_captured_saving_lands_in_the_saved_field(self, tracker):
+        tracker.record_routing_saving(0.42, chosen_model="claude-haiku-4-5")
+        lifetime = tracker.get_lifetime()
+
+        assert lifetime["routing_saved_usd"] == pytest.approx(0.42)
+        assert lifetime.get("routing_available_usd", 0.0) == 0.0
+
+    def test_an_available_saving_never_touches_the_saved_field(self, tracker):
+        """This is money not earned. Summing it into a total would be a lie."""
+        tracker.record_routing_opportunity(1.50, chosen_model="claude-haiku-4-5")
+        lifetime = tracker.get_lifetime()
+
+        assert lifetime["routing_available_usd"] == pytest.approx(1.50)
+        assert lifetime.get("routing_saved_usd", 0.0) == 0.0, (
+            "unrealised value must never be presented as captured"
+        )
+
+    def test_opportunities_are_counted(self, tracker):
+        tracker.record_routing_opportunity(0.10, chosen_model="claude-haiku-4-5")
+        tracker.record_routing_opportunity(0.20, chosen_model="claude-haiku-4-5")
+
+        assert tracker.get_lifetime()["routing_opportunities"] == 2
+
+    def test_non_positive_amounts_are_ignored(self, tracker):
+        tracker.record_routing_opportunity(0.0)
+        tracker.record_routing_opportunity(-5.0)
+
+        assert tracker.get_lifetime().get("routing_available_usd", 0.0) == 0.0
+
+
+class TestShadowMeasuresWithoutSwapping:
+    def test_a_disabled_router_still_evaluates_in_shadow(self):
+        """route() short-circuits when disabled; shadow_route() must not."""
+        from entroly.ravs.router import BayesianRouter
+
+        router = BayesianRouter(enabled=False)
+        live = router.route("claude-opus-4-20250514", "summarise this")
+        shadow = router.shadow_route("claude-opus-4-20250514", "summarise this")
+
+        assert live.reason == "bayesian_router_disabled"
+        assert shadow.reason != "bayesian_router_disabled", (
+            "the user would be authorising routing with no evidence of its worth"
+        )
+
+    def test_shadow_still_refuses_without_evidence(self):
+        """Bypassing the enable check must not bypass the safety gates."""
+        from entroly.ravs.router import BayesianRouter
+
+        shadow = BayesianRouter(enabled=False).shadow_route(
+            "claude-opus-4-20250514", "summarise this")
+
+        assert shadow.use_original is True, "no captured data must mean no recommendation"
+
+    def test_shadow_defers_to_the_live_path_when_enabled(self):
+        from entroly.ravs.router import BayesianRouter
+
+        router = BayesianRouter(enabled=True)
+        assert router.shadow_route("claude-opus-4-20250514", "x").reason != (
+            "bayesian_router_disabled"
+        )
+
+
+class TestProxyWiring:
+    def test_the_swap_site_records_its_saving(self):
+        """Regression: the swap happened and nothing counted it."""
+        import inspect
+
+        from entroly import proxy
+
+        source = inspect.getsource(proxy)
+        assert "_record_routing_value" in source
+        assert source.count("_record_routing_value") >= 3, (
+            "expected the helper plus both the captured and shadow call sites"
+        )
+
+    def test_body_token_estimation_survives_malformed_input(self):
+        from entroly.proxy import PromptCompilerProxy
+
+        estimate = PromptCompilerProxy._estimate_body_tokens
+        assert estimate({}) == 0
+        assert estimate({"messages": None}) == 0
+        assert estimate({"messages": [{"content": "abcd" * 10}]}) == 10
+        assert estimate({"messages": [{"content": [{"text": "abcd" * 10}]}]}) == 10

--- a/tests/test_shadow_calibration.py
+++ b/tests/test_shadow_calibration.py
@@ -251,3 +251,18 @@ class TestItActuallyCertifies:
         assert controller.certificate().permits_routing is False, (
             "a cheap model that keeps diverging must never be authorised"
         )
+
+
+def test_the_module_declares_that_it_is_not_wired():
+    """Env vars that control nothing must not read as if they control cost.
+
+    ENTROLY_RAVS_SHADOW and ENTROLY_RAVS_SHADOW_RATE are documented as opt-out
+    for cheap-model spend, but no production code calls should_sample or
+    supplies invoke_cheap, so setting them changes nothing. Until a caller
+    exists the docstring has to say so; delete this test when it is wired.
+    """
+    from entroly.ravs import shadow_calibration
+
+    assert "NOT YET WIRED" in (shadow_calibration.__doc__ or ""), (
+        "either wire the module or keep the notice; a silent no-op is worse"
+    )

--- a/tests/test_shadow_calibration.py
+++ b/tests/test_shadow_calibration.py
@@ -1,0 +1,214 @@
+"""Calibration must never cost the user an answer, and must stop paying.
+
+The routing certificate could not bootstrap: it needed observations of a cheap
+model, which needed the cheap model to have been used, which needed the
+certificate. Shadow calibration breaks that by separating who answers the user
+from what is learned -- the flagship answers, and the cheap model is called
+only to be compared.
+
+That trade is acceptable only while three things hold, so each is pinned here:
+the user is never served a shadow result, sampling terminates once enough
+observations exist, and no failure in any of it reaches the request.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from entroly.ravs.shadow_calibration import (
+    ShadowCalibrator,
+    diverged,
+    divergence_score,
+    should_sample,
+)
+
+
+class TestDivergenceLabel:
+    def test_identical_answers_do_not_diverge(self):
+        text = "The auth module hashes passwords with a per-user salt."
+        assert divergence_score(text, text) == 0.0
+        assert diverged(text, text) is False
+
+    def test_unrelated_answers_diverge(self):
+        assert diverged(
+            "The auth module hashes passwords with a per-user salt.",
+            "Kubernetes schedules pods onto nodes using taints.",
+        ) is True
+
+    def test_two_empty_answers_agree(self):
+        """Both produced nothing; a shared failure is not a routing fault."""
+        assert divergence_score("", "") == 0.0
+        assert diverged("", "") is False
+
+    def test_one_empty_answer_diverges(self):
+        assert divergence_score("a real answer here", "") == 1.0
+
+    def test_the_score_is_bounded(self):
+        for a, b in [("x", "y"), ("", "z"), ("a b c", "a b c d"), ("", "")]:
+            assert 0.0 <= divergence_score(a, b) <= 1.0
+
+    def test_wording_differences_are_tolerated(self):
+        """Paraphrase must not read as divergence, or nothing ever routes."""
+        assert diverged(
+            "The function hashes the password using a salt value",
+            "The function hashes the password using a salt",
+        ) is False
+
+    def test_the_label_is_symmetric(self):
+        a, b = "alpha beta gamma", "beta gamma delta"
+        assert divergence_score(a, b) == divergence_score(b, a)
+
+
+class TestSamplingPolicy:
+    def test_high_risk_requests_are_never_sampled(self):
+        """Nothing is learned by paying for a request that will never route."""
+        decision = should_sample(
+            risk_level="high", observations=0, samples_needed=49, epsilon=1.0)
+        assert decision.sample is False
+        assert "never routed" in decision.reason
+
+    def test_sampling_stops_once_calibrated(self):
+        """A bootstrap phase with an end, not a standing tax."""
+        decision = should_sample(
+            risk_level="low", observations=49, samples_needed=49, epsilon=1.0)
+        assert decision.sample is False
+        assert "calibration complete" in decision.reason
+
+    def test_low_risk_and_uncalibrated_is_sampled(self):
+        assert should_sample(
+            risk_level="low", observations=0, samples_needed=49,
+            epsilon=1.0).sample is True
+
+    def test_a_zero_rate_disables_sampling(self):
+        assert should_sample(
+            risk_level="low", observations=0, samples_needed=49,
+            epsilon=0.0).sample is False
+
+    def test_the_rate_is_respected(self):
+        """Spend is bounded by epsilon rather than left to chance."""
+        rng = random.Random(11)
+        sampled = sum(
+            should_sample(risk_level="low", observations=0, samples_needed=49,
+                          epsilon=0.10, rng=rng).sample
+            for _ in range(4000)
+        )
+        assert 250 <= sampled <= 550, f"rate drifted from 10 percent: {sampled}/4000"
+
+    def test_it_can_be_turned_off(self, monkeypatch):
+        monkeypatch.setenv("ENTROLY_RAVS_SHADOW", "0")
+        assert should_sample(
+            risk_level="low", observations=0, samples_needed=49,
+            epsilon=1.0).sample is False
+
+
+class TestCalibratorNeverCostsTheRequest:
+    def test_an_observation_is_recorded(self):
+        recorded: list[tuple[float, bool]] = []
+        ShadowCalibrator(
+            invoke_cheap=lambda _m, _p: "a completely unrelated reply about pods",
+            record=lambda c, d: recorded.append((c, d)),
+        ).observe(prompt="q", cheap_model="haiku",
+                  flagship_output="salted password hashing", confidence=0.9)
+
+        assert recorded == [(0.9, True)]
+
+    def test_agreement_is_recorded_as_no_divergence(self):
+        recorded: list[tuple[float, bool]] = []
+        ShadowCalibrator(
+            invoke_cheap=lambda _m, _p: "salted password hashing",
+            record=lambda c, d: recorded.append((c, d)),
+        ).observe(prompt="q", cheap_model="haiku",
+                  flagship_output="salted password hashing", confidence=0.8)
+
+        assert recorded == [(0.8, False)]
+
+    def test_a_failing_cheap_call_records_nothing_and_does_not_raise(self):
+        recorded: list[Any] = []
+
+        def explode(_m, _p):
+            raise RuntimeError("provider down")
+
+        ShadowCalibrator(
+            invoke_cheap=explode, record=lambda c, d: recorded.append((c, d)),
+        ).observe(prompt="q", cheap_model="haiku", flagship_output="x",
+                  confidence=0.9)
+
+        assert recorded == [], "a failed shadow call must not become an observation"
+
+    def test_an_empty_cheap_response_is_not_an_observation(self):
+        """No answer is not the same as a different answer."""
+        recorded: list[Any] = []
+        ShadowCalibrator(
+            invoke_cheap=lambda _m, _p: "",
+            record=lambda c, d: recorded.append((c, d)),
+        ).observe(prompt="q", cheap_model="haiku", flagship_output="x",
+                  confidence=0.9)
+
+        assert recorded == []
+
+    def test_a_failing_recorder_does_not_raise(self):
+        def explode(_c, _d):
+            raise OSError("disk full")
+
+        ShadowCalibrator(
+            invoke_cheap=lambda _m, _p: "different text entirely",
+            record=explode,
+        ).observe(prompt="q", cheap_model="haiku", flagship_output="x",
+                  confidence=0.9)
+
+    def test_background_observation_does_not_block(self):
+        recorded: list[Any] = []
+        thread = ShadowCalibrator(
+            invoke_cheap=lambda _m, _p: "some other answer about pods",
+            record=lambda c, d: recorded.append((c, d)),
+        ).observe_in_background(prompt="q", cheap_model="haiku",
+                                flagship_output="salted hashing", confidence=0.7)
+        thread.join(timeout=5)
+
+        assert thread.daemon is True, "must not hold the process open"
+        assert len(recorded) == 1
+
+
+class TestItActuallyCertifies:
+    def test_shadow_observations_can_earn_a_certificate(self, tmp_path):
+        """The point of the whole design: this path must bootstrap.
+
+        Before it, the controller had no producer that could run before routing
+        was enabled, so the certificate was unreachable by construction.
+        """
+        from entroly.ravs.conformal import ConformalRoutingController
+
+        controller = ConformalRoutingController(tmp_path / "c.json", alpha=0.05)
+        calibrator = ShadowCalibrator(
+            invoke_cheap=lambda _m, _p: "salted password hashing",
+            record=controller.record)
+
+        assert controller.certificate().permits_routing is False
+        for _ in range(40):
+            calibrator.observe(prompt="q", cheap_model="haiku",
+                               flagship_output="salted password hashing",
+                               confidence=0.95)
+
+        certificate = controller.certificate()
+        assert certificate.permits_routing is True, (
+            "shadow calibration must be able to bootstrap the certificate"
+        )
+        assert certificate.lambda_hat <= 0.95
+
+    def test_a_divergent_cheap_model_never_earns_one(self, tmp_path):
+        from entroly.ravs.conformal import ConformalRoutingController
+
+        controller = ConformalRoutingController(tmp_path / "c.json", alpha=0.05)
+        calibrator = ShadowCalibrator(
+            invoke_cheap=lambda _m, _p: "entirely unrelated content about pods",
+            record=controller.record)
+
+        for _ in range(40):
+            calibrator.observe(prompt="q", cheap_model="haiku",
+                               flagship_output="salted password hashing",
+                               confidence=0.95)
+
+        assert controller.certificate().permits_routing is False, (
+            "a cheap model that keeps diverging must never be authorised"
+        )

--- a/tests/test_shadow_calibration.py
+++ b/tests/test_shadow_calibration.py
@@ -68,12 +68,51 @@ class TestSamplingPolicy:
         assert decision.sample is False
         assert "never routed" in decision.reason
 
-    def test_sampling_stops_once_calibrated(self):
+    def test_sampling_stops_once_the_certificate_permits_routing(self):
         """A bootstrap phase with an end, not a standing tax."""
         decision = should_sample(
-            risk_level="low", observations=49, samples_needed=49, epsilon=1.0)
+            risk_level="low", observations=49, samples_needed=49,
+            permits_routing=True, epsilon=1.0)
         assert decision.sample is False
-        assert "calibration complete" in decision.reason
+        assert "certified and routing" in decision.reason
+
+    def test_sampling_continues_when_the_minimum_is_met_but_nothing_certifies(self):
+        """Finding 2: stopping at samples_needed deadlocked the feature.
+
+        samples_needed is only the smallest n at which the route-nothing
+        threshold becomes certifiable. Landing there with a few divergent
+        observations left a valid certificate permitting nothing and no way to
+        ever gather the evidence that would change it.
+        """
+        decision = should_sample(
+            risk_level="low", observations=49, samples_needed=49,
+            permits_routing=False, epsilon=1.0)
+        assert decision.sample is True, (
+            "routing would be permanently disabled with no recovery edge"
+        )
+
+    def test_sampling_gives_up_eventually(self):
+        """A cheap model that never agrees must not be paid for forever."""
+        decision = should_sample(
+            risk_level="low", observations=5000, samples_needed=49,
+            permits_routing=False, max_observations=5000, epsilon=1.0)
+        assert decision.sample is False
+        assert "exhausted" in decision.reason
+
+    def test_unclassified_risk_is_refused_not_assumed_low(self):
+        """Finding 5: the gate tested truthiness first and so failed open.
+
+        Several RoutingDecision early-return paths leave risk_level as "",
+        which skipped the check entirely and sampled traffic that can never be
+        routed -- polluting the calibration set with a population the bound is
+        not about.
+        """
+        for unknown in ("", "   ", "unknown"):
+            decision = should_sample(
+                risk_level=unknown, observations=0, samples_needed=49,
+                epsilon=1.0)
+            assert decision.sample is False, f"fails open on {unknown!r}"
+            assert "never routed" in decision.reason
 
     def test_low_risk_and_uncalibrated_is_sampled(self):
         assert should_sample(


### PR DESCRIPTION
Twelve commits closing the gap between what Entroly does and what a user
can see it doing, plus the fifteen findings a recall-oriented review
raised against them.

## The gap

Every entry point started a dashboard except the MCP server — which is
how most people install. So the common case was: index the repo,
compress context, seed beliefs, block hallucinations, and show the user
nothing. There was no way to tell a working install from a no-op.

Two of the panels that *did* render were reporting numbers nothing
produced. `record_routing_saving` had zero production call sites, so the
"Model-Routing Saved" KPI was structurally pinned at $0 however much
traffic RAVS moved. And `_safe_json` rounded every float to six decimal
places — fine for money, but a few hundred tokens avoid ~1e-8 kWh, which
serialised as `0.0`. A new user's first requests reported exactly the
nothing the dashboard exists to disprove.

## What changed

**Visible by default.** The MCP server starts a dashboard, probing the
port by connecting rather than binding (`allow_reuse_address` plus
Windows `SO_REUSEADDR` lets a second bind to a live port succeed, which
would leave two dashboards splitting requests). Beliefs compile off the
back of indexing instead of a panel telling the user to run
`compile_beliefs`.

**Honest totals.** The hero shows one total, itemised into the lanes
that produced it. Summing modeled and realized value is only defensible
while the reader can tell them apart, so the banked lane keeps its own
wording and rate control inside the total, and the total states it is
modeled rather than billed. Electricity avoided is derived on read from
the same token counts, so it cannot drift from the figures above it.

**Routing measured, not guessed.** Routing substitutes the model on a
live request, so it stays behind an authorisation — but the decision
costs nothing to compute, so it now runs regardless and reports what
routing is worth. Conformal risk control (Angelopoulos et al., ICLR
2024) turns calibration observations into a threshold with a
finite-sample bound, and the certificate revokes itself when outcomes
degrade.

## Review

`/code-review ultra` at extra-high recall returned 15 findings; all 15
are addressed. The most severe: the certified threshold `lambda_hat` was
never enforced — the certificate was read as a boolean and swaps then
proceeded at the router's unrelated `ci_threshold`, so a user who
accepted a 2% divergence rate was served an unbounded one. Also fixed: a
torn read that silently destroyed the whole calibration history, a
sampling stop condition that could deadlock routing permanently, a risk
gate that failed open on unclassified traffic, and a tree signature that
made beliefs stale permanently rather than temporarily.

Two caveats worth carrying into review. `shadow_calibration` has no
production caller — its docstring now says so plainly rather than
leaving two env vars documented as governing spend never incurred. And
the review itself was partial: 8 of 10 finder angles died to a session
limit, so re-running it would likely surface more.

## Verification

Full suite: **4304 passed, 1 failed, 33 skipped, 3 xfailed** in 31m.
The one failure is `test_launch_assets_cannot_imply_publication`, caused
by two untracked `marketing/launch/*.md` drafts in the local working
tree; it is not in this diff and passes on a clean checkout. Baseline
before these commits was 4234 passed with the same single failure.

Lint clean. Pre-push hooks including `cargo test --lib` (112 passed).
