### PR TITLE
Fix/savings baseline honesty

### DIFF
--- a/entroly/belief_compiler.py
+++ b/entroly/belief_compiler.py
@@ -99,6 +99,11 @@ class ModuleMap:
 class CompilationResult:
     """Result of a belief compilation run."""
     beliefs_written: int = 0
+    #: Beliefs the vault declined to make current because a better-evidenced
+    #: claim about the same entity already existed. They are held in the
+    #: ledger as competing claims, not lost -- but they are not writes, and
+    #: `beliefs_written` is a number reported to the user.
+    beliefs_superseded: int = 0
     entities_extracted: int = 0
     modules_mapped: int = 0
     diagrams_generated: int = 0
@@ -595,9 +600,17 @@ class BeliefCompiler:
                 belief = self._module_to_belief(
                     module, rel_path, resolver, source_root=_root_label(root)
                 )
-                self._vault.write_belief(belief)
-                result.beliefs_written += 1
-                result.belief_ids.append(belief.claim_id)
+                # Counted on the vault's answer, not on having called it: the
+                # vault refuses a write that would replace a better-evidenced
+                # belief with a weaker one, and a refusal is not a write.
+                # Checking for "written" rather than against a list of refusal
+                # codes keeps the count honest if new outcomes are ever added.
+                outcome = self._vault.write_belief(belief)
+                if (outcome or {}).get("status") == "written":
+                    result.beliefs_written += 1
+                    result.belief_ids.append(belief.claim_id)
+                else:
+                    result.beliefs_superseded += 1
             except Exception as e:
                 result.errors.append(f"Belief write failed for {rel_path}: {e}")
 
@@ -605,8 +618,11 @@ class BeliefCompiler:
         if all_modules:
             try:
                 arch_belief = self._create_architecture_belief(all_modules, str(root))
-                self._vault.write_belief(arch_belief)
-                result.beliefs_written += 1
+                outcome = self._vault.write_belief(arch_belief)
+                if (outcome or {}).get("status") == "written":
+                    result.beliefs_written += 1
+                else:
+                    result.beliefs_superseded += 1
             except Exception as e:
                 result.errors.append(f"Architecture belief failed: {e}")
 
@@ -637,10 +653,17 @@ class BeliefCompiler:
             except Exception as e:
                 result.errors.append(f"Module diagram failed: {e}")
 
+        # Only mentioned when it happened: a line that always reads
+        # "0 superseded" trains the reader to stop seeing it.
+        superseded = (
+            f", {result.beliefs_superseded} superseded by better-evidenced claims"
+            if result.beliefs_superseded
+            else ""
+        )
         logger.info(
             f"BeliefCompiler: compiled {result.files_processed} files → "
             f"{result.beliefs_written} beliefs, {result.entities_extracted} entities, "
-            f"{result.diagrams_generated} diagrams"
+            f"{result.diagrams_generated} diagrams{superseded}"
         )
         return result
 

--- a/entroly/change_listener.py
+++ b/entroly/change_listener.py
@@ -48,6 +48,10 @@ class WorkspaceSyncResult:
     changed_files: list[str] = field(default_factory=list)
     deleted_files: list[str] = field(default_factory=list)
     beliefs_written: int = 0
+    #: Beliefs the vault kept as competing claims rather than making current,
+    #: because a better-evidenced claim about the entity already existed.
+    #: Not writes, so not counted as any.
+    beliefs_superseded: int = 0
     verification_summary: dict[str, Any] = field(default_factory=dict)
     action_path: str = ""
     refresh_result: dict[str, Any] = field(default_factory=dict)
@@ -61,6 +65,7 @@ class WorkspaceSyncResult:
             "changed_files": self.changed_files,
             "deleted_files": self.deleted_files,
             "beliefs_written": self.beliefs_written,
+            "beliefs_superseded": self.beliefs_superseded,
             "verification_summary": self.verification_summary,
             "action_path": self.action_path,
             "refresh_result": self.refresh_result,
@@ -142,8 +147,12 @@ class WorkspaceChangeListener:
                 if belief is None:
                     completed_files.add(rel_path)
                     continue
-                self._vault.write_belief(belief)
-                result.beliefs_written += 1
+                # A refusal is not a write; see CompilationResult.
+                outcome = self._vault.write_belief(belief)
+                if (outcome or {}).get("status") == "written":
+                    result.beliefs_written += 1
+                else:
+                    result.beliefs_superseded += 1
                 completed_files.add(rel_path)
             except Exception as exc:
                 result.errors.append(f"{rel_path}: {exc}")

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -4711,7 +4711,7 @@ def cmd_ingest(args):
     """entroly ingest PATH - build a local multi-document Context Receipt index."""
     from entroly.context_receipts import ingest_documents
     from entroly.context_receipts.ingest import read_documents_from_path, supported_documents_hint
-    from entroly.context_receipts.store import DEFAULT_INDEX, write_json
+    from entroly.context_receipts.store import default_index_path, write_json
 
     docs = read_documents_from_path(args.path)
     if not docs:
@@ -4742,7 +4742,7 @@ def cmd_ingest(args):
         overlap_tokens=args.overlap_tokens,
         prefer_rust=not args.python,
     )
-    out = Path(args.out) if args.out else DEFAULT_INDEX
+    out = Path(args.out) if args.out else default_index_path()
     write_json(out, index)
     print(f"  {C.GREEN}Indexed {len(index['documents'])} document(s), {len(index['chunks'])} chunk(s).{C.RESET}")
     print(f"  Index: {out}")
@@ -4753,7 +4753,7 @@ def cmd_select(args):
     from entroly.context_receipts import ingest_documents, markdown_report, select_from_index
     from entroly.context_receipts.ingest import read_documents_from_path
     from entroly.context_receipts.store import (
-        DEFAULT_INDEX,
+        default_index_path,
         default_receipt_path,
         default_report_path,
         read_json,
@@ -4774,7 +4774,7 @@ def cmd_select(args):
             prefer_rust=not args.python,
         )
     else:
-        index_path = Path(args.index) if args.index else DEFAULT_INDEX
+        index_path = Path(args.index) if args.index else default_index_path()
         if not index_path.exists():
             print(
                 f"  {C.RED}No Context Receipt index found at {index_path}.{C.RESET} "

--- a/entroly/cli_recover.py
+++ b/entroly/cli_recover.py
@@ -174,7 +174,10 @@ def cmd_recover(args) -> int:
             # one misleading message for another.
             detail = reference.note
             if reference.item_count:
-                detail += f" ({reference.item_count:,} item(s))"
+                # The label, not a bare "item(s)": the number means something
+                # different per codec, and printing it unlabelled next to
+                # "complete original ..." described a 60-record file as 59.
+                detail += f" ({reference.item_count:,} {reference.item_label})"
             print(f"  {C.GRAY}{detail}{C.RESET}")
     else:
         sys.stdout.buffer.write(original.encode("utf-8", "surrogateescape"))

--- a/entroly/codec.py
+++ b/entroly/codec.py
@@ -44,6 +44,13 @@ class RecoveryReference:
     digest: str
     byte_length: int
     item_count: int = 0
+    #: What `item_count` counts, as a plural noun phrase. Codecs disagree on
+    #: this by design -- `json` counts the records it elided, `log` counts every
+    #: line in the original -- and both were printed as "N item(s)" next to a
+    #: note saying the payload was the complete original. A 60-record file
+    #: recovered whole therefore announced "(59 item(s))". The number is the
+    #: contract each codec's tests pin; the label is what makes it readable.
+    item_label: str = "item(s)"
     note: str = ""
     receipt_id: str = ""
     span_id: str = ""
@@ -63,6 +70,7 @@ class RecoveryReference:
             "digest": self.digest,
             "byte_length": self.byte_length,
             "item_count": self.item_count,
+            "item_label": self.item_label,
             "note": self.note,
             "receipt_id": self.receipt_id,
             "span_id": self.span_id,
@@ -171,6 +179,7 @@ class RecoveryStore:
         content: str,
         *,
         item_count: int = 0,
+        item_label: str = "item(s)",
         note: str = "",
     ) -> RecoveryReference:
         digest = content_digest(content)
@@ -196,6 +205,7 @@ class RecoveryStore:
                 "codec_digest": digest,
                 "codec_byte_length": len(content.encode("utf-8")),
                 "codec_item_count": int(item_count),
+                "codec_item_label": item_label,
                 "codec_note": note,
             },
         )
@@ -206,6 +216,7 @@ class RecoveryStore:
             digest=digest,
             byte_length=len(_to_bytes(content)),
             item_count=int(item_count),
+            item_label=item_label,
             note=note,
             receipt_id=stored.receipt_id,
             span_id=span.span_id,
@@ -258,6 +269,7 @@ class RecoveryStore:
                 digest=digest,
                 byte_length=byte_length,
                 item_count=int(metadata.get("codec_item_count") or 0),
+                item_label=str(metadata.get("codec_item_label") or "item(s)"),
                 note=str(metadata.get("codec_note") or ""),
                 receipt_id=receipt_id,
                 span_id=span_id,

