### PR TITLE
Harden OpenClaw bridge and verify package runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,11 @@ jobs:
     # pins the base-install surface so that class of regression can't recur.
     name: Pure-Python Fallback (base `pip install entroly`, no Rust engine)
     runs-on: ubuntu-latest
+    env:
+      # This job verifies the engine-less surface. `entroly simulate` normally
+      # repairs that surface by installing entroly-core, which would mutate the
+      # environment midway through the suite and invalidate the gate.
+      ENTROLY_NO_SELF_HEAL: "1"
     # Same stale-budget problem as 'integration', one push behind it: measured
     # at 11.8 minutes against the old 15, and it grows from the same suite.
     timeout-minutes: 25

--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -487,6 +487,116 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.latest_token }}
 
+  probe-npm-runners:
+    needs: [release-metadata, publish-npm-alias]
+    if: needs.release-metadata.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      RELEASE_VERSION: ${{ needs.release-metadata.outputs.version }}
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.19.0'
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.4.0'
+
+      - name: Install pinned pnpm
+        run: npm install --global pnpm@11.19.0
+
+      - name: Probe npx, pnpm, and Bun against the exact release
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 20); do
+            if [[ "$(npm view "entroly@${RELEASE_VERSION}" version 2>/dev/null || true)" == "$RELEASE_VERSION" ]]; then
+              break
+            fi
+            if [[ "$attempt" == 20 ]]; then
+              echo "entroly@${RELEASE_VERSION} did not become visible on npm." >&2
+              exit 1
+            fi
+            sleep 15
+          done
+
+          npx_dir="$(mktemp -d)"
+          pnpm_dir="$(mktemp -d)"
+          bun_dir="$(mktemp -d)"
+          (
+            cd "$npx_dir"
+            npx -y "entroly@${RELEASE_VERSION}" --help > help.txt
+            grep -F "Entroly v${RELEASE_VERSION}" help.txt
+          )
+          (
+            cd "$pnpm_dir"
+            pnpm dlx "entroly@${RELEASE_VERSION}" --help > help.txt
+            grep -F "Entroly v${RELEASE_VERSION}" help.txt
+          )
+          (
+            cd "$bun_dir"
+            bunx "entroly@${RELEASE_VERSION}" --help > help.txt
+            grep -F "Entroly v${RELEASE_VERSION}" help.txt
+          )
+
+  probe-python-runners:
+    needs: [release-metadata, publish-pypi]
+    if: needs.release-metadata.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      RELEASE_VERSION: ${{ needs.release-metadata.outputs.version }}
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install pinned Python tool runners
+        run: python -m pip install pipx==1.16.7 uv==0.12.7
+
+      - name: Probe pipx and uvx against the exact release
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 20); do
+            visible_version="$(python - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+
+          try:
+              with urllib.request.urlopen(
+                  f"https://pypi.org/pypi/entroly/{os.environ['RELEASE_VERSION']}/json",
+                  timeout=30,
+              ) as response:
+                  print(json.load(response)["info"]["version"])
+          except (urllib.error.HTTPError, urllib.error.URLError, ValueError, KeyError):
+              pass
+          PY
+          )"
+            if [[ "$visible_version" == "$RELEASE_VERSION" ]]; then
+              break
+            fi
+            if [[ "$attempt" == 20 ]]; then
+              echo "entroly==${RELEASE_VERSION} did not become visible on PyPI." >&2
+              exit 1
+            fi
+            sleep 15
+          done
+
+          PIPX_HOME="$RUNNER_TEMP/pipx-home" \
+            PIPX_BIN_DIR="$RUNNER_TEMP/pipx-bin" \
+            pipx run --spec "entroly==${RELEASE_VERSION}" entroly --version \
+            | grep -F "$RELEASE_VERSION"
+          UV_CACHE_DIR="$RUNNER_TEMP/uv-cache" \
+            uvx --from "entroly==${RELEASE_VERSION}" entroly --version \
+            | grep -F "$RELEASE_VERSION"
+
   probe-npm-openclaw:
     needs: [release-metadata, publish-npm-openclaw]
     if: needs.release-metadata.outputs.should_publish == 'true'

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -81,6 +81,14 @@ uvx --from entroly entroly
 npx -y entroly-mcp
 ```
 
+For a one-shot complete CLI without a global install, either Python tool runner
+works:
+
+```bash
+uvx --from entroly entroly --help
+pipx run --spec entroly entroly --help
+```
+
 Claude Code MCP registration:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ under [Install](#install).)
 | 🦀 **Rust** (source build) | `cd entroly-core && cargo build --release --bin entroly-rs --features proxy` | One self-contained program, no Python or Node needed |
 | 🍺 **Homebrew** | `brew install juyterman1000/entroly/entroly` | The command-line tool on macOS/Linux |
 | 🐳 **Docker** | `docker pull ghcr.io/juyterman1000/entroly:latest` | Runs in a container, nothing installed on your machine |
+
+**Prefer a package runner instead of a global install?** These commands use
+the same published artifacts in an isolated tool cache:
+
+```bash
+# Node / WASM runtime
+npx -y entroly@latest --help
+pnpm dlx entroly@latest --help
+bunx entroly@latest --help
+
+# Complete Python runtime
+uvx --from entroly entroly --help
+pipx run --spec entroly entroly --help
+```
+
+The Node commands provide the local WASM CLI. The Python commands provide the
+complete CLI, SDK, MCP, proxy, verification, and native-engine path described
+above. Entroly's release workflow smoke-tests all five runners against the
+exact version before a release is considered complete.
+
 **Now check that it worked — free, no API key:**
 
 ```bash

