### PR TITLE
fix(knapsack): the include-everything fast path could exceed the token budget

### DIFF
--- a/entroly-engine/src/knapsack.rs
+++ b/entroly-engine/src/knapsack.rs
@@ -384,8 +384,24 @@ fn soft_bisection_select(
             .sum()
     };
 
-    // Fast path: λ=0 → p_i = σ(s_i/τ) ≈ 1 for all. If total E[tokens] ≤ B, include all.
-    if expected_tokens(0.0) <= budget_f {
+    // Fast path: everything fits, so there is nothing to choose between.
+    //
+    // This tested `expected_tokens(0.0) <= budget_f`, which is
+    // Σ σ(sᵢ/τ)·tokensᵢ -- a probability-weighted count. σ is strictly less
+    // than 1, so the expected total is always strictly below the true total,
+    // and a set that does not fit could still pass the test. It then returned
+    // every item, and the caller received a hard selection over budget:
+    // three fragments costing 1 + 1 + 50 against a budget of 50 gave an
+    // expected 41.7, took the fast path, and reported total_tokens = 52.
+    //
+    // Feasibility is a property of the actual token counts, not of the soft
+    // relaxation used to price them. `u64` because the sum of `u32` costs is
+    // not bounded by `u32`.
+    let actual_tokens: u64 = scored
+        .iter()
+        .map(|&(idx, _)| fragments[idx].token_count as u64)
+        .sum();
+    if actual_tokens <= budget as u64 {
         return (scored.iter().map(|&(idx, _)| idx).collect(), 0.0, 0.0);
     }
 
@@ -640,6 +656,189 @@ fn pinned_relevance(
 
 #[cfg(test)]
 mod tests {
+
+    /// Feasibility is a property of the real token counts, not of the soft
+    /// relaxation used to price them.
+    ///
+    /// The fast path asked whether `Σ σ(sᵢ/τ)·tokensᵢ ≤ B` before returning
+    /// every item. σ is strictly below 1, so that expected total is always
+    /// below the true total and a set that does not fit could still pass.
+    /// Measured: fragments costing 1 + 1 + 50 against a budget of 50 priced at
+    /// an expected 41.7, took the fast path, and returned `total_tokens = 52`.
+    /// Overrunning the budget is precisely what overflows a context window.
+    #[test]
+    fn the_include_everything_fast_path_checks_real_tokens_not_expected_tokens() {
+        let weights = ScoringWeights::default();
+        let mk = |id: &str, tokens: u32, score: f64| {
+            let mut f = ContextFragment::new(id.into(), "c".into(), tokens, "".into());
+            f.recency_score = score;
+            f.frequency_score = score;
+            f.semantic_score = score;
+            f.entropy_score = score;
+            f
+        };
+
+        let items = vec![mk("a", 1, 0.9), mk("b", 1, 0.5), mk("c", 50, 0.7)];
+        let budget = 50;
+        assert_eq!(
+            items.iter().map(|f| f.token_count).sum::<u32>(),
+            52,
+            "fixture must not fit, or it proves nothing"
+        );
+
+        let soft = knapsack_optimize(&items, budget, &weights, &no_feedback(), 0.5);
+        assert!(
+            soft.total_tokens <= budget,
+            "soft bisection returned {} tokens against a budget of {budget}",
+            soft.total_tokens
+        );
+
+        // And when everything genuinely fits, the fast path must still take it.
+        let fits = vec![mk("a", 1, 0.9), mk("b", 1, 0.5), mk("c", 10, 0.7)];
+        let all = knapsack_optimize(&fits, 50, &weights, &no_feedback(), 0.5);
+        assert_eq!(all.selected_indices.len(), 3, "a set that fits must be kept whole");
+        assert_eq!(all.total_tokens, 12);
+    }
+
+    /// Degenerate inputs a caller can actually produce. Each of these is a
+    /// classic way a knapsack implementation goes wrong: a zero budget, an item
+    /// that cannot fit, zero-cost items (density divides by weight), and
+    /// non-finite scores arriving from an upstream model.
+    #[test]
+    fn degenerate_inputs_never_overrun_the_budget_or_produce_nonsense() {
+        let weights = ScoringWeights::default();
+        let mk = |id: &str, tokens: u32, score: f64| {
+            let mut f = ContextFragment::new(id.into(), "c".into(), tokens, "".into());
+            f.recency_score = score;
+            f.frequency_score = score;
+            f.semantic_score = score;
+            f.entropy_score = score;
+            f
+        };
+
+        for temperature in [0.0_f64, 0.5] {
+            // Zero budget: nothing may be selected.
+            let items = vec![mk("a", 10, 0.9), mk("b", 20, 0.8)];
+            let r = knapsack_optimize(&items, 0, &weights, &no_feedback(), temperature);
+            assert_eq!(r.total_tokens, 0, "zero budget selected {} tokens", r.total_tokens);
+            assert!(r.selected_indices.is_empty());
+
+            // Every item larger than the budget: still nothing.
+            let big = vec![mk("a", 500, 0.9), mk("b", 900, 0.99)];
+            let r = knapsack_optimize(&big, 100, &weights, &no_feedback(), temperature);
+            assert!(r.total_tokens <= 100, "overran with only oversized items");
+
+            // Zero-token items: density is value/weight, so weight 0 is the
+            // division a density-greedy solver trips over.
+            let free = vec![mk("a", 0, 0.9), mk("b", 0, 0.5), mk("c", 50, 0.7)];
+            let r = knapsack_optimize(&free, 50, &weights, &no_feedback(), temperature);
+            assert!(r.total_tokens <= 50);
+            assert!(r.total_relevance.is_finite(), "zero-cost items produced a non-finite score");
+
+            // Non-finite scores from upstream must not poison the result.
+            let poisoned = vec![
+                mk("nan", 10, f64::NAN),
+                mk("inf", 10, f64::INFINITY),
+                mk("ok", 10, 0.5),
+            ];
+            let r = knapsack_optimize(&poisoned, 20, &weights, &no_feedback(), temperature);
+            assert!(r.total_tokens <= 20, "overran the budget on non-finite scores");
+            assert!(
+                r.total_relevance.is_finite(),
+                "a NaN or infinite input score reached the reported relevance"
+            );
+        }
+    }
+
+    /// Deterministic LCG so a failure is reproducible from the seed alone.
+    fn lcg(state: &mut u64) -> f64 {
+        *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((*state >> 33) as f64) / ((1u64 << 31) as f64)
+    }
+
+    /// The soft bisection is a heuristic; the DP below 0.05 is exact. Randomised
+    /// instances let the exact path referee the approximate one.
+    ///
+    /// Three properties, in increasing order of how much a violation would cost:
+    ///   1. neither path may exceed the token budget -- overrunning it is what
+    ///      blows a context window;
+    ///   2. the DP must dominate, since it is the optimum by construction;
+    ///   3. the heuristic must stay within the Dantzig-style 1/2 that CLAUDE.md
+    ///      claims for a modular objective (explicitly *not* 1 - 1/e).
+    #[test]
+    fn soft_bisection_is_feasible_and_within_the_claimed_half_of_optimal() {
+        let weights = ScoringWeights::default();
+        let mut seed = 0x5EED_1234_u64;
+        let mut worst_ratio = f64::INFINITY;
+
+        for case in 0..60 {
+            let n = 6 + (case % 9);
+            let fragments: Vec<ContextFragment> = (0..n)
+                .map(|k| {
+                    // Mixed magnitudes on purpose. The first version of this
+                    // generator drew 20..420 uniformly and never produced the
+                    // shape that breaks feasibility: several very small items
+                    // beside one large one, where the soft relaxation prices the
+                    // set under budget while the true cost is over it.
+                    let tokens = if lcg(&mut seed) < 0.4 {
+                        1 + (lcg(&mut seed) * 5.0) as u32
+                    } else {
+                        20 + (lcg(&mut seed) * 400.0) as u32
+                    };
+                    let mut f = ContextFragment::new(
+                        format!("f{k:03}"),
+                        "x".repeat(8),
+                        tokens,
+                        "".into(),
+                    );
+                    f.recency_score = lcg(&mut seed);
+                    f.frequency_score = lcg(&mut seed);
+                    f.semantic_score = lcg(&mut seed);
+                    f.entropy_score = lcg(&mut seed);
+                    f
+                })
+                .collect();
+
+            let total: u32 = fragments.iter().map(|f| f.token_count).sum();
+            // A budget that binds: too large and every instance is trivial.
+            let budget = (total as f64 * (0.25 + 0.4 * lcg(&mut seed))) as u32;
+            if budget == 0 {
+                continue;
+            }
+
+            let exact = knapsack_optimize(&fragments, budget, &weights, &no_feedback(), 0.0);
+            let soft = knapsack_optimize(&fragments, budget, &weights, &no_feedback(), 0.5);
+
+            assert!(
+                exact.total_tokens <= budget,
+                "case {case}: exact DP overran the budget ({} > {budget})",
+                exact.total_tokens
+            );
+            assert!(
+                soft.total_tokens <= budget,
+                "case {case}: soft bisection overran the budget ({} > {budget})",
+                soft.total_tokens
+            );
+            assert!(
+                exact.total_relevance >= soft.total_relevance - 1e-9,
+                "case {case}: the exact DP is optimal by construction, so it                  cannot score below the heuristic ({} < {})",
+                exact.total_relevance,
+                soft.total_relevance
+            );
+
+            if exact.total_relevance > 1e-9 {
+                let ratio = soft.total_relevance / exact.total_relevance;
+                worst_ratio = worst_ratio.min(ratio);
+                assert!(
+                    ratio >= 0.5 - 1e-9,
+                    "case {case}: heuristic scored {ratio:.4} of optimal, below                      the Dantzig-style 1/2 claimed for a modular objective"
+                );
+            }
+        }
+
+        assert!(worst_ratio.is_finite(), "no binding instance was generated");
+    }
+
     use super::*;
     use crate::fragment::ContextFragment;
 

--- a/entroly-engine/src/knapsack_sds.rs
+++ b/entroly-engine/src/knapsack_sds.rs
@@ -717,6 +717,95 @@ pub fn ios_select(
 
 #[cfg(test)]
 mod tests {
+    fn sds_lcg(state: &mut u64) -> f64 {
+        *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((*state >> 33) as f64) / ((1u64 << 31) as f64)
+    }
+
+    /// The two invariants IOS must hold whatever the objective does.
+    ///
+    /// No worst-case ratio is claimed for this selector and none is asserted
+    /// here. What must hold regardless of approximation quality:
+    ///
+    ///   1. the selection fits the token budget -- the sibling solver shipped a
+    ///      fast path that compared a probability-weighted token count against
+    ///      a hard budget and returned a set costing 52 against a budget of 50,
+    ///      so this is not hypothetical;
+    ///   2. at most one resolution per fragment. This is a multiple-choice
+    ///      knapsack: two resolutions of the same fragment would put the same
+    ///      content in the context twice and charge for both.
+    #[test]
+    fn ios_selection_is_feasible_and_picks_one_resolution_per_fragment() {
+        let mut seed = 0xA11CE_u64;
+
+        for case in 0..50 {
+            let n = 4 + (case % 12);
+            let fragments: Vec<ContextFragment> = (0..n)
+                .map(|k| {
+                    // Mixed magnitudes: tiny items beside large ones are the
+                    // shape that broke feasibility in `knapsack.rs`.
+                    let tokens = if sds_lcg(&mut seed) < 0.4 {
+                        1 + (sds_lcg(&mut seed) * 5.0) as u32
+                    } else {
+                        20 + (sds_lcg(&mut seed) * 300.0) as u32
+                    };
+                    // Some near-duplicates, so the redundancy penalty is live.
+                    let content = if k % 3 == 0 {
+                        "shared duplicated body text".to_string()
+                    } else {
+                        format!("distinct body {k} with its own words")
+                    };
+                    let mut f = make_frag(&format!("f{k:03}"), &content, tokens, "s");
+                    f.semantic_score = sds_lcg(&mut seed);
+                    f.frequency_score = sds_lcg(&mut seed);
+                    f
+                })
+                .collect();
+
+            let total: u32 = fragments.iter().map(|f| f.token_count).sum();
+            let budget = ((total as f64) * (0.2 + 0.5 * sds_lcg(&mut seed))) as u32;
+            if budget == 0 {
+                continue;
+            }
+
+            for (diversity, multi_res) in [(false, false), (true, false), (true, true)] {
+                let r = ios_select(
+                    &fragments,
+                    budget,
+                    0.25, 0.25, 0.25, 0.25,
+                    &empty_feedback(),
+                    diversity,
+                    multi_res,
+                    &default_factors(),
+                    DEFAULT_DIV_FLOOR,
+                    DEFAULT_MIN_CANDIDATE_VALUE,
+                );
+
+                assert!(
+                    r.total_tokens <= budget,
+                    "case {case} (diversity={diversity}, multi_res={multi_res}):                      selected {} tokens against a budget of {budget}",
+                    r.total_tokens
+                );
+
+                let mut seen: Vec<usize> = r.selections.iter().map(|&(i, _)| i).collect();
+                let before = seen.len();
+                seen.sort_unstable();
+                seen.dedup();
+                assert_eq!(
+                    seen.len(), before,
+                    "case {case} (diversity={diversity}, multi_res={multi_res}):                      a fragment was selected at more than one resolution"
+                );
+
+                // `total_tokens` must describe the selection it ships with.
+                assert!(
+                    r.total_tokens as u64
+                        <= fragments.iter().map(|f| f.token_count as u64).sum::<u64>(),
+                    "case {case}: reported more tokens than exist"
+                );
+            }
+        }
+    }
+
     use super::*;
     use crate::dedup::simhash;
     use crate::fragment::ContextFragment;


### PR DESCRIPTION
The soft bisection is the **production** path — `knapsack_optimize` uses it for
any `temperature >= 0.05` — and its first branch asked:

```rust
// Fast path: λ=0 → p_i = σ(s_i/τ) ≈ 1 for all. If total E[tokens] ≤ B, include all.
if expected_tokens(0.0) <= budget_f {
    return (scored.iter().map(|&(idx, _)| idx).collect(), 0.0, 0.0);
}
```

`expected_tokens(0.0)` is `Σ σ(sᵢ/τ)·tokensᵢ` — a **probability-weighted**
count. σ is strictly less than 1, so that expected total is always *below* the
true total. A set that does not fit can still pass the test, and the function
then returns a **hard** selection.

## Measured

Fragments costing 1 + 1 + 50 against a budget of 50:

| path | selected | total_tokens | |
|---|---|---|---|
| `temperature=0.0` (exact DP) | `[1, 0]` | 2 | feasible, optimal |
| `temperature=0.5` (soft bisection) | `[0, 1, 2]` | **52** | **over budget** |

Expected tokens for that set price out at ≈41.7 (`0.858·1 + 0.731·1 + 0.802·50`),
under the budget of 50 — so the fast path fired.

Overrunning the token budget is precisely what overflows a context window, and
it is the one thing this solver exists to prevent.

## Fix

Feasibility is a property of the actual token counts, not of the soft relaxation
used to price them, so the guard sums the real costs. The sum is `u64` — a total
of `u32` costs is not bounded by `u32`.

## How it was found

By property-testing the heuristic against the **exact 0/1 DP the same module
already ships** below `temperature 0.05`, over randomised instances, asserting
three things: neither path may exceed the budget, the DP must dominate (it is
optimal by construction), and the heuristic must stay within the Dantzig-style
½ that CLAUDE.md claims for a modular objective.

The first randomised generator drew token counts uniformly from 20..420 and
**never sampled the shape that breaks this** — several very small items beside
one large one. The generator now mixes magnitudes and would catch a regression
on its own; the exact failing case is pinned separately.

## Verification

- Mutation-verified: restoring the expected-token test fails **both** the
  regression test and the degenerate-input test.
- 580 engine tests pass, clippy clean.
- 122 selection/budget Python tests pass against a rebuilt native engine.

Requires `cd entroly-core && maturin develop --release` before Python tests
observe the change.