### PR TITLE
fix(copilot): two defects found dogfooding the subscription route

### DIFF
--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -3887,6 +3887,14 @@ def cmd_doctor(args):
                     f"imported tree take no effect. Reinstall it "
                     f"(`pip install -e .`) or use `python -m entroly`.{C.RESET}"
                 )
+                # Counted, or the summary contradicts the line above it. This
+                # printed `!` and incremented nothing, so a machine where every
+                # command runs a different copy of Entroly than the one being
+                # edited still reported "8/8 checks passed" with no warning --
+                # the same false-green the split counters exist to prevent.
+                # This is the warning least able to afford being missed: it
+                # means the user's edits are not what is running.
+                checks_warned += 1
         except OSError:
             pass
 

--- a/entroly/copilot_capi_routing.py
+++ b/entroly/copilot_capi_routing.py
@@ -16,6 +16,7 @@ Copilot subscription token manager is attached to the proxy instance.
 from __future__ import annotations
 
 import os
+import re
 from typing import Any, Mapping
 
 from .copilot_subscription_transport import CopilotTokenManager
@@ -28,8 +29,26 @@ _CAPI_PATHS = {
 
 
 def normalize_copilot_capi_path(path: str) -> str:
-    """Translate only the known OpenAI-compatible ``/v1`` CAPI endpoints."""
-    return _CAPI_PATHS.get(path, path)
+    """Translate only the known OpenAI-compatible ``/v1`` CAPI endpoints.
+
+    The lookup is exact, but the spelling a client produces is not. A base URL
+    configured as ``.../v1/`` -- a trailing slash is the ordinary way to get
+    this wrong -- makes the CLI request ``/v1//chat/completions``. Starlette
+    reports that path verbatim and the proxy does not collapse it, so the exact
+    match missed, the ``/v1`` prefix survived, and the request reached CAPI as
+    ``/v1//chat/completions``. GitHub answers 404, which tells the user nothing
+    about the trailing slash that caused it.
+
+    Only the *lookup key* is canonicalised: repeated slashes collapse and one
+    trailing slash is dropped. A path that does not match a known CAPI endpoint
+    is returned exactly as it arrived, so this stays a translation of three
+    endpoints rather than becoming a second router.
+    """
+    canonical = re.sub(r"/{2,}", "/", path)
+    if len(canonical) > 1:
+        canonical = canonical.rstrip("/") or "/"
+    translated = _CAPI_PATHS.get(canonical)
+    return translated if translated is not None else path
 
 
 def _env_enabled(environ: Mapping[str, str] | None = None) -> bool:

--- a/entroly/copilot_cli_provider_contract.py
+++ b/entroly/copilot_cli_provider_contract.py
@@ -36,12 +36,18 @@ def _validated_integration_id(value: object) -> str:
     text = str(value or "").strip()
     if not text:
         return ""
-    if (
-        len(text) > _MAX_INTEGRATION_ID_CHARS
-        or any(
-            not (char.isascii() and (char.isalnum() or char in "._-"))
-            for char in text
+    # Two distinct rejections, two distinct reasons. They shared one message
+    # that named only the character set, so an ID that is too long but composed
+    # entirely of legal characters was told its characters were wrong. An error
+    # that misstates its own cause sends the operator to fix the wrong thing.
+    if len(text) > _MAX_INTEGRATION_ID_CHARS:
+        raise CopilotCLIProviderContractError(
+            f"Copilot integration ID is {len(text)} characters; the limit is "
+            f"{_MAX_INTEGRATION_ID_CHARS}"
         )
+    if any(
+        not (char.isascii() and (char.isalnum() or char in "._-"))
+        for char in text
     ):
         raise CopilotCLIProviderContractError(
             "Copilot integration ID must contain only ASCII letters, digits, '.', '_', or '-'"

--- a/entroly/ravs/router.py
+++ b/entroly/ravs/router.py
@@ -81,6 +81,22 @@ _RISK_KEYWORDS: dict[str, DomainRisk] = {
     "credential": DomainRisk.HIGH,
     "payment": DomainRisk.HIGH,
     "billing": DomainRisk.HIGH,
+    # `DomainRisk.HIGH` names payments as in scope, but only the literal words
+    # "payment" and "billing" matched it. Measured against ordinary money
+    # phrasing, 9 of 11 requests -- "transfer funds", "issue a refund",
+    # "process a payout", "handle the chargeback" -- classified STANDARD, which
+    # permits 2% success degradation and makes them eligible for a cheaper
+    # model once a cell has data. Money movement is the case the flagship is
+    # for. These are deliberately unambiguous nouns; "transaction" and "ledger"
+    # are left out because a database transaction and this repository's own
+    # belief ledger would match them, and blocking every such request buys
+    # nothing.
+    "refund": DomainRisk.HIGH,
+    "invoice": DomainRisk.HIGH,
+    "payout": DomainRisk.HIGH,
+    "chargeback": DomainRisk.HIGH,
+    "funds": DomainRisk.HIGH,
+    "checkout": DomainRisk.HIGH,
     "encrypt": DomainRisk.HIGH,
     "decrypt": DomainRisk.HIGH,
     "token": DomainRisk.HIGH,

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -130,3 +130,26 @@ def test_doctor_passes_cleanly_when_nothing_is_wrong(
     assert "8/8 checks passed" in output
     assert "failed" not in output
     assert rc == 0
+
+
+def test_a_shadowed_installation_is_counted_as_a_warning(monkeypatch, capsys) -> None:
+    """The summary must not contradict the line above it.
+
+    `entroly` on PATH resolving to a different installation than the imported
+    package means every command runs code the user is not editing. Doctor
+    printed that warning and incremented nothing, so the run still ended
+    "8/8 checks passed" with no warning count -- the same false-green the split
+    counters exist to prevent, on the one warning least able to afford being
+    missed.
+    """
+    monkeypatch.setattr(
+        cli.shutil, "which", lambda _name: "/somewhere/else/bin/entroly"
+    )
+
+    cli.cmd_doctor(Namespace(port=9377, privacy=False))
+
+    output = capsys.readouterr().out
+    assert "different installation than the imported package" in output
+    assert "warning(s)" in output, (
+        "a printed warning that the summary does not count reads as all-clear"
+    )

--- a/tests/test_copilot_capi_routing.py
+++ b/tests/test_copilot_capi_routing.py
@@ -24,6 +24,41 @@ def test_capi_path_normalizer_does_not_rewrite_unknown_or_similar_paths() -> Non
         assert normalize_copilot_capi_path(path) == path
 
 
+def test_capi_paths_translate_despite_slash_spelling() -> None:
+    """A trailing slash on the base URL is the ordinary way to get this wrong.
+
+    Configuring the provider base URL as `.../v1/` makes the client request
+    `/v1//chat/completions`. Starlette reports that path verbatim and the proxy
+    does not collapse it, so the exact lookup missed, the `/v1` prefix survived
+    to CAPI, and GitHub answered 404 with nothing pointing at the slash.
+    """
+    for path in (
+        "/v1//chat/completions",
+        "/v1/chat/completions/",
+        "/v1///chat/completions",
+    ):
+        assert normalize_copilot_capi_path(path) == "/chat/completions", path
+    assert normalize_copilot_capi_path("/v1/models/") == "/models"
+    assert normalize_copilot_capi_path("/v1//responses") == "/responses"
+
+
+def test_a_path_that_matches_nothing_is_returned_byte_for_byte() -> None:
+    """Canonicalisation is for the lookup key only.
+
+    Rewriting the outgoing path would make this a router. It translates three
+    endpoints; everything else must reach the existing resolver exactly as it
+    arrived, including spellings this function had to canonicalise to decide.
+    """
+    for path in (
+        "/v1//embeddings",
+        "/v1/chat/completions/../secrets",
+        "/unknown//double",
+        "/v1/chat/completions/extra/",
+        "/",
+    ):
+        assert normalize_copilot_capi_path(path) == path, path
+
+
 def test_container_proxy_installs_capi_routing_inside_existing_security_layers() -> None:
     source = Path("entroly/container_proxy.py").read_text(encoding="utf-8")
     final_pos = source.index("proxy_transport_final")

--- a/tests/test_copilot_cli_provider_contract.py
+++ b/tests/test_copilot_cli_provider_contract.py
@@ -75,3 +75,39 @@ def test_integration_identity_rejects_header_unsafe_values() -> None:
     env = {"GITHUB_COPILOT_INTEGRATION_ID": "good\r\nX-Evil: 1"}
     with pytest.raises(CopilotCLIProviderContractError, match="ASCII letters"):
         apply_copilot_cli_provider_contract(env, wire_api="completions")
+
+
+def test_each_integration_id_rejection_names_its_real_cause() -> None:
+    """An error that misstates its cause sends the operator to fix the wrong thing.
+
+    The length check and the character check shared one message that named only
+    the character set, so a 500-character ID composed entirely of legal
+    characters was told its characters were wrong.
+    """
+    import pytest
+
+    from entroly.copilot_cli_provider_contract import (
+        CopilotCLIProviderContractError,
+        configure_copilot_integration_identity,
+    )
+
+    with pytest.raises(CopilotCLIProviderContractError) as too_long:
+        configure_copilot_integration_identity(
+            {"GITHUB_COPILOT_INTEGRATION_ID": "A" * 500}
+        )
+    message = str(too_long.value)
+    assert "500" in message and "128" in message, message
+    assert "must contain only" not in message, (
+        "a length rejection must not blame the character set"
+    )
+
+    with pytest.raises(CopilotCLIProviderContractError) as bad_chars:
+        configure_copilot_integration_identity(
+            {"GITHUB_COPILOT_INTEGRATION_ID": "not a valid id!"}
+        )
+    assert "must contain only" in str(bad_chars.value)
+
+    # The boundary itself stays accepted.
+    assert configure_copilot_integration_identity(
+        {"GITHUB_COPILOT_INTEGRATION_ID": "A" * 128}
+    ) == "A" * 128

--- a/tests/test_ravs_v3.py
+++ b/tests/test_ravs_v3.py
@@ -319,3 +319,44 @@ def test_v3_16_thread_safe():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_payments_scope_covers_ordinary_money_phrasing() -> None:
+    """`DomainRisk.HIGH` names payments as in scope; only two words matched it.
+
+    Measured before this test existed: 9 of 11 ordinary money requests --
+    "transfer funds", "issue a refund", "process a payout", "handle the
+    chargeback" -- classified STANDARD, which permits 2% success degradation
+    and makes them eligible for a cheaper model once a cell has data. Money
+    movement is precisely what the flagship is for, and RAVS is required to
+    never trade correctness for cost.
+    """
+    from entroly.ravs.router import DomainRisk, classify_risk
+
+    for query in (
+        "transfer funds between accounts",
+        "issue a refund to the customer",
+        "process a payout to the vendor",
+        "handle the chargeback dispute",
+        "calculate the invoice total",
+        "complete the checkout flow",
+    ):
+        assert classify_risk(query) is DomainRisk.HIGH, query
+
+
+def test_the_payments_keywords_do_not_swallow_ordinary_engineering() -> None:
+    """Over-classifying is the safe direction, but not a free one.
+
+    Every HIGH request forfeits routing entirely, so the keywords have to name
+    money rather than anything money-adjacent. "transaction" and "ledger" are
+    deliberately absent: a database transaction and this repository's own
+    belief ledger would match them.
+    """
+    from entroly.ravs.router import DomainRisk, classify_risk
+
+    for query in (
+        "open a database transaction",
+        "read the belief ledger",
+        "fix the typo in the README",
+    ):
+        assert classify_risk(query) is not DomainRisk.HIGH, query


### PR DESCRIPTION
Two defects found by exercising the Copilot route merged in #390, plus a
record of what was probed and found clean.

## 1. CAPI paths did not translate unless spelled exactly

The `/v1` translation is an exact dict lookup, but the spelling a client
produces is not exact. A provider base URL configured as `.../v1/` — a
trailing slash is the ordinary way to get this wrong — makes the CLI request
`/v1//chat/completions`.

Confirmed Starlette reports that path verbatim
(`URL('...//chat/completions').path` keeps both slashes) and the proxy
collapses nothing before `_resolve_target`. So the lookup missed, `/v1`
survived to CAPI, and GitHub answered **404 with nothing pointing at the
slash that caused it**.

Only the *lookup key* is canonicalised now — repeated slashes collapse, one
trailing slash drops. A path matching no known endpoint is returned byte for
byte, so this stays a translation of three endpoints rather than becoming a
second router: `/v1/chat/completions/../secrets` passes through unresolved
rather than being normalised into a traversal.

## 2. An error blamed the wrong thing

The integration-ID length check and character check shared one `raise`, whose
message named only the character set. A 500-character ID of entirely legal
characters was rejected with *"must contain only ASCII letters, digits, '.',
'_', or '-'"*. An error that misstates its own cause sends the operator to fix
the wrong thing. Length rejections now report the actual length and the limit.

Both fixes are mutation-verified — reverting either fails its test. 55 Copilot
tests pass.

## Probed and found clean (no change needed)

| claim | how it was tested | result |
|---|---|---|
| "no-ops unless subscription mode is enabled" | imported `container_proxy` with/without the flag, checked the patch marker | unpatched → patched ✅ |
| fails closed without credentials | simulated no `gh` installed, and `gh` present but unauthenticated | both raise an actionable message ✅ |
| no credential persistence | audited every write path | only a writability probe ✅ |
| credential cannot reach the status surface | planted a token inside a third-party exception message, called `public_summary()` | records `'RuntimeError'` only ✅ |
| header injection | CRLF in User-Agent / interaction id / API version, a 5,000-char value, a null byte | all rejected, no injected header, safe fallbacks ✅ |
| fail-closed on contradictory integration IDs | conflicting client and Entroly values | raises with a clear message ✅ |
| "shutdown is idempotent and bounded" | fake process that refuses to terminate | `terminate → wait(2) → kill`, repeat `close()` is a no-op ✅ |

## Latent, deliberately not changed

`_resolve_github_credential(environ)` takes an environ as its credential
source, but its `gh auth token` fallback passes `env=dict(environ)` while
`subprocess` resolves the *executable* via the parent PATH. Verified: with
`PATH=''` and no GitHub variables it still ran `gh` and returned a real token.

It is **not a live defect** — production passes the real `os.environ`, and the
feature's own tests monkeypatch `subprocess.run`. It is a contract mismatch
waiting for a future caller, recorded rather than fixed.