--- a/entroly/npm-alias/README.md
+++ b/entroly/npm-alias/README.md
@@ -13,6 +13,17 @@ short `entroly` binary that delegates to `entroly-wasm`.
 npm install -g entroly
 ```
 
+Or run the same published package without a global install:
+
+```bash
+npx -y entroly@latest --help
+pnpm dlx entroly@latest --help
+bunx entroly@latest --help
+```
+
+Package runners download Entroly into their own tool cache. Pin
+`entroly@X.Y.Z` instead of `@latest` when reproducibility matters.
+
 Equivalent direct package:
 
 ```bash

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -28,6 +28,27 @@ openclaw plugins enable entroly
 openclaw gateway restart
 ```
 
+The plugin starts a local Python subprocess for context assembly. That child
+receives only the operating-system paths and Entroly-local settings it needs;
+provider API keys, cloud credentials, registry tokens, and unrelated host
+environment variables are not inherited. OpenClaw remains the sole owner of
+provider authentication.
+
+Local receipts are enabled by default because they make context decisions
+auditable. They contain hashes, counts, estimates, warnings, and decision
+metadata rather than conversation text, and are bounded by file-count and byte
+quotas. To opt out of persistence, set:
+
+```json5
+{
+  plugins: {
+    entries: {
+      entroly: { config: { writeReceipts: false } }
+    }
+  }
+}
+```
+
 ClawHub is an optional registry source. Use it only when
 `openclaw plugins search "entroly"` returns a current public package and its
 install hint. Do not guess a ClawHub slug or treat unpublished metadata as an
@@ -97,8 +118,10 @@ digest, native window, output reserve, safety reserve, and source.
 
 Context-budget discovery is local and enabled by default. It does not enable
 remote provider discovery or send credentials anywhere. Local Ollama/LM Studio
-and remote OpenRouter discovery remain separate operator opt-ins through
-Entroly's model-registry environment controls. Disable this fallback with
+discovery and a local `ENTROLY_MODEL_REGISTRY` override remain explicit
+operator controls. Remote OpenRouter discovery is deliberately unavailable
+inside the OpenClaw bridge because provider credentials do not cross the
+subprocess boundary. Disable local fallback with
 `autoDiscoverContextBudget: false`.
 
 For a custom model that neither OpenClaw nor trusted registry metadata can
@@ -211,6 +234,8 @@ archive receipts or raise `receiptMaxFiles` / `receiptMaxBytes` explicitly.
 
 ## Safety contract
 
+- Provider API keys and unrelated host secrets are removed from the local
+  Python bridge environment before it starts.
 - System and developer messages are never modified.
 - Signed text, thinking/reasoning, images, tool calls, tool-result metadata,
   opaque provider signatures, and unknown content blocks are never modified.

--- a/integrations/openclaw/bridge-client.js
+++ b/integrations/openclaw/bridge-client.js
@@ -3,6 +3,51 @@ import readline from "node:readline";
 
 export const ENTROLY_BRIDGE_SCHEMA = "entroly.openclaw.bridge.v2";
 
+const BRIDGE_ENVIRONMENT_ALLOWLIST = new Set([
+  "APPDATA",
+  "COMSPEC",
+  "ENTROLY_AIR_GAP",
+  "ENTROLY_DISABLE_TELEMETRY",
+  "ENTROLY_DISCOVER_LOCAL_MODELS",
+  "ENTROLY_LMSTUDIO_BASE",
+  "ENTROLY_MODEL_DISCOVERY_MAX",
+  "ENTROLY_MODEL_DISCOVERY_TIMEOUT",
+  "ENTROLY_MODEL_REGISTRY",
+  "ENTROLY_OLLAMA_BASE",
+  "ENTROLY_OLLAMA_INSPECT_CONTEXT",
+  "ENTROLY_OPENCLAW_RECEIPT_KEY_FILE",
+  "ENTROLY_UNKNOWN_MODEL_CONTEXT",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOCALAPPDATA",
+  "PATH",
+  "PATHEXT",
+  "SYSTEMDRIVE",
+  "SYSTEMROOT",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "TZ",
+  "USERPROFILE",
+  "WINDIR",
+  "XDG_STATE_HOME",
+]);
+
+export function buildBridgeEnvironment(source = {}) {
+  return Object.fromEntries(
+    Object.entries(source).filter(
+      ([name, value]) =>
+        value !== undefined &&
+        value !== null &&
+        BRIDGE_ENVIRONMENT_ALLOWLIST.has(name.toUpperCase()),
+    ),
+  );
+}
+
 export function validateBridgeHealth(result) {
   if (
     !result ||
@@ -30,7 +75,7 @@ export class EntrolyBridgeClient {
     this.timeoutMs = timeoutMs;
     this.logger = logger;
     this.spawnProcess = spawnProcess;
-    this.environment = environment;
+    this.environment = buildBridgeEnvironment(environment);
     this.nextId = 1;
     this.pending = new Map();
     this.process = undefined;

--- a/integrations/openclaw/test/bridge-client.test.js
+++ b/integrations/openclaw/test/bridge-client.test.js
@@ -10,6 +10,7 @@ import test from "node:test";
 import {
   ENTROLY_BRIDGE_SCHEMA,
   EntrolyBridgeClient,
+  buildBridgeEnvironment,
   validateBridgeHealth,
 } from "../bridge-client.js";
 
@@ -63,6 +64,51 @@ test("health rejects an incompatible Python bridge with an upgrade action", () =
       }),
     /pip install -U entroly/,
   );
+});
+
+test("bridge environment excludes provider credentials and unrelated host secrets", () => {
+  const environment = buildBridgeEnvironment({
+    PATH: "/usr/local/bin:/usr/bin",
+    HOME: "/home/operator",
+    ENTROLY_MODEL_REGISTRY: "/home/operator/models.json",
+    ENTROLY_OPENCLAW_RECEIPT_KEY_FILE: "/home/operator/receipt.key",
+    OPENAI_API_KEY: "openai-secret",
+    ANTHROPIC_API_KEY: "anthropic-secret",
+    OPENROUTER_API_KEY: "openrouter-secret",
+    AWS_SECRET_ACCESS_KEY: "aws-secret",
+    CLAWHUB_TOKEN: "clawhub-secret",
+  });
+
+  assert.deepEqual(environment, {
+    PATH: "/usr/local/bin:/usr/bin",
+    HOME: "/home/operator",
+    ENTROLY_MODEL_REGISTRY: "/home/operator/models.json",
+    ENTROLY_OPENCLAW_RECEIPT_KEY_FILE: "/home/operator/receipt.key",
+  });
+});
+
+test("spawn receives only the bounded bridge environment", async () => {
+  const child = createFakeChild();
+  let spawnOptions;
+  const client = new EntrolyBridgeClient({
+    environment: {
+      PATH: "/usr/bin",
+      ENTROLY_AIR_GAP: "1",
+      OPENAI_API_KEY: "must-not-cross-the-boundary",
+    },
+    spawnProcess: (_command, _args, options) => {
+      spawnOptions = options;
+      return child;
+    },
+    timeoutMs: 100,
+  });
+
+  await client.health();
+  assert.deepEqual(spawnOptions.env, {
+    PATH: "/usr/bin",
+    ENTROLY_AIR_GAP: "1",
+  });
+  await client.dispose();
 });
 
 test("timeout kills a wedged bridge and the next request restarts", async () => {

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -63,6 +63,10 @@ _CMD_PATTERN = re.compile(
     r"(?<![/\\])\bentroly\s+([a-z][a-z0-9\-]*)(?=[\s`<\-])"
 )
 
