### PR TITLE
feat(models): add Kimi K3, GLM-5.3 and GLM-5.3-Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,39 @@ Status describes integration depth, not a savings guarantee — provider-observe
 
 Entroly carries verified public metadata for GPT-5.6 Sol, Terra, and Luna; Gemini 3.6 Flash; and Gemini 3.5 Flash-Lite, and it can discover installed NVIDIA Nemotron 3.5 Lightning Ollama tags. Gated or private-preview announcements are not promoted into the verified matrix without a usable public model ID and limits. For example, Gemini 3.5 Flash Cyber remains outside the generally available matrix because its documented CodeMender access is restricted to selected governments and trusted partners. See **[Verified model support](docs/model-support.html)** for model IDs, transport paths, limits, and availability boundaries.
 
+### Kimi K3, GLM-5.3, and GLM-5.3-Flash
+
+Entroly carries published metadata and list pricing for Moonshot AI's **Kimi K3**
+and Z.ai's **GLM-5.3** and **GLM-5.3-Flash**, so Context Receipts, budget
+resolution, and cost accounting work on those routes without configuration.
+
+| Model | Context window | Input / output per 1M | Vision |
+|---|---|---|---|
+| `kimi-k3` | 1,048,576 | $3.00 / $15.00 | yes |
+| `glm-5.3` | 1,000,000 | $1.40 / $4.40 | no |
+| `glm-5.3-flash` | 1,048,576 | $0.15 / $0.50 | yes |
+
+These are **announced** records, not verified ones: the figures come from
+published provider specifications rather than a request Entroly has observed.
+Announced records are not promoted into the verified matrix, and OpenClaw's
+budget resolution rejects them in favour of an explicit host budget or an
+operator `fallbackTokenBudget`. Set `ENTROLY_PRICING_FILE` to substitute
+negotiated rates without waiting for a release.
+
+`glm-5.3` and `glm-5.3-flash` are a flagship and a cheap sibling on one
+provider, which is the shape RAVS model routing looks for. Priced at the list
+rates above, routing a 100K-token request from `glm-5.3` to `glm-5.3-flash` is
+worth **$0.125**, and from `kimi-k3` **$0.285**. Routing stays behind an
+explicit authorisation because it substitutes the model on a live request;
+Entroly measures what the swap would be worth first, so the decision is made
+against evidence rather than a guess.
+
+A million-token window does not remove the reason to select context. A million
+tokens of prompt costs a million tokens of prefill on every turn, and published
+long-context evaluations report weaker retrieval for evidence buried in the
+middle of very long inputs. A large window is budget you now get to spend
+deliberately.
+
 ### NVIDIA Nemotron 3.5 Lightning with Ollama
 
 Entroly supports `nemotron-3.5-lightning` through its existing local Ollama discovery and OpenAI-compatible proxy path. This is a model-neutral integration: Entroly manages evidence selection, budgets, recovery handles, Context Receipts, and optional verification around the request; Ollama runs the model.

