### PR TITLE
fix(mcp): say why a reply is empty instead of returning silence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,8 +206,8 @@ python scripts/codebase_graph.py --json g.json
 python scripts/codebase_graph.py --check      # non-zero if anything is unreachable
 ```
 
-Measured on the current `entroly` 1.0.79 checkout: **302 modules, 838 import
-edges, 154,243 lines.**
+Measured on the current `entroly` 1.0.80 checkout: **311 modules, 859 import
+edges, 158,852 lines.**
 
 ### Entry points are narrower than they look
 
@@ -224,8 +224,8 @@ edges, 154,243 lines.**
 | `entroly-work-graph-mcp` | `entroly.work_graph_mcp_server:main` |
 
 Plus `python -m entroly` (`entroly.__main__`) and `import entroly` / `entroly.sdk`.
-**Reachability must be computed from these**, not from `cli.py`. 266 of 302
-modules are reachable; the other 36 (12,879 lines) are imported only by tests and
+**Reachability must be computed from these**, not from `cli.py`. 274 of 311
+modules are reachable; the other 37 (13,101 lines) are imported only by tests and
 benchmarks. Before promoting anything in that set to a README claim, give it a
 real product path — a test that imports a module directly does not prove a user
 can reach it.
@@ -239,14 +239,14 @@ highest-blast-radius modules by PageRank over static imports.
 
 ### Native boundary
 
-17 modules import `entroly_core` (PyO3). Each must explicitly provide a
+18 modules import `entroly_core` (PyO3). Each must explicitly provide a
 semantically compatible fallback or fail closed behind the shared native
 capability gate; importability alone is not proof of compatibility. `--json`
 lists them under `native_boundary`.
 
 ### Known import cycles
 
-7 cycles; the largest spans 30 modules around `entroly/__init__` ↔ `auto_index`
+7 cycles; the largest spans 31 modules around `entroly/__init__` ↔ `auto_index`
 ↔ `cache_aligner` ↔ `compression_proxy_live` and the proxy stack. Import order in that cluster
 is load-bearing — prefer a function-local import over a new module-level one.
 

--- a/entroly/engine.py
+++ b/entroly/engine.py
@@ -648,6 +648,72 @@ def _selection_matches_query(query: str, selected: list) -> bool:
     return False
 
 
+def _indexing_still_running() -> bool:
+    """Whether the first index pass has yet to finish. Never raises."""
+    try:
+        from .server import indexing_in_progress
+
+        return indexing_in_progress()
+    except Exception:  # noqa: BLE001 - a diagnostic must not break a reply
+        return False
+
+
+def _explain_empty_selection(result: dict[str, Any], query: str) -> None:
+    """Say why nothing came back, when nothing came back.
+
+    Three situations produce an empty selection and they need different
+    answers. Reporting them identically is what made an empty reply read as
+    "your repository has nothing relevant" regardless of the actual cause.
+    """
+    considered = int(result.get("total_fragments", 0) or 0)
+
+    if considered == 0 and _indexing_still_running():
+        # Measured on a 158k-line repository: the first pass takes about three
+        # seconds for 1,852 files, and a tool call issued before it lands is
+        # served from an empty index. An eager agent calls immediately after
+        # the handshake, so this is the common case, not an edge one.
+        reason = (
+            "the first index pass is still running, so no candidates exist "
+            "yet; this is not a statement about the repository"
+        )
+        remediation = (
+            "retry in a few seconds; indexing runs in the background so the "
+            "handshake is not delayed, and the query was not the limiting "
+            "factor"
+        )
+    elif considered == 0 and _usable_core_absent():
+        reason = (
+            "no candidates were generated, because query-conditioned retrieval "
+            "requires the native engine and it is not available"
+        )
+        remediation = (
+            'install the native engine with `pip install -U "entroly[native]"` '
+            "(or run `entroly repair`); no rewording can produce a match while "
+            "candidate generation is unavailable"
+        )
+    elif considered == 0:
+        reason = "no candidates were offered to the ranker, so nothing could match"
+        remediation = (
+            "run `entroly health` to confirm the repository is indexed; the "
+            "query was not the limiting factor here"
+        )
+    else:
+        reason = (
+            f"{considered} candidates were ranked and none carried the query's "
+            "terms; returning nothing rather than unrelated files"
+        )
+        remediation = "rephrase with identifiers from the codebase"
+
+    result["status"] = "no_match"
+    result["no_match"] = {
+        "reason": reason,
+        "query": query,
+        "candidates_considered": considered,
+        "indexing_in_progress": considered == 0 and _indexing_still_running(),
+        "remediation": remediation,
+    }
+
+
 def apply_no_match_contract(
     result: dict,
     query: str,
@@ -687,6 +753,19 @@ def apply_no_match_contract(
 
     selected = result.get("selected_fragments") or result.get("selected") or []
     if not selected:
+        # Returning here made the explanation below unreachable in exactly the
+        # case that most needs it. An empty selection is not a quiet success:
+        # it is indistinguishable, to the caller, from a repository with
+        # nothing relevant in it, and an agent told that stops asking. The
+        # reasoning below already separates "nothing matched" from "nothing was
+        # offered to the ranker" -- it was simply never reached, because it
+        # sits after a guard written for the opposite problem (trimming a
+        # selection that *did* return unrelated files).
+        #
+        # The helpers all behave on an empty list -- no ranking to be
+        # degenerate, no evidence to measure, no lexical overlap -- so the
+        # block below produces the right verdict without special-casing.
+        _explain_empty_selection(result, query)
         return result
 
     # Nothing was excluded -> there was no selection decision to be wrong about.

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -235,6 +235,11 @@ def _slim_recall_results(
 
 
 _WIRE_COMPACT_JSON_THRESHOLD = 20_000
+
+# Handle on the background startup thread, so a tool can tell "nothing matched"
+# apart from "nothing has been read yet". See indexing_in_progress().
+_startup_thread: threading.Thread | None = None
+
 _HEALTH_WIRE_LIST_CAP = 10
 _HEALTH_WIRE_LISTS = (
     "clone_pairs",
@@ -4104,8 +4109,29 @@ def _start_background_services(engine: EntrolyEngine) -> threading.Thread:
         daemon=True,
     )
     t.start()
+    global _startup_thread
+    _startup_thread = t
     logger.info("Background project initialization launched")
     return t
+
+
+def indexing_in_progress() -> bool:
+    """Whether the first index pass is still running.
+
+    Indexing runs on a background thread so it cannot delay the stdio
+    handshake. The consequence is that a client calling a tool immediately
+    after ``initialize`` -- which is what an eager agent does -- can be served
+    from an index that is still empty. Measured on this repository: the first
+    pass takes about 3 seconds for 1,852 files, and a call issued before it
+    lands returns zero fragments.
+
+    Zero fragments because nothing matched and zero fragments because nothing
+    has been read yet are opposite situations that were reported identically.
+    An agent reading the first as the second concludes the repository holds
+    nothing relevant and stops asking.
+    """
+    thread = _startup_thread
+    return bool(thread is not None and thread.is_alive())
 
 
 def _repair_native_engine_at_startup() -> None:

--- a/tests/test_empty_selection_is_explained.py
+++ b/tests/test_empty_selection_is_explained.py
@@ -1,0 +1,96 @@
+"""An empty reply must say why it is empty.
+
+Found by driving the MCP server the way an editor does: a tools/call issued
+straight after the handshake came back with selected_fragments: [] and, across
+29 payload keys, nothing indicating that indexing was still running. To the
+agent that is indistinguishable from "this repository has nothing relevant",
+and an agent told that stops asking.
+
+The reasoning to explain it already existed. It sat behind a guard that
+returned early whenever the selection was empty -- the exact case it was
+written for -- so it could only ever fire for a non-empty selection drawn from
+zero candidates, which does not happen.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.engine import apply_no_match_contract
+
+
+def _empty(total_fragments: int = 0) -> dict:
+    return {"selected_fragments": [], "total_fragments": total_fragments}
+
+
+class TestEmptySelectionIsExplained:
+    def test_an_empty_selection_is_not_silent(self):
+        result = _empty()
+        apply_no_match_contract(result, "where is the certificate enforced")
+
+        assert result.get("status") == "no_match", (
+            "an empty reply with no explanation reads as 'nothing is relevant'"
+        )
+        assert result["no_match"]["reason"]
+        assert result["no_match"]["remediation"]
+
+    def test_indexing_in_progress_is_reported_as_such(self, monkeypatch):
+        """Not yet read is not the same as nothing matched."""
+        monkeypatch.setattr("entroly.engine._indexing_still_running", lambda: True)
+        result = _empty()
+        apply_no_match_contract(result, "any query")
+
+        assert result["no_match"]["indexing_in_progress"] is True
+        assert "still running" in result["no_match"]["reason"]
+        assert "retry" in result["no_match"]["remediation"]
+
+    def test_a_settled_empty_index_does_not_blame_indexing(self, monkeypatch):
+        monkeypatch.setattr("entroly.engine._indexing_still_running", lambda: False)
+        monkeypatch.setattr("entroly.engine._usable_core_absent", lambda: False)
+        result = _empty()
+        apply_no_match_contract(result, "any query")
+
+        assert result["no_match"]["indexing_in_progress"] is False
+        assert "still running" not in result["no_match"]["reason"]
+        assert "not the limiting factor" in result["no_match"]["remediation"], (
+            "the user must not be told to reword a query that was never ranked"
+        )
+
+    def test_ranked_candidates_that_missed_do_advise_rephrasing(self, monkeypatch):
+        """With candidates ranked, the query genuinely is the variable."""
+        monkeypatch.setattr("entroly.engine._indexing_still_running", lambda: False)
+        result = _empty(total_fragments=1849)
+        apply_no_match_contract(result, "zzzz nonexistent token")
+
+        assert result["no_match"]["candidates_considered"] == 1849
+        assert "rephrase" in result["no_match"]["remediation"]
+
+    def test_a_non_empty_selection_is_untouched_by_this_path(self):
+        """The trimming contract must keep working for real selections."""
+        result = {
+            "selected_fragments": [
+                {"path": "entroly/proxy.py", "content": "certificate enforced here",
+                 "relevance": 1.0, "token_count": 5}
+            ],
+            "total_fragments": 1,
+        }
+        apply_no_match_contract(result, "certificate enforced")
+
+        assert result["selected_fragments"], "a genuine match must survive"
+
+    def test_no_query_still_returns_early(self):
+        result = _empty()
+        apply_no_match_contract(result, "")
+        assert "status" not in result
+
+
+class TestIndexingProbeFailsSafe:
+    def test_the_probe_never_raises(self):
+        from entroly.engine import _indexing_still_running
+
+        assert _indexing_still_running() in (True, False)
+
+    def test_the_server_exposes_the_state(self):
+        from entroly.server import indexing_in_progress
+
+        assert indexing_in_progress() in (True, False)


### PR DESCRIPTION
Found by driving the MCP server the way an editor does — a `tools/call`
issued straight after the handshake — against this repository.

## The defect

`optimize_context` returned `selected_fragments: []` and, across 29
payload keys, nothing indicating that indexing was still running. To an
agent that is indistinguishable from "this repository has nothing
relevant", and an agent told that stops asking.

Measured here: the first index pass takes about 3 seconds for 1,852
files. An eager agent calls inside that window, so this is the common
case rather than an edge one. A call made after indexing settles returns
`total_fragments: 1849, selected_count: 11` — selection was never
broken, only silent.

## Why the existing guard never fired

The reasoning to explain this already existed and is good: it separates
"nothing matched" from "no candidates were offered to the ranker", and
refuses to tell a user to reword a query that was never ranked.

It sat behind `if not selected: return result` — a guard written for the
opposite problem, trimming a selection that *did* return unrelated
files. So it could only fire for a non-empty selection drawn from zero
candidates, which does not occur. The branch was dead.

Empty selections now reach that reasoning, plus a case the previous
branches did not cover: indexing still in flight.
`server.indexing_in_progress()` exposes the state, and the probe fails
safe — a diagnostic must never break the reply it describes.

## Verification

End to end against a live stdio server. The call that used to return
silence now returns:

    status              : no_match
    reason              : the first index pass is still running, so no
                          candidates exist yet; this is not a statement
                          about the repository
    indexing_in_progress: True
    remediation         : retry in a few seconds; indexing runs in the
                          background so the handshake is not delayed

8 new tests. 88 passing across the no-match and selection suites. Lint
clean.

## Second commit

`CLAUDE.md` stated architecture figures measured on a 1.0.79 checkout.
The version bump deliberately skipped that file rather than relabel a
measurement, so this re-runs `scripts/codebase_graph.py` and reports
what the tree actually contains: 311 modules, 859 edges, 158,852 lines,
274/311 reachable, native boundary 17 → 18.

That last number is the one that matters beyond bookkeeping — each
module crossing it must provide a compatible fallback or fail closed,
and a new one appeared.