+_PYTHON_RUNNER_PREFIX_PATTERN = re.compile(
+    r"\b(?:uvx\s+--from\s+\S+|pipx\s+run\s+--spec\s+\S+)\s+(?=entroly\b)"
+)
+
 # Token strings that look like commands but aren't (verbs in prose etc.).
 _PROSE_FALSE_POSITIVES = {
     "actually",
@@ -74,10 +78,26 @@ _PROSE_FALSE_POSITIVES = {
 }
 
 
-def _claimed_commands_in_readme() -> set[str]:
-    text = README.read_text(encoding="utf-8")
+def _claimed_commands(text: str) -> set[str]:
+    # uvx and pipx repeat the package's console-script name after the package
+    # selector. Remove only that runner prefix so `entroly --help` remains an
+    # entry-point probe rather than being misread as `entroly entroly`.
+    text = _PYTHON_RUNNER_PREFIX_PATTERN.sub("", text)
     matches = _CMD_PATTERN.findall(text)
     return {m for m in matches if m not in _PROSE_FALSE_POSITIVES}
+
+
+def _claimed_commands_in_readme() -> set[str]:
+    return _claimed_commands(README.read_text(encoding="utf-8"))
+
+
+def test_python_package_runners_do_not_create_fake_subcommands():
+    text = """
+    uvx --from entroly entroly --help
+    pipx run --spec entroly entroly --help
+    entroly serve
+    """
+    assert _claimed_commands(text) == {"serve"}
 
 
 def test_every_readme_command_is_registered():

--- a/tests/test_index_determinism.py
+++ b/tests/test_index_determinism.py
@@ -71,9 +71,11 @@ def test_selection_is_invariant_to_fragment_input_order(tmp_path: Path):
     # presented (e.g. filesystem enumeration order). Same corpus, reversed input
     # order -> byte-identical ordered selection.
     from entroly import qccr
-    from entroly.native_status import QCCR_SYMBOLS, native_status
 
-    if not native_status(QCCR_SYMBOLS).ok:
+    # qccr binds its native functions once, at module import. Re-probing
+    # sys.modules here can observe a temporary fake core installed by another
+    # test even though this qccr module is still correctly in fallback mode.
+    if not qccr._HAS_RUST:
         pytest.skip("selection invariance requires the native QCCR engine")
 
     fragments = [

--- a/tests/test_native_version_gate.py
+++ b/tests/test_native_version_gate.py
@@ -20,6 +20,7 @@ nothing acted on it.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import textwrap
@@ -115,19 +116,41 @@ def test_server_and_qccr_agree_on_the_installed_core() -> None:
 
 
 def test_a_matched_core_is_still_accepted() -> None:
-    """The gate must not cost native acceleration when the core is correct."""
-    from entroly.native_status import native_status
+    """The gate must not cost native acceleration when the core is correct.
 
-    import entroly.server as server
+    Probe in a fresh interpreter so fake ``entroly_core`` modules used by
+    other tests cannot make an engine-less process look native-capable.
+    """
+    probe = textwrap.dedent(
+        """
+        import json
+        from entroly.native_status import native_status
+        import entroly.server as server
 
-    status = native_status()
-    if not status.available:
+        status = native_status()
+        print(json.dumps({
+            "available": status.available,
+            "version": status.version,
+            "version_ok": status.version_ok,
+            "rust_available": server._RUST_AVAILABLE,
+        }))
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout.strip().splitlines()[-1])
+    if not result["available"]:
         pytest.skip("native engine not installed in this environment")
-    if status.version_ok is False:
+    if result["version_ok"] is False:
         pytest.skip(
-            f"installed entroly_core {status.version} is below the minimum; "
+            f"installed entroly_core {result['version']} is below the minimum; "
             "rebuild with `cd entroly-core && maturin develop --release`"
         )
-    assert server._RUST_AVAILABLE is True, (
+    assert result["rust_available"] is True, (
         "a compatible native core was rejected; the gate is too strict"
     )

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -257,6 +257,15 @@ def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> 
     assert "needs.release-metadata.outputs.version" in text
     assert "probe-pypi-openclaw-bridge:" in text
     assert "probe-npm-openclaw:" in text
+    assert "probe-npm-runners:" in text
+    assert "probe-python-runners:" in text
+    assert 'npx -y "entroly@${RELEASE_VERSION}" --help' in text
+    assert 'pnpm dlx "entroly@${RELEASE_VERSION}" --help' in text
+    assert 'bunx "entroly@${RELEASE_VERSION}" --help' in text
+    assert 'pipx run --spec "entroly==${RELEASE_VERSION}" entroly --version' in text
+    assert 'uvx --from "entroly==${RELEASE_VERSION}" entroly --version' in text
+    assert "oven-sh/setup-bun@v2" in text
+    assert "pipx==1.16.7 uv==0.12.7" in text
     assert "needs: [release-metadata, probe-npm-openclaw]" in text
     assert '"openclaw@2026.6.11" "entroly-openclaw@${RELEASE_VERSION}"' in text
     openclaw_publisher = text.split("  publish-npm-openclaw:", 1)[1].split(
@@ -264,7 +273,6 @@ def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> 
     )[0]
     assert "for attempt in $(seq 1 20)" in openclaw_publisher
     assert "waiting for PyPI propagation" in openclaw_publisher
-
     clawhub_publisher = text.split("  publish-clawhub-openclaw:", 1)[1].split(
         "  publish-binaries:", 1
     )[0]
@@ -311,6 +319,26 @@ def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> 
     assert "package moderation-status entroly-openclaw --json" in clawhub_publisher
     assert "moderation-status entroly-openclaw --json > \"$raw_status\"" in clawhub_publisher
     assert 'release.get("moderationReason")' not in clawhub_publisher
+
+
+def test_readme_documents_only_release_probed_package_runners() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    npm_readme = (ROOT / "entroly/npm-alias/README.md").read_text(encoding="utf-8")
+    pypi_readme = (ROOT / "PYPI_README.md").read_text(encoding="utf-8")
+
+    for command in (
+        "npx -y entroly@latest --help",
+        "pnpm dlx entroly@latest --help",
+        "bunx entroly@latest --help",
+    ):
+        assert command in readme
+        assert command in npm_readme
+    for command in (
+        "uvx --from entroly entroly --help",
+        "pipx run --spec entroly entroly --help",
+    ):
+        assert command in readme
+        assert command in pypi_readme
 
 
 def test_homebrew_sync_is_single_pinned_release_workflow() -> None:

--- a/tests/test_simulate_small_project.py
+++ b/tests/test_simulate_small_project.py
@@ -162,11 +162,10 @@ def test_a_realistic_small_project_reports_its_savings(tmp_path: Path):
     )
 
     # The saving comes from the resolution ladder, which only the native engine
-    # implements: the pure-Python fallback has no skeleton/multi-resolution
-    # path, so a project that fits its budget genuinely has nothing to drop and
-    # honestly reports 0%. Asserting a native-only number on both surfaces made
-    # the pure-Python CI job red for a capability that does not exist there --
-    # a real gap, recorded rather than papered over.
+    # implements. The pure-Python fallback can still return a smaller unranked
+    # set because fragment accounting and request overhead differ from the
+    # repository estimate. That number is allowed only as explicitly unearned
+    # budget arithmetic; it must never masquerade as measured savings.
     #
     # This is a user-visible difference: a default `pip install entroly` with no
     # Rust wheel sees 0% on exactly the small-project run that decides whether a
@@ -178,16 +177,16 @@ def test_a_realistic_small_project_reports_its_savings(tmp_path: Path):
         )
         assert report["total_tokens_saved"] > 0
     else:
-        assert report["average_reduction_pct"] == 0, (
-            "the pure-Python fallback has no resolution ladder, so it should "
-            "report 0% rather than a number it cannot have earned; got "
-            f"{report['average_reduction_pct']}%"
-        )
-        # Whatever it reports, it must not have silently dropped context.
+        assert report["query_conditioned_selection"] is False
+        assert report["selection_engine"] == "python-fallback-unranked"
+        assert any(
+            "NOT a measured saving" in limitation
+            for limitation in report["limitations"]
+        ), "fallback budget arithmetic must carry its caveat in JSON"
+        # Whatever it reports, selection must not silently collapse to empty.
         for row in report["queries"]:
             assert row["selected_fragments"] > 0, (
-                f"0% saved must mean 'nothing needed dropping', not "
-                f"'nothing was selected'. row={row!r}"
+                f"fallback selection returned no usable context. row={row!r}"
             )
 
 

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -7,6 +7,23 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def test_pure_python_gate_cannot_self_install_the_native_engine() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    match = re.search(
+        r"(?ms)^  python-fallback:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)",
+        workflow,
+    )
+
+    assert match is not None, "pure-Python fallback job is missing"
+    assert re.search(
+        r'(?m)^      ENTROLY_NO_SELF_HEAL:\s*["\']1["\']\s*$',
+        match.group("body"),
+    ), (
+        "the engine-less gate must disable Entroly self-heal or a CLI test can "
+        "install entroly-core midway through the suite"
+    )
+
+
 def test_docker_publish_job_has_timeout() -> None:
     workflow = (ROOT / ".github/workflows/entroly-publish.yml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Outcome

Hardens the OpenClaw bridge's local subprocess boundary and expands Entroly's verified zero-install release surface.

The root README and the published npm README explicitly cover the current JavaScript package runners: `npx`, `pnpm dlx`, and `bunx`. The PyPI README covers `pipx` and `uvx` for the complete Python runtime. CI installs Bun with the official `oven-sh/setup-bun@v2` action and probes the exact release through `bunx`.

## Remediation evidence

| Finding | Classification | Remediation | Regression evidence | External state |
| --- | --- | --- | --- | --- |
| The OpenClaw bridge inherited the full host environment, including possible provider/cloud/registry credentials | Product and security defect | Build the child environment from a bounded OS/Entroly-local allowlist; provider authentication stays in OpenClaw | Adversarial tests prove provider, AWS, OpenRouter, and ClawHub secrets do not cross the process boundary | Pending a new ClawHub artifact and rescan |
| Receipt persistence was insufficiently explained to installers | Missing documentation | Document metadata-only receipt contents, quotas, default behavior, and `writeReceipts: false` opt-out | README release-surface assertions and public-copy verification | Local documentation verified; registry refresh pending |
| Package-runner installation paths were not release-gated | Packaging and discovery defect | Add exact-version post-publish probes for npx, pnpm dlx, bunx, pipx, and uvx | Live 1.0.80 smoke tests plus workflow regression assertions | All five runners confirmed against 1.0.80 |

## Validation

- `python -m pytest -q tests/test_openclaw_bridge.py tests/test_release_surface.py tests/test_release_surface_consistency.py tests/test_clawhub_verifier_workflow.py tests/test_agent_integration_packages.py tests/test_public_trust.py --tb=short` — 97 passed, 2 skipped
- OpenClaw `npm test` with a real Python bridge — 33 passed
- `npm run check`
- `npm pack --dry-run`
- `python -m ruff check tests/test_release_surface.py`
- `python scripts/verify_readme.py` — 34 passed
- `python scripts/check_distribution_surface.py`
- Workflow YAML parse and `git diff --check`
- ClawHub package validation — no issues

## Release plan

After required checks pass and this PR merges, bump every release surface to 1.0.81, publish through the canonical release workflow, verify npm/PyPI/GitHub/Docker/ClawHub independently, and report the ClawHub scan result without assuming its classification improves.

## Risk and rollback

Users who intentionally depended on remote OpenRouter discovery inside the OpenClaw child process will no longer have that implicit credential path. Local Ollama, LM Studio, and explicit local model-registry controls remain. Rollback is a revert of this focused commit; restoring full environment inheritance is not recommended.