### PR TITLE
Add frozen external-baseline benchmark matrix

### DIFF
--- a/benchmarks/context_efficiency_baseline.py
+++ b/benchmarks/context_efficiency_baseline.py
@@ -1,0 +1,117 @@
+"""Build frozen, auditable baseline manifests for context-efficiency trials.
+
+The built-in head-tail baseline is a transparent calibration control, not a
+state-of-the-art competitor. The same manifest contract accepts outputs from
+version-pinned external systems without importing them into Entroly's runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from benchmarks.context_efficiency_openai import _load_longbench
+
+BASELINE_SCHEMA_VERSION = "entroly.context-efficiency-baseline.v1"
+HEAD_TAIL_VERSION = "head-tail-o200k-v1"
+HEAD_TAIL_MARKER = "\n\n[... frozen head-tail baseline omission ...]\n\n"
+
+
+def head_tail_context(text: str, *, token_budget: int, encoding: Any) -> str:
+    """Retain equal token slices from both boundaries under an exact token cap."""
+    if token_budget < 8:
+        raise ValueError("token_budget must be at least 8")
+    tokens = encoding.encode(text)
+    if len(tokens) <= token_budget:
+        return text
+    marker_tokens = encoding.encode(HEAD_TAIL_MARKER)
+    retained_budget = token_budget - len(marker_tokens)
+    if retained_budget < 2:
+        raise ValueError("token_budget is too small for the omission marker")
+    head_size = retained_budget // 2
+    tail_size = retained_budget - head_size
+    selected = (
+        encoding.decode(tokens[:head_size])
+        + HEAD_TAIL_MARKER
+        + encoding.decode(tokens[-tail_size:])
+    )
+    if len(encoding.encode(selected)) > token_budget:
+        raise RuntimeError("head-tail baseline exceeded its declared token budget")
+    return selected
+
+
+def build_head_tail_manifest(
+    *, items: list[Any], token_budget: int, encoding: Any, implementation_sha256: str
+) -> dict[str, Any]:
+    tasks = []
+    for item in items:
+        selected = head_tail_context(
+            item.context, token_budget=token_budget, encoding=encoding
+        )
+        tasks.append(
+            {
+                "task_id": item.task_id,
+                "source_context_sha256": hashlib.sha256(
+                    item.context.encode("utf-8")
+                ).hexdigest(),
+                "selected_context": selected,
+                "selected_context_sha256": hashlib.sha256(
+                    selected.encode("utf-8")
+                ).hexdigest(),
+            }
+        )
+    return {
+        "schema_version": BASELINE_SCHEMA_VERSION,
+        "condition": "algorithmic_baseline",
+        "baseline": {
+            "name": "frozen head-tail truncation",
+            "version": HEAD_TAIL_VERSION,
+            "source": "benchmarks/context_efficiency_baseline.py",
+            "config": {
+                "head_fraction": 0.5,
+                "implementation_sha256": implementation_sha256,
+                "token_budget": token_budget,
+                "tokenizer": "tiktoken:o200k_base",
+            },
+        },
+        "tasks": tasks,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, required=True)
+    parser.add_argument(
+        "--selection", choices=("random", "shortest-context"), default="random"
+    )
+    parser.add_argument("--budget", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.samples < 1:
+        parser.error("--samples must be positive")
+    if args.output.exists():
+        parser.error(f"{args.output} already exists")
+
+    import tiktoken
+
+    items = _load_longbench(args.samples, args.selection)
+    implementation_path = Path(__file__)
+    manifest = build_head_tail_manifest(
+        items=items,
+        token_budget=args.budget,
+        encoding=tiktoken.get_encoding("o200k_base"),
+        implementation_sha256=hashlib.sha256(implementation_path.read_bytes()).hexdigest(),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote {args.output} with {len(items)} frozen baseline tasks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/context_efficiency_baseline.schema.json
+++ b/benchmarks/context_efficiency_baseline.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://entroly.com/schemas/context-efficiency-baseline.v1.json",
+  "title": "Entroly Context Efficiency Frozen Baseline",
+  "description": "Exact precomputed contexts from one frozen algorithmic or external baseline.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "condition",
+    "baseline",
+    "tasks"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "entroly.context-efficiency-baseline.v1"
+    },
+    "condition": {
+      "enum": [
+        "algorithmic_baseline",
+        "external_baseline"
+      ]
+    },
+    "baseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "source",
+        "config"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "config": {
+          "type": "object",
+          "minProperties": 1
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "task_id",
+          "source_context_sha256",
+          "selected_context",
+          "selected_context_sha256"
+        ],
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_context_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "selected_context": {
+            "type": "string",
+            "minLength": 1
+          },
+          "selected_context_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/context_efficiency_frontier.py
+++ b/benchmarks/context_efficiency_frontier.py
@@ -24,7 +24,14 @@ FAMILYWISE_ALPHA = 0.05
 MAX_REGRESSION_RATE = 0.05
 MINIMUM_CONTEXT_WIN_RATE = 0.5
 PRIMARY_RISK_GATES = 4
-CONDITIONS = ("raw", "native_compaction", "entroly", "combined")
+CONDITIONS = (
+    "raw",
+    "algorithmic_baseline",
+    "external_baseline",
+    "native_compaction",
+    "entroly",
+    "combined",
+)
 USAGE_SOURCES = (
     "provider_response",
     "provider_log",
@@ -610,9 +617,18 @@ def analyze_frontier(
         )
         has_enough_pairs = len(paired_rows) >= minimum_claim_pairs
         usage_complete = len(usage_pairs) == len(paired_rows)
+        dirty_entroly_runtime = any(
+            json.loads(candidate.experiment_config)
+            .get("entroly_runtime", {})
+            .get("entroly_git_dirty")
+            is True
+            for _, candidate in paired_rows
+        )
         blockers: list[str] = []
         if not has_enough_pairs:
             blockers.append("below_minimum_pair_count")
+        if dirty_entroly_runtime:
+            blockers.append("dirty_entroly_runtime")
         if not usage_complete:
             blockers.append("incomplete_usage_observation")
         if has_enough_pairs and not exact_risk_bounds_pass:
@@ -621,6 +637,8 @@ def analyze_frontier(
             blockers.append("paired_effect_bounds_not_met")
         if not has_enough_pairs:
             claim_status = "insufficient_data"
+        elif dirty_entroly_runtime:
+            claim_status = "non_publishable_runtime"
         elif not usage_complete:
             claim_status = "measurement_incomplete"
         elif not exact_risk_bounds_pass:
@@ -731,6 +749,7 @@ def analyze_frontier(
             "Runs below the minimum pair count are smoke tests and cannot produce a public PASS claim.",
             "Percentile-bootstrap effect intervals are descriptive; PASS additionally requires finite-sample exact binomial risk bounds.",
             "Missing provider usage blocks an efficiency claim instead of being interpreted as zero tokens.",
+            "A dirty Entroly Git worktree is calibration-only and blocks a public PASS claim.",
         ],
     }
 

--- a/benchmarks/context_efficiency_openai.py
+++ b/benchmarks/context_efficiency_openai.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.metadata
 import json
 import os
 import random
 import re
 import string
+import subprocess
 import time
 from collections import Counter
 from dataclasses import dataclass
@@ -84,6 +86,25 @@ class ProviderConfig:
     output_usd_per_million: float
 
 
+@dataclass(frozen=True)
+class FrozenBaseline:
+    condition: str
+    name: str
+    version: str
+    source: str
+    manifest_sha256: str
+    contexts: dict[str, str]
+
+    def experiment_identity(self) -> dict[str, str]:
+        return {
+            "condition": self.condition,
+            "manifest_sha256": self.manifest_sha256,
+            "name": self.name,
+            "source": self.source,
+            "version": self.version,
+        }
+
+
 OPENAI_PROVIDER = ProviderConfig(
     name="openai",
     cost_source="pricing_snapshot",
@@ -99,6 +120,173 @@ def _stable_digest(payload: object) -> str:
         payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source_tree_digest(root: Path) -> str:
+    entries = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or "__pycache__" in path.parts or path.suffix == ".pyc":
+            continue
+        entries.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "sha256": _file_digest(path),
+            }
+        )
+    return _stable_digest(entries)
+
+
+def _git_value(root: Path, *arguments: str) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", str(root), *arguments],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+    value = result.stdout.strip()
+    return value if result.returncode == 0 and value else None
+
+
+def entroly_runtime_identity() -> dict[str, Any]:
+    """Bind every trial to the source and native implementation actually loaded."""
+    import entroly
+
+    package_root = Path(entroly.__file__).resolve().parent
+    repository_root_text = _git_value(package_root, "rev-parse", "--show-toplevel")
+    repository_root = Path(repository_root_text) if repository_root_text else None
+    git_status = (
+        _git_value(repository_root, "status", "--porcelain=v1", "--untracked-files=all")
+        if repository_root
+        else None
+    )
+    native_version: str | None
+    native_artifacts_sha256: str | None = None
+    try:
+        native_version = importlib.metadata.version("entroly-core")
+        import entroly_core
+
+        native_module = Path(entroly_core.__file__).resolve()
+        native_root = native_module.parent
+        native_artifacts = sorted(
+            path
+            for path in native_root.rglob("*")
+            if path.is_file() and path.suffix in {".dylib", ".pyd", ".so"}
+        )
+        if native_module.suffix in {".dylib", ".pyd", ".so"}:
+            native_artifacts = sorted(set(native_artifacts) | {native_module})
+        if native_artifacts:
+            native_artifacts_sha256 = _stable_digest(
+                [
+                    {
+                        "path": path.relative_to(native_root).as_posix(),
+                        "sha256": _file_digest(path),
+                    }
+                    for path in native_artifacts
+                ]
+            )
+    except (ImportError, importlib.metadata.PackageNotFoundError):
+        native_version = None
+
+    return {
+        "benchmark_frontier_sha256": _file_digest(
+            Path(__file__).with_name("context_efficiency_frontier.py")
+        ),
+        "benchmark_runner_sha256": _file_digest(Path(__file__)),
+        "entroly_git_dirty": bool(git_status),
+        "entroly_git_revision": (
+            _git_value(repository_root, "rev-parse", "HEAD")
+            if repository_root
+            else None
+        ),
+        "entroly_git_status_sha256": (
+            hashlib.sha256(git_status.encode("utf-8")).hexdigest()
+            if git_status
+            else None
+        ),
+        "entroly_package_version": getattr(entroly, "__version__", None),
+        "entroly_python_source_sha256": _source_tree_digest(package_root),
+        "native_artifacts_sha256": native_artifacts_sha256,
+        "native_distribution_version": native_version,
+    }
+
+
+def _manifest_text(payload: dict[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"baseline manifest {name} must be a non-empty string")
+    return value.strip()
+
+
+def load_frozen_baseline(
+    path: Path, items: Iterable[WorkloadItem]
+) -> FrozenBaseline:
+    """Validate exact precomputed contexts from an algorithmic or external baseline."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot load baseline manifest {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError("baseline manifest must be a JSON object")
+    if payload.get("schema_version") != "entroly.context-efficiency-baseline.v1":
+        raise ValueError("unsupported baseline manifest schema_version")
+    condition = _manifest_text(payload, "condition")
+    if condition not in {"algorithmic_baseline", "external_baseline"}:
+        raise ValueError(
+            "baseline manifest condition must be algorithmic_baseline or "
+            "external_baseline"
+        )
+    baseline = payload.get("baseline")
+    if not isinstance(baseline, dict):
+        raise ValueError("baseline manifest baseline must be an object")
+    name = _manifest_text(baseline, "name")
+    version = _manifest_text(baseline, "version")
+    source = _manifest_text(baseline, "source")
+    config = baseline.get("config")
+    if not isinstance(config, dict) or not config:
+        raise ValueError("baseline manifest config must be a non-empty object")
+    rows = payload.get("tasks")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("baseline manifest tasks must be a non-empty array")
+
+    materialized = list(items)
+    expected = {item.task_id: item for item in materialized}
+    contexts: dict[str, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("each baseline task must be an object")
+        task_id = _manifest_text(row, "task_id")
+        if task_id in contexts:
+            raise ValueError(f"duplicate baseline task {task_id!r}")
+        item = expected.get(task_id)
+        if item is None:
+            raise ValueError(f"unexpected baseline task {task_id!r}")
+        source_digest = _manifest_text(row, "source_context_sha256")
+        if source_digest != hashlib.sha256(item.context.encode("utf-8")).hexdigest():
+            raise ValueError(f"baseline source digest mismatch for {task_id!r}")
+        selected = row.get("selected_context")
+        if not isinstance(selected, str) or not selected.strip():
+            raise ValueError(f"baseline selected context is empty for {task_id!r}")
+        selected_digest = _manifest_text(row, "selected_context_sha256")
+        if selected_digest != hashlib.sha256(selected.encode("utf-8")).hexdigest():
+            raise ValueError(f"baseline selected digest mismatch for {task_id!r}")
+        contexts[task_id] = selected
+
+    missing = sorted(set(expected).difference(contexts))
+    if missing:
+        raise ValueError("baseline manifest is missing tasks: " + ", ".join(missing))
+    return FrozenBaseline(
+        condition=condition,
+        name=name,
+        version=version,
+        source=source,
+        manifest_sha256=_stable_digest(payload),
+        contexts=contexts,
+    )
 
 
 def prepare_longbench_items(rows: Iterable[dict[str, Any]]) -> list[WorkloadItem]:
@@ -428,6 +616,7 @@ def run_trials(
     max_output_tokens: int = 64,
     reasoning_effort: str | None = None,
     selection_policy: str = "preselected",
+    frozen_baseline: FrozenBaseline | None = None,
 ) -> list[Trial]:
     if token_budget < 1:
         raise ValueError("token_budget must be positive")
@@ -450,6 +639,7 @@ def run_trials(
             "cost_source": provider.cost_source,
             "cost_source_reference": provider.cost_source_reference,
             "input_usd_per_million": provider.input_usd_per_million,
+            "entroly_runtime": entroly_runtime_identity(),
             "longbench_metrics_sha256": LONG_BENCH_METRICS_SHA256,
             "longbench_revision": LONG_BENCH_REVISION,
             "max_output_tokens": max_output_tokens,
@@ -463,6 +653,9 @@ def run_trials(
             ).hexdigest(),
             "temperature": 0,
             "token_budget": token_budget,
+            "frozen_baseline": (
+                frozen_baseline.experiment_identity() if frozen_baseline else None
+            ),
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -486,6 +679,8 @@ def run_trials(
     rng = random.Random(seed)
     for index, item in enumerate(items, 1):
         conditions = ["raw", "entroly"]
+        if frozen_baseline is not None:
+            conditions.append(frozen_baseline.condition)
         rng.shuffle(conditions)
         for condition in conditions:
             if (item.task_id, condition) in completed:
@@ -513,6 +708,8 @@ def run_trials(
                         json.dumps(commit, indent=2, sort_keys=True) + "\n",
                         encoding="utf-8",
                     )
+                elif frozen_baseline is not None and condition == frozen_baseline.condition:
+                    selected_context = frozen_baseline.contexts[item.task_id]
                 provider_started = time.perf_counter()
                 observation = call_openai(
                     client,
@@ -608,6 +805,11 @@ def main() -> int:
     parser.add_argument("--output-usd-per-million", type=float)
     parser.add_argument("--max-output-tokens", type=int, default=64)
     parser.add_argument(
+        "--frozen-baseline-manifest",
+        type=Path,
+        help="Validated JSON manifest of exact algorithmic or external baseline contexts.",
+    )
+    parser.add_argument(
         "--reasoning-effort",
         choices=("none", "minimal", "low", "medium", "high"),
     )
@@ -654,6 +856,11 @@ def main() -> int:
         provider = OPENAI_PROVIDER
 
     items = _load_longbench(args.samples, args.selection)
+    frozen_baseline = (
+        load_frozen_baseline(args.frozen_baseline_manifest, items)
+        if args.frozen_baseline_manifest
+        else None
+    )
     trials = run_trials(
         items=items,
         client=client,
@@ -666,6 +873,7 @@ def main() -> int:
         max_output_tokens=args.max_output_tokens,
         reasoning_effort=args.reasoning_effort,
         selection_policy=args.selection,
+        frozen_baseline=frozen_baseline,
     )
     report = analyze_frontier(trials)
     report_path = args.output.with_suffix(".report.json")

--- a/benchmarks/context_efficiency_report.py
+++ b/benchmarks/context_efficiency_report.py
@@ -100,6 +100,7 @@ def render_markdown(report: dict[str, Any]) -> str:
                     "no_claim": "NO CLAIM",
                     "insufficient_data": "SMOKE ONLY",
                     "measurement_incomplete": "MEASUREMENT INCOMPLETE",
+                    "non_publishable_runtime": "NON-PUBLISHABLE RUNTIME",
                     "insufficient_precision": "INSUFFICIENT PRECISION",
                 }[comparison["claim_status"]],
             )

--- a/benchmarks/context_efficiency_trial.schema.json
+++ b/benchmarks/context_efficiency_trial.schema.json
@@ -128,6 +128,8 @@
     "condition": {
       "enum": [
         "raw",
+        "algorithmic_baseline",
+        "external_baseline",
         "native_compaction",
         "entroly",
         "combined"

--- a/docs/benchmarks/context-efficiency-frontier-v2.md
+++ b/docs/benchmarks/context-efficiency-frontier-v2.md
@@ -39,6 +39,8 @@ Every task-replicate contains the same condition matrix:
 | Condition | Behavior |
 |---|---|
 | `raw` | Complete, unmodified task context; required baseline. |
+| `algorithmic_baseline` | Frozen deterministic baseline, with its implementation and configuration digest bound into the manifest. |
+| `external_baseline` | Frozen third-party output manifest, including source version and exact per-task context hashes. |
 | `native_compaction` | Only documented model or agent compaction. |
 | `entroly` | Entroly context selection with native compaction disabled when controllable. |
 | `combined` | Entroly plus documented native compaction. |
@@ -51,9 +53,44 @@ scorer dependency digest, and pricing configuration. Entroly and combined
 trials also require the exact
 `ctx_...` Context Commit ID.
 
+Every run also binds the loaded Entroly package version, Git revision and dirty
+status digest, a digest of the Python package source tree, hashes of the
+benchmark runner and analyzer, and the installed native distribution and binary
+digest when present. A source change or pure-Python/native runtime change thus
+creates a different pair identity instead of silently pooling incompatible
+observations. Publishable runs must use a clean frozen revision; dirty identities
+are permitted only for calibration and development.
+
 Condition order is randomized within each task. Task sampling is fixed before
 calls begin. A `shortest-context` subset is calibration-only and must be labeled
 `SMOKE ONLY`; it cannot support a public product claim.
+
+Frozen competitor outputs use
+[`context_efficiency_baseline.schema.json`](../../benchmarks/context_efficiency_baseline.schema.json).
+The runner verifies exact task coverage, original-context hashes, selected-text
+hashes, baseline identity, configuration, version, and a canonical digest of
+the complete manifest before making a provider call. This permits official
+third-party tools to run in their own locked environment without making them an
+Entroly runtime dependency. Any manifest change creates a different experiment
+identity and cannot be resumed into an older trial file.
+
+The built-in head-tail generator is a transparent algorithmic calibration
+control, not a competitive baseline:
+
+```bash
+python -m benchmarks.context_efficiency_baseline \
+  --samples 20 --selection random --budget 2000 \
+  --output runs/head-tail.json
+
+python -m benchmarks.context_efficiency_openai \
+  --samples 20 --selection random --budget 2000 \
+  --frozen-baseline-manifest runs/head-tail.json \
+  --output runs/trials.jsonl
+```
+
+A serious public comparison must additionally generate a manifest from a
+version-pinned external compressor such as LLMLingua-2 or LongLLMLingua and
+publish its model revision, package lock, configuration, and output hashes.
 
 ## Outcomes and estimands
 

--- a/tests/test_context_efficiency_frontier.py
+++ b/tests/test_context_efficiency_frontier.py
@@ -83,6 +83,29 @@ def test_frontier_reports_paired_quality_preserving_win():
     assert report["provenance"]["usage_sources"] == ["deterministic_fixture"]
 
 
+def test_dirty_entroly_runtime_blocks_a_public_pass():
+    dirty_config = json.dumps(
+        {"entroly_runtime": {"entroly_git_dirty": True}},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    trials = [
+        Trial.from_dict(
+            _record(task, condition, experiment_config=dirty_config)
+        )
+        for task in range(100)
+        for condition in ("raw", "entroly")
+    ]
+
+    report = analyze_frontier(trials, bootstrap_samples=20, seed=7)
+    comparison = report["comparisons_to_raw"]["entroly"]
+
+    assert comparison["claim_status"] == "non_publishable_runtime"
+    assert comparison["quality_preserving_context_win"] is False
+    assert "dirty_entroly_runtime" in comparison["claim_blockers"]
+    assert "NON-PUBLISHABLE RUNTIME" in render_markdown(report)
+
+
 def test_frontier_refuses_to_call_context_savings_a_quality_win():
     trials = [
         Trial.from_dict(_record(task, "raw"))

--- a/tests/test_context_efficiency_openai.py
+++ b/tests/test_context_efficiency_openai.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from jsonschema import Draft202012Validator
 
+from benchmarks.context_efficiency_baseline import build_head_tail_manifest
 from benchmarks.context_efficiency_frontier import analyze_frontier, load_trials
 from benchmarks.context_efficiency_openai import (
     DEFAULT_MODEL,
@@ -13,6 +16,7 @@ from benchmarks.context_efficiency_openai import (
     ProviderConfig,
     WorkloadItem,
     call_openai,
+    load_frozen_baseline,
     normalize_answer,
     qa_f1_score,
     run_trials,
@@ -144,7 +148,13 @@ def test_run_trials_writes_complete_auditable_matrix(tmp_path):
     assert entroly.cost_observed is True
     assert entroly.task_success is True
     assert entroly.scorer == SCORER
-    assert '"selection_policy":"preselected"' in entroly.experiment_config
+    experiment = json.loads(entroly.experiment_config)
+    assert experiment["selection_policy"] == "preselected"
+    runtime = experiment["entroly_runtime"]
+    assert runtime["entroly_package_version"]
+    assert len(runtime["entroly_python_source_sha256"]) == 64
+    assert len(runtime["benchmark_runner_sha256"]) == 64
+    assert runtime["entroly_git_revision"]
     assert "2026-07-11" in entroly.cost_source_reference
     assert "input-0.15" in entroly.cost_source_reference
     assert list(output.parent.glob("trials_context_commits/*.json"))
@@ -251,3 +261,80 @@ def test_self_hosted_provider_records_zero_api_fee_without_claiming_zero_compute
     assert {trial.provider for trial in trials} == {"ollama"}
     assert {trial.cost_source for trial in trials} == {"self_hosted_no_api_fee"}
     assert all(trial.billed_cost_usd == 0.0 for trial in trials)
+
+
+def test_frozen_algorithmic_baseline_joins_the_same_paired_matrix(tmp_path):
+    tiktoken = pytest.importorskip("tiktoken")
+
+    item = _item()
+    manifest = build_head_tail_manifest(
+        items=[item],
+        token_budget=120,
+        encoding=tiktoken.get_encoding("o200k_base"),
+        implementation_sha256="a" * 64,
+    )
+    baseline_schema = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "benchmarks/context_efficiency_baseline.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+    Draft202012Validator.check_schema(baseline_schema)
+    Draft202012Validator(baseline_schema).validate(manifest)
+    assert (
+        len(
+            tiktoken.get_encoding("o200k_base").encode(
+                manifest["tasks"][0]["selected_context"]
+            )
+        )
+        <= 120
+    )
+    manifest_path = tmp_path / "baseline.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    baseline = load_frozen_baseline(manifest_path, [item])
+    output = tmp_path / "trials.jsonl"
+    client = _client(
+        [
+            _response("ORCHID-17", "request-one", 900),
+            _response("ORCHID-17", "request-two", 500),
+            _response("ORCHID-17", "request-three", 150),
+        ]
+    )
+
+    trials = run_trials(
+        items=[item],
+        client=client,
+        output=output,
+        token_budget=120,
+        frozen_baseline=baseline,
+    )
+    report = analyze_frontier(trials, bootstrap_samples=20)
+
+    assert {trial.condition for trial in trials} == {
+        "raw",
+        "entroly",
+        "algorithmic_baseline",
+    }
+    assert set(report["comparisons_to_raw"]) == {
+        "algorithmic_baseline",
+        "entroly",
+    }
+    assert baseline.manifest_sha256 in trials[0].experiment_config
+
+
+def test_frozen_baseline_rejects_source_or_output_tampering(tmp_path):
+    tiktoken = pytest.importorskip("tiktoken")
+
+    item = _item()
+    manifest = build_head_tail_manifest(
+        items=[item],
+        token_budget=120,
+        encoding=tiktoken.get_encoding("o200k_base"),
+        implementation_sha256="a" * 64,
+    )
+    manifest["tasks"][0]["selected_context"] += " tampered"
+    path = tmp_path / "tampered.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="selected digest mismatch"):
+        load_frozen_baseline(path, [item])


### PR DESCRIPTION
## Outcome\n\nAdds an auditable third condition to the Context Efficiency Frontier:\n\nRAW -> Entroly -> frozen algorithmic/external baseline\n\nThe runner validates exact task coverage and hashes for source context, selected context, manifest, Entroly source, Git revision/status, benchmark code, package version, and native artifacts.\n\n## Safety and claim gates\n\n- the built-in head-tail baseline is labeled calibration-only, not state of the art\n- dirty Entroly worktrees can run calibration but cannot produce a public PASS\n- missing or tampered baseline tasks fail before provider calls\n- external compressors can run in separate pinned environments and enter only through a frozen manifest\n- no benchmark result or headline performance claim is added to README\n\n## Verification\n\n- 50 focused evidence/discovery tests passed\n- Ruff passed\n- pre-push Clippy passed\n- Rust library tests: 112 passed, 5 ignored, 0 failed\n- clean local 2-task calibration reproduced the three-condition matrix; it remains SMOKE ONLY and is not committed as public evidence\n\nBuilds on the evidence protocol merged in #408.