### PR TITLE
fix(tests): give the ledger soak a budget that matches its cost

### DIFF
--- a/tests/test_vault_faults.py
+++ b/tests/test_vault_faults.py
@@ -203,6 +203,18 @@ def test_an_unreadable_belief_does_not_break_a_vault_scan(tmp_path):
     ) is not None
 
 
+# A soak, not a unit test: two writers race a verifier that re-reads the whole
+# ledger on every iteration, so the work is quadratic in the number of writes
+# and the wall time is dominated by the runner's disk and core count. It takes
+# ~39s on a developer machine and exceeded the suite's 60s ceiling twice on a
+# CI runner -- once on PR #391 and again on main at e4d2b049 -- both times on
+# Python 3.12 alone while the other four versions passed the same commit.
+#
+# The ceiling was wrong, not the test. Lowering the write count would cut the
+# cost, but the number of verifications landing inside the race window is
+# exactly what gives this test its power to catch the false alarm it guards, so
+# the budget is raised instead of the exposure reduced.
+@pytest.mark.timeout(180)
 def test_verification_during_concurrent_writes_does_not_false_alarm(tmp_path):
     """The log and the head are two files.
 


### PR DESCRIPTION
`main` is red at `e4d2b049`.

```
tests/test_vault_faults.py::test_verification_during_concurrent_writes_does_not_false_alarm
Failed: Timeout (>60.0s) from pytest-timeout
```

It failed on **Python 3.12 only** — the other four versions passed the same
commit. It failed the same way on #391 an hour earlier and went green on
re-run, so this is the second occurrence, not a one-off.

## Why it is slow

The test is a soak, not a unit test: two writer threads race a verifier that
re-reads the **whole ledger on every iteration**, so the work is quadratic in
the number of writes and the wall time is set by the runner's disk and core
count.

Measured on one machine, three consecutive runs of the same test:

| run | time |
|---|---|
| 1 | 38.9s |
| 2 | 55.2s |
| 3 | 35.2s |

Against a 60s ceiling that is not headroom, it is a coin flip.

## Why raise the budget rather than shrink the test

Cutting the write count would make it cheaper, but the number of
verifications that land inside the race window is exactly what gives this
test its power to catch the false alarm it guards — a tamper alarm firing on
a healthy chain. So the budget is raised, not the exposure reduced.

`@pytest.mark.timeout` is the mechanism this repository already uses for slow
tests (`test_dashboard_panel_resilience.py`, `test_dashboard_failing_panel_still_answers.py`).

## Verification

Confirmed the marker actually takes precedence over the command-line flag
rather than being silently ignored: run with `--timeout=5`, the test still
completes and passes (35.16s). A run that merely finished under 60s would not
have proved this either way.

Whole file passes under the CI ceiling: 8 passed in 48.06s.