### PR TITLE
fix(health): dead-symbol detection was wrong in both directions

### DIFF
--- a/entroly-engine/src/depgraph.rs
+++ b/entroly-engine/src/depgraph.rs
@@ -857,7 +857,7 @@ pub fn extract_identifiers(content: &str) -> Vec<String> {
 }
 
 /// Extract symbol definitions (def, class, fn, struct, etc.)
-fn extract_definitions(content: &str) -> Vec<String> {
+pub(crate) fn extract_definitions(content: &str) -> Vec<String> {
     let mut defs = Vec::new();
 
     for line in content.lines() {
@@ -868,6 +868,7 @@ fn extract_definitions(content: &str) -> Vec<String> {
             if let Some(name) = trimmed.split_whitespace().nth(1) {
                 // Split on '(' to get the name before params
                 let clean = name.split('(').next().unwrap_or(name);
+                let clean = clean.split('[').next().unwrap_or(clean);
                 let clean = clean.trim_end_matches(':');
                 if !clean.is_empty() {
                     defs.push(clean.to_string());
@@ -887,6 +888,11 @@ fn extract_definitions(content: &str) -> Vec<String> {
             let name_idx = if words.first() == Some(&"pub") { 2 } else { 1 };
             if let Some(name) = words.get(name_idx) {
                 let clean = name.split('(').next().unwrap_or(name);
+                // A generic or lifetime list is part of the signature, not the
+                // name. `fn pick<'a>(` yielded the definition `pick<'a>`, which
+                // the reference scan -- which splits on non-alphanumerics --
+                // can never produce, so every generic function looked dead.
+                let clean = clean.split('<').next().unwrap_or(clean);
                 let clean = clean.trim_end_matches(['{', '<', ':']);
                 if !clean.is_empty() {
                     defs.push(clean.to_string());
@@ -1218,6 +1224,42 @@ fn is_keyword(word: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn definitions_stop_at_generic_and_lifetime_parameters() {
+        // `fn pick<'a>(` produced the definition `pick<'a>`. The reference scan
+        // splits on non-alphanumerics and can only ever produce `pick`, so the
+        // two could never match and every generic function looked dead.
+        // Measured on this repository: `pick<'a>`, `serialize<S>` and
+        // `WorkContinuationProofPayload<'a>` were all reported dead while
+        // having live call sites.
+        let defs = extract_definitions(
+            "fn pick<'a>(&mut self, values: &'a [&'a str]) -> &'a str {
+             pub fn serialize<S>(value: &T, ser: S) -> Result<S::Ok, S::Error> {
+             pub struct WorkContinuationProofPayload<'a> {
+",
+        );
+        assert!(defs.contains(&"pick".to_string()), "got {defs:?}");
+        assert!(defs.contains(&"serialize".to_string()), "got {defs:?}");
+        assert!(
+            defs.contains(&"WorkContinuationProofPayload".to_string()),
+            "got {defs:?}"
+        );
+        for d in &defs {
+            assert!(!d.contains('<'), "definition kept a generic list: {d}");
+        }
+    }
+
+    #[test]
+    fn plain_definitions_are_unaffected() {
+        let defs = extract_definitions("def compute_total(items, tax):
+class Ledger:
+fn plain() {
+");
+        assert!(defs.contains(&"compute_total".to_string()), "got {defs:?}");
+        assert!(defs.contains(&"Ledger".to_string()), "got {defs:?}");
+        assert!(defs.contains(&"plain".to_string()), "got {defs:?}");
+    }
+
     use super::*;
 
     #[test]

--- a/entroly-engine/src/health.rs
+++ b/entroly-engine/src/health.rs
@@ -225,11 +225,30 @@ fn find_dead_symbols(fragments: &[&ContextFragment], dep_graph: &DepGraph) -> Ve
     let all_content: Vec<&str> = fragments.iter().map(|f| f.content.as_str()).collect();
 
     // Build a frequency map of all identifiers across all fragments
-    let mut referenced: HashSet<String> = HashSet::new();
+    // Counted, not a set membership test. A symbol's own `def`/`fn` line is
+    // part of the content being scanned, so every defined symbol was trivially
+    // "referenced" by the line that defined it and nothing could ever be
+    // reported dead. Measured: four functions called from nowhere reported as
+    // 0 dead symbols.
+    //
+    // A definition line contributes exactly one occurrence of the name, so a
+    // symbol is unreferenced when its total occurrence count does not exceed
+    // the number of lines that define it.
+    let mut reference_counts: HashMap<String, usize> = HashMap::new();
+    let mut definition_line_counts: HashMap<String, usize> = HashMap::new();
     for content in &all_content {
-        for word in content.split(|c: char| !c.is_alphanumeric() && c != '_') {
-            if word.len() >= 2 {
-                referenced.insert(word.to_lowercase());
+        for line in content.lines() {
+            let defined_here: HashSet<String> = crate::depgraph::extract_definitions(line)
+                .into_iter()
+                .map(|d| d.to_lowercase())
+                .collect();
+            for name in &defined_here {
+                *definition_line_counts.entry(name.clone()).or_insert(0) += 1;
+            }
+            for word in line.split(|c: char| !c.is_alphanumeric() && c != '_') {
+                if word.len() >= 2 {
+                    *reference_counts.entry(word.to_lowercase()).or_insert(0) += 1;
+                }
             }
         }
     }
@@ -250,8 +269,10 @@ fn find_dead_symbols(fragments: &[&ContextFragment], dep_graph: &DepGraph) -> Ve
             continue;
         }
 
-        // Check if referenced anywhere
-        if referenced.contains(&sym_lower) {
+        // Referenced somewhere other than the lines that define it.
+        let uses = reference_counts.get(&sym_lower).copied().unwrap_or(0);
+        let defs = definition_line_counts.get(&sym_lower).copied().unwrap_or(0);
+        if uses > defs {
             continue;
         }
 
@@ -844,6 +865,50 @@ mod tests {
     use crate::dedup::simhash;
     use crate::depgraph::DepGraph;
     use crate::fragment::ContextFragment;
+
+    #[test]
+    fn a_symbol_referenced_only_by_its_own_definition_is_dead() {
+        // The reference scan read every line of every fragment, including the
+        // line that defined the symbol, so a definition always "referenced"
+        // itself and nothing could ever be reported dead. Measured on a
+        // four-file project with four functions called from nowhere:
+        // "Dead symbols: 0", printed with a green marker.
+        let a = make_frag(
+            "f1",
+            "def compute_total(items):
+    return sum(items)
+
+def zzqqx_unused(x):
+    return x * 2
+",
+            "billing.py",
+        );
+        let b = make_frag(
+            "f2",
+            "from billing import compute_total
+
+def run(items):
+    return compute_total(items)
+",
+            "main.py",
+        );
+        let frags: Vec<&ContextFragment> = vec![&a, &b];
+        let mut dep = DepGraph::new();
+        dep.register_symbol("compute_total", "f1");
+        dep.register_symbol("zzqqx_unused", "f1");
+
+        let dead = find_dead_symbols(&frags, &dep);
+        let names: Vec<&str> = dead.iter().map(|d| d.name.as_str()).collect();
+
+        assert!(
+            names.contains(&"zzqqx_unused"),
+            "a function called from nowhere must be reported dead; got {names:?}"
+        );
+        assert!(
+            !names.contains(&"compute_total"),
+            "a function called from another file is alive; got {names:?}"
+        );
+    }
 
     fn make_frag(id: &str, content: &str, source: &str) -> ContextFragment {
         let mut f = ContextFragment::new(


### PR DESCRIPTION
`entroly health` prints a **Dead symbols** count and feeds it into the
user-facing grade via `dead_code_penalty`. Both halves were broken.

## Nothing could ever be reported dead

`find_dead_symbols` built its "referenced anywhere" set from every line of
every fragment — including the line that *defines* the symbol. Every
definition therefore referenced itself.

Measured on a four-file project whose functions are called from nowhere:

```
Dead symbols: 0        <- printed with a green "good" marker
```

The scan now counts occurrences and subtracts definition lines, so a symbol
is dead when it appears only where it is defined.

## What it did report was mostly artifacts

`extract_definitions` split a name on `(` but not `<`, so `fn pick<'a>(`
registered the definition `pick<'a>`. The reference scan splits on
non-alphanumerics and can only ever produce `pick`, so the two could never
match and **every generic Rust function looked dead**.

On this repository that meant:

| reported dead | reality |
|---|---|
| `pick<'a>` | defined `coordination_index.rs:187`, called at 212, 213, 218 |
| `serialize<S>` | defined `resonance.rs:91` |
| `WorkContinuationProofPayload<'a>` | a live struct |
| `failures.append` | not a definition — that file defines `_git`, `release_readiness`, `main` |

Names now stop at a generic or lifetime list.

## Evidence

| check | result |
|---|---|
| project with known-dead code | `0 -> 5` dead symbols, all five genuinely uncalled, grade C -> D |
| generic-parameter artifacts on this repo | gone — no reported name carries `<...>` |
| dotted call-like names | gone — 0 remaining |
| real finds confirmed by grep | `_clean_session_state`, `_calibrated_limit`, `_innermost_traceback_file` have zero references |
| engine suite | 573 pass |
| clippy | clean |
| mutation | reverting either half fails its test |
| Python surfaces on the rebuilt engine | 107 pass (coupling, codebase-graph, selection, receipts, health) |

## Still imprecise — not claimed fixed

- `__bool__` is reported dead: dunders are invoked implicitly, never by name.
- `_protected_json_values` is reported dead despite a call at
  `codecs_builtin.py:233` in its own file. This change does not explain that;
  the leading suspicion is that `find_dead_symbols` does not receive all
  fragments, but that is unconfirmed.

The count is much better, not correct.

## Note for reviewers

This is a Rust change. Run `cd entroly-core && maturin develop --release`
before any Python test will observe it.