### PR TITLE
test(graph,dedup): pin the invariants and one load-bearing coupling

### DIFF
--- a/entroly-engine/src/depgraph.rs
+++ b/entroly-engine/src/depgraph.rs
@@ -1224,6 +1224,56 @@ fn is_keyword(word: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    /// `auto_link` accumulates; correctness depends on fragment ids being
+    /// unique per ingest.
+    ///
+    /// It appends edges without clearing prior ones, so calling it twice for
+    /// the same fragment id doubles that fragment's edges: measured 2 -> 4 -> 6
+    /// over three calls. `compute_dep_boosts` sums `dep.strength` across
+    /// outgoing edges, so a re-linked fragment would push its targets above
+    /// equally-related ones after normalisation.
+    ///
+    /// This is not reachable today: `EntrolyEngine::ingest` mints
+    /// `f{instance:08x}_{counter:06x}` from a monotonic counter, so no id is
+    /// ever linked twice. That is the property this test guards. Making
+    /// fragment ids content-addressed -- a natural optimisation, since it would
+    /// let re-ingesting an unchanged file be a no-op -- would silently
+    /// duplicate every edge and distort selection. `rebuild` is unaffected; it
+    /// resets with `*self = Self::new()` first.
+    #[test]
+    fn auto_link_is_additive_so_ids_must_not_repeat() {
+        let mut g = DepGraph::new();
+        g.register_definitions_for_fragment("lib", "def helper():
+    pass
+");
+        let caller = "from lib import helper
+helper()
+";
+
+        g.auto_link("caller", caller);
+        let once = g.edge_count();
+        assert!(once > 0, "the fixture must produce at least one edge");
+
+        g.auto_link("caller", caller);
+        assert_eq!(
+            g.edge_count(),
+            once * 2,
+            "auto_link is additive by design; if this stops doubling the              comment above is stale, but if fragment ids ever become stable              this doubling is a live selection bug"
+        );
+
+        let snapshot = vec![
+            ("lib".to_string(), "def helper():
+    pass
+".to_string()),
+            ("caller".to_string(), caller.to_string()),
+        ];
+        let mut r = DepGraph::new();
+        r.rebuild(&snapshot);
+        let first = r.edge_count();
+        r.rebuild(&snapshot);
+        assert_eq!(r.edge_count(), first, "rebuild must be idempotent");
+    }
+
     #[test]
     fn definitions_stop_at_generic_and_lifetime_parameters() {
         // `fn pick<'a>(` produced the definition `pick<'a>`. The reference scan

--- a/entroly-engine/src/semantic_dedup.rs
+++ b/entroly-engine/src/semantic_dedup.rs
@@ -174,6 +174,62 @@ pub fn semantic_deduplicate_with_stats(
 
 #[cfg(test)]
 mod tests {
+    fn dd_lcg(state: &mut u64) -> u64 {
+        *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        *state >> 33
+    }
+
+    /// A filter's invariants, asserted over randomised inputs.
+    ///
+    /// This is a threshold filter, not an optimiser, so no approximation ratio
+    /// is claimed or asserted. What must hold:
+    ///
+    ///   1. output is a subset of input with no repeated indices -- a
+    ///      deduplicator that invents or repeats indices corrupts everything
+    ///      downstream;
+    ///   2. the highest-relevance candidate is always kept, which the module
+    ///      docstring states as step 1 of the algorithm;
+    ///   3. idempotence -- re-filtering an already-filtered set changes
+    ///      nothing, because every survivor was already distinct enough to
+    ///      keep. A filter that kept dropping on each pass would make
+    ///      selection depend on how many times it happened to run.
+    #[test]
+    fn dedup_is_a_subset_keeps_the_top_candidate_and_is_idempotent() {
+        let mut seed = 0xDEDD_1234_5678_9ABC_u64;
+        for case in 0..40 {
+            let n = 3 + (dd_lcg(&mut seed) % 12) as usize;
+            let fragments: Vec<ContextFragment> = (0..n)
+                .map(|k| {
+                    let content = match dd_lcg(&mut seed) % 3 {
+                        0 => "def handler(request): return process(request)".to_string(),
+                        1 => format!("def handler{k}(request): return process(request)"),
+                        _ => format!("class Widget{k}: pass  # unrelated body {k}"),
+                    };
+                    make_frag(&format!("f{k}"), &content, 50)
+                })
+                .collect();
+            let order: Vec<usize> = (0..n).collect();
+
+            let kept = semantic_deduplicate(&fragments, &order, None);
+
+            assert!(!kept.is_empty(), "case {case}: a non-empty input produced nothing");
+            assert_eq!(kept[0], order[0], "case {case}: the top candidate was dropped");
+
+            let mut sorted = kept.clone();
+            sorted.sort_unstable();
+            let before = sorted.len();
+            sorted.dedup();
+            assert_eq!(sorted.len(), before, "case {case}: an index was repeated");
+            assert!(kept.iter().all(|i| *i < n), "case {case}: index outside input");
+
+            let again = semantic_deduplicate(&fragments, &kept, None);
+            assert_eq!(
+                again, kept,
+                "case {case}: re-filtering a filtered set changed it, so the                  result depends on how many times the filter ran"
+            );
+        }
+    }
+
     use super::*;
     use crate::fragment::ContextFragment;
 


### PR DESCRIPTION
Continuing the sweep from #400/#401 into `depgraph.rs` and
`semantic_dedup.rs`. **No defects found in either.** Two things worth
recording.

## A coupling that is currently safe and would break silently

`DepGraph::auto_link` appends edges without clearing prior ones, so calling it
twice for one fragment id doubles that fragment's edges — measured **2 → 4 → 6**
over three calls. `compute_dep_boosts` sums `dep.strength` across outgoing
edges, so a re-linked fragment would push its targets above equally-related ones
after normalisation.

That is **not reachable today**, and the reason deserves to be written down
rather than rediscovered: `EntrolyEngine::ingest` mints
`f{instance:08x}_{counter:06x}` from a monotonic counter, so no id is ever
linked twice.

Making fragment ids **content-addressed** is a natural optimisation — it would
let re-ingesting an unchanged file be a no-op — and it would silently duplicate
every edge and distort selection. The test asserts the additive behaviour so
that change trips a test instead of shipping.

`rebuild` is separately asserted idempotent (it resets with
`*self = Self::new()` first).

## Cycle termination

`transitive_deps` was checked against cycles and is correct: it marks visited on
*enqueue* and pre-inserts the start node, so the repository's own seven import
cycles cannot loop it.

## Filter invariants

`semantic_deduplicate` is a threshold filter, not an optimiser, so no
approximation ratio is asserted — the module explicitly declines to claim one.
What is asserted, over 40 randomised inputs mixing exact repeats, near-repeats
and unrelated bodies:

1. the output is a subset of the input with no repeated indices — a
   deduplicator that invents or repeats indices corrupts everything downstream;
2. the highest-relevance candidate always survives (step 1 of the documented
   algorithm);
3. **idempotence** — re-filtering an already-filtered set changes nothing, so
   selection cannot depend on how many times the filter happened to run.

## Verification

588 engine tests pass, clippy clean.