### PR TITLE
docs(guardrails): the module header promised more than criticality gives

### DIFF
--- a/entroly-engine/src/guardrails.rs
+++ b/entroly-engine/src/guardrails.rs
@@ -6,8 +6,19 @@
 //!   3. No awareness of file criticality independent of content
 //!
 //! This module implements:
-//!   - **Critical file patterns**: files that must NEVER be dropped
-//!   - **Safety signals**: content patterns that force inclusion
+//!   - **Critical file patterns**: files that must never be evicted from the
+//!     store, and that carry a selection score multiplier
+//!   - **Safety signals**: content patterns that raise criticality
+//!
+//! Criticality is deliberately not a hard include. It sets `is_protected`
+//! ("never drop from the store"), not `is_pinned` ("the operator required this
+//! in the answer") -- see `ContextFragment` and `migrate_pin_semantics`.
+//! Conflating the two is not hypothetical: criticality used to set `is_pinned`,
+//! which force-included every manifest and security file in every query
+//! regardless of relevance. In selection a critical file is score-boosted
+//! (`Safety` 3.0x, `Critical` 2.0x, `Important` 1.5x in `channel.rs`) and
+//! remains budget-constrained, exactly as `file_criticality` documents for
+//! nested monorepo configs.
 //!   - **Adaptive budgeting**: task-type-aware token budgets
 //!   - **Context ordering**: LLM-sensitive fragment ordering
 //!


### PR DESCRIPTION
The `guardrails.rs` header advertised:

```
//!   - **Critical file patterns**: files that must NEVER be dropped
//!   - **Safety signals**: content patterns that force inclusion
```

Neither is what the code does — and the gap is precisely the one this codebase
has already been burned by.

## The real, deliberate design

`ContextFragment` documents the split:

> `is_pinned` means "the operator required this in the answer" and forces
> inclusion. `is_protected` means "never drop this from the store" and does not.
> **Criticality used to set `is_pinned`, conflating the two**, so a manifest or
> security file was force-included in every query regardless of relevance.

There is a `migrate_pin_semantics` migration that exists solely to undo that.

In *selection*, a critical file is score-boosted and remains budget-constrained
— `channel.rs` applies `Safety 3.0x`, `Critical 2.0x`, `Important 1.5x`. And
`file_criticality`'s own docstring already states this for nested monorepo
configs (*"score-boosted but budget-constrained"*), with the reason hard pinning
is not viable there: **langfuse, 90 pinned files = 167K tokens against an 8K
budget**.

## So

The two-level guarantee — never evicted from the store, score-boosted in
selection — is real and deliberate. Only the header was wrong, and it was wrong
in the direction that invites the next reader to reintroduce the exact
conflation the migration exists to undo.

**No behaviour changes.** 591 engine tests pass, clippy clean.