### PR TITLE
Harden context-efficiency evidence against false wins

### DIFF
--- a/benchmarks/context_efficiency_frontier.py
+++ b/benchmarks/context_efficiency_frontier.py
@@ -16,9 +16,14 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-SCHEMA_VERSION = "entroly.context-efficiency-trial.v1"
-REPORT_VERSION = "entroly.context-efficiency-frontier.v1"
+SCHEMA_VERSION = "entroly.context-efficiency-trial.v2"
+REPORT_VERSION = "entroly.context-efficiency-frontier.v2"
 BASELINE = "raw"
+MINIMUM_CLAIM_PAIRS = 20
+FAMILYWISE_ALPHA = 0.05
+MAX_REGRESSION_RATE = 0.05
+MINIMUM_CONTEXT_WIN_RATE = 0.5
+PRIMARY_RISK_GATES = 4
 CONDITIONS = ("raw", "native_compaction", "entroly", "combined")
 USAGE_SOURCES = (
     "provider_response",
@@ -62,6 +67,13 @@ def _integer(payload: dict[str, Any], name: str, *, minimum: int = 0) -> int:
     return value
 
 
+def _boolean(payload: dict[str, Any], name: str) -> bool:
+    value = payload.get(name)
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
 def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
@@ -71,6 +83,20 @@ def _sha256(payload: dict[str, Any], name: str) -> str:
     if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
         raise ValueError(f"{name} must be a lowercase SHA-256 hex digest")
     return value
+
+
+def _canonical_json_object(payload: dict[str, Any], name: str) -> str:
+    value = _text(payload, name)
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{name} must be canonical JSON") from error
+    if not isinstance(decoded, dict) or not decoded:
+        raise ValueError(f"{name} must encode a non-empty JSON object")
+    canonical = json.dumps(decoded, sort_keys=True, separators=(",", ":"))
+    if value != canonical:
+        raise ValueError(f"{name} must use canonical JSON object encoding")
+    return canonical
 
 
 @dataclass(frozen=True)
@@ -93,8 +119,13 @@ class Trial:
     condition: str
     scorer: str
     task_score: float
+    task_success: bool
     evidence_recall: float
     unsupported_claim_rate: float
+    experiment_config: str
+    usage_observed: bool
+    cost_observed: bool
+    error_fingerprint: str | None
     context_tokens: int
     reasoning_tokens: int
     output_tokens: int
@@ -132,6 +163,7 @@ class Trial:
         if outcome not in OUTCOMES:
             raise ValueError(f"outcome must be one of {OUTCOMES}")
         error_type = payload.get("error_type")
+        error_fingerprint = payload.get("error_fingerprint")
         if outcome == "success":
             if error_type is not None:
                 raise ValueError("successful trials must not set error_type")
@@ -142,6 +174,8 @@ class Trial:
             response_sha256 = _sha256(payload, "response_sha256")
             if response_sha256 != _sha256_text(response_text):
                 raise ValueError("response_sha256 does not match response_text")
+            if error_fingerprint is not None:
+                raise ValueError("successful trials must not set error_fingerprint")
         else:
             if not isinstance(error_type, str) or not error_type.strip():
                 raise ValueError("error trials require error_type")
@@ -151,6 +185,7 @@ class Trial:
             response_sha256 = payload.get("response_sha256")
             if response_text is not None or response_sha256 is not None:
                 raise ValueError("error trials must not contain a provider response")
+            error_fingerprint = _sha256(payload, "error_fingerprint")
 
         scores = {
             name: _number(payload, name)
@@ -159,6 +194,24 @@ class Trial:
         for name, value in scores.items():
             if value > 1.0:
                 raise ValueError(f"{name} must be <= 1.0")
+        task_success = _boolean(payload, "task_success")
+        usage_observed = _boolean(payload, "usage_observed")
+        cost_observed = _boolean(payload, "cost_observed")
+        if outcome == "error" and task_success:
+            raise ValueError("error trials cannot set task_success")
+
+        context_tokens = _integer(
+            payload, "context_tokens", minimum=minimum_context_tokens
+        )
+        reasoning_tokens = _integer(payload, "reasoning_tokens")
+        output_tokens = _integer(payload, "output_tokens")
+        billed_cost_usd = _number(payload, "billed_cost_usd")
+        if not usage_observed and any(
+            (context_tokens, reasoning_tokens, output_tokens)
+        ):
+            raise ValueError("unobserved usage must use zero token placeholders")
+        if not cost_observed and billed_cost_usd != 0.0:
+            raise ValueError("unobserved cost must use a zero placeholder")
 
         return cls(
             workload=_text(payload, "workload"),
@@ -179,20 +232,23 @@ class Trial:
             condition=condition,
             scorer=_text(payload, "scorer"),
             task_score=scores["task_score"],
+            task_success=task_success,
             evidence_recall=scores["evidence_recall"],
             unsupported_claim_rate=scores["unsupported_claim_rate"],
-            context_tokens=_integer(
-                payload, "context_tokens", minimum=minimum_context_tokens
-            ),
-            reasoning_tokens=_integer(payload, "reasoning_tokens"),
-            output_tokens=_integer(payload, "output_tokens"),
-            billed_cost_usd=_number(payload, "billed_cost_usd"),
+            experiment_config=_canonical_json_object(payload, "experiment_config"),
+            usage_observed=usage_observed,
+            cost_observed=cost_observed,
+            error_fingerprint=error_fingerprint,
+            context_tokens=context_tokens,
+            reasoning_tokens=reasoning_tokens,
+            output_tokens=output_tokens,
+            billed_cost_usd=billed_cost_usd,
             latency_ms=_number(payload, "latency_ms"),
             context_commit_id=commit_id,
         )
 
     @property
-    def pair_key(self) -> tuple[str, str, str, str, str, int, str]:
+    def pair_key(self) -> tuple[str, str, str, str, str, int, str, str]:
         return (
             self.workload,
             self.workload_version,
@@ -201,6 +257,7 @@ class Trial:
             self.model,
             self.replicate,
             self.scorer,
+            self.experiment_config,
         )
 
     def as_record(self) -> dict[str, Any]:
@@ -280,6 +337,58 @@ def _bootstrap_mean_ci(
     ]
 
 
+def _binomial_cdf(events: int, trials: int, probability: float) -> float:
+    if probability <= 0.0:
+        return 1.0
+    if probability >= 1.0:
+        return 1.0 if events >= trials else 0.0
+    return sum(
+        math.comb(trials, index)
+        * probability**index
+        * (1.0 - probability) ** (trials - index)
+        for index in range(events + 1)
+    )
+
+
+def clopper_pearson_upper(
+    events: int, trials: int, *, alpha: float
+) -> float:
+    """One-sided exact upper bound for a binomial event probability."""
+    if trials < 1 or not 0 <= events <= trials:
+        raise ValueError("events must be between zero and positive trials")
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must be between zero and one")
+    if events == trials:
+        return 1.0
+    if events == 0:
+        return 1.0 - alpha ** (1.0 / trials)
+    lower = events / trials
+    upper = 1.0
+    for _ in range(80):
+        midpoint = (lower + upper) / 2.0
+        if _binomial_cdf(events, trials, midpoint) > alpha:
+            lower = midpoint
+        else:
+            upper = midpoint
+    return upper
+
+
+def clopper_pearson_lower(
+    events: int, trials: int, *, alpha: float
+) -> float:
+    """One-sided exact lower bound for a binomial event probability."""
+    return 1.0 - clopper_pearson_upper(trials - events, trials, alpha=alpha)
+
+
+def zero_event_sample_size(*, upper_rate: float, alpha: float) -> int:
+    """Pairs required for an exact upper bound when no adverse event occurs."""
+    if not 0.0 < upper_rate < 1.0:
+        raise ValueError("upper_rate must be between zero and one")
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must be between zero and one")
+    return math.ceil(math.log(alpha) / math.log(1.0 - upper_rate))
+
+
 def _reduction(candidate: float, baseline: float) -> float:
     if baseline <= 0:
         return 0.0
@@ -287,23 +396,64 @@ def _reduction(candidate: float, baseline: float) -> float:
 
 
 def _aggregate(trials: list[Trial]) -> dict[str, Any]:
+    usage_trials = [trial for trial in trials if trial.usage_observed]
+    cost_trials = [trial for trial in trials if trial.cost_observed]
+    successful_tasks = sum(trial.task_success for trial in trials)
+    cost_complete = len(cost_trials) == len(trials)
+    total_observed_cost = sum(trial.billed_cost_usd for trial in cost_trials)
     return {
         "trials": len(trials),
         "errors": sum(t.outcome == "error" for t in trials),
+        "successful_tasks": successful_tasks,
         "mean_task_score": round(_mean(t.task_score for t in trials), 6),
         "mean_evidence_recall": round(_mean(t.evidence_recall for t in trials), 6),
         "mean_unsupported_claim_rate": round(
             _mean(t.unsupported_claim_rate for t in trials), 6
         ),
-        "mean_context_tokens": round(_mean(t.context_tokens for t in trials), 3),
-        "mean_reasoning_tokens": round(_mean(t.reasoning_tokens for t in trials), 3),
-        "mean_output_tokens": round(_mean(t.output_tokens for t in trials), 3),
-        "mean_billed_cost_usd": round(_mean(t.billed_cost_usd for t in trials), 8),
+        "usage_observations": len(usage_trials),
+        "usage_observation_complete": len(usage_trials) == len(trials),
+        "mean_context_tokens": (
+            round(_mean(t.context_tokens for t in usage_trials), 3)
+            if usage_trials
+            else None
+        ),
+        "mean_reasoning_tokens": (
+            round(_mean(t.reasoning_tokens for t in usage_trials), 3)
+            if usage_trials
+            else None
+        ),
+        "mean_output_tokens": (
+            round(_mean(t.output_tokens for t in usage_trials), 3)
+            if usage_trials
+            else None
+        ),
+        "cost_observations": len(cost_trials),
+        "cost_observation_complete": cost_complete,
+        "mean_billed_cost_usd": (
+            round(_mean(t.billed_cost_usd for t in cost_trials), 8)
+            if cost_trials
+            else None
+        ),
+        "cost_per_successful_task_usd": (
+            round(total_observed_cost / successful_tasks, 8)
+            if cost_complete and successful_tasks
+            else None
+        ),
         "mean_latency_ms": round(_mean(t.latency_ms for t in trials), 3),
     }
 
 
 def _dominates(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    required = ("mean_context_tokens", "mean_billed_cost_usd")
+    if any(left[name] is None or right[name] is None for name in required):
+        return False
+    if not (
+        left["usage_observation_complete"]
+        and right["usage_observation_complete"]
+        and left["cost_observation_complete"]
+        and right["cost_observation_complete"]
+    ):
+        return False
     no_worse = (
         left["mean_task_score"] >= right["mean_task_score"]
         and left["mean_evidence_recall"] >= right["mean_evidence_recall"]
@@ -335,9 +485,21 @@ def analyze_frontier(
     bootstrap_samples: int = 2_000,
     seed: int = 42,
     quality_tolerance: float = 0.01,
+    minimum_claim_pairs: int = MINIMUM_CLAIM_PAIRS,
+    familywise_alpha: float = FAMILYWISE_ALPHA,
+    max_regression_rate: float = MAX_REGRESSION_RATE,
+    minimum_context_win_rate: float = MINIMUM_CONTEXT_WIN_RATE,
 ) -> dict[str, Any]:
     if not 0.0 <= quality_tolerance <= 1.0:
         raise ValueError("quality_tolerance must be between 0 and 1")
+    if minimum_claim_pairs < 1:
+        raise ValueError("minimum_claim_pairs must be positive")
+    if not 0.0 < familywise_alpha < 1.0:
+        raise ValueError("familywise_alpha must be between zero and one")
+    if not 0.0 < max_regression_rate < 1.0:
+        raise ValueError("max_regression_rate must be between zero and one")
+    if not 0.0 <= minimum_context_win_rate < 1.0:
+        raise ValueError("minimum_context_win_rate must be in [0, 1)")
     materialized = list(trials)
     pairs = _paired(materialized)
     by_condition = {
@@ -371,9 +533,14 @@ def analyze_frontier(
             candidate.unsupported_claim_rate - raw.unsupported_claim_rate
             for raw, candidate in paired_rows
         ]
+        usage_pairs = [
+            (raw, candidate)
+            for raw, candidate in paired_rows
+            if raw.usage_observed and candidate.usage_observed
+        ]
         context_reduction = [
             _reduction(candidate.context_tokens, raw.context_tokens)
-            for raw, candidate in paired_rows
+            for raw, candidate in usage_pairs
         ]
         latency_reduction = [
             _reduction(candidate.latency_ms, raw.latency_ms)
@@ -382,16 +549,86 @@ def analyze_frontier(
         cost_reduction = [
             _reduction(candidate.billed_cost_usd, raw.billed_cost_usd)
             for raw, candidate in paired_rows
-            if raw.billed_cost_usd > 0
+            if raw.cost_observed
+            and candidate.cost_observed
+            and raw.billed_cost_usd > 0
         ]
         quality_ci = _bootstrap_mean_ci(quality_delta, samples=bootstrap_samples, rng=rng)
         evidence_ci = _bootstrap_mean_ci(evidence_delta, samples=bootstrap_samples, rng=rng)
-        context_ci = _bootstrap_mean_ci(
-            context_reduction, samples=bootstrap_samples, rng=rng
+        context_ci = (
+            _bootstrap_mean_ci(context_reduction, samples=bootstrap_samples, rng=rng)
+            if context_reduction
+            else None
         )
         unsupported_ci = _bootstrap_mean_ci(
             unsupported_delta, samples=bootstrap_samples, rng=rng
         )
+        descriptive_bounds_pass = (
+            quality_ci[0] >= -quality_tolerance
+            and evidence_ci[0] >= -quality_tolerance
+            and unsupported_ci[1] <= quality_tolerance
+            and context_ci is not None
+            and context_ci[0] > 0.0
+        )
+        adjusted_alpha = familywise_alpha / PRIMARY_RISK_GATES
+        task_regressions = sum(
+            raw.task_success and not candidate.task_success
+            for raw, candidate in paired_rows
+        )
+        evidence_regressions = sum(
+            candidate.evidence_recall < raw.evidence_recall
+            for raw, candidate in paired_rows
+        )
+        unsupported_regressions = sum(
+            candidate.unsupported_claim_rate > raw.unsupported_claim_rate
+            for raw, candidate in paired_rows
+        )
+        context_wins = sum(
+            candidate.context_tokens < raw.context_tokens
+            for raw, candidate in usage_pairs
+        )
+        task_regression_upper = clopper_pearson_upper(
+            task_regressions, len(paired_rows), alpha=adjusted_alpha
+        )
+        evidence_regression_upper = clopper_pearson_upper(
+            evidence_regressions, len(paired_rows), alpha=adjusted_alpha
+        )
+        unsupported_regression_upper = clopper_pearson_upper(
+            unsupported_regressions, len(paired_rows), alpha=adjusted_alpha
+        )
+        context_win_lower = (
+            clopper_pearson_lower(context_wins, len(usage_pairs), alpha=adjusted_alpha)
+            if usage_pairs
+            else None
+        )
+        exact_risk_bounds_pass = (
+            task_regression_upper <= max_regression_rate
+            and evidence_regression_upper <= max_regression_rate
+            and unsupported_regression_upper <= max_regression_rate
+            and context_win_lower is not None
+            and context_win_lower > minimum_context_win_rate
+        )
+        has_enough_pairs = len(paired_rows) >= minimum_claim_pairs
+        usage_complete = len(usage_pairs) == len(paired_rows)
+        blockers: list[str] = []
+        if not has_enough_pairs:
+            blockers.append("below_minimum_pair_count")
+        if not usage_complete:
+            blockers.append("incomplete_usage_observation")
+        if has_enough_pairs and not exact_risk_bounds_pass:
+            blockers.append("exact_risk_bounds_not_met")
+        if has_enough_pairs and usage_complete and not descriptive_bounds_pass:
+            blockers.append("paired_effect_bounds_not_met")
+        if not has_enough_pairs:
+            claim_status = "insufficient_data"
+        elif not usage_complete:
+            claim_status = "measurement_incomplete"
+        elif not exact_risk_bounds_pass:
+            claim_status = "insufficient_precision"
+        elif not descriptive_bounds_pass:
+            claim_status = "no_claim"
+        else:
+            claim_status = "pass"
         comparisons[condition] = {
             "paired_trials": len(paired_rows),
             "mean_quality_delta": round(_mean(quality_delta), 6),
@@ -400,18 +637,41 @@ def analyze_frontier(
             "evidence_recall_delta_95ci": evidence_ci,
             "mean_unsupported_claim_rate_delta": round(_mean(unsupported_delta), 6),
             "unsupported_claim_rate_delta_95ci": unsupported_ci,
-            "mean_context_reduction": round(_mean(context_reduction), 6),
+            "usage_observed_pairs": len(usage_pairs),
+            "usage_observation_complete": usage_complete,
+            "mean_context_reduction": (
+                round(_mean(context_reduction), 6) if context_reduction else None
+            ),
             "context_reduction_95ci": context_ci,
             "mean_latency_reduction": round(_mean(latency_reduction), 6),
             "mean_billed_cost_reduction": (
                 round(_mean(cost_reduction), 6) if cost_reduction else None
             ),
-            "quality_preserving_context_win": (
-                quality_ci[0] >= -quality_tolerance
-                and evidence_ci[0] >= -quality_tolerance
-                and unsupported_ci[1] <= quality_tolerance
-                and context_ci[0] > 0.0
+            "minimum_claim_pairs": minimum_claim_pairs,
+            "familywise_alpha": familywise_alpha,
+            "per_gate_alpha": adjusted_alpha,
+            "max_regression_rate": max_regression_rate,
+            "minimum_context_win_rate": minimum_context_win_rate,
+            "task_regressions": task_regressions,
+            "task_regression_rate_upper_bound": round(task_regression_upper, 6),
+            "evidence_regressions": evidence_regressions,
+            "evidence_regression_rate_upper_bound": round(
+                evidence_regression_upper, 6
             ),
+            "unsupported_claim_regressions": unsupported_regressions,
+            "unsupported_claim_regression_rate_upper_bound": round(
+                unsupported_regression_upper, 6
+            ),
+            "context_token_wins": context_wins,
+            "context_token_win_rate_lower_bound": (
+                round(context_win_lower, 6) if context_win_lower is not None else None
+            ),
+            "zero_regression_pairs_required": zero_event_sample_size(
+                upper_rate=max_regression_rate, alpha=adjusted_alpha
+            ),
+            "claim_blockers": blockers,
+            "claim_status": claim_status,
+            "quality_preserving_context_win": claim_status == "pass",
         }
 
     frontier = [
@@ -434,11 +694,18 @@ def analyze_frontier(
                 "model",
                 "replicate",
                 "scorer",
+                "experiment_config",
             ],
             "bootstrap_samples": bootstrap_samples,
             "bootstrap_seed": seed,
-            "confidence_interval": "paired percentile bootstrap 95%",
+            "descriptive_confidence_interval": "paired percentile bootstrap 95%",
             "quality_tolerance": quality_tolerance,
+            "minimum_claim_pairs": minimum_claim_pairs,
+            "familywise_alpha": familywise_alpha,
+            "risk_gate_correction": "Bonferroni across four one-sided exact bounds",
+            "per_gate_alpha": familywise_alpha / PRIMARY_RISK_GATES,
+            "max_regression_rate": max_regression_rate,
+            "minimum_context_win_rate": minimum_context_win_rate,
         },
         "pair_count": len(pairs),
         "provenance": {
@@ -450,6 +717,7 @@ def analyze_frontier(
             "cost_source_references": sorted(
                 {t.cost_source_reference for t in materialized}
             ),
+            "experiment_configs": sorted({t.experiment_config for t in materialized}),
         },
         "aggregates": aggregates,
         "comparisons_to_raw": comparisons,
@@ -460,6 +728,9 @@ def analyze_frontier(
             "Self-hosted zero API cost excludes hardware, energy, operations, and depreciation.",
             "Context Commit IDs prove artifact integrity, not task-score validity or signer identity.",
             "A non-dominated point is not necessarily statistically better than every alternative.",
+            "Runs below the minimum pair count are smoke tests and cannot produce a public PASS claim.",
+            "Percentile-bootstrap effect intervals are descriptive; PASS additionally requires finite-sample exact binomial risk bounds.",
+            "Missing provider usage blocks an efficiency claim instead of being interpreted as zero tokens.",
         ],
     }
 
@@ -471,12 +742,26 @@ def main() -> int:
     parser.add_argument("--bootstrap-samples", type=int, default=2_000)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--quality-tolerance", type=float, default=0.01)
+    parser.add_argument(
+        "--minimum-claim-pairs", type=int, default=MINIMUM_CLAIM_PAIRS
+    )
+    parser.add_argument("--familywise-alpha", type=float, default=FAMILYWISE_ALPHA)
+    parser.add_argument(
+        "--max-regression-rate", type=float, default=MAX_REGRESSION_RATE
+    )
+    parser.add_argument(
+        "--minimum-context-win-rate", type=float, default=MINIMUM_CONTEXT_WIN_RATE
+    )
     args = parser.parse_args()
     report = analyze_frontier(
         load_trials(args.input),
         bootstrap_samples=args.bootstrap_samples,
         seed=args.seed,
         quality_tolerance=args.quality_tolerance,
+        minimum_claim_pairs=args.minimum_claim_pairs,
+        familywise_alpha=args.familywise_alpha,
+        max_regression_rate=args.max_regression_rate,
+        minimum_context_win_rate=args.minimum_context_win_rate,
     )
     rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
     if args.output:

--- a/benchmarks/context_efficiency_openai.py
+++ b/benchmarks/context_efficiency_openai.py
@@ -11,7 +11,10 @@ import hashlib
 import json
 import os
 import random
+import re
+import string
 import time
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -29,6 +32,15 @@ from entroly.context_commit import create_context_commit, replay_context
 DEFAULT_MODEL = "gpt-4o-mini-2024-07-18"
 DEFAULT_BUDGET = 2_000
 DEFAULT_SEED = 42
+SELECTIONS = ("random", "shortest-context")
+LONG_BENCH_REVISION = "2e00731f8d0bff23dc4325161044d0ed8af94c1e"
+LONG_BENCH_METRICS_SHA256 = (
+    "587b87e8ea520f6093ebd061a7a99b0fb53ade84356ba16e95c518b28fe23d85"
+)
+SCORER = (
+    "longbench-v1-hotpotqa-official-qa-f1@"
+    f"{LONG_BENCH_REVISION}:metrics-sha256:{LONG_BENCH_METRICS_SHA256}"
+)
 PRICING_REFERENCE = (
     "openai:gpt-4o-mini:2026-07-11:usd-per-1m="
     "input-0.15,cached-input-0.075,output-0.60;"
@@ -117,12 +129,22 @@ def prepare_longbench_items(rows: Iterable[dict[str, Any]]) -> list[WorkloadItem
     return items
 
 
-def workload_version(items: Iterable[WorkloadItem]) -> str:
+def workload_version(
+    items: Iterable[WorkloadItem], *, selection_policy: str
+) -> str:
     manifest = [
-        {"task_id": item.task_id, "question": item.question, "answers": item.answers}
+        {
+            "task_id": item.task_id,
+            "context_sha256": hashlib.sha256(item.context.encode("utf-8")).hexdigest(),
+            "question": item.question,
+            "answers": item.answers,
+        }
         for item in items
     ]
-    return "longbench-hotpotqa-test-seed42-" + _stable_digest(manifest)[:16]
+    return (
+        f"longbench-v1-hotpotqa:{LONG_BENCH_REVISION}:{selection_policy}:"
+        + _stable_digest(manifest)
+    )
 
 
 def _selected_context(commit: dict[str, Any]) -> str:
@@ -133,9 +155,53 @@ def _selected_context(commit: dict[str, Any]) -> str:
     )
 
 
+def normalize_answer(text: str) -> str:
+    """Match the official LongBench English-QA normalization."""
+    lowered = text.lower()
+    without_punctuation = "".join(
+        character for character in lowered if character not in set(string.punctuation)
+    )
+    without_articles = re.sub(r"\b(a|an|the)\b", " ", without_punctuation)
+    return " ".join(without_articles.split())
+
+
+def qa_f1_score(prediction: str, ground_truth: str) -> float:
+    predicted = normalize_answer(prediction).split()
+    expected = normalize_answer(ground_truth).split()
+    if not predicted or not expected:
+        return float(predicted == expected)
+    shared = Counter(predicted) & Counter(expected)
+    overlap = sum(shared.values())
+    if overlap == 0:
+        return 0.0
+    precision = overlap / len(predicted)
+    recall = overlap / len(expected)
+    return 2 * precision * recall / (precision + recall)
+
+
 def _answer_present(text: str, answers: Iterable[str]) -> bool:
-    folded = text.casefold()
-    return any(answer.casefold() in folded for answer in answers)
+    normalized_text = normalize_answer(text)
+    return any(
+        normalized_answer and normalized_answer in normalized_text
+        for answer in answers
+        if (normalized_answer := normalize_answer(answer))
+    )
+
+
+def _exact_answer(prediction: str, answers: Iterable[str]) -> bool:
+    normalized_prediction = normalize_answer(prediction)
+    return any(
+        normalized_prediction == normalize_answer(answer) for answer in answers
+    )
+
+
+def _answer_score(prediction: str, answers: Iterable[str]) -> float:
+    return max(qa_f1_score(prediction, answer) for answer in answers)
+
+
+def _response_supported(response: str, context: str) -> bool:
+    normalized_response = normalize_answer(response)
+    return bool(normalized_response) and normalized_response in normalize_answer(context)
 
 
 def _usage_int(value: Any, name: str) -> int:
@@ -144,17 +210,28 @@ def _usage_int(value: Any, name: str) -> int:
     return value
 
 
-def call_openai(client: Any, *, model: str, context: str, question: str) -> ProviderObservation:
+def call_openai(
+    client: Any,
+    *,
+    model: str,
+    context: str,
+    question: str,
+    max_output_tokens: int = 64,
+    reasoning_effort: str | None = None,
+) -> ProviderObservation:
     started = time.perf_counter()
-    response = client.chat.completions.create(
-        model=model,
-        temperature=0,
-        max_tokens=64,
-        messages=[
+    request: dict[str, Any] = {
+        "model": model,
+        "temperature": 0,
+        "max_tokens": max_output_tokens,
+        "messages": [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": f"Context:\n{context}\n\nQuestion:\n{question}"},
         ],
-    )
+    }
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+    response = client.chat.completions.create(**request)
     latency_ms = (time.perf_counter() - started) * 1_000
     usage = getattr(response, "usage", None)
     if usage is None:
@@ -212,8 +289,11 @@ def _success_trial(
     commit_id: str | None,
     observation: ProviderObservation,
     provider: ProviderConfig,
+    experiment_config: str,
 ) -> Trial:
-    correct = _answer_present(observation.response_text, item.answers)
+    score = _answer_score(observation.response_text, item.answers)
+    task_success = _exact_answer(observation.response_text, item.answers)
+    has_claim = bool(normalize_answer(observation.response_text))
     return Trial.from_dict(
         {
             "schema_version": SCHEMA_VERSION,
@@ -235,10 +315,17 @@ def _success_trial(
             ).hexdigest(),
             "replicate": 0,
             "condition": condition,
-            "scorer": "longbench-hotpotqa-answer-only-v1",
-            "task_score": float(correct),
+            "scorer": SCORER,
+            "task_score": score,
+            "task_success": task_success,
             "evidence_recall": float(_answer_present(selected_context, item.answers)),
-            "unsupported_claim_rate": float(not correct),
+            "unsupported_claim_rate": float(
+                has_claim and not _response_supported(observation.response_text, selected_context)
+            ),
+            "experiment_config": experiment_config,
+            "usage_observed": True,
+            "cost_observed": True,
+            "error_fingerprint": None,
             "context_tokens": observation.prompt_tokens,
             "reasoning_tokens": observation.reasoning_tokens,
             "output_tokens": observation.completion_tokens,
@@ -259,10 +346,25 @@ def _error_trial(
     commit_id: str | None,
     error: Exception,
     provider: ProviderConfig,
+    experiment_config: str,
+    latency_ms: float,
 ) -> Trial:
     error_type = type(error).__name__
+    error_fingerprint = _stable_digest(
+        {
+            "error_type": error_type,
+            "message_sha256": hashlib.sha256(
+                str(error).encode("utf-8")
+            ).hexdigest(),
+            "status_code": getattr(error, "status_code", None),
+        }
+    )
     error_id = _stable_digest(
-        {"task": item.task_id, "condition": condition, "error": error_type}
+        {
+            "task": item.task_id,
+            "condition": condition,
+            "error_fingerprint": error_fingerprint,
+        }
     )[:20]
     usage_source = "provider_error" if error_type != "ContextPreparationError" else "runner_error"
     return Trial.from_dict(
@@ -284,15 +386,20 @@ def _error_trial(
             "response_sha256": None,
             "replicate": 0,
             "condition": condition,
-            "scorer": "longbench-hotpotqa-answer-only-v1",
+            "scorer": SCORER,
             "task_score": 0.0,
+            "task_success": False,
             "evidence_recall": float(_answer_present(selected_context, item.answers)),
-            "unsupported_claim_rate": 1.0,
+            "unsupported_claim_rate": 0.0,
+            "experiment_config": experiment_config,
+            "usage_observed": False,
+            "cost_observed": False,
+            "error_fingerprint": error_fingerprint,
             "context_tokens": 0,
             "reasoning_tokens": 0,
             "output_tokens": 0,
             "billed_cost_usd": 0.0,
-            "latency_ms": 0.0,
+            "latency_ms": latency_ms,
             "context_commit_id": commit_id,
         }
     )
@@ -318,18 +425,58 @@ def run_trials(
     seed: int = DEFAULT_SEED,
     resume: bool = False,
     provider: ProviderConfig = OPENAI_PROVIDER,
+    max_output_tokens: int = 64,
+    reasoning_effort: str | None = None,
+    selection_policy: str = "preselected",
 ) -> list[Trial]:
     if token_budget < 1:
         raise ValueError("token_budget must be positive")
+    if max_output_tokens < 1:
+        raise ValueError("max_output_tokens must be positive")
+    task_ids = [item.task_id for item in items]
+    if len(task_ids) != len(set(task_ids)):
+        raise ValueError("task_id values must be unique")
+    missing_evidence = [
+        item.task_id for item in items if not _answer_present(item.context, item.answers)
+    ]
+    if missing_evidence:
+        raise ValueError(
+            "raw context does not contain normalized answer evidence for: "
+            + ", ".join(missing_evidence)
+        )
+    experiment_config = json.dumps(
+        {
+            "cached_input_usd_per_million": provider.cached_input_usd_per_million,
+            "cost_source": provider.cost_source,
+            "cost_source_reference": provider.cost_source_reference,
+            "input_usd_per_million": provider.input_usd_per_million,
+            "longbench_metrics_sha256": LONG_BENCH_METRICS_SHA256,
+            "longbench_revision": LONG_BENCH_REVISION,
+            "max_output_tokens": max_output_tokens,
+            "output_usd_per_million": provider.output_usd_per_million,
+            "reasoning_effort": reasoning_effort,
+            "runner_contract": "context-efficiency-openai-v2",
+            "seed": seed,
+            "selection_policy": selection_policy,
+            "system_prompt_sha256": hashlib.sha256(
+                SYSTEM_PROMPT.encode("utf-8")
+            ).hexdigest(),
+            "temperature": 0,
+            "token_budget": token_budget,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
     if output.exists() and not resume:
         raise FileExistsError(f"{output} exists; use --resume or choose another path")
     existing = load_trials(output) if output.exists() else []
     completed = {(trial.task_id, trial.condition) for trial in existing}
-    version = workload_version(items)
+    version = workload_version(items, selection_policy=selection_policy)
     if any(
         trial.workload_version != version
         or trial.model != model
         or trial.provider != provider.name
+        or trial.experiment_config != experiment_config
         for trial in existing
     ):
         raise ValueError("existing trials do not match this workload/model configuration")
@@ -346,6 +493,7 @@ def run_trials(
             selected_context = item.context
             commit: dict[str, Any] | None = None
             commit_id: str | None = None
+            provider_started: float | None = None
             try:
                 if condition == "entroly":
                     chunk_tokens = min(360, token_budget)
@@ -365,11 +513,14 @@ def run_trials(
                         json.dumps(commit, indent=2, sort_keys=True) + "\n",
                         encoding="utf-8",
                     )
+                provider_started = time.perf_counter()
                 observation = call_openai(
                     client,
                     model=model,
                     context=selected_context,
                     question=item.question,
+                    max_output_tokens=max_output_tokens,
+                    reasoning_effort=reasoning_effort,
                 )
                 trial = _success_trial(
                     item=item,
@@ -380,8 +531,14 @@ def run_trials(
                     commit_id=commit_id,
                     observation=observation,
                     provider=provider,
+                    experiment_config=experiment_config,
                 )
             except Exception as error:  # Every failed request remains in the matrix.
+                failed_latency_ms = (
+                    (time.perf_counter() - provider_started) * 1_000
+                    if provider_started is not None
+                    else 0.0
+                )
                 trial = _error_trial(
                     item=item,
                     condition=condition,
@@ -391,6 +548,8 @@ def run_trials(
                     commit_id=commit_id,
                     error=error,
                     provider=provider,
+                    experiment_config=experiment_config,
+                    latency_ms=failed_latency_ms,
                 )
             _append_trial(output, trial)
             existing.append(trial)
@@ -402,15 +561,38 @@ def run_trials(
     return existing
 
 
-def _load_longbench(samples: int) -> list[WorkloadItem]:
+def select_longbench_rows(
+    rows: Iterable[dict[str, Any]], samples: int, selection: str
+) -> list[dict[str, Any]]:
+    candidates = list(rows)
+    if selection == "shortest-context":
+        candidates.sort(
+            key=lambda row: (
+                len(str(row.get("context", ""))),
+                _stable_digest(row),
+            )
+        )
+    elif selection != "random":
+        raise ValueError(f"unsupported LongBench selection: {selection}")
+    return candidates[:samples]
+
+
+def _load_longbench(samples: int, selection: str = "random") -> list[WorkloadItem]:
     from bench.accuracy import _load_longbench as load_rows
 
-    return prepare_longbench_items(load_rows(samples))
+    source_rows = load_rows(200 if selection == "shortest-context" else samples)
+    return prepare_longbench_items(select_longbench_rows(source_rows, samples, selection))
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument(
+        "--selection",
+        choices=SELECTIONS,
+        default="random",
+        help="Dataset selection; shortest-context is a biased, quick calibration subset.",
+    )
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--budget", type=int, default=DEFAULT_BUDGET)
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
@@ -424,9 +606,24 @@ def main() -> int:
     parser.add_argument("--input-usd-per-million", type=float)
     parser.add_argument("--cached-input-usd-per-million", type=float)
     parser.add_argument("--output-usd-per-million", type=float)
+    parser.add_argument("--max-output-tokens", type=int, default=64)
+    parser.add_argument(
+        "--reasoning-effort",
+        choices=("none", "minimal", "low", "medium", "high"),
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=60.0,
+        help="Per-request timeout in seconds (default: 60).",
+    )
     args = parser.parse_args()
     if args.samples < 1:
         parser.error("--samples must be positive")
+    if args.request_timeout <= 0:
+        parser.error("--request-timeout must be positive")
+    if args.max_output_tokens < 1:
+        parser.error("--max-output-tokens must be positive")
 
     from openai import OpenAI
 
@@ -438,7 +635,12 @@ def main() -> int:
         if args.api_key_env and not os.environ.get(args.api_key_env):
             parser.error(f"environment variable {args.api_key_env!r} is not set")
         api_key = os.environ[args.api_key_env] if args.api_key_env else "no-auth"
-        client = OpenAI(base_url=args.base_url, api_key=api_key, max_retries=0)
+        client = OpenAI(
+            base_url=args.base_url,
+            api_key=api_key,
+            max_retries=0,
+            timeout=args.request_timeout,
+        )
         provider = ProviderConfig(
             name=args.provider,
             cost_source=args.cost_source or "self_hosted_no_api_fee",
@@ -448,10 +650,10 @@ def main() -> int:
             output_usd_per_million=args.output_usd_per_million or 0.0,
         )
     else:
-        client = OpenAI(max_retries=2)
+        client = OpenAI(max_retries=2, timeout=args.request_timeout)
         provider = OPENAI_PROVIDER
 
-    items = _load_longbench(args.samples)
+    items = _load_longbench(args.samples, args.selection)
     trials = run_trials(
         items=items,
         client=client,
@@ -461,6 +663,9 @@ def main() -> int:
         seed=args.seed,
         resume=args.resume,
         provider=provider,
+        max_output_tokens=args.max_output_tokens,
+        reasoning_effort=args.reasoning_effort,
+        selection_policy=args.selection,
     )
     report = analyze_frontier(trials)
     report_path = args.output.with_suffix(".report.json")

--- a/benchmarks/context_efficiency_report.py
+++ b/benchmarks/context_efficiency_report.py
@@ -14,8 +14,12 @@ def _percent(value: float | None) -> str:
     return "n/a" if value is None else f"{value:.1%}"
 
 
-def _interval(value: list[float]) -> str:
-    return f"[{value[0]:.1%}, {value[1]:.1%}]"
+def _interval(value: list[float] | None) -> str:
+    return "n/a" if value is None else f"[{value[0]:.1%}, {value[1]:.1%}]"
+
+
+def _number(value: float | None, *, digits: int = 0) -> str:
+    return "n/a" if value is None else f"{value:,.{digits}f}"
 
 
 def render_markdown(report: dict[str, Any]) -> str:
@@ -41,22 +45,27 @@ def render_markdown(report: dict[str, Any]) -> str:
         "",
         "## Operating Points",
         "",
-        "| Condition | Trials | Errors | Task score | Evidence recall | Unsupported claims | Context tokens | Cost (USD) | Latency (ms) | Pareto |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| Condition | Trials | Errors | Successful tasks | Task score | Evidence recall | Unsupported-output proxy | Context tokens | Usage observed | Cost (USD) | Cost / successful task | Latency (ms) | Pareto |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     frontier = set(report.get("pareto_frontier", []))
     for condition, aggregate in aggregates.items():
         lines.append(
-            "| {condition} | {trials} | {errors} | {score:.3f} | {evidence:.3f} | "
-            "{unsupported:.3f} | {context:,.0f} | {cost:.6f} | {latency:,.1f} | {pareto} |".format(
+            "| {condition} | {trials} | {errors} | {successes} | {score:.3f} | {evidence:.3f} | "
+            "{unsupported:.3f} | {context} | {usage}/{trials} | {cost} | {cost_per_success} | {latency:,.1f} | {pareto} |".format(
                 condition=condition,
                 trials=aggregate["trials"],
                 errors=aggregate["errors"],
+                successes=aggregate["successful_tasks"],
                 score=aggregate["mean_task_score"],
                 evidence=aggregate["mean_evidence_recall"],
                 unsupported=aggregate["mean_unsupported_claim_rate"],
-                context=aggregate["mean_context_tokens"],
-                cost=aggregate["mean_billed_cost_usd"],
+                context=_number(aggregate["mean_context_tokens"]),
+                usage=aggregate["usage_observations"],
+                cost=_number(aggregate["mean_billed_cost_usd"], digits=6),
+                cost_per_success=_number(
+                    aggregate["cost_per_successful_task_usd"], digits=6
+                ),
                 latency=aggregate["mean_latency_ms"],
                 pareto="yes" if condition in frontier else "no",
             )
@@ -67,7 +76,7 @@ def render_markdown(report: dict[str, Any]) -> str:
             "",
             "## Paired Results Versus Raw Context",
             "",
-            "`PASS` requires the 95% paired-bootstrap bounds to preserve task score and evidence recall, avoid excess unsupported claims, and reduce context beyond zero.",
+            "`PASS` requires complete provider usage, the minimum pair count, descriptive paired-bootstrap bounds, and simultaneous exact one-sided risk bounds for task regressions, evidence regressions, unsupported-claim regressions, and per-task context wins. Smaller runs are `SMOKE ONLY`; imprecise larger runs remain `INSUFFICIENT PRECISION`.",
             "",
             "| Condition | Pairs | Quality delta (95% CI) | Evidence delta (95% CI) | Context reduction (95% CI) | Cost reduction | Result |",
             "|---|---:|---:|---:|---:|---:|---|",
@@ -86,11 +95,49 @@ def render_markdown(report: dict[str, Any]) -> str:
                 context=_percent(comparison["mean_context_reduction"]),
                 context_ci=_interval(comparison["context_reduction_95ci"]),
                 cost=_percent(comparison["mean_billed_cost_reduction"]),
-                result=(
-                    "PASS"
-                    if comparison["quality_preserving_context_win"]
-                    else "NO CLAIM"
+                result={
+                    "pass": "PASS",
+                    "no_claim": "NO CLAIM",
+                    "insufficient_data": "SMOKE ONLY",
+                    "measurement_incomplete": "MEASUREMENT INCOMPLETE",
+                    "insufficient_precision": "INSUFFICIENT PRECISION",
+                }[comparison["claim_status"]],
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Exact Per-Task Risk Gates",
+            "",
+            "Bounds are one-sided Clopper-Pearson intervals with Bonferroni correction across the four primary gates.",
+            "",
+            "| Condition | Task regressions (upper) | Evidence regressions (upper) | Unsupported-output regressions (upper) | Context wins (lower) | Blockers |",
+            "|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for condition, comparison in comparisons.items():
+        blockers = ", ".join(comparison["claim_blockers"]) or "none"
+        lines.append(
+            "| {condition} | {task}/{pairs} ({task_upper}) | {evidence}/{pairs} "
+            "({evidence_upper}) | {unsupported}/{pairs} ({unsupported_upper}) | "
+            "{wins}/{usage_pairs} ({win_lower}) | {blockers} |".format(
+                condition=condition,
+                task=comparison["task_regressions"],
+                pairs=comparison["paired_trials"],
+                task_upper=_percent(comparison["task_regression_rate_upper_bound"]),
+                evidence=comparison["evidence_regressions"],
+                evidence_upper=_percent(
+                    comparison["evidence_regression_rate_upper_bound"]
                 ),
+                unsupported=comparison["unsupported_claim_regressions"],
+                unsupported_upper=_percent(
+                    comparison["unsupported_claim_regression_rate_upper_bound"]
+                ),
+                wins=comparison["context_token_wins"],
+                usage_pairs=comparison["usage_observed_pairs"],
+                win_lower=_percent(comparison["context_token_win_rate_lower_bound"]),
+                blockers=blockers,
             )
         )
 
@@ -101,9 +148,14 @@ def render_markdown(report: dict[str, Any]) -> str:
             "",
             f"- Baseline: `{methodology['baseline']}`",
             f"- Pair count: {report['pair_count']}",
-            f"- Confidence interval: {methodology['confidence_interval']}",
+            f"- Descriptive confidence interval: {methodology['descriptive_confidence_interval']}",
             f"- Bootstrap samples: {methodology['bootstrap_samples']}",
             f"- Quality tolerance: {_percent(methodology['quality_tolerance'])}",
+            f"- Minimum pairs for a public claim: {methodology['minimum_claim_pairs']}",
+            f"- Familywise alpha: {methodology['familywise_alpha']}",
+            f"- Exact-risk correction: {methodology['risk_gate_correction']}",
+            f"- Maximum allowed per-task regression risk: {_percent(methodology['max_regression_rate'])}",
+            f"- Minimum context-token win rate: {_percent(methodology['minimum_context_win_rate'])}",
             f"- Usage sources: {', '.join(report['provenance']['usage_sources'])}",
             f"- Cost sources: {', '.join(report['provenance']['cost_sources'])}",
             "- Cost source references: "

--- a/benchmarks/context_efficiency_trial.schema.json
+++ b/benchmarks/context_efficiency_trial.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://entroly.com/schemas/context-efficiency-trial.v1.json",
+  "$id": "https://entroly.com/schemas/context-efficiency-trial.v2.json",
   "title": "Entroly Context Efficiency Trial",
   "description": "One provider-observed task trial in a paired context-efficiency experiment.",
   "type": "object",
@@ -25,8 +25,13 @@
     "condition",
     "scorer",
     "task_score",
+    "task_success",
     "evidence_recall",
     "unsupported_claim_rate",
+    "experiment_config",
+    "usage_observed",
+    "cost_observed",
+    "error_fingerprint",
     "context_tokens",
     "reasoning_tokens",
     "output_tokens",
@@ -36,7 +41,7 @@
   ],
   "properties": {
     "schema_version": {
-      "const": "entroly.context-efficiency-trial.v1"
+      "const": "entroly.context-efficiency-trial.v2"
     },
     "workload": {
       "type": "string",
@@ -137,6 +142,10 @@
       "minimum": 0,
       "maximum": 1
     },
+    "task_success": {
+      "type": "boolean",
+      "description": "Predeclared binary success gate; separate from a potentially fractional benchmark score."
+    },
     "evidence_recall": {
       "type": "number",
       "minimum": 0,
@@ -146,6 +155,24 @@
       "type": "number",
       "minimum": 0,
       "maximum": 1
+    },
+    "experiment_config": {
+      "type": "string",
+      "minLength": 2,
+      "description": "Canonical JSON object binding decoding, prompt, budget, selection, and scorer dependencies."
+    },
+    "usage_observed": {
+      "type": "boolean"
+    },
+    "cost_observed": {
+      "type": "boolean"
+    },
+    "error_fingerprint": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{64}$"
     },
     "context_tokens": {
       "type": "integer",
@@ -218,6 +245,9 @@
           "error_type": {
             "type": "null"
           },
+          "error_fingerprint": {
+            "type": "null"
+          },
           "response_text": {
             "type": "string"
           },
@@ -233,11 +263,62 @@
             "type": "string",
             "minLength": 1
           },
+          "error_fingerprint": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "task_success": {
+            "const": false
+          },
           "response_text": {
             "type": "null"
           },
           "response_sha256": {
             "type": "null"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "usage_observed": {
+            "const": false
+          }
+        },
+        "required": [
+          "usage_observed"
+        ]
+      },
+      "then": {
+        "properties": {
+          "context_tokens": {
+            "const": 0
+          },
+          "reasoning_tokens": {
+            "const": 0
+          },
+          "output_tokens": {
+            "const": 0
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "cost_observed": {
+            "const": false
+          }
+        },
+        "required": [
+          "cost_observed"
+        ]
+      },
+      "then": {
+        "properties": {
+          "billed_cost_usd": {
+            "const": 0
           }
         }
       }

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -30,12 +30,14 @@ they do not measure model-answer quality or claim identical Python/Rust selectio
 
 Entroly is building a paired, model-neutral benchmark for the question
 token-savings tables cannot answer: does less context preserve real task
-quality? The preregistered protocol compares raw context, model-native
+quality? The versioned protocol compares raw context, model-native
 compaction, Entroly, and their combination using provider-observed tokens,
 cost, latency, task success, evidence recall, and unsupported claims.
 
-[Read the preregistered protocol](benchmarks/context-efficiency-frontier.md).
-No headline result will be claimed until the paired confidence bounds pass.
+[Read protocol v2](benchmarks/context-efficiency-frontier-v2.md) and the
+[preserved v1 preregistration](benchmarks/context-efficiency-frontier.md).
+No headline result will be claimed until the paired effect and exact harm-risk
+bounds pass.
 
 ## Matched token-cap active-context quality frontier (1.0.59 source candidate)
 

--- a/docs/benchmarks/context-efficiency-frontier-v2.md
+++ b/docs/benchmarks/context-efficiency-frontier-v2.md
@@ -1,0 +1,230 @@
+# Entroly Context Efficiency Frontier v2
+
+Status: post-pilot protocol revision for future frozen runs. This protocol was
+written after inspecting calibration behavior, so it is not a retroactive
+preregistration. A publishable run must pin this protocol, code revision,
+dataset manifest, scorer, model, and experiment configuration before any paid
+observations are collected.
+
+## Decision question
+
+For a fixed task distribution, model, prompt, decoding configuration, context
+budget, and scorer, does an Entroly condition reduce provider-observed input
+while keeping per-task harm below a declared bound?
+
+The primary decision is not percentage of text removed. It is whether context
+reduction survives task-success, evidence-retention, grounding, measurement,
+and cost-per-success gates. Results apply only to the evaluated operating
+point; no single aggregate establishes universal superiority.
+
+## Why v2 exists
+
+The v1 pilot identified four threats to validity:
+
+1. The runner used answer containment instead of the pinned official LongBench
+   HotpotQA token-F1 scorer.
+2. A failed request with unavailable provider usage looked like zero-token,
+   zero-cost inference.
+3. A percentile bootstrap can have zero width when every observed delta ties;
+   that does not bound the probability of a regression on the next task.
+4. Model, decoding, selection, prompt, and budget settings were not bound into
+   the pair identity as one canonical experiment configuration.
+
+V2 repairs those defects. V1 artifacts remain v1 and cannot be relabeled.
+
+## Conditions and pairing
+
+Every task-replicate contains the same condition matrix:
+
+| Condition | Behavior |
+|---|---|
+| `raw` | Complete, unmodified task context; required baseline. |
+| `native_compaction` | Only documented model or agent compaction. |
+| `entroly` | Entroly context selection with native compaction disabled when controllable. |
+| `combined` | Entroly plus documented native compaction. |
+
+The pair key binds workload and manifest version, task ID, provider, actual
+model ID, replicate, scorer, and canonical experiment configuration. That
+configuration binds the prompt digest, temperature, output limit, reasoning
+setting, context budget, random seed, selection policy, dataset revision,
+scorer dependency digest, and pricing configuration. Entroly and combined
+trials also require the exact
+`ctx_...` Context Commit ID.
+
+Condition order is randomized within each task. Task sampling is fixed before
+calls begin. A `shortest-context` subset is calibration-only and must be labeled
+`SMOKE ONLY`; it cannot support a public product claim.
+
+## Outcomes and estimands
+
+Each trial records these distinct quantities:
+
+- `task_score`: the frozen benchmark metric, which may be fractional.
+- `task_success`: a preregistered binary criterion used for cost per successful
+  task and per-task regression risk. For the initial answer-only HotpotQA
+  runner, success is normalized exact answer match.
+- `evidence_recall`: whether answer-critical evidence remains in active context.
+- `unsupported_claim_rate`: a scorer-specific grounding quantity. In the
+  initial answer-only runner, it is a conservative lexical proxy: whether a
+  non-empty response is absent as a normalized contiguous span of supplied
+  evidence. It detects extra or reformulated output but is not a semantic
+  factuality judgment. A missing answer is a task failure, not automatically a
+  fabricated claim.
+- provider-observed context, reasoning, and output tokens; latency; observed
+  API cost; and cost per successful task.
+
+The official LongBench v1 HotpotQA scorer is token-overlap F1 after lowercase,
+ASCII-punctuation removal, English-article removal, and whitespace folding. Its
+implementation is pinned by LongBench revision and the SHA-256 digest of
+`LongBench/metrics.py`.
+
+Before any provider call, the runner rejects a task whose raw context does not
+contain normalized answer evidence. This prevents a retrieval failure from
+being blamed on compression when the reference answer was absent at baseline.
+
+## Missingness and failures
+
+Timeouts, refusals, context-limit failures, malformed outputs, and tool errors
+remain in the task matrix with failed task success. They are not retried until
+successful and are not dropped.
+
+When a failed request has no provider usage record, token and cost fields are
+zero-valued placeholders accompanied by `usage_observed: false` and
+`cost_observed: false`. The analyzer excludes those placeholders from token and
+cost means and blocks an efficiency claim. It never interprets them as free or
+zero-token inference. A stable error fingerprint binds the error class, status,
+and hashed message without publishing provider text that may contain secrets.
+
+Self-hosted zero API fees exclude hardware, energy, operations, depreciation,
+and opportunity cost. Reports must say so.
+
+## Statistical decision rule
+
+The paired bootstrap intervals are descriptive effect summaries. They are not
+the only evidence gate.
+
+For each candidate versus raw, v2 additionally computes exact one-sided
+Clopper-Pearson bounds for four task-level event rates:
+
+1. raw success followed by candidate failure;
+2. candidate evidence recall below raw;
+3. candidate unsupported-claim rate above raw;
+4. candidate context tokens below raw (a desired event).
+
+The default familywise alpha is `0.05`, Bonferroni-corrected across four primary
+gates (`alpha = 0.0125` per gate). The three regression-rate upper bounds must
+be at most `0.05`; the context-win-rate lower bound must exceed `0.50`.
+
+The descriptive bounds must also show:
+
+- mean task-score delta lower bound at least `-0.01`;
+- mean evidence-recall delta lower bound at least `-0.01`;
+- mean unsupported-claim delta upper bound at most `0.01`;
+- mean context-reduction lower bound above zero.
+
+The minimum reportable sample is 20 pairs, but that is not sufficient by
+itself. With zero observed regressions, the simultaneous 5% regression-risk
+gate requires 86 independent task pairs under the default correction. Twenty
+clean pairs still have a one-sided 95% upper regression bound of about 13.9%
+before multiple-comparison correction.
+
+The analyzer emits:
+
+- `SMOKE ONLY` below the minimum pair count;
+- `MEASUREMENT INCOMPLETE` when provider usage is missing;
+- `INSUFFICIENT PRECISION` when exact risk bounds do not pass;
+- `NO CLAIM` when descriptive effect bounds do not pass; or
+- `PASS` only when every gate passes.
+
+All workloads are reported separately. A pooled headline cannot hide a failed
+or incomplete workload.
+
+## Workload validity matrix
+
+No single benchmark represents "AI token efficiency." A public evidence set
+must cover complementary failure modes:
+
+| Construct | Primary workload | Required control |
+|---|---|---|
+| Long-context QA | LongBench/LongBench v2 plus HELMET tasks | official scorer, length and answer-position strata |
+| Weak lexical cues | NoLiMa | no answer-keyword shortcut |
+| Retrieval and aggregation | RULER and noisy-document RAG | answer present in raw context |
+| Repository coding | SWE-bench Verified | pinned image, patch/test oracle, resolved rate |
+| Terminal agents | Terminal-Bench 2.0 | pinned task image and executable verifier |
+| Tool/log/JSON work | frozen public fixtures plus executable schema checks | exact field recovery and valid tool calls |
+| Growing sessions | frozen multi-turn traces | repeated-query quality, cumulative usage, recovery audit |
+
+Synthetic needle and deterministic conformance tasks remain engineering tests,
+not headline evidence. Stochastic agent workloads require preregistered
+replicates and task-clustered analysis; repeated runs of one task are not
+independent tasks.
+
+## Bias and contamination controls
+
+- Freeze train/development/test decisions before the public run.
+- Report performance by context-length and answer-position strata to detect
+  lost-in-the-middle behavior.
+- Use immutable repository revisions, container digests, dependency locks, and
+  provider model IDs where available.
+- Keep prompt and cache prefixes identical across paired conditions except for
+  the context transformation under test.
+- Preserve append-only trial JSONL, exact response and context digests,
+  provider request IDs or stable redactions, and Entroly receipts.
+- Declare infrastructure exclusions before unblinding scores. Provider/model
+  failures are outcomes unless the same infrastructure fault invalidates every
+  paired condition.
+- Do not tune thresholds, budgets, or task subsets on the held-out report set.
+
+## Publication packet
+
+A publishable result includes the frozen protocol and repository commit; task
+manifest hashes; raw append-only trials or a license-safe hash manifest;
+generated JSON and Markdown reports; exact scorer and dependency hashes;
+provider usage/cost provenance; all failures and exclusions; Context Commits;
+and per-workload results.
+
+Use a bounded claim such as:
+
+> On the named model, frozen workload manifest, budget, and scorer, Entroly met
+> the preregistered task-level harm bounds while reducing provider-observed
+> context by X% (paired descriptive interval L-U, N independent tasks).
+
+Never shorten that to "best compression tool" or generalize it to unevaluated
+models, tasks, providers, or budgets.
+
+## Reproduce
+
+```bash
+python -m benchmarks.context_efficiency_frontier trials.jsonl \
+  --bootstrap-samples 2000 \
+  --quality-tolerance 0.01 \
+  --minimum-claim-pairs 20 \
+  --familywise-alpha 0.05 \
+  --max-regression-rate 0.05 \
+  --minimum-context-win-rate 0.50 \
+  --output report.json
+
+python -m benchmarks.context_efficiency_report report.json --output report.md
+```
+
+The JSON report is the source of truth. The Markdown report is generated from
+it and must show caveats, missingness, risk bounds, and failed gates alongside
+passing results.
+
+## Research basis
+
+- [LongBench](https://arxiv.org/abs/2308.14508) and
+  [LongBench v2](https://arxiv.org/abs/2412.15204)
+- [HELMET](https://arxiv.org/abs/2410.02694)
+- [RULER](https://arxiv.org/abs/2404.06654)
+- [NoLiMa](https://openreview.net/forum?id=A0Ajt0YQEU)
+- [Lost in the Middle](https://arxiv.org/abs/2307.03172)
+- [LongLLMLingua](https://arxiv.org/abs/2310.06839) and
+  [LLMLingua-2](https://arxiv.org/abs/2403.12968)
+- [SWE-bench](https://arxiv.org/abs/2310.06770) and
+  [Terminal-Bench 2.0](https://arxiv.org/abs/2601.11868)
+- [Time-uniform confidence sequences](https://arxiv.org/abs/1810.08240)
+- [Estimating bounded means by betting](https://arxiv.org/abs/2010.09686)
+- [Anytime-valid inference for count data](https://arxiv.org/abs/2302.10108)
+- [How Do AI Agents Spend Your Money?](https://arxiv.org/abs/2604.22750)
+- [AI Tokenomics](https://arxiv.org/abs/2606.24616)

--- a/docs/benchmarks/context-efficiency-frontier.md
+++ b/docs/benchmarks/context-efficiency-frontier.md
@@ -1,5 +1,11 @@
 # Entroly Context Efficiency Frontier
 
+> Historical protocol v1. The first calibration run exposed weaknesses in the
+> scoring, missing-usage, and small-sample rules. This file is preserved as the
+> preregistration record and is superseded for future experiments by
+> [protocol v2](context-efficiency-frontier-v2.md). No v1 observation is
+> retroactively presented as if it had been collected under v2.
+
 The Context Efficiency Frontier (CEF) measures whether a context-control system
 reduces model input while preserving task outcomes. It does not treat token
 savings alone as a product win.

--- a/docs/research/context-efficiency-evaluation-2026.md
+++ b/docs/research/context-efficiency-evaluation-2026.md
@@ -1,0 +1,145 @@
+# Context-efficiency evaluation: research map and design consequences
+
+Date reviewed: 2026-09-02
+
+This is a scoped, reproducible literature map, not a claim to have enumerated
+every paper published by arXiv, ICLR, ICML, NeurIPS, ACL, or EMNLP. The review
+targets work that can change Entroly's benchmark design: long-context
+evaluation, retrieval and prompt compression, agent task validity, inference
+cost, and finite-sample uncertainty. Primary papers, official benchmark sites,
+and official repositories are preferred over summaries.
+
+## Conclusions that change the benchmark
+
+### Long context is not one construct
+
+LongBench v2 spans multiple reasoning categories and input lengths rather than
+treating context length as the task. HELMET reports that synthetic
+needle-in-a-haystack performance does not reliably predict application
+performance. RULER adds multi-needle retrieval, tracing, aggregation, and QA,
+while NoLiMa reduces lexical overlap between questions and relevant passages.
+
+Design consequence: Entroly cannot support a general quality claim with one
+HotpotQA slice. The evidence suite must report retrieval, aggregation,
+multi-hop QA, weak-lexical-cue retrieval, repository tasks, tool use, and
+growing sessions independently. Synthetic needles remain diagnostics.
+
+Sources: [LongBench v2](https://arxiv.org/abs/2412.15204),
+[HELMET](https://arxiv.org/abs/2410.02694),
+[RULER](https://arxiv.org/abs/2404.06654), and
+[NoLiMa](https://openreview.net/forum?id=A0Ajt0YQEU).
+
+### Position and length can create hidden regressions
+
+Lost in the Middle shows that answer position within a long prompt can
+materially change model performance. Reported maximum context length therefore
+does not establish effective use of information throughout that context.
+
+Design consequence: freeze and publish context-length and evidence-position
+strata. A compressor must not be evaluated only on short examples or examples
+whose answer is near a favored boundary. The existing `shortest-context`
+selection is explicitly a smoke calibration and cannot produce a public pass.
+
+Source: [Lost in the Middle](https://arxiv.org/abs/2307.03172).
+
+### Compression quality is task- and method-dependent
+
+LongLLMLingua uses question-aware coarse-to-fine compression and addresses
+information position. LLMLingua-2 frames compression as token classification
+trained from distilled data. Comparative prompt-compression research reports
+that simple extractive strategies can be strong and that downstream effects
+vary by task.
+
+Design consequence: compare at matched active-token budgets, name the exact
+competitor version and configuration, retain loss cases, and avoid treating
+compression ratio as the dependent variable. Frozen extractive and algorithmic
+baselines are required alongside raw context; learned baselines require pinned
+weights and inference settings.
+
+Sources: [LongLLMLingua](https://arxiv.org/abs/2310.06839),
+[LLMLingua-2](https://arxiv.org/abs/2403.12968), and
+[Characterizing Prompt Compression Methods](https://openreview.net/forum?id=Y3FjKSsfmy).
+
+### Real agent success needs executable oracles
+
+SWE-bench evaluates patches against repository tests. SWE-bench Verified uses
+a human-filtered subset, while Terminal-Bench 2.0 uses real terminal tasks and
+task verifiers. These are closer to buyer value than a model judging its own
+summary.
+
+Design consequence: the repository and terminal gauntlets use pinned execution
+environments and executable success checks. Token savings are secondary to
+resolved-task rate and cost per resolved task. Model-judged quality is not a
+replacement for tests where tests exist.
+
+Sources: [SWE-bench paper](https://arxiv.org/abs/2310.06770),
+[SWE-bench Verified](https://www.swebench.com/verified.html), and
+[Terminal-Bench 2.0](https://arxiv.org/abs/2601.11868).
+
+### More tokens are not equivalent to more value
+
+Recent analysis of agentic coding traces reports large token-consumption
+variation for the same tasks and does not find that higher consumption
+necessarily produces higher accuracy. AI-tokenomics work separately models
+token expenditure and economic value, including hidden reasoning expenditure.
+
+Design consequence: record input, cached input, reasoning, and output usage
+separately when the provider exposes them. The primary economic quantity is
+total observed cost divided by successful tasks, reported beside success and
+harm—not tokens removed. Provider usage that is missing remains missing.
+
+Sources: [How Do AI Agents Spend Your Money?](https://arxiv.org/abs/2604.22750)
+and [AI Tokenomics](https://arxiv.org/abs/2606.24616).
+
+### A narrow bootstrap does not bound unseen harm
+
+Resampling the observed pairs estimates uncertainty in an observed mean under
+its assumptions. If all observed differences are identical, a percentile
+bootstrap can collapse even when the sample is too small to rule out a
+meaningful future regression rate. Work on confidence sequences and bounded
+means also makes clear that optional stopping and repeated inspection require
+explicit treatment.
+
+Design consequence: v2 keeps paired bootstrap intervals as descriptive effect
+summaries and adds exact one-sided binomial bounds for task regression,
+evidence regression, unsupported-claim regression, and context-win rates.
+Bonferroni correction controls the declared family of four primary gates. Runs
+must be frozen before observation; sequential stopping requires a separately
+specified anytime-valid design.
+
+Sources: [Time-uniform confidence sequences](https://arxiv.org/abs/1810.08240),
+[Estimating bounded means by betting](https://arxiv.org/abs/2010.09686), and
+[Anytime-valid inference for count data](https://arxiv.org/abs/2302.10108).
+
+## Implemented now
+
+- Trial/report schema v2 and canonical experiment-configuration binding.
+- Official LongBench HotpotQA F1 normalization, pinned to repository revision
+  and scorer-file digest.
+- Separate fractional score, binary task success, evidence retention, and
+  unsupported-output fields.
+- Honest labeling of the initial answer-only grounding signal as a conservative
+  lexical proxy rather than a semantic factuality oracle.
+- Preflight proof that reference answer evidence exists in raw context.
+- Missing usage/cost indicators; unknown measurements cannot become zeros in
+  efficiency means or Pareto claims.
+- Cost per successful task.
+- Exact task-level risk bounds with a familywise error policy and explicit
+  claim blockers.
+- Stable, non-plaintext error fingerprints.
+- Historical v1 preservation and explicit v2 post-pilot status.
+
+## Still required before a broad public claim
+
+- Freeze a representative held-out manifest with length and answer-position
+  strata; do not use the shortest-context calibration sample.
+- Add official adapters for LongBench v2/HELMET, RULER, and NoLiMa.
+- Add executable SWE-bench Verified and Terminal-Bench 2.0 conditions with
+  pinned containers.
+- Add frozen external/algorithmic baselines at matched active-token budgets.
+- Add repeated-run, task-clustered analysis for stochastic agents.
+- Run at least the sample size required by the declared harm bounds, then
+  publish every failure and workload-specific non-pass.
+- Obtain independent reproduction. Internal evidence can establish a result;
+  third-party reproduction is what makes it credible beyond Entroly's own
+  repository.

--- a/tests/test_context_efficiency_frontier.py
+++ b/tests/test_context_efficiency_frontier.py
@@ -5,6 +5,7 @@ import hashlib
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator
 
 from benchmarks.context_efficiency_frontier import (
     CONDITIONS,
@@ -14,7 +15,9 @@ from benchmarks.context_efficiency_frontier import (
     USAGE_SOURCES,
     Trial,
     analyze_frontier,
+    clopper_pearson_upper,
     load_trials,
+    zero_event_sample_size,
 )
 from benchmarks.context_efficiency_report import render_markdown
 
@@ -40,8 +43,13 @@ def _record(task: int, condition: str, **overrides):
         "condition": condition,
         "scorer": "exact-match-v1",
         "task_score": 1.0,
+        "task_success": True,
         "evidence_recall": 1.0,
         "unsupported_claim_rate": 0.0,
+        "experiment_config": '{"fixture":"v2"}',
+        "usage_observed": True,
+        "cost_observed": True,
+        "error_fingerprint": None,
         "context_tokens": 1_000 if condition == "raw" else 400,
         "reasoning_tokens": 100,
         "output_tokens": 50,
@@ -56,18 +64,21 @@ def _record(task: int, condition: str, **overrides):
 def test_frontier_reports_paired_quality_preserving_win():
     trials = [
         Trial.from_dict(_record(task, condition))
-        for task in range(8)
+        for task in range(100)
         for condition in ("raw", "entroly")
     ]
 
-    report = analyze_frontier(trials, bootstrap_samples=200, seed=7)
+    report = analyze_frontier(
+        trials, bootstrap_samples=200, seed=7
+    )
     comparison = report["comparisons_to_raw"]["entroly"]
 
-    assert report["pair_count"] == 8
+    assert report["pair_count"] == 100
     assert comparison["mean_quality_delta"] == 0.0
     assert comparison["mean_context_reduction"] == 0.6
     assert comparison["mean_billed_cost_reduction"] == 0.5
     assert comparison["quality_preserving_context_win"] is True
+    assert comparison["claim_status"] == "pass"
     assert report["pareto_frontier"] == ["entroly"]
     assert report["provenance"]["usage_sources"] == ["deterministic_fixture"]
 
@@ -78,7 +89,13 @@ def test_frontier_refuses_to_call_context_savings_a_quality_win():
         for task in range(6)
     ] + [
         Trial.from_dict(
-            _record(task, "entroly", task_score=0.8, evidence_recall=0.8)
+            _record(
+                task,
+                "entroly",
+                task_score=0.8,
+                task_success=False,
+                evidence_recall=0.8,
+            )
         )
         for task in range(6)
     ]
@@ -119,6 +136,10 @@ def test_error_trial_can_record_zero_provider_usage():
         task_score=0.0,
         evidence_recall=0.0,
         unsupported_claim_rate=1.0,
+        task_success=False,
+        usage_observed=False,
+        cost_observed=False,
+        error_fingerprint="a" * 64,
         response_text=None,
         response_sha256=None,
     )
@@ -127,6 +148,7 @@ def test_error_trial_can_record_zero_provider_usage():
 
     assert trial.outcome == "error"
     assert trial.context_tokens == 0
+    assert trial.usage_observed is False
 
 
 def test_success_trial_rejects_error_metadata_and_zero_context():
@@ -186,19 +208,36 @@ def test_load_trials_reports_the_invalid_line(tmp_path):
 def test_public_report_exposes_pass_rule_and_caveats():
     trials = [
         Trial.from_dict(_record(task, condition))
-        for task in range(4)
+        for task in range(100)
         for condition in ("raw", "entroly")
     ]
     report = analyze_frontier(trials, bootstrap_samples=50)
 
     markdown = render_markdown(report)
 
-    assert "| entroly | 4 |" in markdown
+    assert "| entroly | 100 |" in markdown
     assert "**PASS**" in markdown
-    assert "95% paired-bootstrap bounds" in markdown
+    assert "exact one-sided risk bounds" in markdown
     assert "Usage sources: deterministic_fixture" in markdown
     assert "Cost source references: fixture://zero-cost" in markdown
     assert "Context Commit IDs prove artifact integrity" in markdown
+
+
+def test_public_report_marks_small_runs_as_smoke_only():
+    trials = [
+        Trial.from_dict(_record(task, condition))
+        for task in range(2)
+        for condition in ("raw", "entroly")
+    ]
+
+    report = analyze_frontier(trials, bootstrap_samples=20)
+    comparison = report["comparisons_to_raw"]["entroly"]
+    markdown = render_markdown(report)
+
+    assert comparison["claim_status"] == "insufficient_data"
+    assert comparison["quality_preserving_context_win"] is False
+    assert "**SMOKE ONLY**" in markdown
+    assert "Minimum pairs for a public claim: 20" in markdown
 
 
 def test_public_report_rejects_unknown_schema():
@@ -219,3 +258,69 @@ def test_public_json_schema_matches_python_trial_contract():
     assert tuple(schema["properties"]["usage_source"]["enum"]) == USAGE_SOURCES
     assert tuple(schema["properties"]["cost_source"]["enum"]) == COST_SOURCES
     assert tuple(schema["properties"]["outcome"]["enum"]) == OUTCOMES
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    validator.validate(_record(1, "raw"))
+    validator.validate(
+        _record(
+            1,
+            "entroly",
+            outcome="error",
+            error_type="TimeoutError",
+            task_score=0.0,
+            task_success=False,
+            context_tokens=0,
+            reasoning_tokens=0,
+            output_tokens=0,
+            billed_cost_usd=0.0,
+            usage_observed=False,
+            cost_observed=False,
+            error_fingerprint="c" * 64,
+            response_text=None,
+            response_sha256=None,
+        )
+    )
+
+
+def test_exact_zero_event_bound_exposes_small_sample_uncertainty():
+    assert clopper_pearson_upper(0, 20, alpha=0.05) == pytest.approx(
+        0.139108, abs=1e-6
+    )
+    assert zero_event_sample_size(upper_rate=0.05, alpha=0.0125) == 86
+
+
+def test_missing_usage_blocks_efficiency_claim_instead_of_counting_as_zero():
+    trials = [Trial.from_dict(_record(1, "raw"))]
+    trials.append(
+        Trial.from_dict(
+            _record(
+                1,
+                "entroly",
+                outcome="error",
+                error_type="TimeoutError",
+                task_score=0.0,
+                task_success=False,
+                unsupported_claim_rate=0.0,
+                context_tokens=0,
+                reasoning_tokens=0,
+                output_tokens=0,
+                billed_cost_usd=0.0,
+                usage_observed=False,
+                cost_observed=False,
+                error_fingerprint="b" * 64,
+                response_text=None,
+                response_sha256=None,
+            )
+        )
+    )
+
+    report = analyze_frontier(
+        trials, bootstrap_samples=20, minimum_claim_pairs=1
+    )
+    aggregate = report["aggregates"]["entroly"]
+    comparison = report["comparisons_to_raw"]["entroly"]
+
+    assert aggregate["mean_context_tokens"] is None
+    assert aggregate["mean_billed_cost_usd"] is None
+    assert comparison["mean_context_reduction"] is None
+    assert comparison["claim_status"] == "measurement_incomplete"

--- a/tests/test_context_efficiency_openai.py
+++ b/tests/test_context_efficiency_openai.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from benchmarks.context_efficiency_frontier import analyze_frontier, load_trials
 from benchmarks.context_efficiency_openai import (
     DEFAULT_MODEL,
+    LONG_BENCH_METRICS_SHA256,
+    SCORER,
     ProviderConfig,
     WorkloadItem,
     call_openai,
+    normalize_answer,
+    qa_f1_score,
     run_trials,
+    select_longbench_rows,
 )
 
 
@@ -73,6 +80,43 @@ def test_call_openai_captures_provider_usage_and_request_id():
     assert client.fake_completions.requests[0]["temperature"] == 0
 
 
+def test_call_openai_forwards_explicit_reasoning_configuration():
+    client = _client([_response("ORCHID-17", "chatcmpl_reasoning", 123)])
+
+    call_openai(
+        client,
+        model="gemini-2.5-flash",
+        context="The launch code is ORCHID-17.",
+        question="What is the launch code?",
+        max_output_tokens=80,
+        reasoning_effort="none",
+    )
+
+    request = client.fake_completions.requests[0]
+    assert request["max_tokens"] == 80
+    assert request["reasoning_effort"] == "none"
+
+
+def test_shortest_context_selection_is_deterministic_and_explicitly_biased():
+    rows = [
+        {"context": "long context", "question": "q3"},
+        {"context": "x", "question": "q1"},
+        {"context": "medium", "question": "q2"},
+    ]
+
+    selected = select_longbench_rows(rows, 2, "shortest-context")
+
+    assert [row["context"] for row in selected] == ["x", "medium"]
+    assert select_longbench_rows(rows, 2, "random") == rows[:2]
+
+
+def test_longbench_hotpotqa_scorer_matches_official_normalization_and_f1():
+    assert normalize_answer("The, ORCHID-17!") == "orchid17"
+    assert qa_f1_score("Alpha Beta", "the alpha beta gamma") == 0.8
+    assert "longbench-v1-hotpotqa-official-qa-f1" in SCORER
+    assert len(LONG_BENCH_METRICS_SHA256) == 64
+
+
 def test_run_trials_writes_complete_auditable_matrix(tmp_path):
     output = tmp_path / "trials.jsonl"
     client = _client(
@@ -96,6 +140,11 @@ def test_run_trials_writes_complete_auditable_matrix(tmp_path):
     entroly = next(trial for trial in loaded if trial.condition == "entroly")
     assert entroly.context_commit_id and entroly.context_commit_id.startswith("ctx_")
     assert entroly.usage_source == "provider_response"
+    assert entroly.usage_observed is True
+    assert entroly.cost_observed is True
+    assert entroly.task_success is True
+    assert entroly.scorer == SCORER
+    assert '"selection_policy":"preselected"' in entroly.experiment_config
     assert "2026-07-11" in entroly.cost_source_reference
     assert "input-0.15" in entroly.cost_source_reference
     assert list(output.parent.glob("trials_context_commits/*.json"))
@@ -126,6 +175,28 @@ def test_run_trials_keeps_provider_errors_as_zero_score_outcomes(tmp_path):
     assert error["task_score"] == 0.0
     assert error["context_tokens"] == 0
     assert error["error_type"] == "TimeoutError"
+    assert error["usage_observed"] is False
+    assert error["cost_observed"] is False
+    assert len(error["error_fingerprint"]) == 64
+
+
+def test_run_trials_refuses_tasks_without_answer_evidence_before_calling_provider(
+    tmp_path,
+):
+    output = tmp_path / "trials.jsonl"
+    client = _client([])
+    item = WorkloadItem(
+        task_id="missing-evidence",
+        context="Only distractors are present.",
+        question="What is the launch code?",
+        answers=("ORCHID-17",),
+    )
+
+    with pytest.raises(ValueError, match="raw context does not contain"):
+        run_trials(items=[item], client=client, output=output)
+
+    assert not output.exists()
+    assert client.fake_completions.requests == []
 
 
 def test_resume_does_not_rebill_completed_conditions(tmp_path):


### PR DESCRIPTION
## Outcome

Hardens the Context Efficiency Frontier so Entroly cannot turn small samples, provider failures, or non-official scoring into a public efficiency claim.

## What changes

- upgrades trial and report contracts to v2
- pins the official LongBench HotpotQA scorer to an exact upstream revision and metrics digest
- separates fractional task score, binary task success, evidence retention, and the conservative answer-only grounding proxy
- binds prompt, decoding, selection, budget, scorer, model, and pricing configuration into paired identity
- treats missing provider usage and cost as unobserved, never as zero-token or free inference
- reports cost per successful task
- adds exact one-sided Clopper-Pearson task-level risk bounds with Bonferroni familywise correction
- preserves protocol v1 and labels v2 honestly as a post-pilot revision
- adds a primary-research map and an explicit multi-workload path toward publishable evidence

## Falsification evidence

A local two-task v2 calibration was intentionally not committed as a headline result. It observed lower prompt usage but also detected an Entroly unsupported-output-proxy regression. The generated result remained `SMOKE ONLY`, demonstrating that the new gates retain loss cases rather than manufacturing a win.

Under the default simultaneous risk policy, zero observed regressions require at least 86 independent task pairs; the minimum 20-pair label alone cannot produce `PASS`.

## Verification

- `47 passed` across Context Efficiency, claim-honesty, and search-discovery tests after merging current main
- `31 passed` across neighboring benchmark/claim/compression suites before the main sync
- Ruff passed
- `cargo clippy --all-targets -- -D warnings` pre-push gate passed
- `cargo test --lib`: 112 passed, 5 ignored, 0 failed
- staged diff was checked for key-like strings; none were present

## Limits

This PR is benchmark infrastructure and protocol, not evidence that Entroly is universally best. It does not add a README ranking claim. A public generic superiority claim remains blocked on representative held-out workloads, serious frozen baselines, sufficient independent task counts, complete usage provenance, and publication of every failure.