### PR TITLE
fix(prism): the Jacobi rotation used the wrong sign convention

### DIFF
--- a/entroly-engine/src/dedup.rs
+++ b/entroly-engine/src/dedup.rs
@@ -197,8 +197,25 @@ pub fn simhash_cosine_lcb(a: u64, b: u64, comparisons: usize, alpha: f64) -> f64
     let p_hat = hamming_distance(a, b) as f64 / SIMHASH_BITS;
     let k = comparisons.max(1) as f64;
     let z = normal_upper_quantile(alpha.clamp(1e-9, 0.5) / k);
-    let se = (p_hat * (1.0 - p_hat) / SIMHASH_BITS).sqrt();
-    let p_hi = (p_hat + z * se).min(1.0);
+    // Wilson score upper bound, not Wald.
+    //
+    // The Wald form `p_hat + z * sqrt(p(1-p)/n)` has zero width at p_hat = 0,
+    // so two fragments whose fingerprints matched exactly received a lower
+    // bound of exactly 1.000000 -- at every alpha and every comparison count.
+    // Observing zero disagreements in 64 bits does not establish p = 0: by the
+    // rule of three the true rate can be near 3/64, which is a similarity
+    // around 0.989. Claiming certainty is worst precisely where it matters,
+    // since a fingerprint match is when the index decides "duplicate" and drops
+    // a fragment.
+    //
+    // Wilson stays non-degenerate at both boundaries and needs no extra
+    // machinery: at p_hat = 0 it reduces to (z^2/n) / (1 + z^2/n) > 0.
+    let n = SIMHASH_BITS;
+    let z2 = z * z;
+    let denom = 1.0 + z2 / n;
+    let center = p_hat + z2 / (2.0 * n);
+    let margin = z * (p_hat * (1.0 - p_hat) / n + z2 / (4.0 * n * n)).sqrt();
+    let p_hi = ((center + margin) / denom).clamp(0.0, 1.0);
     (std::f64::consts::PI * p_hi).cos().clamp(0.0, 1.0)
 }
 
