### PR TITLE
test: property-test the selection and scoring math

### DIFF
--- a/entroly-engine/src/bm25.rs
+++ b/entroly-engine/src/bm25.rs
@@ -492,6 +492,65 @@ pub fn normalize_scores(scores: &[f64]) -> Vec<f64> {
 
 #[cfg(test)]
 mod tests {
+    /// IDF is documented as giving "low (but non-negative) scores to common
+    /// terms". With the Lucene `+1` form that is provable, so assert it at the
+    /// boundary that would break a plain probabilistic IDF: a term present in
+    /// every document.
+    #[test]
+    fn idf_stays_non_negative_and_falls_as_the_term_gets_commoner() {
+        let docs: Vec<(String, String, String)> = (0..20)
+            .map(|k| {
+                (
+                    format!("d{k}"),
+                    // `ubiquitous` in every doc; `rare_token` in only the first.
+                    if k == 0 {
+                        "ubiquitous rare_token body".to_string()
+                    } else {
+                        "ubiquitous body".to_string()
+                    },
+                    format!("src/f{k}.rs"),
+                )
+            })
+            .collect();
+        let index = BM25Index::build(&docs);
+
+        let common = index.idf("ubiquitous");
+        let rare = index.idf("rare_token");
+        let absent = index.idf("token_that_appears_nowhere");
+
+        assert!(common >= 0.0, "a term in every document produced negative IDF: {common}");
+        assert!(rare > common, "a rarer term must not score below a commoner one");
+        assert!(absent >= rare, "an unseen term cannot be commoner than a seen one");
+    }
+
+    /// The scoring docstring claims the cubic coverage multiplier "cannot
+    /// promote documents that match FEWER query terms".
+    ///
+    /// The multiplier `1 + 1.5·coverage³` is monotonic in coverage, and that
+    /// part is asserted here. The stronger reading -- that the *combined*
+    /// score respects coverage order -- is not asserted, because `combined`
+    /// also carries `bm25_base`, `path_boost` and `identifier_boost`, and a
+    /// document matching one query term many times can out-score one matching
+    /// two terms once. Asserting the stronger claim would be asserting a
+    /// property the formula does not have.
+    #[test]
+    fn coverage_multiplier_is_monotonic_in_coverage() {
+        let mut previous = f64::NEG_INFINITY;
+        for step in 0..=20 {
+            let coverage = step as f64 / 20.0;
+            let multiplier = 1.0 + 1.5 * coverage.powi(3);
+            assert!(
+                multiplier >= previous,
+                "multiplier fell from {previous} at coverage {coverage}"
+            );
+            previous = multiplier;
+        }
+        // The documented endpoints: full coverage amplifies 2.5x, and ~60%
+        // coverage amplifies ~1.32x.
+        assert!((1.0 + 1.5 * 1.0_f64.powi(3) - 2.5).abs() < 1e-12);
+        assert!(((1.0 + 1.5 * 0.6_f64.powi(3)) - 1.324).abs() < 1e-3);
+    }
+
     use super::*;
 
     #[test]
@@ -599,6 +658,35 @@ mod tests {
 
 #[cfg(test)]
 mod stemming_tests {
+    /// The two retrieval surfaces must not disagree about morphology.
+    ///
+    /// `entroly select` (Python, `context_receipts::retrieval::tokenize`) does
+    /// no morphological normalisation, so
+    /// `-q "how are passwords verified"` scored lexical 0.000000 against a
+    /// corpus containing "Verify a password against the stored bcrypt hash".
+    /// This Rust path does stem, so the same query is not blind here. Pinning
+    /// the cases that differ makes the divergence visible rather than folklore.
+    #[test]
+    fn the_rust_path_normalises_the_forms_the_python_path_misses() {
+        // Stemming here is additive: the stem is emitted *alongside* the
+        // original, so an exact match still scores and an inflected one meets
+        // it on the shared stem. The contract is a shared token, not equality.
+        let shares = |a: &str, b: &str| {
+            let left = tokenize_code(a);
+            let right = tokenize_code(b);
+            left.iter().any(|t| right.contains(t))
+        };
+        assert!(shares("passwords", "password"), "{:?}", tokenize_code("passwords"));
+        assert!(shares("queries", "query"), "{:?}", tokenize_code("queries"));
+        assert!(shares("verified", "verify") || shares("verified", "verifi"),
+                "{:?}", tokenize_code("verified"));
+
+        // And the conservatism the docstring promises still holds: these must
+        // NOT be merged, or unrelated identifiers collide.
+        assert_ne!(tokenize_code("class"), tokenize_code("clas"));
+        assert_ne!(tokenize_code("address"), tokenize_code("addres"));
+    }
+
     use super::*;
 
     /// The exact failure that motivated this: a natural-language query scored

--- a/entroly-engine/src/entropy.rs
+++ b/entroly-engine/src/entropy.rs
@@ -890,6 +890,70 @@ pub fn information_mass_factor(token_count: u32) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    fn ent_lcg(state: &mut u64) -> u64 {
+        *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        *state >> 33
+    }
+
+    /// Shannon entropy has closed-form values; assert them rather than a range.
+    #[test]
+    fn shannon_matches_its_closed_form_on_known_distributions() {
+        // A constant source carries no information.
+        assert!(shannon_entropy("aaaaaaaa").abs() < 1e-12);
+        assert!(shannon_entropy("").abs() < 1e-12);
+
+        // n equiprobable symbols: H = log2(n), exactly.
+        assert!((shannon_entropy("ab") - 1.0).abs() < 1e-12);
+        assert!((shannon_entropy("abcd") - 2.0).abs() < 1e-12);
+        assert!((shannon_entropy("abcdefgh") - 3.0).abs() < 1e-12);
+
+        // This scorer histograms *bytes*, so the closed form has to be stated
+        // over bytes. Code points above 127 encode as two UTF-8 bytes, and a
+        // string of chars 0..=255 has a byte histogram of 128 singletons plus
+        // 0xC2/0xC3 sixty-four times each -- H = 6.25, not 8. Restricting the
+        // input to ASCII keeps one byte per symbol.
+        let ascii: String = (0u8..=127).map(|b| b as char).collect();
+        assert_eq!(ascii.len(), 128, "the fixture must be one byte per symbol");
+        assert!(
+            (shannon_entropy(&ascii) - 7.0).abs() < 1e-9,
+            "H over 128 equiprobable bytes must be log2(128) = 7, got {}",
+            shannon_entropy(&ascii)
+        );
+    }
+
+    /// Rényi order 2 is documented as "always <= Shannon entropy". That is a
+    /// theorem (Rényi entropy is non-increasing in α), which makes it a
+    /// falsifiable property of this implementation rather than a range check.
+    #[test]
+    fn collision_entropy_never_exceeds_shannon_entropy() {
+        let mut seed = 0xE470_9E37_79B9_1234_u64;
+        for case in 0..400 {
+            let len = 1 + (ent_lcg(&mut seed) % 300) as usize;
+            // Skewed alphabets make the two measures diverge most.
+            let alphabet = 1 + (ent_lcg(&mut seed) % 40) as u8;
+            let text: String = (0..len)
+                .map(|_| (b'a' + (ent_lcg(&mut seed) % alphabet as u64) as u8) as char)
+                .collect();
+
+            let h1 = shannon_entropy(&text);
+            let h2 = renyi_entropy_2(&text);
+
+            assert!(h1 >= -1e-12, "case {case}: Shannon entropy went negative: {h1}");
+            assert!(h2 >= -1e-12, "case {case}: collision entropy went negative: {h2}");
+            assert!(h1 <= 8.0 + 1e-9, "case {case}: Shannon exceeded the byte bound: {h1}");
+            assert!(
+                h2 <= h1 + 1e-9,
+                "case {case}: collision entropy {h2} exceeded Shannon {h1},                  contradicting the monotonicity of Renyi entropy in alpha"
+            );
+
+            let norm = normalized_entropy(&text);
+            assert!(
+                (0.0..=1.0).contains(&norm),
+                "case {case}: normalized entropy {norm} left [0, 1]"
+            );
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/entroly-engine/src/knapsack.rs
+++ b/entroly-engine/src/knapsack.rs
@@ -384,8 +384,24 @@ fn soft_bisection_select(
             .sum()
     };
 
-    // Fast path: λ=0 → p_i = σ(s_i/τ) ≈ 1 for all. If total E[tokens] ≤ B, include all.
-    if expected_tokens(0.0) <= budget_f {
+    // Fast path: everything fits, so there is nothing to choose between.
+    //
+    // This tested `expected_tokens(0.0) <= budget_f`, which is
+    // Σ σ(sᵢ/τ)·tokensᵢ -- a probability-weighted count. σ is strictly less
+    // than 1, so the expected total is always strictly below the true total,
+    // and a set that does not fit could still pass the test. It then returned
+    // every item, and the caller received a hard selection over budget:
+    // three fragments costing 1 + 1 + 50 against a budget of 50 gave an
+    // expected 41.7, took the fast path, and reported total_tokens = 52.
+    //
+    // Feasibility is a property of the actual token counts, not of the soft
+    // relaxation used to price them. `u64` because the sum of `u32` costs is
+    // not bounded by `u32`.
+    let actual_tokens: u64 = scored
+        .iter()
+        .map(|&(idx, _)| fragments[idx].token_count as u64)
+        .sum();
+    if actual_tokens <= budget as u64 {
         return (scored.iter().map(|&(idx, _)| idx).collect(), 0.0, 0.0);
     }
 
@@ -640,6 +656,189 @@ fn pinned_relevance(
 
 #[cfg(test)]
 mod tests {
+
+    /// Feasibility is a property of the real token counts, not of the soft
+    /// relaxation used to price them.
+    ///
+    /// The fast path asked whether `Σ σ(sᵢ/τ)·tokensᵢ ≤ B` before returning
+    /// every item. σ is strictly below 1, so that expected total is always
+    /// below the true total and a set that does not fit could still pass.
+    /// Measured: fragments costing 1 + 1 + 50 against a budget of 50 priced at
+    /// an expected 41.7, took the fast path, and returned `total_tokens = 52`.
+    /// Overrunning the budget is precisely what overflows a context window.
+    #[test]
+    fn the_include_everything_fast_path_checks_real_tokens_not_expected_tokens() {
+        let weights = ScoringWeights::default();
+        let mk = |id: &str, tokens: u32, score: f64| {
+            let mut f = ContextFragment::new(id.into(), "c".into(), tokens, "".into());
+            f.recency_score = score;
+            f.frequency_score = score;
+            f.semantic_score = score;
+            f.entropy_score = score;
+            f
+        };
+
+        let items = vec![mk("a", 1, 0.9), mk("b", 1, 0.5), mk("c", 50, 0.7)];
+        let budget = 50;
+        assert_eq!(
+            items.iter().map(|f| f.token_count).sum::<u32>(),
+            52,
+            "fixture must not fit, or it proves nothing"
+        );
+
+        let soft = knapsack_optimize(&items, budget, &weights, &no_feedback(), 0.5);
+        assert!(
+            soft.total_tokens <= budget,
+            "soft bisection returned {} tokens against a budget of {budget}",
+            soft.total_tokens
+        );
+
+        // And when everything genuinely fits, the fast path must still take it.
+        let fits = vec![mk("a", 1, 0.9), mk("b", 1, 0.5), mk("c", 10, 0.7)];
+        let all = knapsack_optimize(&fits, 50, &weights, &no_feedback(), 0.5);
+        assert_eq!(all.selected_indices.len(), 3, "a set that fits must be kept whole");
+        assert_eq!(all.total_tokens, 12);
+    }
+
+    /// Degenerate inputs a caller can actually produce. Each of these is a
+    /// classic way a knapsack implementation goes wrong: a zero budget, an item
+    /// that cannot fit, zero-cost items (density divides by weight), and
+    /// non-finite scores arriving from an upstream model.
+    #[test]
+    fn degenerate_inputs_never_overrun_the_budget_or_produce_nonsense() {
+        let weights = ScoringWeights::default();
+        let mk = |id: &str, tokens: u32, score: f64| {
+            let mut f = ContextFragment::new(id.into(), "c".into(), tokens, "".into());
+            f.recency_score = score;
+            f.frequency_score = score;
+            f.semantic_score = score;
+            f.entropy_score = score;
+            f
+        };
+
+        for temperature in [0.0_f64, 0.5] {
+            // Zero budget: nothing may be selected.
+            let items = vec![mk("a", 10, 0.9), mk("b", 20, 0.8)];
+            let r = knapsack_optimize(&items, 0, &weights, &no_feedback(), temperature);
+            assert_eq!(r.total_tokens, 0, "zero budget selected {} tokens", r.total_tokens);
+            assert!(r.selected_indices.is_empty());
+
+            // Every item larger than the budget: still nothing.
+            let big = vec![mk("a", 500, 0.9), mk("b", 900, 0.99)];
+            let r = knapsack_optimize(&big, 100, &weights, &no_feedback(), temperature);
+            assert!(r.total_tokens <= 100, "overran with only oversized items");
+
+            // Zero-token items: density is value/weight, so weight 0 is the
+            // division a density-greedy solver trips over.
+            let free = vec![mk("a", 0, 0.9), mk("b", 0, 0.5), mk("c", 50, 0.7)];
+            let r = knapsack_optimize(&free, 50, &weights, &no_feedback(), temperature);
+            assert!(r.total_tokens <= 50);
+            assert!(r.total_relevance.is_finite(), "zero-cost items produced a non-finite score");
+
+            // Non-finite scores from upstream must not poison the result.
+            let poisoned = vec![
+                mk("nan", 10, f64::NAN),
+                mk("inf", 10, f64::INFINITY),
+                mk("ok", 10, 0.5),
+            ];
+            let r = knapsack_optimize(&poisoned, 20, &weights, &no_feedback(), temperature);
+            assert!(r.total_tokens <= 20, "overran the budget on non-finite scores");
+            assert!(
+                r.total_relevance.is_finite(),
+                "a NaN or infinite input score reached the reported relevance"
+            );
+        }
+    }
+
+    /// Deterministic LCG so a failure is reproducible from the seed alone.
+    fn lcg(state: &mut u64) -> f64 {
+        *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((*state >> 33) as f64) / ((1u64 << 31) as f64)
+    }
+
+    /// The soft bisection is a heuristic; the DP below 0.05 is exact. Randomised
+    /// instances let the exact path referee the approximate one.
+    ///
+    /// Three properties, in increasing order of how much a violation would cost:
+    ///   1. neither path may exceed the token budget -- overrunning it is what
+    ///      blows a context window;
+    ///   2. the DP must dominate, since it is the optimum by construction;
+    ///   3. the heuristic must stay within the Dantzig-style 1/2 that CLAUDE.md
+    ///      claims for a modular objective (explicitly *not* 1 - 1/e).
+    #[test]
+    fn soft_bisection_is_feasible_and_within_the_claimed_half_of_optimal() {
+        let weights = ScoringWeights::default();
+        let mut seed = 0x5EED_1234_u64;
+        let mut worst_ratio = f64::INFINITY;
+
+        for case in 0..60 {
+            let n = 6 + (case % 9);
+            let fragments: Vec<ContextFragment> = (0..n)
+                .map(|k| {
+                    // Mixed magnitudes on purpose. The first version of this
+                    // generator drew 20..420 uniformly and never produced the
+                    // shape that breaks feasibility: several very small items
+                    // beside one large one, where the soft relaxation prices the
+                    // set under budget while the true cost is over it.
+                    let tokens = if lcg(&mut seed) < 0.4 {
+                        1 + (lcg(&mut seed) * 5.0) as u32
+                    } else {
+                        20 + (lcg(&mut seed) * 400.0) as u32
+                    };
+                    let mut f = ContextFragment::new(
+                        format!("f{k:03}"),
+                        "x".repeat(8),
+                        tokens,
+                        "".into(),
+                    );
+                    f.recency_score = lcg(&mut seed);
+                    f.frequency_score = lcg(&mut seed);
+                    f.semantic_score = lcg(&mut seed);
+                    f.entropy_score = lcg(&mut seed);
+                    f
+                })
+                .collect();
+
+            let total: u32 = fragments.iter().map(|f| f.token_count).sum();
+            // A budget that binds: too large and every instance is trivial.
+            let budget = (total as f64 * (0.25 + 0.4 * lcg(&mut seed))) as u32;
+            if budget == 0 {
+                continue;
+            }
+
+            let exact = knapsack_optimize(&fragments, budget, &weights, &no_feedback(), 0.0);
+            let soft = knapsack_optimize(&fragments, budget, &weights, &no_feedback(), 0.5);
+
+            assert!(
+                exact.total_tokens <= budget,
+                "case {case}: exact DP overran the budget ({} > {budget})",
+                exact.total_tokens
+            );
+            assert!(
+                soft.total_tokens <= budget,
+                "case {case}: soft bisection overran the budget ({} > {budget})",
+                soft.total_tokens
+            );
+            assert!(
+                exact.total_relevance >= soft.total_relevance - 1e-9,
+                "case {case}: the exact DP is optimal by construction, so it                  cannot score below the heuristic ({} < {})",
+                exact.total_relevance,
+                soft.total_relevance
+            );
+
+            if exact.total_relevance > 1e-9 {
+                let ratio = soft.total_relevance / exact.total_relevance;
+                worst_ratio = worst_ratio.min(ratio);
+                assert!(
+                    ratio >= 0.5 - 1e-9,
+                    "case {case}: heuristic scored {ratio:.4} of optimal, below                      the Dantzig-style 1/2 claimed for a modular objective"
+                );
+            }
+        }
+
+        assert!(worst_ratio.is_finite(), "no binding instance was generated");
+    }
+
     use super::*;
     use crate::fragment::ContextFragment;
 

--- a/entroly-engine/src/knapsack_sds.rs
+++ b/entroly-engine/src/knapsack_sds.rs
@@ -717,6 +717,95 @@ pub fn ios_select(
 
 #[cfg(test)]
 mod tests {
+    fn sds_lcg(state: &mut u64) -> f64 {
+        *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((*state >> 33) as f64) / ((1u64 << 31) as f64)
+    }
+
+    /// The two invariants IOS must hold whatever the objective does.
+    ///
+    /// No worst-case ratio is claimed for this selector and none is asserted
+    /// here. What must hold regardless of approximation quality:
+    ///
+    ///   1. the selection fits the token budget -- the sibling solver shipped a
+    ///      fast path that compared a probability-weighted token count against
+    ///      a hard budget and returned a set costing 52 against a budget of 50,
+    ///      so this is not hypothetical;
+    ///   2. at most one resolution per fragment. This is a multiple-choice
+    ///      knapsack: two resolutions of the same fragment would put the same
+    ///      content in the context twice and charge for both.
+    #[test]
+    fn ios_selection_is_feasible_and_picks_one_resolution_per_fragment() {
+        let mut seed = 0xA11CE_u64;
+
+        for case in 0..50 {
+            let n = 4 + (case % 12);
+            let fragments: Vec<ContextFragment> = (0..n)
+                .map(|k| {
+                    // Mixed magnitudes: tiny items beside large ones are the
+                    // shape that broke feasibility in `knapsack.rs`.
+                    let tokens = if sds_lcg(&mut seed) < 0.4 {
+                        1 + (sds_lcg(&mut seed) * 5.0) as u32
+                    } else {
+                        20 + (sds_lcg(&mut seed) * 300.0) as u32
+                    };
+                    // Some near-duplicates, so the redundancy penalty is live.
+                    let content = if k % 3 == 0 {
+                        "shared duplicated body text".to_string()
+                    } else {
+                        format!("distinct body {k} with its own words")
+                    };
+                    let mut f = make_frag(&format!("f{k:03}"), &content, tokens, "s");
+                    f.semantic_score = sds_lcg(&mut seed);
+                    f.frequency_score = sds_lcg(&mut seed);
+                    f
+                })
+                .collect();
+
+            let total: u32 = fragments.iter().map(|f| f.token_count).sum();
+            let budget = ((total as f64) * (0.2 + 0.5 * sds_lcg(&mut seed))) as u32;
+            if budget == 0 {
+                continue;
+            }
+
+            for (diversity, multi_res) in [(false, false), (true, false), (true, true)] {
+                let r = ios_select(
+                    &fragments,
+                    budget,
+                    0.25, 0.25, 0.25, 0.25,
+                    &empty_feedback(),
+                    diversity,
+                    multi_res,
+                    &default_factors(),
+                    DEFAULT_DIV_FLOOR,
+                    DEFAULT_MIN_CANDIDATE_VALUE,
+                );
+
+                assert!(
+                    r.total_tokens <= budget,
+                    "case {case} (diversity={diversity}, multi_res={multi_res}):                      selected {} tokens against a budget of {budget}",
+                    r.total_tokens
+                );
+
+                let mut seen: Vec<usize> = r.selections.iter().map(|&(i, _)| i).collect();
+                let before = seen.len();
+                seen.sort_unstable();
+                seen.dedup();
+                assert_eq!(
+                    seen.len(), before,
+                    "case {case} (diversity={diversity}, multi_res={multi_res}):                      a fragment was selected at more than one resolution"
+                );
+
+                // `total_tokens` must describe the selection it ships with.
+                assert!(
+                    r.total_tokens as u64
+                        <= fragments.iter().map(|f| f.token_count as u64).sum::<u64>(),
+                    "case {case}: reported more tokens than exist"
+                );
+            }
+        }
+    }
+
     use super::*;
     use crate::dedup::simhash;
     use crate::fragment::ContextFragment;


### PR DESCRIPTION
Follow-up to #400, applying the same approach — check the mathematics against
closed forms and against the module's own exact oracle — to the neighbouring
modules. **No new defects found**; this records what was verified and pins two
traps that cost real time.

## `knapsack_sds.rs` — IOS (clean)

Two invariants asserted over 50 randomised instances × 3 modes (plain,
diversity, diversity + multi-resolution):

1. the selection fits the token budget;
2. **at most one resolution per fragment** — this is a multiple-choice
   knapsack, and two resolutions of one fragment would put the same content in
   the context twice and charge for both.

No approximation ratio is asserted. The module explicitly declines to claim
one, because a subtractive redundancy penalty can violate monotonicity, and a
test should not assert a bound the code does not have.

The generator mixes token magnitudes and seeds near-duplicates, so the
redundancy penalty is live rather than dormant — this is the shape that broke
feasibility in the sibling solver in #400.

## `entropy.rs` (clean)

Shannon entropy has exact values, so they are asserted rather than a range:
constant → 0, n equiprobable symbols → log2(n), 128 equiprobable bytes → 7.

`renyi_entropy_2` documents "always ≤ Shannon entropy", which is a theorem
(Rényi entropy is non-increasing in α) and therefore a falsifiable property of
the implementation. The existing test covers one case; this adds 400 randomised
skewed alphabets, where the two measures diverge most.

**Trap recorded:** this scorer histograms *bytes*. A fixture built from chars
`0..=255` does not give 256 equiprobable symbols — code points above 127 encode
as two UTF-8 bytes, and the histogram becomes 128 singletons plus `0xC2`/`0xC3`
sixty-four times each. That measures 6.25 and reads like a broken implementation
when it is a broken fixture. It caught me first.

## `bm25.rs` (clean, plus a surface divergence)

IDF non-negativity asserted at the boundary that breaks a plain probabilistic
IDF: a term present in *every* document. Rarity ordering asserted alongside.

The cubic coverage multiplier is asserted monotonic, including both endpoints
the docstring names. The stronger reading — that the *combined* score respects
coverage order — is **deliberately not asserted**, because `combined` also
carries `bm25_base`, `path_boost` and `identifier_boost`, so a document matching
one query term many times can out-score one matching two terms once.

**Worth knowing:** Entroly has two retrieval surfaces that disagree about
morphology. This Rust path stems; `context_receipts/retrieval.py` does not,
which is why `entroly select -q "how are passwords verified"` scored lexical
`0.000000` against a corpus containing *"Verify a password against the stored
bcrypt hash"*. The Rust stemming is **additive** — stem emitted alongside the
original, so exact matches still score — and its documented conservatism is
asserted (`class` must not become `clas`).

The divergence is left as-is: which surface is right is a measurement question,
and an earlier benchmark of adding stemming to the Python side found no
significant gain on two query populations (n=82 and n=250, p≥0.69).

## Verification

586 engine tests pass, clippy clean.