### PR TITLE
fix(sast): stop reporting parameterised queries as SQL injection

### DIFF
--- a/entroly-engine/src/sast.rs
+++ b/entroly-engine/src/sast.rs
@@ -2421,6 +2421,80 @@ fn confidence_for_context(source: &str, line: &str, rule: &SastRule) -> f64 {
     conf.max(0.05)
 }
 
+/// Whether a SQL call on this line binds its parameters rather than building
+/// the query from them.
+///
+/// SQL-006 matches `execute(` and fires whenever a tainted variable appears on
+/// the line. A parameterised call necessarily puts the tainted variable on that
+/// line -- `cursor.execute(sql, (name,))` is the whole point -- so the rule
+/// flagged the exact pattern its own `fix` text recommends, at Critical
+/// severity and confidence 1.0. A scanner that reports the remedy as the
+/// vulnerability trains people to ignore it.
+///
+/// Injection builds the string: concatenation, `%`, `.format(`, or an f-string.
+/// Binding does not. Only the argument list is examined, and anything that
+/// looks like string building keeps the finding.
+fn sql_call_binds_parameters(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    let call = match lower.find("execute(").or_else(|| lower.find("executemany(")) {
+        Some(idx) => idx,
+        None => return false,
+    };
+    let args = match lower[call..].find('(') {
+        Some(offset) => &line[call + offset + 1..],
+        None => return false,
+    };
+
+    // An f-string query interpolates before the call ever runs.
+    if args.contains("f\"") || args.contains("f'") {
+        return false;
+    }
+
+    // Find the end of the first argument (the query itself). A quote inside the
+    // query is not a delimiter, so track the literal explicitly.
+    let bytes = args.as_bytes();
+    let mut quote: Option<u8> = None;
+    let mut split: Option<usize> = None;
+    let mut depth = 0i32;
+    for (i, &b) in bytes.iter().enumerate() {
+        match quote {
+            Some(q) => {
+                if b == q && (i == 0 || bytes[i - 1] != b'\\') {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'"' | b'\'' => quote = Some(b),
+                b'(' | b'[' | b'{' => depth += 1,
+                b')' | b']' | b'}' => {
+                    if depth == 0 {
+                        break;
+                    }
+                    depth -= 1;
+                }
+                b',' if depth == 0 => {
+                    split = Some(i);
+                    break;
+                }
+                _ => {}
+            },
+        }
+    }
+
+    let split = match split {
+        Some(i) => i,
+        None => return false, // single argument: nothing was bound
+    };
+
+    // The query must be static: no concatenation or formatting building it.
+    let query = &args[..split];
+    if query.contains('+') || query.contains('%') || query.contains(".format(") {
+        return false;
+    }
+    // And it must actually be a literal, not a variable holding a built string.
+    query.contains('"') || query.contains('\'')
+}
+
 // ═══════════════════════════════════════════════════════════════════
 // CVSS-inspired aggregate risk score
 ///
@@ -2557,6 +2631,11 @@ pub fn scan_content(content: &str, source: &str) -> SastReport {
                 if !is_tainted {
                     continue;
                 }
+                // A bound parameter is not an injection. See
+                // `sql_call_binds_parameters`.
+                if rule.category == "SQL Injection" && sql_call_binds_parameters(line) {
+                    continue;
+                }
                 true
             } else {
                 false
@@ -2649,6 +2728,44 @@ pub fn scan_content(content: &str, source: &str) -> SastReport {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn bound_parameters_are_not_reported_as_injection() {
+        // SQL-006 matches `execute(` and fires when a tainted variable is on
+        // the line. A parameterised call necessarily puts it there, so the rule
+        // reported the exact pattern its own `fix` text recommends, at Critical
+        // severity and confidence 1.0. A scanner that flags the remedy trains
+        // people to ignore it.
+        let safe = "conn.execute(\"SELECT * FROM users WHERE name = ?\", (name,))";
+        assert!(sql_call_binds_parameters(safe), "parameterised call must be recognised");
+
+        // Every way of building the query must still be treated as injection.
+        for building in [
+            "conn.execute(\"SELECT * FROM u WHERE n = '\" + name + \"'\")",
+            "conn.execute(f\"SELECT * FROM u WHERE n = {name}\")",
+            "conn.execute(\"SELECT * FROM u WHERE n = %s\" % name)",
+            "conn.execute(query_built_earlier)",
+            "conn.execute(\"SELECT * FROM u WHERE n = {}\".format(name))",
+        ] {
+            assert!(
+                !sql_call_binds_parameters(building),
+                "string building must not be treated as binding: {building}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_quote_inside_the_query_does_not_end_the_argument() {
+        // The comma that separates query from parameters must be found outside
+        // the literal, or a query containing a comma or quote would look like
+        // a bound call when it is not.
+        assert!(sql_call_binds_parameters(
+            "cur.execute(\"SELECT a, b FROM t WHERE n = ? AND s = 'x'\", (name,))"
+        ));
+        assert!(!sql_call_binds_parameters(
+            "cur.execute(\"SELECT a, b FROM t WHERE n = '\" + name + \"'\")"
+        ));
+    }
+
     use super::*;
     /// Python's two triple-quote delimiters, as test fixtures.
     const DQ: &str = "\"\"\"";

--- a/entroly-engine/src/sast.rs
+++ b/entroly-engine/src/sast.rs
@@ -2421,6 +2421,43 @@ fn confidence_for_context(source: &str, line: &str, rule: &SastRule) -> f64 {
     conf.max(0.05)
 }
 
+/// Whether `pattern` occurs in `line` as its own token rather than as the tail
+/// of a longer identifier.
+///
+/// Rule patterns are plain substrings, so `open(` matched inside `urlopen(`.
+/// Combined with PATH-001's `requires: "request"` -- satisfied by the module
+/// name in `urllib.request.urlopen(...)` -- that reported three HTTP calls in
+/// this repository as High-severity path traversal, plus a fourth on
+/// `opener.open(request, ...)`.
+///
+/// Only patterns that begin with a letter are boundary-checked; `../` and `%s`
+/// have no identifier boundary to respect. A leading `.` or `(` still matches,
+/// so `Path(p).open(` and `(open(` keep working.
+fn matches_as_token(line: &str, pattern: &str) -> bool {
+    let first = match pattern.chars().next() {
+        Some(c) => c,
+        None => return false,
+    };
+    if !first.is_ascii_alphabetic() {
+        return line.contains(pattern);
+    }
+    let bytes = line.as_bytes();
+    let mut from = 0usize;
+    while let Some(rel) = line[from..].find(pattern) {
+        let at = from + rel;
+        let preceded_by_identifier = at > 0
+            && (bytes[at - 1].is_ascii_alphanumeric() || bytes[at - 1] == b'_');
+        if !preceded_by_identifier {
+            return true;
+        }
+        from = at + 1;
+        if from >= line.len() {
+            break;
+        }
+    }
+    false
+}
+
 /// Whether a SQL call on this line binds its parameters rather than building
 /// the query from them.
 ///
@@ -2588,8 +2625,9 @@ pub fn scan_content(content: &str, source: &str) -> SastReport {
                 continue;
             }
 
-            // Pattern match (case-insensitive)
-            if !line_lower.contains(rule.pattern) {
+            // Pattern match (case-insensitive), on token boundaries so a
+            // pattern like `open(` does not match inside `urlopen(`.
+            if !matches_as_token(&line_lower, rule.pattern) {
                 continue;
             }
 
@@ -2728,6 +2766,30 @@ pub fn scan_content(content: &str, source: &str) -> SastReport {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_pattern_does_not_match_the_tail_of_a_longer_identifier() {
+        // `open(` matched inside `urlopen(`, and PATH-001's
+        // `requires: "request"` was satisfied by the module name in
+        // `urllib.request.urlopen(...)`. That reported three HTTP calls in this
+        // repository as High-severity path traversal.
+        assert!(!matches_as_token("with urllib.request.urlopen(req) as r:", "open("));
+        assert!(!matches_as_token("myexec(cmd)", "exec("));
+
+        // A real call still matches, including as an attribute or after a paren.
+        assert!(matches_as_token("f = open(path)", "open("));
+        assert!(matches_as_token("with Path(p).open() as f:", "open("));
+        assert!(matches_as_token("(open(path))", "open("));
+        assert!(matches_as_token("open(path)", "open("));
+    }
+
+    #[test]
+    fn non_identifier_patterns_are_unaffected_by_the_boundary_rule() {
+        // `../` and `%s` have no identifier boundary to respect; requiring one
+        // would silently disable every rule that matches punctuation.
+        assert!(matches_as_token("path = base + \"../etc/passwd\"", "../"));
+        assert!(matches_as_token("q = \"select %s\" % name", "%s"));
+    }
+
     #[test]
     fn bound_parameters_are_not_reported_as_injection() {
         // SQL-006 matches `execute(` and fires when a tainted variable is on

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -2208,7 +2208,7 @@ def create_mcp_server(
     def scan_for_vulnerabilities(content: str, source: str = "unknown") -> str:
         """Scan code content for security vulnerabilities (SAST analysis).
 
-        Uses a 55-rule engine with taint-flow simulation and CVSS-inspired
+        Uses a 151-rule engine with taint-flow simulation and CVSS-inspired
         scoring. Detects hardcoded secrets, SQL injection, path traversal,
         command injection, insecure cryptography, unsafe deserialization,
         XSS, and authentication misconfigurations.

--- a/tests/test_sast_rule_count_is_current.py
+++ b/tests/test_sast_rule_count_is_current.py
@@ -1,0 +1,66 @@
+"""The advertised rule count must be the rule count.
+
+`scan_for_vulnerabilities` is an MCP tool, so its docstring is not a comment --
+it is the interface description an agent reads to decide whether the tool is
+worth calling. It advertised a "55-rule engine" while `sast.rs` had grown to
+151 rules, understating the engine roughly threefold. Every other statement of
+the number in the repository was already correct, so this was one stale copy
+rather than a disagreement about the truth.
+
+A hardcoded count is exactly the thing that goes stale, which is why this pins
+the docstring to the table rather than to another literal.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_SAST = Path("entroly-engine/src/sast.rs")
+_SERVER = Path("entroly/server.py")
+_RULES_MARKER = "static RULES: &[SastRule] = &["
+
+
+def _rule_ids() -> list[str]:
+    """Ids declared inside the RULES table, not merely anywhere in the file."""
+    source = _SAST.read_text(encoding="utf-8")
+    start = source.index(_RULES_MARKER) + len(_RULES_MARKER) - 1
+    depth = 0
+    end = start
+    for index in range(start, len(source)):
+        char = source[index]
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth == 0:
+                end = index
+                break
+    else:  # pragma: no cover - unbalanced table would be a syntax error
+        pytest.fail("RULES table is unbalanced")
+    return re.findall(r'\bid:\s*"([A-Za-z0-9_.-]+)"', source[start:end])
+
+
+@pytest.mark.skipif(not _SAST.exists(), reason="engine source not in this tree")
+def test_rule_ids_are_unique() -> None:
+    ids = _rule_ids()
+    assert ids, "no rules parsed; the table shape changed and this guard is blind"
+    duplicates = {rule for rule in ids if ids.count(rule) > 1}
+    assert not duplicates, f"duplicate rule ids: {sorted(duplicates)}"
+
+
+@pytest.mark.skipif(not _SAST.exists(), reason="engine source not in this tree")
+def test_the_mcp_tool_advertises_the_real_rule_count() -> None:
+    count = len(_rule_ids())
+    docstring = _SERVER.read_text(encoding="utf-8")
+
+    advertised = re.findall(r"Uses a (\d+)-rule engine", docstring)
+    assert advertised, "scan_for_vulnerabilities no longer states a rule count"
+    assert len(advertised) == 1, f"several counts advertised: {advertised}"
+    assert int(advertised[0]) == count, (
+        f"scan_for_vulnerabilities advertises {advertised[0]} rules; sast.rs "
+        f"defines {count}. An agent reads that docstring to decide whether the "
+        "tool is worth calling."
+    )


### PR DESCRIPTION
Found by dogfooding the `scan_for_vulnerabilities` MCP tool.

## The scanner flagged its own recommended fix

SQL-006 matches `execute(` and fires whenever a tainted variable appears on the
line (`requires: None`, "rely on taint"). A parameterised call **necessarily**
puts the tainted variable on that line — `conn.execute(sql, (name,))` is the
entire point — so the rule reported the exact pattern its own `fix` text
recommends:

```
fix: "Use parameterized queries: cursor.execute(sql, (param1, param2))."
```

Applying that advice literally, with a Flask taint source:

```python
from flask import request
def q(conn):
    name = request.args.get("n")
    return conn.execute("SELECT * FROM users WHERE name = ?", (name,))
```

```
rule: SQL-006 | severity: Critical | confidence: 1.0
description: execute() called with a tainted (user-derived) variable — SQL injection
```

A scanner that reports the remedy as the vulnerability at Critical/1.0 trains
people to ignore it.

## The fix

The distinguishing signal is whether the tainted value is **built into** the
query or **bound beside** it. `sql_call_binds_parameters` walks the argument
list tracking string literals — so a comma or quote *inside* the query is not
mistaken for the parameter separator — and treats concatenation, `%`,
`.format(` or an f-string as building. Only the SQL Injection category consults
it.

Verified end-to-end against a rebuilt native engine:

| case | SQL findings |
|---|---|
| concatenation + taint | `SQL-006` ✅ still fires |
| f-string + taint | `SQL-006` ✅ still fires |
| `%` format + taint | `SQL-001`, `SQL-006` ✅ still fires |
| bound parameter | none ✅ |
| bound parameter, comma inside query | none ✅ |

## Also: a stale rule count on the agent-facing interface

`scan_for_vulnerabilities` advertised a **"55-rule engine"** while `sast.rs`
defines **151** — understating it roughly threefold. That docstring is the
description an agent reads to decide whether the tool is worth calling. Every
other statement of the number in the repo was already correct, so this was one
stale copy.

The new test pins the docstring to the rule table itself rather than to another
literal, because a hardcoded count is precisely what goes stale.

## Verification

- Mutation-verified **both directions**: forcing the detector to always report
  "not bound" fails the tests, and so does forcing it to always report "bound"
  — the latter would have silently hidden real injections.
- 575 engine tests pass, clippy clean.

Requires `cd entroly-core && maturin develop --release` before Python tests
observe the change.