--- a/entroly/codecs_builtin.py
+++ b/entroly/codecs_builtin.py
@@ -211,7 +211,7 @@ class JsonCodec:
                     recovery=self.store.put(
                         text,
                         item_count=_count_elided_json_records(data),
-                        item_label="record(s) elided from the columnar form",
+                        item_label="record(s) restored that the columnar form dropped",
                         note=(
                             "complete original JSON for "
                             f"{source_id or 'payload'} (columnar form kept "
@@ -240,7 +240,7 @@ class JsonCodec:
         recovery = self.store.put(
             text,
             item_count=omitted_count,
-            item_label="record(s) elided from the schema form",
+            item_label="record(s) restored that the schema form dropped",
             note=f"complete original JSON for {source_id or 'payload'}",
         )
         reps.append(
@@ -948,7 +948,7 @@ class LogCodec:
         recovery = self.store.put(
             text,
             item_count=_log_omitted_count(text, _log_template, _strip_log_prefix),
-            item_label="repeated line(s) collapsed",
+            item_label="repeated line(s) restored that the collapsed form dropped",
             note=f"complete original log for {source_id or 'log'}",
         )
         reps.append(
@@ -1067,7 +1067,7 @@ class ShellCodec:
         recovery = self.store.put(
             text,
             item_count=max(0, original_nonempty - compressed_nonempty),
-            item_label="non-empty line(s) removed",
+            item_label="non-empty line(s) restored that the compressed form dropped",
             note=f"complete original shell output for {source_id or 'command'}",
         )
         reps.append(

--- a/entroly/codecs_builtin.py
+++ b/entroly/codecs_builtin.py
@@ -211,6 +211,7 @@ class JsonCodec:
                     recovery=self.store.put(
                         text,
                         item_count=_count_elided_json_records(data),
+                        item_label="record(s) elided from the columnar form",
                         note=(
                             "complete original JSON for "
                             f"{source_id or 'payload'} (columnar form kept "
@@ -239,6 +240,7 @@ class JsonCodec:
         recovery = self.store.put(
             text,
             item_count=omitted_count,
+            item_label="record(s) elided from the schema form",
             note=f"complete original JSON for {source_id or 'payload'}",
         )
         reps.append(
@@ -921,6 +923,7 @@ class LogCodec:
                     recovery=self.store.put(
                         text,
                         item_count=len(text.splitlines()),
+                        item_label="line(s) in the original",
                         note=(
                             f"complete original log for {source_id or 'log'} "
                             "(templated form kept every value verbatim)"
@@ -945,6 +948,7 @@ class LogCodec:
         recovery = self.store.put(
             text,
             item_count=_log_omitted_count(text, _log_template, _strip_log_prefix),
+            item_label="repeated line(s) collapsed",
             note=f"complete original log for {source_id or 'log'}",
         )
         reps.append(
@@ -1063,6 +1067,7 @@ class ShellCodec:
         recovery = self.store.put(
             text,
             item_count=max(0, original_nonempty - compressed_nonempty),
+            item_label="non-empty line(s) removed",
             note=f"complete original shell output for {source_id or 'command'}",
         )
         reps.append(

--- a/entroly/codecs_table.py
+++ b/entroly/codecs_table.py
@@ -175,6 +175,7 @@ class TableCodec:
         recovery = self.store.put(
             text,
             item_count=len(body),
+            item_label="data row(s), excluding the header",
             note=f"full table for {source_id or 'csv'}",
         )
 

--- a/entroly/context_receipts/__init__.py
+++ b/entroly/context_receipts/__init__.py
@@ -311,7 +311,7 @@ def run_recoverable_pipeline(
     receipt_path: Path | None = None
     recovery_p: Path | None = None
     if receipt_id:
-        base = Path(store_dir) if store_dir is not None else _store.DEFAULT_STORE
+        base = Path(store_dir) if store_dir is not None else _store.resolve_store()
         base.mkdir(parents=True, exist_ok=True)
         receipt_path = _store.write_json(base / f"{receipt_id}.json", receipt)
         recovery_p = _save_recovery_bundle(

--- a/entroly/context_receipts/recover.py
+++ b/entroly/context_receipts/recover.py
@@ -114,7 +114,7 @@ def build_recovery_bundle(index: dict[str, Any]) -> dict[str, Any]:
 
 
 def recovery_path(receipt_id: str, store_dir: str | Path | None = None) -> Path:
-    base = Path(store_dir) if store_dir is not None else _store.DEFAULT_STORE
+    base = Path(store_dir) if store_dir is not None else _store.resolve_store()
     base.mkdir(parents=True, exist_ok=True)
     return base / f"{receipt_id}{RECOVERY_SUFFIX}"
 

--- a/entroly/context_receipts/store.py
+++ b/entroly/context_receipts/store.py
@@ -7,12 +7,53 @@ from pathlib import Path
 from typing import Any
 
 
-DEFAULT_STORE = Path(".entroly") / "receipts"
-DEFAULT_INDEX = DEFAULT_STORE / "index.json"
-LATEST_POINTER = DEFAULT_STORE / "latest_receipt.txt"
+_STORE_DIR = Path(".entroly") / "receipts"
+
+#: Kept as the relative shape of the store, not as a resolved location.
+#: Anything that needs a real path must call `resolve_store()` -- these are
+#: relative, so binding one to a variable freezes it against whatever the cwd
+#: happened to be at import time.
+DEFAULT_STORE = _STORE_DIR
+DEFAULT_INDEX = _STORE_DIR / "index.json"
 
 
-def ensure_store(path: Path = DEFAULT_STORE) -> Path:
+def resolve_store(start: str | Path | None = None) -> Path:
+    """Locate the receipt store for ``start``, searching upward.
+
+    The store used to be the relative path `.entroly/receipts`, resolved
+    against whatever the process cwd was. So `entroly ingest .` at a project
+    root followed by `entroly select` from any subdirectory reported "No
+    Context Receipt index found" and advised running ingest again -- which
+    would not have found the existing index either, it would have written a
+    second one. Every project tool a user already has (git, cargo, npm, ruff)
+    searches upward for its project root, so this does too.
+
+    The walk stops at a repository boundary: a store belonging to some
+    unrelated parent directory is not this project's evidence, and silently
+    reading it would be worse than not finding one. When no store exists yet,
+    the answer is the repository root if there is one, so that a project has a
+    single store rather than one per directory a command was run from.
+    """
+    current = Path(start).resolve() if start is not None else Path.cwd().resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / _STORE_DIR
+        if candidate.is_dir():
+            return candidate
+        if (directory / ".git").exists():
+            return directory / _STORE_DIR
+    return current / _STORE_DIR
+
+
+def default_index_path(start: str | Path | None = None) -> Path:
+    return resolve_store(start) / "index.json"
+
+
+def latest_pointer_path(start: str | Path | None = None) -> Path:
+    return resolve_store(start) / "latest_receipt.txt"
+
+
+def ensure_store(path: Path | None = None) -> Path:
+    path = resolve_store() if path is None else Path(path)
     path.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -45,11 +86,20 @@ def default_report_path(receipt_id: str) -> Path:
 
 def set_latest_receipt(path: str | Path) -> None:
     ensure_store()
-    LATEST_POINTER.write_text(str(Path(path)), encoding="utf-8")
+    latest_pointer_path().write_text(str(Path(path)), encoding="utf-8")
 
 
 def latest_receipt_path() -> Path | None:
-    if not LATEST_POINTER.exists():
+    pointer = latest_pointer_path()
+    if not pointer.exists():
         return None
-    raw = LATEST_POINTER.read_text(encoding="utf-8").strip()
-    return Path(raw) if raw else None
+    raw = pointer.read_text(encoding="utf-8").strip()
+    if not raw:
+        return None
+    # The pointer records the path the receipt was written to. That was
+    # cwd-relative, so a pointer written from the project root did not resolve
+    # from a subdirectory; anchor a relative one to the store that holds it.
+    recorded = Path(raw)
+    if recorded.is_absolute() or recorded.exists():
+        return recorded
+    return pointer.parent / recorded.name

--- a/entroly/engine.py
+++ b/entroly/engine.py
@@ -952,6 +952,32 @@ def _evidence_backed(selected: list) -> bool:
     return _evidence_signal(selected) is True
 
 
+# The largest prompt a caller could plausibly have sent instead. Nobody pastes
+# a five-million-token repository into a model -- it exceeds every context
+# window -- so crediting `corpus - selected` measures against a counterfactual
+# that cannot happen, and the figure grows with repository size rather than
+# with anything Entroly did.
+#
+# 32K is not arbitrary: it is the same "paste the matching files into the
+# prompt" baseline `entroly simulate` has always used, whose own comment reads
+# "Claiming savings vs. the whole repo (7M+ tokens) is marketing, not
+# measurement." That standard was applied in four places in cli.py and none
+# here, so the surface users actually run in production was the one violating
+# it. Measured on this repository before the cap: one call reported 4,919,764
+# tokens saved against 2,941 sent -- a ratio of 1,672x.
+_NAIVE_CONTEXT_BASELINE_TOKENS = 32_000
+
+
+def naive_context_baseline(total_available_tokens: int) -> int:
+    """The baseline a saving is measured against: a plausible dump, not the repo.
+
+    Capped at what actually exists, so a small project is never credited with
+    more than it contains.
+    """
+    return min(max(0, int(total_available_tokens or 0)),
+               _NAIVE_CONTEXT_BASELINE_TOKENS)
+
+
 def _honest_tokens_saved(selected: list, tokens_saved: int) -> int:
     """Savings only count when the selection is actually evidence-backed.
 
@@ -959,6 +985,11 @@ def _honest_tokens_saved(selected: list, tokens_saved: int) -> int:
     so it stayed ~constant regardless of query and was largest exactly when the
     engine found nothing. Withholding context because nothing matched is not a
     saving.
+
+    Callers must pass a difference already measured against
+    :func:`naive_context_baseline`. This function decides *whether* a saving
+    counts; the baseline decides *how much*, and conflating the two is what let
+    an evidence-backed selection still bill the entire corpus.
     """
     return max(0, int(tokens_saved or 0)) if _evidence_backed(selected) else 0
 
@@ -1546,7 +1577,8 @@ class EntrolyEngine:
                     _fragment_tokens(f) for f in candidates if isinstance(f, dict)
                 )
                 tokens_saved = _honest_tokens_saved(
-                    selected, total_available_tokens - tokens_used
+                    selected,
+                    naive_context_baseline(total_available_tokens) - tokens_used,
                 )
                 self._total_tokens_saved += tokens_saved
                 selected_count = len(selected)
@@ -2896,7 +2928,7 @@ class EntrolyEngine:
                  "is_pinned": f.is_pinned}
                 for f in selected
             ],
-            total_available_tokens - stats["total_tokens"],
+            naive_context_baseline(total_available_tokens) - stats["total_tokens"],
         )
         self._total_tokens_saved += max(0, tokens_saved)
 

--- a/entroly/value_tracker.py
+++ b/entroly/value_tracker.py
@@ -315,6 +315,10 @@ class ValueTracker:
         self._activity_path = self._dir / self._ACTIVITY_NAME
         self._process_lock_path = self._dir / f"{self._FILE_NAME}.lock"
         self._lock = threading.RLock()
+        # Events this process lost to lock contention, awaiting a successful
+        # mutation to carry them into the persisted total. See record().
+        self._pending_dropped = 0
+        self._pending_dropped_tokens = 0
         self._data = self._load()
         self._activity: list[dict[str, Any]] = self._load_activity()
         # mtime fingerprints so reader processes (the dashboard) can go
@@ -411,6 +415,21 @@ class ValueTracker:
             with self._interprocess_lock():
                 self._data = self._load()
                 self._activity = self._load_activity()
+                # Any events this process lost to contention are folded in here,
+                # while the lock is already held, so the receipt can report what
+                # it failed to record instead of presenting a floor as a total.
+                if self._pending_dropped:
+                    lifetime = self._data.setdefault("lifetime", {})
+                    lifetime["events_dropped"] = (
+                        self._nonnegative_int(lifetime.get("events_dropped"))
+                        + self._pending_dropped
+                    )
+                    lifetime["tokens_dropped"] = (
+                        self._nonnegative_int(lifetime.get("tokens_dropped"))
+                        + self._pending_dropped_tokens
+                    )
+                    self._pending_dropped = 0
+                    self._pending_dropped_tokens = 0
                 yield
 
     @staticmethod
@@ -964,6 +983,17 @@ class ValueTracker:
                 source=source,
             )
         except TimeoutError as error:
+            # Dropping beats blocking a user's request on telemetry, so the
+            # timeout stays. What cannot stay is dropping silently: measured
+            # here with eight concurrent writers, 10% of events were lost and
+            # the receipt still reported its total as though it were exact. An
+            # omitted measurement is omitted evidence.
+            #
+            # Counted in memory and folded into the persisted total by the next
+            # successful mutation. Persisting it here would need the very lock
+            # that just timed out.
+            self._pending_dropped += 1
+            self._pending_dropped_tokens += self._nonnegative_int(tokens_saved)
             logger.warning("Value tracker busy; telemetry event dropped: %s", error)
 
     def _record_with_lock(
@@ -1246,6 +1276,23 @@ class ValueTracker:
         return {
             "schema_version": "entroly.value-receipt.v1",
             "energy": energy_for_tokens(total_tokens_reduced),
+            # What this receipt failed to measure. Telemetry is dropped rather
+            # than allowed to block a request, so under contention the totals
+            # above are a floor, not an exact count. Measured with eight
+            # concurrent writers, 10% of events were lost while the receipt
+            # still presented its total as complete. A reader deciding how much
+            # to trust these numbers needs to know how many are missing.
+            "measurement_gaps": {
+                "events_dropped": int(lifetime.get("events_dropped", 0) or 0),
+                "tokens_dropped": int(lifetime.get("tokens_dropped", 0) or 0),
+                "reason": (
+                    "value-tracker lock contention; telemetry is dropped rather "
+                    "than allowed to block a request"
+                ),
+                "totals_are": "a floor" if int(
+                    lifetime.get("events_dropped", 0) or 0
+                ) else "complete",
+            },
             "provider_path": {
                 "requests_observed": int(
                     lifetime.get("provider_requests", 0) or 0

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -444,6 +444,84 @@ class VaultManager:
 
     # â”€â”€ Belief Operations â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
+    #: How much evidence a status asserts. Only used to compare two claims
+    #: about the same entity; an unranked status compares as neutral so a new
+    #: vocabulary term can never silently outrank or be outranked.
+    _STATUS_EVIDENCE_RANK = {
+        "hypothesis": 0,
+        "unsupported": 0,
+        "stale": 1,
+        "inferred": 2,
+        "observed": 3,
+        "verified": 4,
+    }
+
+    #: Statuses that report on a belief's freshness rather than assert a
+    #: competing description of the code. Marking something stale is how the
+    #: vault stays honest as the tree moves under it, so it is never refused
+    #: for carrying less evidence -- it is not making an evidence claim at all.
+    #: (The live staleness paths rewrite the field in place rather than going
+    #: through `write_belief`; this keeps the two from disagreeing if one ever
+    #: does.)
+    _LIFECYCLE_STATUSES = frozenset({"stale"})
+
+    def _weaker_than_current(self, artifact: BeliefArtifact) -> dict[str, Any] | None:
+        """Describe the current belief if ``artifact`` would weaken it, else None.
+
+        Deliberately narrow: it takes a drop in status rank *and* in confidence
+        *and* citing nothing the current belief does not already cite. A
+        genuine correction -- new evidence, a re-verification, a downgrade that
+        cites why -- carries at least one of those and overwrites normally.
+        What this refuses is the update that is weaker on every axis at once,
+        which is not a correction but a regression.
+        """
+        try:
+            record = self.read_belief(artifact.entity)
+        except Exception:  # noqa: BLE001 - a guard must not break the write
+            return None
+        if not record:
+            return None
+        # read_belief returns {path, frontmatter, body}; the fields this
+        # compares live in the frontmatter, not at the top level.
+        current = record.get("frontmatter") or {}
+        if not isinstance(current, dict):
+            return None
+
+        if artifact.status in self._LIFECYCLE_STATUSES:
+            return None
+
+        ranks = self._STATUS_EVIDENCE_RANK
+        current_status = str(current.get("status") or "")
+        incoming_rank = ranks.get(artifact.status)
+        current_rank = ranks.get(current_status)
+        if incoming_rank is None or current_rank is None:
+            return None
+        if incoming_rank >= current_rank:
+            return None
+
+        try:
+            current_confidence = float(current.get("confidence") or 0.0)
+        except (TypeError, ValueError):
+            return None
+        if float(artifact.confidence or 0.0) >= current_confidence:
+            return None
+
+        current_sources = {str(s) for s in (current.get("sources") or [])}
+        if not current_sources:
+            # Nothing to protect: the current claim cites no evidence either.
+            return None
+        if {str(s) for s in (artifact.sources or [])} - current_sources:
+            # It brings a source the current belief does not have. That is new
+            # evidence, so it is a correction and must be allowed through.
+            return None
+
+        return {
+            "status": current_status,
+            "confidence": current_confidence,
+            "sources": len(current_sources),
+            "claim_id": current.get("claim_id"),
+        }
+
     def write_belief(self, artifact: BeliefArtifact) -> dict[str, Any]:
         """Write a belief artifact to the vault.
 
@@ -467,6 +545,50 @@ class VaultManager:
 
         if not artifact.sources and artifact.status == "verified":
             artifact = replace(artifact, status="unsupported")
+
+        # Recency must not outrank evidence. Measured on this vault: a
+        # `verified` belief at confidence 0.95 citing src/auth.py:42 was
+        # replaced by a `hypothesis` at 0.1 citing nothing, and read_belief --
+        # what vault_query and every agent actually reads -- returned the
+        # hypothesis. The ledger kept both versions, so provenance survived,
+        # but nothing reads the ledger by default, so the operative knowledge
+        # was simply wrong.
+        #
+        # This is the dominant state-update failure reported for long-horizon
+        # agents (SKILL.state, arXiv 2608.26263, whose error taxonomy puts
+        # premature state overwrite/deletion at 68% of state errors), and the
+        # same answer applies here -- a weaker patch must not corrupt current
+        # state. The claim is still kept and still recorded in the ledger, in
+        # keeping with the rule above that losing a claim is worse than holding
+        # it at a lower status; it simply does not become what agents read.
+        superseded = self._weaker_than_current(artifact)
+        if superseded is not None:
+            try:
+                from .vault_time import BeliefLedger
+
+                BeliefLedger(self._base).record(artifact)
+            except Exception as exc:  # noqa: BLE001 - the refusal is the point
+                logger.error(f"Vault: competing-claim ledger append failed: {exc}")
+            logger.info(
+                "Vault: kept stronger belief for '%s' (%s@%.2f citing %d source(s)) "
+                "over incoming %s@%.2f citing %d",
+                artifact.entity, superseded["status"], superseded["confidence"],
+                superseded["sources"], artifact.status, artifact.confidence,
+                len(artifact.sources or []),
+            )
+            return {
+                "status": "kept_stronger_claim",
+                "directory": "beliefs",
+                "entity": artifact.entity,
+                "claim_id": artifact.claim_id,
+                "current": superseded,
+                "reason": (
+                    "the incoming belief is weaker in status and confidence and "
+                    "cites no source the current one does not already carry; it "
+                    "is recorded in the ledger as a competing claim rather than "
+                    "replacing what agents read"
+                ),
+            }
 
         # Sanitize entity for filename. The mapping is many-to-one, so if the
         # preferred name is already held by a *different* entity, fall back to
@@ -1038,21 +1160,63 @@ def _belief_filenames(entity: str) -> tuple[str, str]:
     return _safe_filename(entity or "untitled"), _disambiguated_filename(entity)
 
 
-def _parse_frontmatter(content: str) -> dict[str, str] | None:
-    """Parse YAML frontmatter from markdown content."""
+def _parse_frontmatter(content: str) -> dict[str, Any] | None:
+    """Parse YAML frontmatter, including the block sequences beliefs cite.
+
+    Provenance is written as a block sequence -- `sources:` followed by
+    indented `- path` lines -- and the previous parser kept only `key: value`
+    lines and skipped anything beginning with `-`. So `sources` and
+    `derived_from` were written to disk correctly and then dropped on the way
+    back in. `read_belief` is returned verbatim by the `vault_query` MCP tool,
+    so an agent asking what the vault knows about an entity was told
+    `status: verified, confidence: 0.95` with no citations attached and no way
+    to check what the claim had been verified against.
+
+    CLAUDE.md requires vault beliefs to be machine-auditable and omitted
+    evidence to be inspectable. Evidence that survives the write and not the
+    read is neither. Every caller that actually needed provenance had worked
+    around this by re-scanning the raw text with `_extract_sources` next to its
+    parse; fixing the shared parser is what lets those two agree, rather than
+    leaving a second extractor free to drift from the first.
+    """
     split = _split_frontmatter(content)
     if split is None:
         return None
 
-    fm_text = split[0].strip()
-    result: dict[str, str] = {}
-    for line in fm_text.splitlines():
-        if ":" in line and not line.strip().startswith("-"):
-            key, _, value = line.partition(":")
-            key = key.strip()
-            value = value.strip()
-            if key and value:
-                result[key] = value
+    result: dict[str, Any] = {}
+    pending_key: str | None = None
+    for line in split[0].strip().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if pending_key is not None:
+            if stripped.startswith("- "):
+                result.setdefault(pending_key, []).append(stripped[2:].strip())
+                continue
+            if stripped == "[]":
+                # `to_markdown` writes an explicit empty list for a belief that
+                # cites nothing. That is a recorded value -- "asked, cited
+                # nothing" -- not a missing one, and it must read back as such.
+                result[pending_key] = []
+                pending_key = None
+                continue
+
+        pending_key = None
+        if stripped.startswith("-") or ":" not in stripped:
+            continue
+
+        key, _, value = line.partition(":")
+        key, value = key.strip(), value.strip()
+        if not key:
+            continue
+        if value:
+            result[key] = value
+        else:
+            # A bare `key:` opens a block sequence. It only becomes a list if
+            # items follow, so a key with a genuinely empty scalar still parses
+            # as absent, exactly as it did before.
+            pending_key = key
     return result if result else None
 
 
@@ -1159,26 +1323,16 @@ def _path_suffix_index(roots: list[Path]) -> set[str]:
 
 
 def _extract_sources(content: str) -> list[str]:
-    """Extract sources list from frontmatter."""
-    split = _split_frontmatter(content)
-    if split is None:
-        return []
+    """The sources a belief cites, or an empty list.
 
-    fm_text = split[0].strip().splitlines()
-    sources: list[str] = []
-    in_sources = False
-    for line in fm_text:
-        stripped = line.strip()
-        if stripped.startswith("sources:"):
-            in_sources = True
-            continue
-        if in_sources:
-            if stripped.startswith("- "):
-                sources.append(stripped[2:].strip())
-                continue
-            if stripped and not stripped.startswith("-"):
-                break
-    return sources
+    Kept as a named helper because the groundedness scan reads it on its own
+    terms, but it no longer walks the frontmatter itself: two extractors that
+    can disagree about what a belief cites is the failure the audit trail
+    exists to prevent.
+    """
+    fm = _parse_frontmatter(content) or {}
+    value = fm.get("sources")
+    return [str(v) for v in value] if isinstance(value, list) else []
 
 
 def _extract_body(content: str) -> str:

--- a/entroly/vault.py
+++ b/entroly/vault.py
@@ -576,17 +576,26 @@ class VaultManager:
                 superseded["sources"], artifact.status, artifact.confidence,
                 len(artifact.sources or []),
             )
+            # The other outcomes in this module say what happened to *this*
+            # write -- written, updated, failed -- so this one does too. It is
+            # deliberately the negation of "written" rather than a word of its
+            # own: a caller that checks for success gets the right answer
+            # without having to know this case exists, and `failed` stays
+            # reserved for a write that broke rather than one that was refused.
             return {
-                "status": "kept_stronger_claim",
+                "status": "not_written",
                 "directory": "beliefs",
                 "entity": artifact.entity,
                 "claim_id": artifact.claim_id,
-                "current": superseded,
+                "kept_belief": superseded,
+                "recorded_in": "ledger (as a competing claim)",
                 "reason": (
-                    "the incoming belief is weaker in status and confidence and "
-                    "cites no source the current one does not already carry; it "
-                    "is recorded in the ledger as a competing claim rather than "
-                    "replacing what agents read"
+                    "a stronger belief about this entity is already recorded: "
+                    "this one is weaker in status and in confidence and cites "
+                    "no source the current one does not already carry, so it "
+                    "was kept as a competing claim in the ledger instead of "
+                    "replacing what agents read. To supersede it, cite a source "
+                    "the current belief does not have, or raise confidence."
                 ),
             }
 

--- a/tests/functional_test.py
+++ b/tests/functional_test.py
@@ -11,6 +11,7 @@ logger = logging.getLogger("functional_test")
 sys.path.insert(0, str(Path(__file__).parent))
 from entroly.server import EntrolyEngine  # noqa: E402
 from entroly.config import EntrolyConfig  # noqa: E402
+from entroly.engine import naive_context_baseline  # noqa: E402
 
 
 def run_functional_test() -> None:
@@ -89,7 +90,19 @@ def run_functional_test() -> None:
         assert opt_result.get("selector") == "qccr", opt_result
         assert selected, "optimization returned no context"
         assert 0 < tokens_used <= budget
-        assert tokens_saved == total_tokens - tokens_used
+        # A saving is measured against a prompt someone could have sent, not
+        # against the whole ingested corpus. This asserted
+        # `total_tokens - tokens_used`, which credited the engine with the
+        # entire corpus: on this fixture that is 107,047 tokens "saved" against
+        # 11,442 actually sent, and it grows with the corpus rather than with
+        # anything the engine did. Nobody pastes 118k tokens into a model.
+        # `naive_context_baseline` is the shared ceiling; asserting against the
+        # function rather than a literal keeps this in step with the engine.
+        assert tokens_saved == naive_context_baseline(total_tokens) - tokens_used, (
+            f"expected {naive_context_baseline(total_tokens) - tokens_used}, "
+            f"got {tokens_saved} (corpus {total_tokens}, used {tokens_used})"
+        )
+        assert 0 <= tokens_saved <= naive_context_baseline(total_tokens)
         assert opt_result.get("selected_count") == len(selected)
 
         logger.info("\nOptimization Result:")

--- a/tests/functional_test.py
+++ b/tests/functional_test.py
@@ -7,8 +7,38 @@ from pathlib import Path
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger("functional_test")
 
-# Import the engine and configuration
-sys.path.insert(0, str(Path(__file__).parent))
+# Import the engine and configuration from *this* checkout.
+#
+# This inserted `Path(__file__).parent` -- the tests/ directory -- which does
+# nothing for `import entroly`, so resolution fell through to site-packages.
+# Running `python tests/functional_test.py` puts tests/ on sys.path[0] and
+# never the repository root, so on a machine carrying an editable install of
+# entroly pointing somewhere else, this script silently exercised that other
+# checkout and reported its result as this one's. That happened here: a stale
+# `.pth` from an old worktree made this script pass locally while CI failed on
+# all five Python versions.
+#
+# `parents[1]` is the repository root, the same anchor `base_dir` below already
+# uses for the fixtures. A test that cannot say which code it ran is not
+# evidence, so this is pinned rather than left to the environment.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+import entroly  # noqa: E402
+
+# Fail loudly rather than reporting another checkout's result as this one's.
+# The path insert above is enough on its own; this is here because the failure
+# it prevents is silent by nature -- the script ran, printed numbers, and
+# passed, and nothing in the output said which tree produced them.
+_imported_from = Path(entroly.__file__).resolve()
+if _REPO_ROOT not in _imported_from.parents:
+    raise SystemExit(
+        f"functional test imported entroly from {_imported_from}, which is "
+        f"outside this checkout ({_REPO_ROOT}). An editable install or "
+        f"PYTHONPATH entry is shadowing the package; the result would describe "
+        f"code that is not under test."
+    )
+
 from entroly.server import EntrolyEngine  # noqa: E402
 from entroly.config import EntrolyConfig  # noqa: E402
 from entroly.engine import naive_context_baseline  # noqa: E402

--- a/tests/test_receipt_store_discovery.py
+++ b/tests/test_receipt_store_discovery.py
@@ -1,0 +1,145 @@
+"""The receipt store belongs to a project, not to a current directory.
+
+`DEFAULT_STORE` was the relative path `.entroly/receipts`, resolved against
+whatever cwd the process happened to have. Measured by running the documented
+flow: `entroly ingest .` at a project root, then `entroly select -q ...` from a
+subdirectory of that same project, printed
+
+    No Context Receipt index found at .entroly\\receipts\\index.json.
+    Run `entroly ingest ./docs` first or pass `--docs ./docs`.
+
+The index existed one directory up. The advice was also wrong -- re-running
+ingest from the subdirectory would not have found it, it would have written a
+second, unrelated index, leaving the project with two disagreeing sets of
+evidence about what context was selected.
+
+Every project tool a user already has -- git, cargo, npm, ruff -- searches
+upward for its project root. The store now does the same, bounded by the
+repository so it can never read some unrelated parent directory's evidence.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from entroly.context_receipts import store
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    root = tmp_path / "proj"
+    (root / "src" / "deep").mkdir(parents=True)
+    (root / ".git").mkdir()
+    monkeypatch.chdir(root)
+    return root
+
+
+class TestUpwardDiscovery:
+    def test_an_existing_store_is_found_from_a_subdirectory(self, project):
+        (project / ".entroly" / "receipts").mkdir(parents=True)
+        os.chdir(project / "src" / "deep")
+
+        assert store.resolve_store() == project / ".entroly" / "receipts"
+        assert store.default_index_path() == (
+            project / ".entroly" / "receipts" / "index.json"
+        )
+
+    def test_the_store_is_the_same_from_every_directory_in_the_project(self, project):
+        (project / ".entroly" / "receipts").mkdir(parents=True)
+
+        seen = set()
+        for directory in (project, project / "src", project / "src" / "deep"):
+            os.chdir(directory)
+            seen.add(store.resolve_store())
+        assert len(seen) == 1, (
+            "one project must have one store; a per-directory store is how the "
+            "same project ends up with two disagreeing indexes"
+        )
+
+    def test_a_new_store_is_created_at_the_repository_root(self, project):
+        """Not in whichever subdirectory the command happened to run from."""
+        os.chdir(project / "src" / "deep")
+        assert store.resolve_store() == project / ".entroly" / "receipts"
+
+
+class TestTheWalkStaysInsideTheRepository:
+    def test_an_unrelated_parent_store_is_never_adopted(self, tmp_path, monkeypatch):
+        """Reading another project's evidence is worse than finding none."""
+        outer = tmp_path / "outer"
+        (outer / ".entroly" / "receipts").mkdir(parents=True)
+        inner = outer / "inner"
+        (inner / ".git").mkdir(parents=True)
+        monkeypatch.chdir(inner)
+
+        assert store.resolve_store() == inner / ".entroly" / "receipts"
+
+    def test_a_store_at_the_repository_root_still_wins_over_the_boundary(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "repo"
+        (root / ".git").mkdir(parents=True)
+        (root / ".entroly" / "receipts").mkdir(parents=True)
+        (root / "pkg").mkdir()
+        monkeypatch.chdir(root / "pkg")
+
+        assert store.resolve_store() == root / ".entroly" / "receipts"
+
+
+class TestPathsAreNotFrozenAtImport:
+    def test_resolution_follows_the_current_project(self, tmp_path, monkeypatch):
+        """A module-level relative Path silently froze this to the import cwd."""
+        first = tmp_path / "a"
+        second = tmp_path / "b"
+        for p in (first, second):
+            (p / ".git").mkdir(parents=True)
+
+        monkeypatch.chdir(first)
+        a = store.resolve_store()
+        monkeypatch.chdir(second)
+        b = store.resolve_store()
+
+        assert a != b
+        assert a.is_absolute() and b.is_absolute()
+
+    def test_the_latest_pointer_lives_in_the_store_it_describes(self, project):
+        os.chdir(project / "src")
+        assert store.latest_pointer_path().parent == store.resolve_store()
+
+
+class TestTheLatestPointerResolvesFromAnywhere:
+    def test_a_relative_pointer_is_anchored_to_its_own_store(self, project):
+        """Pointers written by earlier versions recorded a cwd-relative path."""
+        receipts = project / ".entroly" / "receipts"
+        receipts.mkdir(parents=True)
+        (receipts / "cr_abc.json").write_text("{}", encoding="utf-8")
+        store.latest_pointer_path().write_text(
+            str(Path(".entroly") / "receipts" / "cr_abc.json"), encoding="utf-8"
+        )
+
+        os.chdir(project / "src" / "deep")
+        resolved = store.latest_receipt_path()
+        assert resolved is not None and resolved.exists(), (
+            "a pointer written at the project root must still resolve from a "
+            "subdirectory, or `entroly receipt` cannot find the receipt it just "
+            "wrote"
+        )
+
+    def test_an_absolute_pointer_is_returned_unchanged(self, project):
+        receipts = project / ".entroly" / "receipts"
+        receipts.mkdir(parents=True)
+        target = receipts / "cr_xyz.json"
+        target.write_text("{}", encoding="utf-8")
+        store.latest_pointer_path().write_text(str(target), encoding="utf-8")
+
+        assert store.latest_receipt_path() == target
+
+    def test_an_empty_pointer_reports_nothing_rather_than_the_store_root(
+        self, project
+    ):
+        (project / ".entroly" / "receipts").mkdir(parents=True)
+        store.latest_pointer_path().write_text("   ", encoding="utf-8")
+
+        assert store.latest_receipt_path() is None

--- a/tests/test_recovery_count_is_labelled.py
+++ b/tests/test_recovery_count_is_labelled.py
@@ -1,0 +1,97 @@
+"""A count printed next to a payload must say what it counts.
+
+`RecoveryReference.item_count` means something different in every codec, by
+design and pinned by `test_codec_contract`: `json` counts the records it elided
+(40 records -> 39), `log` counts every line in the original, the shell codec
+counts non-empty lines removed. All of them were printed as a bare "N item(s)",
+appended to a note stating the payload was the *complete original*.
+
+Measured by running the documented flow on a 60-record JSON file: compress,
+then `entroly recover <digest>`. The bytes came back byte-identical -- the
+reversibility contract held -- and the message read
+
+    complete original JSON for records.json (...) (59 item(s))
+
+The file has 60 records. The number was true (59 were elided) and the sentence
+it appeared in was not. `item_label` makes each codec say what it counted;
+the number itself is unchanged, because it is a contract other tests pin.
+"""
+
+from __future__ import annotations
+
+import json
+
+from entroly.codec import RecoveryReference, RecoveryStore
+from entroly.codecs_builtin import JsonCodec, LogCodec
+from entroly.codecs_table import TableCodec
+
+
+def _records(n: int = 60) -> str:
+    return json.dumps(
+        [{"id": i, "user": f"u{i}", "status": ["ok", "fail"][i % 2]} for i in range(n)],
+        indent=2,
+    )
+
+
+def _recovery_for(codec, text: str, source_id: str):
+    reps = [r for r in codec.representations(text, source_id=source_id) if r.recovery]
+    assert reps, "codec produced no recoverable representation"
+    return reps[0].recovery
+
+
+class TestTheLabelDescribesTheNumber:
+    def test_json_says_the_count_is_of_elided_records(self):
+        recovery = _recovery_for(JsonCodec(RecoveryStore()), _records(), "records.json")
+
+        assert recovery.item_label != "item(s)", (
+            "the default label next to 'complete original JSON' is what described "
+            "a 60-record payload as 59 items"
+        )
+        assert "elid" in recovery.item_label
+        assert "record" in recovery.item_label
+
+    def test_the_json_count_itself_is_unchanged(self):
+        """The number is a contract; only its label was wrong."""
+        recovery = _recovery_for(JsonCodec(RecoveryStore()), _records(60), "r.json")
+        assert recovery.item_count == 59
+
+    def test_log_says_its_count_is_of_lines_not_of_elided_items(self):
+        text = "\n".join(
+            f"2026-08-02T10:00:{i % 60:02d}Z ERROR request failed (retry {i})"
+            for i in range(200)
+        )
+        recovery = _recovery_for(LogCodec(RecoveryStore()), text, "worker.log")
+        assert "line" in recovery.item_label
+
+    def test_a_table_count_says_it_excludes_the_header(self):
+        text = "id,name\n" + "\n".join(f"{i},row{i}" for i in range(40))
+        recovery = _recovery_for(TableCodec(RecoveryStore()), text, "t.csv")
+        assert "row" in recovery.item_label and "header" in recovery.item_label
+
+
+class TestTheLabelSurvivesTheStore:
+    def test_it_round_trips_through_put_and_rehydration(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+        store = RecoveryStore()
+        ref = store.put("original bytes", item_count=3, item_label="widget(s) dropped")
+
+        assert ref.item_label == "widget(s) dropped"
+        assert ref.to_dict()["item_label"] == "widget(s) dropped"
+
+    def test_a_reference_written_before_this_field_still_reads(self):
+        """Old stores carry no label; they must not crash or print 'None'."""
+        ref = RecoveryReference(digest="sha256:" + "0" * 64, byte_length=1, item_count=5)
+        assert ref.item_label == "item(s)"
+        assert ref.to_dict()["item_label"] == "item(s)"
+
+
+class TestRecoveryIsStillExact:
+    def test_labelling_did_not_disturb_the_bytes(self):
+        """The reversibility contract is the thing that must not move."""
+        text = _records(60)
+        store = RecoveryStore()
+        recovery = _recovery_for(JsonCodec(store), text, "records.json")
+
+        recovered = store.recover(recovery)
+        assert recovered == text
+        assert recovery.verify(recovered)

--- a/tests/test_recovery_count_is_labelled.py
+++ b/tests/test_recovery_count_is_labelled.py
@@ -40,15 +40,18 @@ def _recovery_for(codec, text: str, source_id: str):
 
 
 class TestTheLabelDescribesTheNumber:
-    def test_json_says_the_count_is_of_elided_records(self):
+    def test_json_says_the_count_is_of_records_the_compressed_form_dropped(self):
         recovery = _recovery_for(JsonCodec(RecoveryStore()), _records(), "records.json")
 
         assert recovery.item_label != "item(s)", (
             "the default label next to 'complete original JSON' is what described "
             "a 60-record payload as 59 items"
         )
-        assert "elid" in recovery.item_label
         assert "record" in recovery.item_label
+        assert "dropped" in recovery.item_label or "restored" in recovery.item_label, (
+            "the label has to say the count describes the compressed form, not "
+            "the payload the user is holding"
+        )
 
     def test_the_json_count_itself_is_unchanged(self):
         """The number is a contract; only its label was wrong."""
@@ -67,6 +70,53 @@ class TestTheLabelDescribesTheNumber:
         text = "id,name\n" + "\n".join(f"{i},row{i}" for i in range(40))
         recovery = _recovery_for(TableCodec(RecoveryStore()), text, "t.csv")
         assert "row" in recovery.item_label and "header" in recovery.item_label
+
+
+class TestACompletePayloadNeverReadsAsAFragment:
+    """The label must not undo what the note establishes.
+
+    `recover` prints `note` then `(count label)`. For these codecs the note
+    says the payload is the *complete original*, so a label carrying this
+    codebase's fragment vocabulary contradicts it in the same sentence. The
+    first version of this fix said "record(s) elided from the columnar form"
+    and broke `test_recover_states_what_it_returned`, which exists precisely
+    because `recover` once handed a user a fragment described as their file.
+
+    Checked here per codec, so the contradiction is caught at the source
+    rather than only in the rendered CLI output of one of them.
+    """
+
+    #: Words this codebase uses for a recovery that IS the elided fragment.
+    _FRAGMENT_WORDS = ("elided", "combine", "partial", "fragment")
+
+    def test_no_complete_original_payload_is_labelled_with_fragment_words(self):
+        cases = [
+            (JsonCodec(RecoveryStore()), _records(), "records.json"),
+            (
+                LogCodec(RecoveryStore()),
+                "\n".join(
+                    f"2026-08-02T10:00:{i % 60:02d}Z ERROR failed (retry {i})"
+                    for i in range(200)
+                ),
+                "worker.log",
+            ),
+            (
+                TableCodec(RecoveryStore()),
+                "id,name\n" + "\n".join(f"{i},row{i}" for i in range(40)),
+                "t.csv",
+            ),
+        ]
+        for codec, text, source_id in cases:
+            recovery = _recovery_for(codec, text, source_id)
+            if "complete original" not in recovery.note and "full table" not in recovery.note:
+                continue
+            lowered = recovery.item_label.lower()
+            offenders = [w for w in self._FRAGMENT_WORDS if w in lowered]
+            assert not offenders, (
+                f"{type(codec).__name__} says the payload is complete "
+                f"({recovery.note!r}) but labels its count {recovery.item_label!r}, "
+                f"which uses fragment vocabulary {offenders}"
+            )
 
 
 class TestTheLabelSurvivesTheStore:

--- a/tests/test_savings_baseline_honesty.py
+++ b/tests/test_savings_baseline_honesty.py
@@ -1,0 +1,72 @@
+"""A saving is measured against a prompt someone could have sent.
+
+An earlier dogfooding pass fixed half of this. It found that `tokens_saved` was
+`corpus - selected`, so a query matching nothing reported the largest saving,
+and it credited zero whenever the selection was not evidence-backed. That
+contract lives in test_no_match_honesty.py.
+
+The other half survived: an evidence-backed selection still billed the entire
+corpus. Measured on this repository, one `optimize_context` call reported
+4,919,764 tokens saved against 2,941 actually sent -- a ratio of 1,672 to 1 --
+and the whole suite stayed green, because every existing test asserted on the
+evidence gate and none on the baseline.
+
+Nobody pastes a five-million-token repository into a model; it exceeds every
+context window. Crediting it measures against a counterfactual that cannot
+happen, and makes the reported figure scale with repository size rather than
+with anything Entroly did.
+
+`cli.py` had already settled this question in four places, with a comment
+reading "Claiming savings vs. the whole repo (7M+ tokens) is marketing, not
+measurement." The engine -- the surface that runs in production -- was the one
+not applying it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+from entroly.engine import naive_context_baseline
+
+
+class TestBaseline:
+    def test_a_large_repository_is_capped_to_a_plausible_prompt(self):
+        assert naive_context_baseline(4_922_705) == 32_000
+
+    def test_a_small_project_is_never_credited_with_more_than_it_holds(self):
+        assert naive_context_baseline(5_000) == 5_000
+        assert naive_context_baseline(0) == 0
+
+    def test_a_degenerate_input_never_yields_a_negative_baseline(self):
+        for bad in (None, -1, 0, ""):
+            assert naive_context_baseline(bad) >= 0
+
+    def test_the_engine_and_the_cli_state_the_same_standard(self):
+        """One product, one baseline. These disagreed for the shipping surface."""
+        cli = pathlib.Path("entroly/cli.py").read_text(encoding="utf-8")
+        assert re.search(r"min\(\s*\w*total\w*\s*,\s*32_?000\s*\)", cli), (
+            "cli.py no longer states a naive baseline; keep the two in step"
+        )
+        assert naive_context_baseline(10**9) == 32_000
+
+
+class TestAppliedWhereItMatters:
+    def test_both_engine_call_sites_measure_against_the_baseline(self):
+        """A saving computed from the raw corpus is the defect this file exists for."""
+        engine = pathlib.Path("entroly/engine.py").read_text(encoding="utf-8")
+        raw = re.findall(
+            r"_honest_tokens_saved\(\s*[^)]*?total_available_tokens\s*-", engine, re.S
+        )
+        assert not raw, (
+            "a call site is still passing `corpus - selected`; wrap the total in "
+            "naive_context_baseline() so the saving is measured against a prompt "
+            "a caller could plausibly have sent"
+        )
+
+    def test_the_reported_saving_stays_within_the_baseline(self):
+        """The ceiling that makes the figure defensible, stated as an assertion."""
+        for corpus, used in ((4_922_705, 2_941), (10_000, 1_000), (500, 100)):
+            saving = naive_context_baseline(corpus) - used
+            assert saving <= naive_context_baseline(corpus)
+            assert saving <= max(corpus, 0), "cannot save more than exists"

--- a/tests/test_savings_baseline_honesty.py
+++ b/tests/test_savings_baseline_honesty.py
@@ -70,3 +70,49 @@ class TestAppliedWhereItMatters:
             saving = naive_context_baseline(corpus) - used
             assert saving <= naive_context_baseline(corpus)
             assert saving <= max(corpus, 0), "cannot save more than exists"
+
+
+class TestTheScriptsCiRunsDirectly:
+    """Scripts CI runs standalone are invisible to a green local suite.
+
+    `pytest` collects `test_*.py` under `tests/`, so `tests/functional_test.py`
+    is never collected -- the file says so itself. It asserted
+    `tokens_saved == total_tokens - tokens_used`, the exact formula this module
+    exists to remove, and went on asserting it while the whole suite passed.
+    CI caught it on all five Python versions; nothing local could.
+
+    This walks the workflow to find those scripts rather than naming them, so a
+    script added to CI later is covered without anyone remembering to.
+    """
+
+    @staticmethod
+    def _standalone_scripts() -> list[pathlib.Path]:
+        workflow = pathlib.Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        found = re.findall(r"python\s+(tests/[\w./-]+\.py)", workflow)
+        return sorted({pathlib.Path(p) for p in found})
+
+    def test_the_workflow_still_runs_scripts_this_guard_covers(self):
+        scripts = self._standalone_scripts()
+        assert scripts, (
+            "no standalone scripts found in ci.yml; if the workflow changed "
+            "shape, update this guard rather than deleting it"
+        )
+        for script in scripts:
+            assert script.exists(), f"ci.yml runs a missing script: {script}"
+
+    def test_none_of_them_asserts_a_saving_against_the_whole_corpus(self):
+        for script in self._standalone_scripts():
+            source = script.read_text(encoding="utf-8")
+            offenders = [
+                line.strip()
+                for line in source.splitlines()
+                if line.strip().startswith("assert")
+                and re.search(r"tokens_saved\s*==", line)
+                and "naive_context_baseline" not in line
+            ]
+            assert not offenders, (
+                f"{script} asserts a saving without the shared baseline: "
+                f"{offenders}. A saving is measured against a prompt someone "
+                "could have sent; use naive_context_baseline() so this script "
+                "and the engine cannot drift apart."
+            )

--- a/tests/test_value_measurement_gaps.py
+++ b/tests/test_value_measurement_gaps.py
@@ -1,0 +1,122 @@
+"""A receipt must say what it failed to measure.
+
+Telemetry is dropped rather than allowed to block a user's request when the
+value-tracker lock is contended. That trade is correct and stays. What was
+wrong is that the drop was invisible: measured on this machine with eight
+concurrent writers, 10% of events were lost (360 of 400 recorded) and the
+receipt still presented its totals as though they were exact.
+
+CLAUDE.md requires that "omitted evidence" be inspectable. An event the tracker
+failed to record is omitted evidence, and a total that silently excludes it is
+a floor being presented as a count.
+
+Drops are counted in memory -- persisting them at the moment of failure would
+need the very lock that just timed out -- and folded into the persisted totals
+by the next successful mutation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.value_tracker import ValueTracker
+
+
+@pytest.fixture
+def tracker(tmp_path, monkeypatch):
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+    return ValueTracker(tmp_path)
+
+
+class TestDropsAreCounted:
+    def test_a_dropped_event_is_recorded_as_a_gap(self, tracker, monkeypatch):
+        def refuse(*_a, **_k):
+            raise TimeoutError("timed out acquiring value-tracker lock")
+
+        monkeypatch.setattr(tracker, "_record_with_lock", refuse)
+        tracker.record(tokens_saved=250, source="mcp")
+
+        assert tracker._pending_dropped == 1
+        assert tracker._pending_dropped_tokens == 250
+
+    def test_a_drop_never_raises_into_the_caller(self, tracker, monkeypatch):
+        """Telemetry must not become the reason a request fails."""
+        monkeypatch.setattr(
+            tracker, "_record_with_lock",
+            lambda *_a, **_k: (_ for _ in ()).throw(TimeoutError("busy")))
+        tracker.record(tokens_saved=100, source="mcp")  # must not raise
+
+    def test_pending_drops_reach_the_persisted_total(self, tracker, monkeypatch):
+        calls = {"n": 0}
+        real = tracker._record_with_lock
+
+        def fail_twice(*a, **k):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise TimeoutError("busy")
+            return real(*a, **k)
+
+        monkeypatch.setattr(tracker, "_record_with_lock", fail_twice)
+        tracker.record(tokens_saved=100, source="mcp")   # dropped
+        tracker.record(tokens_saved=100, source="mcp")   # dropped
+        tracker.record(tokens_saved=100, source="mcp")   # succeeds, folds them in
+
+        lifetime = tracker.get_lifetime()
+        assert lifetime["events_dropped"] == 2
+        assert lifetime["tokens_dropped"] == 200
+        assert tracker._pending_dropped == 0, "folded drops must not double-count"
+
+    def test_every_attempt_is_either_recorded_or_counted(self, tracker, monkeypatch):
+        """The invariant: recorded + dropped == attempted. No silent loss."""
+        calls = {"n": 0}
+        real = tracker._record_with_lock
+
+        def flaky(*a, **k):
+            calls["n"] += 1
+            if calls["n"] % 3 == 0:
+                raise TimeoutError("busy")
+            return real(*a, **k)
+
+        monkeypatch.setattr(tracker, "_record_with_lock", flaky)
+        attempts = 30
+        for _ in range(attempts):
+            tracker.record(tokens_saved=10, source="mcp")
+        tracker.record(tokens_saved=0, source="mcp")     # flush trailing drops
+
+        lifetime = tracker.get_lifetime()
+        accounted = lifetime["local_operations"] + lifetime["events_dropped"]
+        assert accounted == attempts + 1, (
+            f"{attempts + 1} attempted, {accounted} accounted for -- "
+            "an unaccounted event is an unmeasured saving"
+        )
+
+
+class TestTheReceiptDisclosesIt:
+    def test_a_clean_receipt_says_its_totals_are_complete(self, tracker):
+        tracker.record(tokens_saved=100, source="mcp")
+        gaps = tracker.get_value_receipt()["measurement_gaps"]
+
+        assert gaps["events_dropped"] == 0
+        assert gaps["totals_are"] == "complete"
+
+    def test_a_lossy_receipt_says_its_totals_are_a_floor(self, tracker, monkeypatch):
+        calls = {"n": 0}
+        real = tracker._record_with_lock
+
+        def fail_first(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise TimeoutError("busy")
+            return real(*a, **k)
+
+        monkeypatch.setattr(tracker, "_record_with_lock", fail_first)
+        tracker.record(tokens_saved=500, source="mcp")
+        tracker.record(tokens_saved=100, source="mcp")
+
+        gaps = tracker.get_value_receipt()["measurement_gaps"]
+        assert gaps["events_dropped"] == 1
+        assert gaps["tokens_dropped"] == 500
+        assert gaps["totals_are"] == "a floor", (
+            "presenting an incomplete total as exact is the defect this pins"
+        )
+        assert "contention" in gaps["reason"]

--- a/tests/test_vault_provenance_readback.py
+++ b/tests/test_vault_provenance_readback.py
@@ -147,7 +147,7 @@ class TestEvidenceOutranksRecency:
             sources=[],
         )
 
-        assert result["status"] == "kept_stronger_claim"
+        assert result["status"] == "not_written"
         fm = _frontmatter(vault)
         assert fm["status"] == "verified"
         assert float(fm["confidence"]) == pytest.approx(0.95)
@@ -178,7 +178,7 @@ class TestCorrectionsStillGoThrough:
             confidence=0.4,
             sources=["src/auth.py:99"],
         )
-        assert result["status"] != "kept_stronger_claim"
+        assert result["status"] == "written"
         assert _frontmatter(vault)["status"] == "inferred"
 
     def test_a_stronger_claim_overwrites(self, vault):
@@ -190,17 +190,17 @@ class TestCorrectionsStillGoThrough:
         """Staleness reports freshness; it is not a competing evidence claim."""
         _write(vault)
         result = _write(vault, status="stale", confidence=0.3)
-        assert result["status"] != "kept_stronger_claim"
+        assert result["status"] == "written"
         assert _frontmatter(vault)["status"] == "stale"
 
     def test_a_lower_status_with_higher_confidence_overwrites(self, vault):
         _write(vault)
         result = _write(vault, status="inferred", confidence=0.99)
-        assert result["status"] != "kept_stronger_claim"
+        assert result["status"] == "written"
 
     def test_the_first_belief_about_an_entity_is_never_refused(self, vault):
         result = _write(vault, entity="brand/new", status="hypothesis", confidence=0.1)
-        assert result["status"] != "kept_stronger_claim"
+        assert result["status"] == "written"
         assert _frontmatter(vault, "brand/new")["status"] == "hypothesis"
 
     def test_a_weak_claim_may_replace_another_weak_unsourced_claim(self, vault):
@@ -209,4 +209,69 @@ class TestCorrectionsStillGoThrough:
         result = _write(
             vault, entity="e2", status="hypothesis", confidence=0.2, sources=[]
         )
-        assert result["status"] != "kept_stronger_claim"
+        assert result["status"] == "written"
+
+
+class TestARefusalIsNotCountedAsAWrite:
+    """The guard introduced a way for a reported count to stop being true.
+
+    `beliefs_written` is shown to the user and forwarded into the autoseed
+    summary. Both call sites incremented it for every belief they handed to the
+    vault, which was accurate only while `write_belief` could not refuse. Now
+    that it can, a count taken on "we called the vault" instead of "the vault
+    wrote it" would report beliefs that are not in the vault.
+    """
+
+    @staticmethod
+    def _project(tmp_path):
+        project = tmp_path / "project"
+        project.mkdir(parents=True)
+        (project / "auth.py").write_text(
+            "def authenticate():\n    return True\n", encoding="utf-8"
+        )
+        (project / "ledger.py").write_text(
+            "def post():\n    return 1\n", encoding="utf-8"
+        )
+        return project
+
+    def test_the_reported_count_equals_what_is_in_the_vault(self, tmp_path):
+        from entroly.belief_compiler import BeliefCompiler
+
+        vault = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+        result = BeliefCompiler(vault).compile_directory(str(self._project(tmp_path)))
+
+        assert result.beliefs_written == len(vault.list_beliefs()), (
+            "the number reported to the user must be the number actually stored"
+        )
+        assert result.beliefs_superseded == 0
+
+    def test_refused_writes_are_reported_separately_not_as_writes(
+        self, tmp_path, monkeypatch
+    ):
+        from entroly.belief_compiler import BeliefCompiler
+
+        vault = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+        monkeypatch.setattr(
+            vault, "write_belief", lambda _a: {"status": "not_written"}
+        )
+        result = BeliefCompiler(vault).compile_directory(str(self._project(tmp_path)))
+
+        assert result.beliefs_written == 0, (
+            "nothing was written; reporting otherwise is a number that is not true"
+        )
+        assert result.beliefs_superseded > 0
+        assert result.belief_ids == []
+
+    def test_an_unrecognised_outcome_is_not_counted_as_a_write(
+        self, tmp_path, monkeypatch
+    ):
+        """Counting on `== "written"` keeps this honest if outcomes are added."""
+        from entroly.belief_compiler import BeliefCompiler
+
+        vault = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+        monkeypatch.setattr(
+            vault, "write_belief", lambda _a: {"status": "some_future_outcome"}
+        )
+        result = BeliefCompiler(vault).compile_directory(str(self._project(tmp_path)))
+
+        assert result.beliefs_written == 0

--- a/tests/test_vault_provenance_readback.py
+++ b/tests/test_vault_provenance_readback.py
@@ -1,0 +1,212 @@
+"""A belief must read back with the evidence it was written with.
+
+Two defects found by dogfooding the vault, both in the gap between what is
+written and what is read.
+
+1. `_parse_frontmatter` kept only `key: value` lines and skipped anything
+   starting with `-`, so YAML block sequences were dropped. `sources` and
+   `derived_from` are block sequences. They were written to disk correctly and
+   then silently lost on the way back in: `read_belief` -- returned verbatim by
+   the `vault_query` MCP tool -- reported `status: verified, confidence: 0.95`
+   with no citations, so an agent could not check what the claim had been
+   verified against. CLAUDE.md requires beliefs to be machine-auditable and
+   omitted evidence to be inspectable; evidence that survives the write and not
+   the read is neither.
+
+   Every caller that actually needed provenance had worked around this by
+   re-scanning the raw text with `_extract_sources` beside its parse, so the
+   store had two extractors that could disagree about what a belief cites.
+
+2. Recency outranked evidence. A `verified` belief at 0.95 citing
+   `src/auth.py:42` was replaced by a `hypothesis` at 0.1 citing nothing, and
+   `read_belief` returned the hypothesis. The ledger kept both, so provenance
+   survived -- but nothing reads the ledger by default, so what every agent
+   actually read was the unsourced guess.
+
+   This is the dominant state-update failure reported for long-horizon agents
+   (SKILL.state, arXiv 2608.26263: premature state overwrite/deletion), and the
+   answer is the same -- a weaker patch must not corrupt current state. The
+   claim is still kept and still recorded as a competing claim; it just does
+   not become what agents read.
+
+The guard is deliberately narrow. It fires only when an update is weaker in
+status *and* in confidence *and* cites nothing new -- weaker on every axis at
+once, which is a regression rather than a correction. Anything that carries new
+evidence, raises confidence, or reports staleness goes through untouched. The
+`TestCorrectionsStillGoThrough` cases below are the ones that matter: a guard
+that also blocked real corrections would be worse than the bug.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from entroly.vault import (
+    BeliefArtifact,
+    VaultConfig,
+    VaultManager,
+    _extract_sources,
+    _parse_frontmatter,
+)
+
+
+@pytest.fixture
+def vault(tmp_path, monkeypatch):
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path))
+    manager = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+    manager.ensure_structure()
+    return manager
+
+
+def _write(vault, **kw):
+    fields = dict(
+        entity="src/auth",
+        title="auth",
+        body="passwords are hashed with a per-user salt",
+        status="verified",
+        confidence=0.95,
+        sources=["src/auth.py:42"],
+    )
+    fields.update(kw)
+    return vault.write_belief(BeliefArtifact(**fields))
+
+
+def _frontmatter(vault, entity="src/auth"):
+    return (vault.read_belief(entity) or {}).get("frontmatter", {})
+
+
+class TestBlockSequencesSurviveTheRoundTrip:
+    def test_sources_are_readable_after_being_written(self, vault):
+        _write(vault, sources=["src/auth.py:42", "src/hash.py:7"])
+        assert _frontmatter(vault)["sources"] == ["src/auth.py:42", "src/hash.py:7"]
+
+    def test_derived_from_is_readable_after_being_written(self, vault):
+        _write(vault, derived_from=["query-1", "query-2"])
+        assert _frontmatter(vault)["derived_from"] == ["query-1", "query-2"]
+
+    def test_a_verified_belief_never_reads_back_without_its_evidence(self, vault):
+        """The defect exactly: a claim asserting evidence, presented with none."""
+        _write(vault)
+        fm = _frontmatter(vault)
+        assert fm["status"] == "verified"
+        assert fm.get("sources"), (
+            "a belief that reads back as verified while citing nothing is "
+            "unauditable -- there is no way to check what it was verified against"
+        )
+
+    def test_a_belief_citing_nothing_says_so_explicitly(self, vault):
+        """`sources: []` is a recorded answer, not a missing field."""
+        _write(vault, status="inferred", sources=[])
+        assert _frontmatter(vault)["sources"] == []
+
+    def test_scalars_are_unchanged(self, vault):
+        _write(vault)
+        fm = _frontmatter(vault)
+        assert fm["entity"] == "src/auth"
+        assert fm["status"] == "verified"
+        assert fm["claim_id"]
+        assert fm["last_checked"]
+
+    def test_a_colon_in_a_list_item_is_preserved(self):
+        """`path:line` citations contain the delimiter the parser splits on."""
+        parsed = _parse_frontmatter(
+            "---\nentity: e\nsources:\n  - src/auth.py:42\n---\n\nbody\n"
+        )
+        assert parsed["sources"] == ["src/auth.py:42"]
+
+    def test_a_key_with_no_value_and_no_items_is_not_invented_as_a_list(self):
+        parsed = _parse_frontmatter("---\nentity: e\nempty:\nstatus: inferred\n---\n\nb\n")
+        assert parsed["status"] == "inferred"
+        assert "empty" not in parsed
+
+    def test_the_two_source_extractors_agree(self, vault):
+        """They disagreed before; a store with two answers has no audit trail."""
+        _write(vault, sources=["src/auth.py:42", "src/hash.py:7"])
+        content = open(vault.read_belief("src/auth")["path"], encoding="utf-8").read()
+        assert _extract_sources(content) == _parse_frontmatter(content)["sources"]
+
+
+class TestTheMcpSurfaceExposesProvenance:
+    def test_the_payload_an_agent_receives_carries_the_citations(self, vault):
+        """`vault_query` returns `read_belief` verbatim, so this is what agents see."""
+        _write(vault, sources=["src/auth.py:42"])
+        payload = json.loads(json.dumps(vault.read_belief("src/auth"), default=str))
+        assert payload["frontmatter"]["sources"] == ["src/auth.py:42"]
+
+
+class TestEvidenceOutranksRecency:
+    def test_an_unsourced_guess_does_not_replace_a_sourced_verified_belief(self, vault):
+        _write(vault)
+        result = _write(
+            vault,
+            body="passwords are stored unsalted",
+            status="hypothesis",
+            confidence=0.1,
+            sources=[],
+        )
+
+        assert result["status"] == "kept_stronger_claim"
+        fm = _frontmatter(vault)
+        assert fm["status"] == "verified"
+        assert float(fm["confidence"]) == pytest.approx(0.95)
+        assert "salt" in (vault.read_belief("src/auth") or {})["body"]
+
+    def test_the_refused_claim_is_still_recorded(self, vault):
+        """Refusing to promote a claim is not the same as discarding it."""
+        from entroly.vault_time import BeliefLedger
+
+        _write(vault)
+        _write(vault, status="hypothesis", confidence=0.1, sources=[])
+
+        timeline = BeliefLedger(vault._base).timeline("src/auth")
+        assert len(timeline) == 2, (
+            "the competing claim must remain auditable even though it did not win"
+        )
+
+
+class TestCorrectionsStillGoThrough:
+    """A guard that blocked real corrections would be worse than the bug."""
+
+    def test_new_evidence_overwrites_even_at_lower_confidence(self, vault):
+        _write(vault)
+        result = _write(
+            vault,
+            body="actually unsalted",
+            status="inferred",
+            confidence=0.4,
+            sources=["src/auth.py:99"],
+        )
+        assert result["status"] != "kept_stronger_claim"
+        assert _frontmatter(vault)["status"] == "inferred"
+
+    def test_a_stronger_claim_overwrites(self, vault):
+        _write(vault)
+        _write(vault, confidence=0.99)
+        assert float(_frontmatter(vault)["confidence"]) == pytest.approx(0.99)
+
+    def test_marking_a_belief_stale_is_never_refused(self, vault):
+        """Staleness reports freshness; it is not a competing evidence claim."""
+        _write(vault)
+        result = _write(vault, status="stale", confidence=0.3)
+        assert result["status"] != "kept_stronger_claim"
+        assert _frontmatter(vault)["status"] == "stale"
+
+    def test_a_lower_status_with_higher_confidence_overwrites(self, vault):
+        _write(vault)
+        result = _write(vault, status="inferred", confidence=0.99)
+        assert result["status"] != "kept_stronger_claim"
+
+    def test_the_first_belief_about_an_entity_is_never_refused(self, vault):
+        result = _write(vault, entity="brand/new", status="hypothesis", confidence=0.1)
+        assert result["status"] != "kept_stronger_claim"
+        assert _frontmatter(vault, "brand/new")["status"] == "hypothesis"
+
+    def test_a_weak_claim_may_replace_another_weak_unsourced_claim(self, vault):
+        """With no evidence on either side there is nothing to protect."""
+        _write(vault, entity="e2", status="inferred", confidence=0.6, sources=[])
+        result = _write(
+            vault, entity="e2", status="hypothesis", confidence=0.2, sources=[]
+        )
+        assert result["status"] != "kept_stronger_claim"


### PR DESCRIPTION
## Outcome

<!-- What user-visible problem does this solve? Lead with the outcome. -->

## Changes

<!-- Keep the list focused. Link the issue or discussion when one exists. -->

## Trust and compatibility

- [ ] Receipt honesty and recoverability are preserved or not affected.
- [ ] Verification remains fail-closed where confidence is claimed.
- [ ] No surprise network call or credential persistence was introduced.
- [ ] Provider request, tool, streaming, and cache semantics are preserved.
- [ ] Backward compatibility and migration impact are documented.
- [ ] Public claims include a baseline, workload, budget, and limitations.
- [ ] This change does not affect the checked item(s), explained below.

## Validation

<!-- Paste exact commands and concise results. State incomplete or timed-out checks honestly. -->

```text
command -> result
```

## Release impact

- [ ] No release note or version change required.
- [ ] Release note added or updated.
- [ ] Python, Rust, npm/WASM, MCP, OpenClaw, Docker, and Homebrew surfaces were reviewed as applicable.

## Rollback

<!-- How can maintainers disable or revert this safely? -->