@@ -324,6 +341,55 @@ impl DedupIndex {
 
 #[cfg(test)]
 mod tests {
+    /// A lower confidence bound must not claim certainty it does not have.
+    ///
+    /// The Wald form has zero width at p_hat = 0, so two fragments whose
+    /// fingerprints matched exactly received a bound of exactly 1.000000 at
+    /// every alpha and every comparison count. Observing zero disagreements in
+    /// 64 bits does not establish p = 0 -- by the rule of three the true rate
+    /// can be near 3/64, a similarity around 0.989 -- and a fingerprint match
+    /// is precisely when the index decides "duplicate" and drops a fragment.
+    #[test]
+    fn the_bound_stays_uncertain_when_fingerprints_match_exactly() {
+        let a = simhash("a representative fragment body with several distinct words");
+        assert_eq!(hamming_distance(a, a), 0, "fixture must be an exact match");
+        assert_eq!(simhash_cosine(a, a), 1.0, "the point estimate is still 1");
+
+        let lcb = simhash_cosine_lcb(a, a, 1, 0.05);
+        assert!(
+            lcb < 1.0,
+            "a zero-width interval at p_hat = 0 asserts certainty: got {lcb}"
+        );
+        assert!(lcb > 0.9, "a single comparison should still be a tight bound: {lcb}");
+
+        // More comparisons must widen it, exactly as for any other distance.
+        let bounds: Vec<f64> = [1usize, 100, 10_000]
+            .iter()
+            .map(|&k| simhash_cosine_lcb(a, a, k, 0.05))
+            .collect();
+        for w in bounds.windows(2) {
+            assert!(w[1] < w[0], "the bound must widen with k, got {bounds:?}");
+        }
+
+        // A tighter alpha must also widen it.
+        assert!(
+            simhash_cosine_lcb(a, a, 1, 0.01) < simhash_cosine_lcb(a, a, 1, 0.05),
+            "a smaller alpha must give a more conservative bound"
+        );
+
+        // The invariant that must survive at the boundary too.
+        for k in [1usize, 64, 4096] {
+            for alpha in [0.05_f64, 0.01] {
+                let b = simhash_cosine_lcb(a, a, k, alpha);
+                assert!(
+                    (0.0..=simhash_cosine(a, a) + 1e-12).contains(&b),
+                    "bound {b} left [0, point] at k={k} alpha={alpha}"
+                );
+            }
+        }
+    }
+
+
     use super::*;
 
     #[test]
@@ -422,7 +488,18 @@ mod tests {
         // redundancy — that would trade a noisy penalty for an inert one.
         let text = realistic_fragment();
         let base = simhash(&text);
-        assert_eq!(simhash_cosine_lcb(base, base, 256, 0.05), 1.0);
+        // Not `== 1.0`. That asserted a zero-width confidence interval: the
+        // Wald form collapsed at p_hat = 0, so an exact fingerprint match
+        // claimed certainty at every alpha and every k. The bound is Wilson
+        // now, so an exact match reads ~0.87 at k=256 -- still far above any
+        // duplicate threshold, which is what this test actually exists to
+        // protect.
+        let exact = simhash_cosine_lcb(base, base, 256, 0.05);
+        assert!(
+            exact > 0.8,
+            "an exact fingerprint match must still read as a duplicate: {exact}"
+        );
+        assert!(exact < 1.0, "a lower bound must not claim certainty: {exact}");
 
         let near = simhash(&format!("// reviewed for correctness\n{text}"));
         let lcb = simhash_cosine_lcb(base, near, 256, 0.05);

--- a/entroly-engine/src/knapsack_sds.rs
+++ b/entroly-engine/src/knapsack_sds.rs
@@ -856,7 +856,18 @@ mod tests {
 
         // A real fingerprint of 0 is reachable, so the guard cannot be
         // "simhash == 0"; it must be the explicit absence of a fingerprint.
-        assert_eq!(diversity_factor(Some(0), &[0]), 0.0);
+        //
+        // Asserted as "essentially no diversity credit" rather than exactly
+        // 0.0: that exact value depended on `simhash_cosine_lcb` returning
+        // exactly 1.0 for an exact match, which was a zero-width confidence
+        // interval. The bound is Wilson now, so an exact match leaves a hair
+        // of diversity (~0.008). What this test is about is that `Some(0)` is
+        // compared at all, unlike `None` above.
+        let identical = diversity_factor(Some(0), &[0]);
+        assert!(
+            identical < 0.05,
+            "an exact fingerprint match must earn essentially no diversity: {identical}"
+        );
 
         // End to end: a budget that fits every stub must select every stub.
         let frags: Vec<ContextFragment> = (0..6)

--- a/entroly-engine/src/prism.rs
+++ b/entroly-engine/src/prism.rs
@@ -111,7 +111,27 @@ impl<const N: usize> SymMatrixN<N> {
             let app = a.get(p, p);
             let arr = a.get(r, r);
             let apr = a.get(p, r);
-            let theta = 0.5 * (2.0 * apr / (app - arr + 1e-15)).atan();
+            // The rotation that zeroes a[p][r] depends on the sign convention
+            // used by the update formulas below. Those implement
+            // J[p][r] = +s, J[r][p] = -s, whose zeroing angle is
+            // -atan2(2*a_pr, a_pp - a_rr)/2. This computed +that, so the
+            // transform did not actually eliminate a[p][r] -- and the code
+            // then forced `a.set(p, r, 0.0)`, discarding a nonzero value.
+            //
+            // That is why the loop still "converged": off-diagonals were being
+            // zeroed by assignment rather than by rotation. Trace survived (the
+            // diagonal formulas are self-consistent) but the determinant did
+            // not, which is the signature of a transform that is not a
+            // similarity transform. Measured on
+            // [[4,1,0,0],[1,3,1,0],[0,1,2,1],[0,0,1,1]]: det 7 became 8.6 after
+            // one rotation, and the returned eigenvalues were
+            // [1.64, 2.29, 2.71, 3.36] against the true
+            // [0.25, 1.82, 3.18, 4.75].
+            //
+            // `atan2` also removes the `1e-15` denominator fudge, which was
+            // papering over a_pp == a_rr where the correct angle is exactly 45
+            // degrees.
+            let theta = -0.5 * (2.0 * apr).atan2(app - arr);
             let c = theta.cos();
             let s = theta.sin();
 
@@ -495,6 +515,153 @@ pub struct ResonanceDiagnostics {
 
 #[cfg(test)]
 mod tests {
+    fn pr_lcg(state: &mut u64) -> f64 {
+        *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((*state >> 33) as f64) / ((1u64 << 31) as f64) - 0.5
+    }
+
+    /// The defining property of an eigendecomposition, asserted directly.
+    ///
+    /// `jacobi_eigendecomposition` returns (Q, Λ) claiming C = Q Λ Qᵀ. Two
+    /// things make that true and both are checkable: Q must be orthogonal
+    /// (QᵀQ = I), and reassembling Q Λ Qᵀ must return the original matrix.
+    ///
+    /// The pre-existing tests checked orthogonality, spectral energy and
+    /// condition number -- all of which held while the eigenvalues themselves
+    /// were wrong, because an orthogonal-but-arbitrary basis satisfies them.
+    /// Reconstruction is the property that does not.
+    #[test]
+    fn jacobi_returns_an_orthogonal_basis_that_reconstructs_the_matrix() {
+        let mut seed = 0x5A17_C0DE_1234_5678_u64;
+        let rnd = |s: &mut u64| {
+            *s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((*s >> 33) as f64) / ((1u64 << 31) as f64) - 0.5
+        };
+
+        for case in 0..25 {
+            let a: Vec<Vec<f64>> =
+                (0..4).map(|_| (0..4).map(|_| rnd(&mut seed)).collect()).collect();
+            // `SymMatrixN` stores a full N x N array and `set` writes exactly
+            // one cell -- despite the name it does not mirror. Writing only the
+            // upper triangle would hand Jacobi a non-symmetric matrix.
+            let mut c = SymMatrixN::<4>::new();
+            for i in 0..4 {
+                for j in 0..4 {
+                    let v: f64 = (0..4).map(|k| a[k][i] * a[k][j]).sum();
+                    c.set(i, j, v);
+                }
+            }
+
+            let (q, lambda) = c.jacobi_eigendecomposition();
+
+            for i in 0..4 {
+                for j in 0..4 {
+                    let dot: f64 = (0..4).map(|k| q.get(k, i) * q.get(k, j)).sum();
+                    let expected = if i == j { 1.0 } else { 0.0 };
+                    assert!(
+                        (dot - expected).abs() < 1e-8,
+                        "case {case}: QᵀQ[{i}][{j}] = {dot}, expected {expected}"
+                    );
+                }
+            }
+
+            for i in 0..4 {
+                for j in 0..4 {
+                    let rebuilt: f64 =
+                        (0..4).map(|k| q.get(i, k) * lambda[k] * q.get(j, k)).sum();
+                    assert!(
+                        (rebuilt - c.get(i, j)).abs() < 1e-8,
+                        "case {case}: (QΛQᵀ)[{i}][{j}] = {rebuilt}, matrix has {}",
+                        c.get(i, j)
+                    );
+                }
+            }
+
+            for (k, ev) in lambda.iter().enumerate() {
+                assert!(*ev > -1e-9, "case {case}: eigenvalue {k} of a PSD matrix was {ev}");
+            }
+        }
+    }
+
+    /// A known spectrum, checked against values computed independently.
+    #[test]
+    fn jacobi_matches_a_known_spectrum() {
+        // [[4,1,0,0],[1,3,1,0],[0,1,2,1],[0,0,1,1]] has eigenvalues
+        // 0.25471876, 1.82271708, 3.17728292, 4.74528124 (numpy.linalg.eigvalsh).
+        let vals = [
+            [4.0, 1.0, 0.0, 0.0],
+            [1.0, 3.0, 1.0, 0.0],
+            [0.0, 1.0, 2.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0],
+        ];
+        let mut c = SymMatrixN::<4>::new();
+        for (i, row) in vals.iter().enumerate() {
+            for (j, v) in row.iter().enumerate() {
+                c.set(i, j, *v);
+            }
+        }
+
+        let (_, mut lambda) = c.jacobi_eigendecomposition();
+        lambda.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let expected = [0.254_718_76, 1.822_717_08, 3.177_282_92, 4.745_281_24];
+        for (got, want) in lambda.iter().zip(expected.iter()) {
+            assert!(
+                (got - want).abs() < 1e-7,
+                "eigenvalues {lambda:?} do not match {expected:?}"
+            );
+        }
+
+        // Determinant is preserved by a similarity transform; the product of
+        // the eigenvalues must equal det(C) = 7. Trace alone does not catch
+        // this -- it survived while the spectrum was wrong.
+        let product: f64 = lambda.iter().product();
+        assert!((product - 7.0).abs() < 1e-6, "eigenvalue product was {product}, det is 7");
+    }
+
+    /// The update must stay finite whatever the gradient stream does.
+    #[test]
+    fn compute_update_stays_finite_on_degenerate_gradient_streams() {
+        let scenarios: Vec<(&str, Vec<Vec<f64>>)> = vec![
+            ("all-zero gradients", vec![vec![0.0; 4]; 12]),
+            ("constant gradients", vec![vec![0.7, 0.7, 0.7, 0.7]; 12]),
+            ("single-axis gradients", vec![vec![1.0, 0.0, 0.0, 0.0]; 12]),
+            ("enormous gradients", vec![vec![1e12, -1e12, 1e12, -1e12]; 8]),
+            ("denormal gradients", vec![vec![1e-300, 1e-300, 1e-300, 1e-300]; 8]),
+            ("one sample", vec![vec![0.3, -0.2, 0.5, 0.1]]),
+        ];
+
+        for (label, stream) in scenarios {
+            let mut opt = PrismOptimizerN::<4>::new(0.01);
+            for g in &stream {
+                let update = opt.compute_update(g);
+                assert_eq!(update.len(), 4, "{label}: wrong update arity");
+                for (k, v) in update.iter().enumerate() {
+                    assert!(v.is_finite(), "{label}: component {k} of the update was {v}");
+                }
+            }
+            let cond = opt.condition_number();
+            assert!(cond.is_finite() && cond >= 0.0, "{label}: condition number was {cond}");
+            for (k, ev) in opt.eigenvalues().iter().enumerate() {
+                assert!(ev.is_finite(), "{label}: eigenvalue {k} was {ev}");
+            }
+        }
+    }
+
+    /// Selection feeds prompt prefixes, which must stay byte-stable.
+    #[test]
+    fn compute_update_is_deterministic_for_one_gradient_sequence() {
+        let mut seed = 0x9E37_79B9_7F4A_7C15_u64;
+        let stream: Vec<Vec<f64>> =
+            (0..40).map(|_| (0..4).map(|_| pr_lcg(&mut seed)).collect()).collect();
+
+        let run = |stream: &[Vec<f64>]| -> Vec<Vec<f64>> {
+            let mut opt = PrismOptimizerN::<4>::new(0.01);
+            stream.iter().map(|g| opt.compute_update(g)).collect()
+        };
+
+        assert_eq!(run(&stream), run(&stream), "the same gradients gave different updates");
+    }
+
     use super::*;
 
     // ── 4D Tests (backward compatibility) ────────────────────────────


### PR DESCRIPTION
`jacobi_eigendecomposition` returned **wrong eigenvalues** and a basis that does
not diagonalise its input. PRISM's whole premise — anisotropic damping along the
covariance's principal axes, `w += α Q Λ^(-1/2) Qᵀ g` — was therefore being
applied in an arbitrary orthogonal basis.

## Measured

On `[[4,1,0,0],[1,3,1,0],[0,1,2,1],[0,0,1,1]]`:

```
returned  [1.640824, 2.285480, 2.714520, 3.359176]
true      [0.254719, 1.822717, 3.177283, 4.745281]   (numpy.linalg.eigvalsh)

det(C) = 7.0     product of returned eigenvalues = 34.195
QᵀCQ max off-diagonal = 1.27          (a true eigenbasis gives 0)
|QᵀQ − I| = 1.1e-16                   (Q *was* orthogonal — just not the eigenbasis)
```

## Root cause

The update formulas implement the convention `J[p][r] = +s, J[r][p] = −s`, whose
zeroing angle is `−atan2(2·a_pr, a_pp − a_rr)/2`. The code computed **+that**, so
the rotation never eliminated `a[p][r]` — and then forced `a.set(p, r, 0.0)`,
discarding a nonzero value.

That is why the loop still reported convergence: the off-diagonals were being
zeroed **by assignment rather than by rotation**.

## Why nothing caught it

**Trace was preserved.** The diagonal formulas are self-consistent, so
`Σλ = tr(C) = 10` held exactly while the determinant did not — the signature of
a transform that is not a similarity transform. Trace alone is not enough.

All **eleven** pre-existing PRISM tests still pass, unchanged. They asserted
orthogonality, spectral energy and condition number — and an
orthogonal-but-arbitrary basis satisfies all three. Reconstruction is the
property that does not.

## What is now asserted

- `C = Q Λ Qᵀ` over 25 randomised PSD matrices (built as `AᵀA`);
- one known spectrum against independently computed values;
- the eigenvalue **product** against `det(C)`, since trace alone survived the bug;
- `compute_update` stays finite across six degenerate gradient streams
  (all-zero, constant, rank-1, `1e12`, denormal, single sample) — `Λ^(-1/2)` is
  undefined at a zero eigenvalue and a covariance from fewer samples than
  dimensions is singular;
- `compute_update` is deterministic for a fixed sequence, since selection feeds
  prompt prefixes that must stay byte-stable.

`atan2` also removes the `1e-15` denominator fudge, which was papering over
`a_pp == a_rr`, where the correct angle is exactly 45°.

## Verification

Mutation-verified: restoring the old angle fails the reconstruction test.
590 engine tests pass, clippy clean, 101 selection tests pass against a rebuilt
native engine.

Requires `cd entroly-core && maturin develop --release` before Python tests
observe the change.