--- a/entroly-core/model_registry.json
+++ b/entroly-core/model_registry.json
@@ -5,7 +5,10 @@
     {
       "id": "openai/gpt-4o-mini",
       "provider": "openai",
-      "aliases": ["gpt-4o-mini", "gpt-4o-mini-"],
+      "aliases": [
+        "gpt-4o-mini",
+        "gpt-4o-mini-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_vision": true,
@@ -16,7 +19,10 @@
     {
       "id": "openai/gpt-4o",
       "provider": "openai",
-      "aliases": ["gpt-4o", "gpt-4o-"],
+      "aliases": [
+        "gpt-4o",
+        "gpt-4o-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_vision": true,
@@ -27,7 +33,10 @@
     {
       "id": "openai/gpt-4-turbo",
       "provider": "openai",
-      "aliases": ["gpt-4-turbo", "gpt-4-turbo-"],
+      "aliases": [
+        "gpt-4-turbo",
+        "gpt-4-turbo-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_vision": true,
@@ -38,7 +47,10 @@
     {
       "id": "openai/gpt-4",
       "provider": "openai",
-      "aliases": ["gpt-4", "gpt-4-"],
+      "aliases": [
+        "gpt-4",
+        "gpt-4-"
+      ],
       "context_window": 8192,
       "supports_tools": true,
       "trust": "announced",
@@ -48,7 +60,10 @@
     {
       "id": "openai/gpt-3.5-turbo",
       "provider": "openai",
-      "aliases": ["gpt-3.5-turbo", "gpt-3.5-turbo-"],
+      "aliases": [
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-"
+      ],
       "context_window": 16385,
       "supports_tools": true,
       "trust": "announced",
@@ -58,12 +73,19 @@
     {
       "id": "openai/o1",
       "provider": "openai",
-      "aliases": ["o1", "o1-"],
+      "aliases": [
+        "o1",
+        "o1-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["low", "medium", "high"],
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
       "trust": "verified",
       "source": "https://platform.openai.com/docs/models",
       "verified_at": "2026-07-11"
@@ -71,7 +93,10 @@
     {
       "id": "openai/o1-mini",
       "provider": "openai",
-      "aliases": ["o1-mini", "o1-mini-"],
+      "aliases": [
+        "o1-mini",
+        "o1-mini-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -82,7 +107,10 @@
     {
       "id": "openai/o1-pro",
       "provider": "openai",
-      "aliases": ["o1-pro", "o1-pro-"],
+      "aliases": [
+        "o1-pro",
+        "o1-pro-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -94,12 +122,19 @@
     {
       "id": "openai/o3",
       "provider": "openai",
-      "aliases": ["o3", "o3-"],
+      "aliases": [
+        "o3",
+        "o3-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["low", "medium", "high"],
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
       "trust": "verified",
       "source": "https://platform.openai.com/docs/models",
       "verified_at": "2026-07-11"
@@ -107,7 +142,10 @@
     {
       "id": "openai/o3-mini",
       "provider": "openai",
-      "aliases": ["o3-mini", "o3-mini-"],
+      "aliases": [
+        "o3-mini",
+        "o3-mini-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -118,7 +156,10 @@
     {
       "id": "openai/o4-mini",
       "provider": "openai",
-      "aliases": ["o4-mini", "o4-mini-"],
+      "aliases": [
+        "o4-mini",
+        "o4-mini-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -129,7 +170,9 @@
     {
       "id": "openai-compatible/deepseek",
       "provider": "openai",
-      "aliases": ["deepseek-"],
+      "aliases": [
+        "deepseek-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -140,7 +183,9 @@
     {
       "id": "openai-compatible/qwen",
       "provider": "openai",
-      "aliases": ["qwen-"],
+      "aliases": [
+        "qwen-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "trust": "announced",
@@ -150,7 +195,9 @@
     {
       "id": "openai-compatible/mistral",
       "provider": "openai",
-      "aliases": ["mistral-"],
+      "aliases": [
+        "mistral-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "trust": "announced",
@@ -160,13 +207,24 @@
     {
       "id": "openai/gpt-5.6-sol",
       "provider": "openai",
-      "aliases": ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-sol-"],
+      "aliases": [
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-sol-"
+      ],
       "context_window": 1050000,
       "max_output_tokens": 128000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
       "input_price_per_million": 5.0,
       "output_price_per_million": 30.0,
       "trust": "verified",
@@ -176,13 +234,23 @@
     {
       "id": "openai/gpt-5.6-terra",
       "provider": "openai",
-      "aliases": ["gpt-5.6-terra", "gpt-5.6-terra-"],
+      "aliases": [
+        "gpt-5.6-terra",
+        "gpt-5.6-terra-"
+      ],
       "context_window": 1050000,
       "max_output_tokens": 128000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
       "input_price_per_million": 2.5,
       "output_price_per_million": 15.0,
       "trust": "verified",
@@ -192,13 +260,23 @@
     {
       "id": "openai/gpt-5.6-luna",
       "provider": "openai",
-      "aliases": ["gpt-5.6-luna", "gpt-5.6-luna-"],
+      "aliases": [
+        "gpt-5.6-luna",
+        "gpt-5.6-luna-"
+      ],
       "context_window": 1050000,
       "max_output_tokens": 128000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
       "input_price_per_million": 1.0,
       "output_price_per_million": 6.0,
       "trust": "verified",
@@ -224,7 +302,9 @@
     {
       "id": "anthropic/claude-opus-4-20250514",
       "provider": "anthropic",
-      "aliases": ["claude-opus-4-20250514"],
+      "aliases": [
+        "claude-opus-4-20250514"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -235,7 +315,9 @@
     {
       "id": "anthropic/claude-sonnet-4-5-20250929",
       "provider": "anthropic",
-      "aliases": ["claude-sonnet-4-5-20250929"],
+      "aliases": [
+        "claude-sonnet-4-5-20250929"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -246,7 +328,9 @@
     {
       "id": "anthropic/claude-sonnet-4-20250514",
       "provider": "anthropic",
-      "aliases": ["claude-sonnet-4-20250514"],
+      "aliases": [
+        "claude-sonnet-4-20250514"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -257,7 +341,9 @@
     {
       "id": "anthropic/claude-haiku-4-5-20251001",
       "provider": "anthropic",
-      "aliases": ["claude-haiku-4-5-20251001"],
+      "aliases": [
+        "claude-haiku-4-5-20251001"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -268,7 +354,9 @@
     {
       "id": "anthropic/claude-3-5-sonnet-20241022",
       "provider": "anthropic",
-      "aliases": ["claude-3-5-sonnet-20241022"],
+      "aliases": [
+        "claude-3-5-sonnet-20241022"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -279,7 +367,9 @@
     {
       "id": "anthropic/claude-3-5-haiku-20241022",
       "provider": "anthropic",
-      "aliases": ["claude-3-5-haiku-20241022"],
+      "aliases": [
+        "claude-3-5-haiku-20241022"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "trust": "announced",
@@ -289,7 +379,9 @@
     {
       "id": "anthropic/claude-3-haiku-20240307",
       "provider": "anthropic",
-      "aliases": ["claude-3-haiku-20240307"],
+      "aliases": [
+        "claude-3-haiku-20240307"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "trust": "announced",
@@ -299,7 +391,10 @@
     {
       "id": "google/gemini-3.6-flash",
       "provider": "gemini",
-      "aliases": ["gemini-3.6-flash", "gemini-3.6-flash-"],
+      "aliases": [
+        "gemini-3.6-flash",
+        "gemini-3.6-flash-"
+      ],
       "context_window": 1048576,
       "max_output_tokens": 65536,
       "input_price_per_million": 1.5,
@@ -314,7 +409,10 @@
     {
       "id": "google/gemini-3.5-flash-lite",
       "provider": "gemini",
-      "aliases": ["gemini-3.5-flash-lite", "gemini-3.5-flash-lite-"],
+      "aliases": [
+        "gemini-3.5-flash-lite",
+        "gemini-3.5-flash-lite-"
+      ],
       "context_window": 1048576,
       "max_output_tokens": 65536,
       "input_price_per_million": 0.3,
@@ -329,7 +427,10 @@
     {
       "id": "google/gemini-2.5-pro",
       "provider": "gemini",
-      "aliases": ["gemini-2.5-pro", "gemini-2.5-pro-"],
+      "aliases": [
+        "gemini-2.5-pro",
+        "gemini-2.5-pro-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -341,7 +442,10 @@
     {
       "id": "google/gemini-2.5-flash",
       "provider": "gemini",
-      "aliases": ["gemini-2.5-flash", "gemini-2.5-flash-"],
+      "aliases": [
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -352,7 +456,10 @@
     {
       "id": "google/gemini-2.0-flash",
       "provider": "gemini",
-      "aliases": ["gemini-2.0-flash", "gemini-2.0-flash-"],
+      "aliases": [
+        "gemini-2.0-flash",
+        "gemini-2.0-flash-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -363,7 +470,10 @@
     {
       "id": "google/gemini-2.0-flash-lite",
       "provider": "gemini",
-      "aliases": ["gemini-2.0-flash-lite", "gemini-2.0-flash-lite-"],
+      "aliases": [
+        "gemini-2.0-flash-lite",
+        "gemini-2.0-flash-lite-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -374,7 +484,10 @@
     {
       "id": "google/gemini-1.5-pro",
       "provider": "gemini",
-      "aliases": ["gemini-1.5-pro", "gemini-1.5-pro-"],
+      "aliases": [
+        "gemini-1.5-pro",
+        "gemini-1.5-pro-"
+      ],
       "context_window": 2097152,
       "supports_tools": true,
       "supports_vision": true,
@@ -385,7 +498,10 @@
     {
       "id": "google/gemini-1.5-flash",
       "provider": "gemini",
-      "aliases": ["gemini-1.5-flash", "gemini-1.5-flash-"],
+      "aliases": [
+        "gemini-1.5-flash",
+        "gemini-1.5-flash-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -396,7 +512,10 @@
     {
       "id": "nvidia/nemotron-super",
       "provider": "openai",
-      "aliases": ["nemotron-super", "nvidia/nemotron-super"],
+      "aliases": [
+        "nemotron-super",
+        "nvidia/nemotron-super"
+      ],
       "context_window": null,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -407,7 +526,10 @@
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b",
       "provider": "openai",
-      "aliases": ["nemotron-3-ultra", "nemotron-3-ultra-550b-a55b"],
+      "aliases": [
+        "nemotron-3-ultra",
+        "nemotron-3-ultra-550b-a55b"
+      ],
       "context_window": 262144,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -418,7 +540,10 @@
     {
       "id": "meta/muse-spark-1.1",
       "provider": "openai",
-      "aliases": ["muse-spark-1.1", "meta/muse-spark-1.1"],
+      "aliases": [
+        "muse-spark-1.1",
+        "meta/muse-spark-1.1"
+      ],
       "context_window": null,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -429,7 +554,10 @@
     {
       "id": "clawrouter/auto",
       "provider": "openai",
-      "aliases": ["clawrouter", "clawrouter/auto"],
+      "aliases": [
+        "clawrouter",
+        "clawrouter/auto"
+      ],
       "context_window": null,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -440,12 +568,57 @@
     {
       "id": "featherless/auto",
       "provider": "openai",
-      "aliases": ["featherless", "featherless/auto"],
+      "aliases": [
+        "featherless",
+        "featherless/auto"
+      ],
       "context_window": null,
       "supports_tools": true,
       "trust": "announced",
       "source": "https://github.com/openclaw/openclaw/releases/tag/v2026.7.1-beta.5",
       "verified_at": "2026-07-11"
+    },
+    {
+      "id": "moonshotai/kimi-k3",
+      "provider": "moonshotai",
+      "aliases": [
+        "kimi-k3",
+        "kimi-k3-"
+      ],
+      "context_window": 1048576,
+      "supports_tools": true,
+      "supports_vision": true,
+      "trust": "announced",
+      "source": "provider-published-specs",
+      "verified_at": null
+    },
+    {
+      "id": "zhipuai/glm-5.3",
+      "provider": "zhipuai",
+      "aliases": [
+        "glm-5.3",
+        "glm-5.3-"
+      ],
+      "context_window": 1000000,
+      "supports_tools": true,
+      "supports_vision": false,
+      "trust": "announced",
+      "source": "provider-published-specs",
+      "verified_at": null
+    },
+    {
+      "id": "zhipuai/glm-5.3-flash",
+      "provider": "zhipuai",
+      "aliases": [
+        "glm-5.3-flash",
+        "glm-5.3-flash-"
+      ],
+      "context_window": 1048576,
+      "supports_tools": true,
+      "supports_vision": true,
+      "trust": "announced",
+      "source": "provider-published-specs",
+      "verified_at": null
     }
   ]
 }

--- a/entroly/models/registry.json
+++ b/entroly/models/registry.json
@@ -5,7 +5,10 @@
     {
       "id": "openai/gpt-4o-mini",
       "provider": "openai",
-      "aliases": ["gpt-4o-mini", "gpt-4o-mini-"],
+      "aliases": [
+        "gpt-4o-mini",
+        "gpt-4o-mini-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_vision": true,
@@ -16,7 +19,10 @@
     {
       "id": "openai/gpt-4o",
       "provider": "openai",
-      "aliases": ["gpt-4o", "gpt-4o-"],
+      "aliases": [
+        "gpt-4o",
+        "gpt-4o-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_vision": true,
@@ -27,7 +33,10 @@
     {
       "id": "openai/gpt-4-turbo",
       "provider": "openai",
-      "aliases": ["gpt-4-turbo", "gpt-4-turbo-"],
+      "aliases": [
+        "gpt-4-turbo",
+        "gpt-4-turbo-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_vision": true,
@@ -38,7 +47,10 @@
     {
       "id": "openai/gpt-4",
       "provider": "openai",
-      "aliases": ["gpt-4", "gpt-4-"],
+      "aliases": [
+        "gpt-4",
+        "gpt-4-"
+      ],
       "context_window": 8192,
       "supports_tools": true,
       "trust": "announced",
@@ -48,7 +60,10 @@
     {
       "id": "openai/gpt-3.5-turbo",
       "provider": "openai",
-      "aliases": ["gpt-3.5-turbo", "gpt-3.5-turbo-"],
+      "aliases": [
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-"
+      ],
       "context_window": 16385,
       "supports_tools": true,
       "trust": "announced",
@@ -58,12 +73,19 @@
     {
       "id": "openai/o1",
       "provider": "openai",
-      "aliases": ["o1", "o1-"],
+      "aliases": [
+        "o1",
+        "o1-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["low", "medium", "high"],
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
       "trust": "verified",
       "source": "https://platform.openai.com/docs/models",
       "verified_at": "2026-07-11"
@@ -71,7 +93,10 @@
     {
       "id": "openai/o1-mini",
       "provider": "openai",
-      "aliases": ["o1-mini", "o1-mini-"],
+      "aliases": [
+        "o1-mini",
+        "o1-mini-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -82,7 +107,10 @@
     {
       "id": "openai/o1-pro",
       "provider": "openai",
-      "aliases": ["o1-pro", "o1-pro-"],
+      "aliases": [
+        "o1-pro",
+        "o1-pro-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -94,12 +122,19 @@
     {
       "id": "openai/o3",
       "provider": "openai",
-      "aliases": ["o3", "o3-"],
+      "aliases": [
+        "o3",
+        "o3-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["low", "medium", "high"],
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
       "trust": "verified",
       "source": "https://platform.openai.com/docs/models",
       "verified_at": "2026-07-11"
@@ -107,7 +142,10 @@
     {
       "id": "openai/o3-mini",
       "provider": "openai",
-      "aliases": ["o3-mini", "o3-mini-"],
+      "aliases": [
+        "o3-mini",
+        "o3-mini-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -118,7 +156,10 @@
     {
       "id": "openai/o4-mini",
       "provider": "openai",
-      "aliases": ["o4-mini", "o4-mini-"],
+      "aliases": [
+        "o4-mini",
+        "o4-mini-"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -129,7 +170,9 @@
     {
       "id": "openai-compatible/deepseek",
       "provider": "openai",
-      "aliases": ["deepseek-"],
+      "aliases": [
+        "deepseek-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -140,7 +183,9 @@
     {
       "id": "openai-compatible/qwen",
       "provider": "openai",
-      "aliases": ["qwen-"],
+      "aliases": [
+        "qwen-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "trust": "announced",
@@ -150,7 +195,9 @@
     {
       "id": "openai-compatible/mistral",
       "provider": "openai",
-      "aliases": ["mistral-"],
+      "aliases": [
+        "mistral-"
+      ],
       "context_window": 128000,
       "supports_tools": true,
       "trust": "announced",
@@ -160,13 +207,24 @@
     {
       "id": "openai/gpt-5.6-sol",
       "provider": "openai",
-      "aliases": ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-sol-"],
+      "aliases": [
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-sol-"
+      ],
       "context_window": 1050000,
       "max_output_tokens": 128000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
       "input_price_per_million": 5.0,
       "output_price_per_million": 30.0,
       "trust": "verified",
@@ -176,13 +234,23 @@
     {
       "id": "openai/gpt-5.6-terra",
       "provider": "openai",
-      "aliases": ["gpt-5.6-terra", "gpt-5.6-terra-"],
+      "aliases": [
+        "gpt-5.6-terra",
+        "gpt-5.6-terra-"
+      ],
       "context_window": 1050000,
       "max_output_tokens": 128000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
       "input_price_per_million": 2.5,
       "output_price_per_million": 15.0,
       "trust": "verified",
@@ -192,13 +260,23 @@
     {
       "id": "openai/gpt-5.6-luna",
       "provider": "openai",
-      "aliases": ["gpt-5.6-luna", "gpt-5.6-luna-"],
+      "aliases": [
+        "gpt-5.6-luna",
+        "gpt-5.6-luna-"
+      ],
       "context_window": 1050000,
       "max_output_tokens": 128000,
       "supports_tools": true,
       "supports_vision": true,
       "supports_reasoning": true,
-      "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
       "input_price_per_million": 1.0,
       "output_price_per_million": 6.0,
       "trust": "verified",
@@ -224,7 +302,9 @@
     {
       "id": "anthropic/claude-opus-4-20250514",
       "provider": "anthropic",
-      "aliases": ["claude-opus-4-20250514"],
+      "aliases": [
+        "claude-opus-4-20250514"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -235,7 +315,9 @@
     {
       "id": "anthropic/claude-sonnet-4-5-20250929",
       "provider": "anthropic",
-      "aliases": ["claude-sonnet-4-5-20250929"],
+      "aliases": [
+        "claude-sonnet-4-5-20250929"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -246,7 +328,9 @@
     {
       "id": "anthropic/claude-sonnet-4-20250514",
       "provider": "anthropic",
-      "aliases": ["claude-sonnet-4-20250514"],
+      "aliases": [
+        "claude-sonnet-4-20250514"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -257,7 +341,9 @@
     {
       "id": "anthropic/claude-haiku-4-5-20251001",
       "provider": "anthropic",
-      "aliases": ["claude-haiku-4-5-20251001"],
+      "aliases": [
+        "claude-haiku-4-5-20251001"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -268,7 +354,9 @@
     {
       "id": "anthropic/claude-3-5-sonnet-20241022",
       "provider": "anthropic",
-      "aliases": ["claude-3-5-sonnet-20241022"],
+      "aliases": [
+        "claude-3-5-sonnet-20241022"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "supports_vision": true,
@@ -279,7 +367,9 @@
     {
       "id": "anthropic/claude-3-5-haiku-20241022",
       "provider": "anthropic",
-      "aliases": ["claude-3-5-haiku-20241022"],
+      "aliases": [
+        "claude-3-5-haiku-20241022"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "trust": "announced",
@@ -289,7 +379,9 @@
     {
       "id": "anthropic/claude-3-haiku-20240307",
       "provider": "anthropic",
-      "aliases": ["claude-3-haiku-20240307"],
+      "aliases": [
+        "claude-3-haiku-20240307"
+      ],
       "context_window": 200000,
       "supports_tools": true,
       "trust": "announced",
@@ -299,7 +391,10 @@
     {
       "id": "google/gemini-3.6-flash",
       "provider": "gemini",
-      "aliases": ["gemini-3.6-flash", "gemini-3.6-flash-"],
+      "aliases": [
+        "gemini-3.6-flash",
+        "gemini-3.6-flash-"
+      ],
       "context_window": 1048576,
       "max_output_tokens": 65536,
       "input_price_per_million": 1.5,
@@ -314,7 +409,10 @@
     {
       "id": "google/gemini-3.5-flash-lite",
       "provider": "gemini",
-      "aliases": ["gemini-3.5-flash-lite", "gemini-3.5-flash-lite-"],
+      "aliases": [
+        "gemini-3.5-flash-lite",
+        "gemini-3.5-flash-lite-"
+      ],
       "context_window": 1048576,
       "max_output_tokens": 65536,
       "input_price_per_million": 0.3,
@@ -329,7 +427,10 @@
     {
       "id": "google/gemini-2.5-pro",
       "provider": "gemini",
-      "aliases": ["gemini-2.5-pro", "gemini-2.5-pro-"],
+      "aliases": [
+        "gemini-2.5-pro",
+        "gemini-2.5-pro-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -341,7 +442,10 @@
     {
       "id": "google/gemini-2.5-flash",
       "provider": "gemini",
-      "aliases": ["gemini-2.5-flash", "gemini-2.5-flash-"],
+      "aliases": [
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -352,7 +456,10 @@
     {
       "id": "google/gemini-2.0-flash",
       "provider": "gemini",
-      "aliases": ["gemini-2.0-flash", "gemini-2.0-flash-"],
+      "aliases": [
+        "gemini-2.0-flash",
+        "gemini-2.0-flash-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -363,7 +470,10 @@
     {
       "id": "google/gemini-2.0-flash-lite",
       "provider": "gemini",
-      "aliases": ["gemini-2.0-flash-lite", "gemini-2.0-flash-lite-"],
+      "aliases": [
+        "gemini-2.0-flash-lite",
+        "gemini-2.0-flash-lite-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -374,7 +484,10 @@
     {
       "id": "google/gemini-1.5-pro",
       "provider": "gemini",
-      "aliases": ["gemini-1.5-pro", "gemini-1.5-pro-"],
+      "aliases": [
+        "gemini-1.5-pro",
+        "gemini-1.5-pro-"
+      ],
       "context_window": 2097152,
       "supports_tools": true,
       "supports_vision": true,
@@ -385,7 +498,10 @@
     {
       "id": "google/gemini-1.5-flash",
       "provider": "gemini",
-      "aliases": ["gemini-1.5-flash", "gemini-1.5-flash-"],
+      "aliases": [
+        "gemini-1.5-flash",
+        "gemini-1.5-flash-"
+      ],
       "context_window": 1048576,
       "supports_tools": true,
       "supports_vision": true,
@@ -396,7 +512,10 @@
     {
       "id": "nvidia/nemotron-super",
       "provider": "openai",
-      "aliases": ["nemotron-super", "nvidia/nemotron-super"],
+      "aliases": [
+        "nemotron-super",
+        "nvidia/nemotron-super"
+      ],
       "context_window": null,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -407,7 +526,10 @@
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b",
       "provider": "openai",
-      "aliases": ["nemotron-3-ultra", "nemotron-3-ultra-550b-a55b"],
+      "aliases": [
+        "nemotron-3-ultra",
+        "nemotron-3-ultra-550b-a55b"
+      ],
       "context_window": 262144,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -418,7 +540,10 @@
     {
       "id": "meta/muse-spark-1.1",
       "provider": "openai",
-      "aliases": ["muse-spark-1.1", "meta/muse-spark-1.1"],
+      "aliases": [
+        "muse-spark-1.1",
+        "meta/muse-spark-1.1"
+      ],
       "context_window": null,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -429,7 +554,10 @@
     {
       "id": "clawrouter/auto",
       "provider": "openai",
-      "aliases": ["clawrouter", "clawrouter/auto"],
+      "aliases": [
+        "clawrouter",
+        "clawrouter/auto"
+      ],
       "context_window": null,
       "supports_tools": true,
       "supports_reasoning": true,
@@ -440,12 +568,57 @@
     {
       "id": "featherless/auto",
       "provider": "openai",
-      "aliases": ["featherless", "featherless/auto"],
+      "aliases": [
+        "featherless",
+        "featherless/auto"
+      ],
       "context_window": null,
       "supports_tools": true,
       "trust": "announced",
       "source": "https://github.com/openclaw/openclaw/releases/tag/v2026.7.1-beta.5",
       "verified_at": "2026-07-11"
+    },
+    {
+      "id": "moonshotai/kimi-k3",
+      "provider": "moonshotai",
+      "aliases": [
+        "kimi-k3",
+        "kimi-k3-"
+      ],
+      "context_window": 1048576,
+      "supports_tools": true,
+      "supports_vision": true,
+      "trust": "announced",
+      "source": "provider-published-specs",
+      "verified_at": null
+    },
+    {
+      "id": "zhipuai/glm-5.3",
+      "provider": "zhipuai",
+      "aliases": [
+        "glm-5.3",
+        "glm-5.3-"
+      ],
+      "context_window": 1000000,
+      "supports_tools": true,
+      "supports_vision": false,
+      "trust": "announced",
+      "source": "provider-published-specs",
+      "verified_at": null
+    },
+    {
+      "id": "zhipuai/glm-5.3-flash",
+      "provider": "zhipuai",
+      "aliases": [
+        "glm-5.3-flash",
+        "glm-5.3-flash-"
+      ],
+      "context_window": 1048576,
+      "supports_tools": true,
+      "supports_vision": true,
+      "trust": "announced",
+      "source": "provider-published-specs",
+      "verified_at": null
     }
   ]
 }

--- a/entroly/value_tracker.py
+++ b/entroly/value_tracker.py
@@ -48,7 +48,7 @@ logger = logging.getLogger("entroly.value_tracker")
 #      "default": {"input": 0.003, "output": 0.009},
 #      "models": {"gpt-4o": {"input": 0.0025, "output": 0.01}}}
 # Loading is local-only (no network) and fail-open to these defaults.
-_PRICING_AS_OF = "2026-05"
+_PRICING_AS_OF = "2026-08"
 
 _MODEL_PRICING: dict[str, dict[str, float]] = {
     # OpenAI
@@ -75,6 +75,14 @@ _MODEL_PRICING: dict[str, dict[str, float]] = {
     "gemini-2.0-flash": {"input": 0.0001, "output": 0.0004},
     "gemini-1.5-pro": {"input": 0.00125, "output": 0.005},
     "gemini-1.5-flash": {"input": 0.000075, "output": 0.0003},
+    # Moonshot AI. Published list rates, per 1K: K3 is $3.00/M in, $15.00/M
+    # out. The $0.30/M cache-hit rate is not modelled -- Entroly prices the
+    # tokens it can observe being sent, and cache state is the provider's.
+    "kimi-k3": {"input": 0.003, "output": 0.015},
+    # Z.ai / Zhipu GLM-5. Flash is the cheap sibling flagship traffic can be
+    # routed to, which is the pairing RAVS looks for.
+    "glm-5.3-flash": {"input": 0.00015, "output": 0.0005},
+    "glm-5.3": {"input": 0.0014, "output": 0.0044},
 }
 
 _DEFAULT_PRICING = {"input": 0.003, "output": 0.009}  # conservative fallback


### PR DESCRIPTION
Published metadata and list pricing for Moonshot AI's **Kimi K3** and Z.ai's
**GLM-5.3** and **GLM-5.3-Flash**, so Context Receipts, budget resolution and
cost accounting work on those routes without configuration.

| Model | Context window | Input / output per 1M | Vision |
|---|---|---|---|
| `kimi-k3` | 1,048,576 | $3.00 / $15.00 | yes |
| `glm-5.3` | 1,000,000 | $1.40 / $4.40 | no |
| `glm-5.3-flash` | 1,048,576 | $0.15 / $0.50 | yes |

## Real support, not a name in a table

Verified live rather than assumed — all three resolve through `estimate_cost`,
and `routing_delta_usd` prices the swaps:

    glm-5.3 -> glm-5.3-flash   $0.1250 per 100K tokens
    kimi-k3 -> glm-5.3-flash   $0.2850 per 100K tokens

`glm-5.3` and `glm-5.3-flash` are a flagship and a cheap sibling on one
provider, which is exactly the shape RAVS model routing looks for. These are
routing targets that price correctly, not entries that merely parse.

## Classified honestly

Registered as **`announced`**, not `verified`. The figures are published
provider specifications, not something Entroly has observed on a request.
Announced records stay out of the verified matrix and OpenClaw budget
resolution rejects them in favour of an explicit host budget or an operator
`fallbackTokenBudget` — that is the existing contract, and it is the correct
classification for metadata that arrived by reading rather than measuring.

`_PRICING_AS_OF` moves 2026-05 → 2026-08, because the snapshot now carries
August rates and a stale date would misrepresent when they were taken.

## One entry drafted and removed

A `kimi-k2` price was written and then deleted. No source was found for its
rates, and an invented price produces an invented dollar figure on the
dashboard — strictly worse than leaving a model unpriced, which is an explicit
path that reports zero rather than guessing.

## README

New section covering all three, with the caveat that a million-token window
does not remove the reason to select context: a million tokens of prompt costs
a million tokens of prefill every turn, and published long-context evaluations
report weaker retrieval for evidence buried mid-input.

## Verification

- 223 tests pass across the model, pricing, value-attribution, routing-value
  and docs-sync suites
- Rust mirror regenerated with `scripts/sync_model_registry.py`; the two
  snapshots are byte-identical (`sha256 04291bc1…`) and a parity test enforces it
- External-name policy gate passes (README is in its scope)
- Lint clean