### PR TITLE
fix: surfaces that reported more than they measured

### DIFF
--- a/benchmarks/contextbench_floor.py
+++ b/benchmarks/contextbench_floor.py
@@ -11,12 +11,42 @@ Checkouts are downloaded to an external short-path root and deleted per task.
 """
 from __future__ import annotations
 
+import functools
 import os
 
 # Raise the source-size cap BEFORE any entroly import so gold-bearing large files
 # (e.g. astropy table.py = 147 KB) are indexable — a v2 protocol requirement.
-os.environ.setdefault("ENTROLY_MAX_SOURCE_FILE_BYTES", "500000")
-os.environ.setdefault("ENTROLY_MAX_FILE_BYTES", "500000")
+#
+# Applied around `main` rather than at module import. These variables are
+# process-global and `tests/test_contextbench_runner_safety.py` imports this
+# module, so setting them at import time leaked a 500,000-byte cap into every
+# test that ran afterwards in the same session: `_max_bytes_for_path` returns
+# early whenever `ENTROLY_MAX_FILE_BYTES` is set, so thousands of tests silently
+# ran against a different indexing configuration. `main` imports entroly lazily,
+# so this is still "before any entroly import" on the script path, which is what
+# the protocol requires.
+_SIZE_CAP_VARS = ("ENTROLY_MAX_SOURCE_FILE_BYTES", "ENTROLY_MAX_FILE_BYTES")
+
+
+def _with_raised_size_caps(fn):
+    """Raise the caps for the duration of the call, then restore them."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        previous = {name: os.environ.get(name) for name in _SIZE_CAP_VARS}
+        for name in _SIZE_CAP_VARS:
+            os.environ.setdefault(name, "500000")
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            for name, value in previous.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+    return wrapper
+
 
 import json  # noqa: E402
 import random  # noqa: E402
@@ -45,6 +75,7 @@ def _tokens(records) -> int:
     return sum(r.token_cost for r in records)
 
 
+@_with_raised_size_caps
 def main(tasks_json: str, co_root: str, budget: int, n: int) -> int:
     from benchmarks.contextbench_determinism_tax import (
         bm25_rank_files,

--- a/benchmarks/subfile_experiment.py
+++ b/benchmarks/subfile_experiment.py
@@ -15,6 +15,7 @@ Success criteria (not a preregistered precision target — establishing the rang
 """
 from __future__ import annotations
 
+import functools
 import hashlib
 import json
 import os
@@ -22,7 +23,32 @@ import shutil
 import sys
 import time
 
-os.environ.setdefault("ENTROLY_MAX_SOURCE_FILE_BYTES", "500000")
+# Applied around `main` rather than at module import. This variable is
+# process-global and `tests/test_contextbench_runner_safety.py` imports this
+# module, so setting it at import time leaked the raised cap into every test
+# that ran afterwards in the same session. `main` imports entroly lazily, so
+# this is still set before any entroly import on the script path.
+_SIZE_CAP_VARS = ("ENTROLY_MAX_SOURCE_FILE_BYTES",)
+
+
+def _with_raised_size_caps(fn):
+    """Raise the caps for the duration of the call, then restore them."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        previous = {name: os.environ.get(name) for name in _SIZE_CAP_VARS}
+        for name in _SIZE_CAP_VARS:
+            os.environ.setdefault(name, "500000")
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            for name, value in previous.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+    return wrapper
 
 
 def _read_py_files(
@@ -58,6 +84,7 @@ def _spans_digest(spans) -> str:
     return hashlib.sha256(blob.encode()).hexdigest()
 
 
+@_with_raised_size_caps
 def main(tasks_json: str, co_root: str, n: int, budget: int, topk: int) -> int:
     from benchmarks.contextbench_determinism_tax import file_score, line_score, parse_gold
     from benchmarks.contextbench_pilot import _download, _extract_stripped

--- a/entroly-core/src/archetype.rs
+++ b/entroly-core/src/archetype.rs
@@ -107,9 +107,19 @@ impl Fingerprint {
         }
         let denom = norm_a.sqrt() * norm_b.sqrt();
         if denom < 1e-12 {
+            // No direction, so similarity is undefined. Report none rather
+            // than dividing by zero and handing a NaN downstream.
             0.0
         } else {
-            dot / denom
+            // Clamped to the documented range. `dot / denom` is exactly 1 only
+            // in exact arithmetic: measured, `a.cosine_similarity(&a)` returns
+            // 1.0000000000000002 for ordinary fingerprints. Nothing calls this
+            // in production yet, which is the reason to fix it now -- the first
+            // caller to pass the result to `acos`, or to treat it as a
+            // probability, gets a NaN from a value the docstring promised was
+            // in range. `dedup::simhash_cosine` already clamps for the same
+            // reason.
+            (dot / denom).clamp(-1.0, 1.0)
         }
     }
 }
@@ -782,6 +792,91 @@ fn log_norm(value: f64, max_ref: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    fn fp_lcg(state: &mut u64) -> f64 {
+        *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((*state >> 33) as f64) / ((1u64 << 31) as f64) - 0.5
+    }
+
+    fn random_fp(seed: &mut u64) -> Fingerprint {
+        let mut fp = Fingerprint::zero();
+        for k in 0..FINGERPRINT_DIM {
+            fp.dims[k] = fp_lcg(seed);
+        }
+        fp
+    }
+
+    /// `distance` claims to be L2 and `cosine_similarity` claims a range.
+    /// Both are closed-form, so assert the defining properties rather than a
+    /// plausible-looking value: identity, symmetry, the triangle inequality,
+    /// and the stated range. A self-similarity that lands at 1.0000000000000002
+    /// is outside a documented `[-1, 1]` and breaks any caller that feeds it to
+    /// `acos` or treats it as a probability.
+    #[test]
+    fn fingerprint_distance_and_similarity_obey_their_definitions() {
+        let mut seed = 0xF1_2345_6789_ABCD_u64;
+
+        for case in 0..200 {
+            let a = random_fp(&mut seed);
+            let b = random_fp(&mut seed);
+            let c = random_fp(&mut seed);
+
+            // Identity and symmetry.
+            assert!(a.distance(&a).abs() < 1e-12, "case {case}: d(a,a) != 0");
+            assert!(
+                (a.distance(&b) - b.distance(&a)).abs() < 1e-12,
+                "case {case}: distance is not symmetric"
+            );
+
+            // Triangle inequality: L2 is a metric.
+            let (ab, bc, ac) = (a.distance(&b), b.distance(&c), a.distance(&c));
+            assert!(
+                ac <= ab + bc + 1e-9,
+                "case {case}: triangle inequality violated: {ac} > {ab} + {bc}"
+            );
+
+            // Cosine: symmetric, within range, and 1 against itself.
+            let sim = a.cosine_similarity(&b);
+            assert!(
+                (sim - b.cosine_similarity(&a)).abs() < 1e-12,
+                "case {case}: cosine is not symmetric"
+            );
+            assert!(
+                (-1.0..=1.0).contains(&sim),
+                "case {case}: cosine {sim} left the documented [-1, 1]"
+            );
+            let self_sim = a.cosine_similarity(&a);
+            assert!(
+                (-1.0..=1.0).contains(&self_sim),
+                "case {case}: self-similarity {self_sim} left [-1, 1]"
+            );
+            assert!(
+                (self_sim - 1.0).abs() < 1e-9,
+                "case {case}: self-similarity was {self_sim}, expected 1"
+            );
+        }
+    }
+
+    /// A zero fingerprint has no direction, so similarity is undefined. The
+    /// implementation reports 0 rather than dividing by zero; assert that
+    /// rather than leaving it to be rediscovered as a NaN downstream.
+    #[test]
+    fn a_zero_fingerprint_reports_no_similarity_instead_of_nan() {
+        let zero = Fingerprint::zero();
+        let mut seed = 0xABCD_u64;
+        let other = random_fp(&mut seed);
+
+        for value in [
+            zero.cosine_similarity(&zero),
+            zero.cosine_similarity(&other),
+            other.cosine_similarity(&zero),
+        ] {
+            assert!(value.is_finite(), "similarity against a zero vector was {value}");
+            assert_eq!(value, 0.0);
+        }
+        assert!(zero.distance(&zero).abs() < 1e-12);
+        assert!(zero.distance(&other).is_finite());
+    }
+
     use super::*;
 
     #[test]

--- a/entroly-core/src/lib.rs
+++ b/entroly-core/src/lib.rs
@@ -5220,7 +5220,29 @@ impl EntrolyEngine {
     pub fn export_fragments(&self) -> PyResult<PyObject> {
         Python::with_gil(|py| {
             let list = pyo3::types::PyList::empty(py);
-            for frag in self.fragments.values() {
+            // Stable order, for the same reason the cogops candidate vector is
+            // sorted: HashMap iteration is randomized per map instance, and
+            // selection must not inherit that entropy.
+            //
+            // This list feeds the QCCR selector, which is the DEFAULT path.
+            // `optimize_context` exports fragments here and hands them to
+            // `qccr::select`, which groups by "first-seen order" over this
+            // slice -- so score ties were broken in HashMap order.
+            //
+            // Measured before this sort: 12 fragments all scoring exactly 1.0
+            // selected the same set every run but in a different order every
+            // run, so the injected bytes and their SHA-256 changed on every
+            // process start, and between two engines in one process. That
+            // defeats the provider KV cache this project exists to align --
+            // caches match an exact prefix, and `CacheAligner` only reuses on
+            // an exact digest -- and makes a selection non-re-derivable. The
+            // pure-Python selector was already deterministic here.
+            //
+            // Sorting by fragment_id recovers ingest order (shared engine
+            // prefix plus a monotonic counter) without changing scoring.
+            let mut ordered: Vec<&ContextFragment> = self.fragments.values().collect();
+            ordered.sort_by(|a, b| a.fragment_id.cmp(&b.fragment_id));
+            for frag in ordered {
                 let d = PyDict::new(py);
                 d.set_item("fragment_id", &frag.fragment_id)?;
                 d.set_item("content", &frag.content)?;

--- a/entroly-engine/src/conversation_pruner.rs
+++ b/entroly-engine/src/conversation_pruner.rs
@@ -922,6 +922,106 @@ mod tests {
     use super::*;
     use crate::dedup::simhash;
 
+    /// The pruned conversation fits the budget, or is at the floor the
+    /// protection contract imposes -- never above both.
+    ///
+    /// `prune_conversation` exists to make a conversation fit a context window,
+    /// but nothing asserted that it does. The two passes that run after the
+    /// knapsack solve are both safe today for reasons that are easy to break:
+    /// `enforce_dag_coherence` assigns `max(child, parent)` on an ordering
+    /// where a larger `Resolution` is *more* compressed, so it only removes
+    /// tokens; and `protect_recent` raises only the last `protect_last` blocks,
+    /// and only as far as `Skeleton`. Flip either -- reverse the comparison to
+    /// make a child inherit its parent's *fidelity*, or lift the tail to
+    /// `Verbatim` -- and the result silently exceeds the budget it was given,
+    /// because the returned `total_tokens_after` is never compared against
+    /// `token_budget` again.
+    ///
+    /// The bound is `max(budget, contract_floor)` rather than `budget` alone:
+    /// user and system messages are contractually never compressed, so a
+    /// conversation whose protected messages already exceed the budget cannot
+    /// meet it. Comparing against the raw budget conflates that contract with a
+    /// real overshoot and reports a violation on 44 of 60 conversations that
+    /// are in fact optimal.
+    #[test]
+    fn pruning_respects_the_budget_or_the_protection_floor() {
+        let mut state = 0x5EED_1234_9ABC_DEF0_u64;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as usize
+        };
+
+        let roles = ["user", "assistant", "tool", "system"];
+        let sizes = [1u32, 2, 3, 5, 900, 1500, 3000];
+
+        for protect_last in [0usize, 2] {
+            for case in 0..60 {
+                let n = 4 + next() % 22;
+                let blocks: Vec<ConvBlock> = (0..n)
+                    .map(|i| {
+                        let tokens = sizes[next() % sizes.len()];
+                        let role = roles[next() % roles.len()];
+                        make_block(i, role, &"x ".repeat((tokens as usize / 4).max(4)), tokens)
+                    })
+                    .collect();
+
+                let total_before: u32 = blocks.iter().map(|b| b.token_count).sum();
+                let budget = ((total_before as usize * (15 + next() % 46)) / 100).max(1) as u32;
+
+                // Smallest total the contract permits: every block it forbids
+                // compressing at full cost, everything else at the cheapest
+                // resolution the enum offers.
+                let cutoff = n.saturating_sub(protect_last);
+                let floor: u32 = blocks
+                    .iter()
+                    .enumerate()
+                    .map(|(i, b)| {
+                        let forced = matches!(
+                            b.kind,
+                            BlockKind::UserMessage | BlockKind::SystemMessage
+                        ) || i >= cutoff;
+                        let fraction = if forced {
+                            Resolution::Verbatim.token_fraction()
+                        } else {
+                            Resolution::Fingerprint.token_fraction()
+                        };
+                        (b.token_count as f64 * fraction).round() as u32
+                    })
+                    .fold(0u32, u32::saturating_add);
+
+                let result = prune_conversation(&blocks, budget, 0.1, protect_last);
+                let allowance = budget.max(floor);
+
+                assert!(
+                    result.total_tokens_after <= allowance,
+                    "protect_last={protect_last} case={case}: returned {} tokens \
+                     against a budget of {budget} with a contract floor of {floor} \
+                     ({} blocks, {total_before} tokens before)",
+                    result.total_tokens_after,
+                    n
+                );
+
+                // The reported total has to match the assignments it reports,
+                // or the caller is budgeting against a number the pruner made up.
+                let recomputed: u32 = blocks
+                    .iter()
+                    .enumerate()
+                    .map(|(i, b)| {
+                        (b.token_count as f64 * result.assignments[i].1.token_fraction()).round()
+                            as u32
+                    })
+                    .fold(0u32, u32::saturating_add);
+                assert_eq!(
+                    result.total_tokens_after, recomputed,
+                    "protect_last={protect_last} case={case}: reported total does not \
+                     match the returned assignments"
+                );
+            }
+        }
+    }
+
     fn make_block(index: usize, role: &str, content: &str, tokens: u32) -> ConvBlock {
         ConvBlock {
             index,

--- a/entroly-engine/src/guardrails.rs
+++ b/entroly-engine/src/guardrails.rs
@@ -6,8 +6,19 @@
 //!   3. No awareness of file criticality independent of content
 //!
 //! This module implements:
-//!   - **Critical file patterns**: files that must NEVER be dropped
-//!   - **Safety signals**: content patterns that force inclusion
+//!   - **Critical file patterns**: files that must never be evicted from the
+//!     store, and that carry a selection score multiplier
+//!   - **Safety signals**: content patterns that raise criticality
+//!
+//! Criticality is deliberately not a hard include. It sets `is_protected`
+//! ("never drop from the store"), not `is_pinned` ("the operator required this
+//! in the answer") -- see `ContextFragment` and `migrate_pin_semantics`.
+//! Conflating the two is not hypothetical: criticality used to set `is_pinned`,
+//! which force-included every manifest and security file in every query
+//! regardless of relevance. In selection a critical file is score-boosted
+//! (`Safety` 3.0x, `Critical` 2.0x, `Important` 1.5x in `channel.rs`) and
+//! remains budget-constrained, exactly as `file_criticality` documents for
+//! nested monorepo configs.
 //!   - **Adaptive budgeting**: task-type-aware token budgets
 //!   - **Context ordering**: LLM-sensitive fragment ordering
 //!

--- a/entroly-engine/src/query.rs
+++ b/entroly-engine/src/query.rs
@@ -203,8 +203,27 @@ pub fn extract_key_terms(query: &str, fragment_summaries: &[String], top_n: usiz
             .collect()
     };
 
+    // Tie-break on the term itself. `scored` is built by iterating a HashMap,
+    // whose order is randomized per map instance, and `sort_unstable_by` does
+    // not preserve input order either -- so equal scores came out in an
+    // arbitrary order that changed between engines and between processes.
+    //
+    // Ties are the common case here, not a corner case: with no fragment
+    // summaries the score is `tf + min(len/10, 0.5)`, so every distinct word of
+    // five or more characters occurring once scores exactly 1.5. Measured on
+    // "how do the payload handlers compute totals", two engines in one process
+    // returned ['handlers','compute','totals','payload'] and
+    // ['totals','handlers','compute','payload'].
+    //
+    // `key_terms` is handed back to callers in `query_analysis` and feeds query
+    // refinement, so an unstable order makes the refined query -- and any
+    // prompt bytes built from it -- non-reproducible.
     let mut sorted = scored;
-    sorted.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    sorted.sort_unstable_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
     sorted.truncate(top_n);
     sorted.into_iter().map(|(t, _)| t).collect()
 }
@@ -433,6 +452,35 @@ mod tests {
         assert!(!terms.contains(&"the".to_string()));
         assert!(!terms.contains(&"is".to_string()));
         assert!(!terms.contains(&"in".to_string()));
+    }
+
+    /// Equal scores must order deterministically, not by HashMap chance.
+    ///
+    /// `scored` is built by iterating a HashMap and then sorted with
+    /// `sort_unstable_by`, which neither preserves input order nor breaks
+    /// ties. With no fragment summaries the score is `tf + min(len/10, 0.5)`,
+    /// so every distinct word of five or more characters occurring once scores
+    /// exactly 1.5 -- ties are the common case. Measured before the tie-break,
+    /// two engines in one process returned the same four terms in different
+    /// orders, which propagates into `query_analysis` and query refinement.
+    #[test]
+    fn key_terms_break_ties_deterministically() {
+        let query = "how do the payload handlers compute totals";
+
+        let first = extract_key_terms(query, &[], 12);
+        for _ in 0..25 {
+            assert_eq!(
+                extract_key_terms(query, &[], 12),
+                first,
+                "key term order is not reproducible for the same query"
+            );
+        }
+
+        // The tied terms must come back in a defined order, and every tie in
+        // this query is total, so the whole run is alphabetical.
+        let mut expected = first.clone();
+        expected.sort();
+        assert_eq!(first, expected, "tied terms are not ordered by term");
     }
 
     #[test]

--- a/entroly-engine/src/utilization.rs
+++ b/entroly-engine/src/utilization.rs
@@ -165,6 +165,96 @@ pub fn score_utilization(fragments: &[&ContextFragment], response: &str) -> Util
 
 #[cfg(test)]
 mod tests {
+    fn util_frag(id: &str, content: &str) -> ContextFragment {
+        ContextFragment::new(id.into(), content.into(), 50, "src/mod.rs".into())
+    }
+
+    /// A report's counts have to add up, and its mean has to be a mean.
+    ///
+    /// `fragments_used + fragments_ignored` is the whole population, and
+    /// `session_utilization` is documented as the mean combined score. Counts
+    /// that do not reconcile are how a surface reports work it did not do --
+    /// the same defect class as a belief writer counting refusals as writes.
+    #[test]
+    fn utilization_counts_reconcile_and_the_mean_stays_in_range() {
+        let cases: Vec<(&str, Vec<ContextFragment>, &str)> = vec![
+            (
+                "response quotes one fragment",
+                vec![
+                    util_frag("a", "fn compute_tax(amount: f64) -> f64 { amount * 0.2 }"),
+                    util_frag("b", "struct Widget { name: String, size: u32 }"),
+                ],
+                "The function compute_tax multiplies amount by 0.2 to get the tax.",
+            ),
+            (
+                "response ignores everything",
+                vec![
+                    util_frag("a", "fn compute_tax(amount: f64) -> f64 { amount * 0.2 }"),
+                    util_frag("b", "struct Widget { name: String, size: u32 }"),
+                ],
+                "I cannot help with that request.",
+            ),
+            (
+                "empty response",
+                vec![util_frag("a", "fn alpha() -> u32 { 1 }")],
+                "",
+            ),
+            (
+                "response is a verbatim copy",
+                vec![util_frag("a", "fn alpha() -> u32 { 1 }")],
+                "fn alpha() -> u32 { 1 }",
+            ),
+        ];
+
+        for (label, frags, response) in cases {
+            let refs: Vec<&ContextFragment> = frags.iter().collect();
+            let report = score_utilization(&refs, response);
+
+            assert_eq!(
+                report.fragments_injected,
+                refs.len(),
+                "{label}: injected count does not match what was passed"
+            );
+            assert_eq!(
+                report.fragments_used + report.fragments_ignored,
+                report.fragments_injected,
+                "{label}: {} used + {} ignored != {} injected",
+                report.fragments_used,
+                report.fragments_ignored,
+                report.fragments_injected
+            );
+            assert_eq!(
+                report.per_fragment.len(),
+                report.fragments_injected,
+                "{label}: per-fragment breakdown does not cover every fragment"
+            );
+            assert!(
+                report.session_utilization.is_finite(),
+                "{label}: session_utilization was {}",
+                report.session_utilization
+            );
+            assert!(
+                (0.0..=1.0).contains(&report.session_utilization),
+                "{label}: session_utilization {} left [0, 1]",
+                report.session_utilization
+            );
+        }
+    }
+
+    /// No fragments means nothing to score, not a division by zero.
+    #[test]
+    fn an_empty_injection_reports_zero_rather_than_nan() {
+        let report = score_utilization(&[], "any response at all");
+        assert_eq!(report.fragments_injected, 0);
+        assert_eq!(report.fragments_used, 0);
+        assert_eq!(report.fragments_ignored, 0);
+        assert!(
+            report.session_utilization.is_finite(),
+            "empty injection produced {}",
+            report.session_utilization
+        );
+    }
+
     use super::*;
     use crate::fragment::ContextFragment;
 

--- a/entroly/auto_index.py
+++ b/entroly/auto_index.py
@@ -547,7 +547,16 @@ def _max_bytes_for_path(rel_path: str) -> int:
     if os.environ.get("ENTROLY_MAX_FILE_BYTES"):
         return MAX_FILE_BYTES
 
-    p = rel_path.lower().replace("\\", "/")
+    # Leading slash so a top-level directory matches the same markers a nested
+    # one does. Both marker lists are written with surrounding slashes (`/src/`,
+    # `/dist/`) so that `mysrc/` does not match, but the paths tested here are
+    # workspace-relative and carry no leading slash -- so `src/app.py` missed
+    # `/src/` while `pkg/src/app.py` matched it. Measured: a top-level `src/`,
+    # `lib/`, `server/` or `core/` got the conservative 50 KiB cap instead of
+    # the 192 KiB this function exists to grant, and `dist/src/x.js` got the
+    # *larger* cap because it matched `/src/` but not `/dist/`. A top-level
+    # `src/` is the most common layout there is.
+    p = "/" + rel_path.lower().replace("\\", "/").lstrip("/")
     _, ext = os.path.splitext(p.rsplit("/", 1)[-1])
     if ext not in SOURCE_CODE_EXTENSIONS:
         return MAX_FILE_BYTES
@@ -1462,8 +1471,13 @@ def _auto_index(
                         }
                         for fragment in engine._fragments.values()
                     ]
+                # Collapse chunk parts, same as the ingest paths below. A
+                # chunked file contributes `file:p`, `file:p#1`, ... and
+                # counting raw sources reported 68 "files" for a 5-file project
+                # on the cache path -- the same overcount, reached by reloading
+                # a persisted index instead of building one.
                 existing_files = len({
-                    fragment.get("source", "")
+                    _logical_rel_path(fragment["source"])
                     for fragment in frags
                     if fragment.get("source")
                 })
@@ -1644,22 +1658,28 @@ def _auto_index(
             # `ingested` counts FRAGMENTS, and a file yields more than one, so
             # returning it as `files_indexed` reported more files than the
             # repository contains: "Auto-indexed 1799 files" against 1525
-            # indexable ones, and 188 against an explicit cap of 120. The
-            # debug line below already compared it to `len(batch)` -- fragments
-            # over files -- which is where the mismatch was visible all along.
+            # indexable ones, and 188 against an explicit cap of 120.
             #
-            # This number is printed to users, returned by `simulate`/`perf`
-            # `--json` and by `verify-claims`, and published as the headline in
-            # the CI dogfood evidence artifact, so it overstated coverage
-            # everywhere at once.
+            # `len(batch)` does not fix that, because an oversized source file
+            # appends one batch entry per chunk (`file:p`, `file:p#1`, ...).
+            # Measured on this repository after that change: `verify-claims
+            # --max-files 20` reported 60 files and `--max-files 120` reported
+            # 189 -- the same over-the-cap symptom, one layer down.
+            #
+            # Count distinct source files instead, which is what the field
+            # claims to be. This number is printed to users, returned by
+            # `simulate`/`perf` `--json` and by `verify-claims`, and published
+            # as the headline in the CI dogfood evidence artifact, so it
+            # overstated coverage everywhere at once.
             fragments_ingested = int(r.get("ingested", 0))
-            indexed = len(batch)
+            indexed = len({_logical_rel_path(source) for _, source, _ in batch})
             total_tokens = int(r.get("total_tokens", 0))
             p1 = r.get('phase1_ms', '?')
             p2 = r.get('phase2_ms', '?')
             p3 = r.get('phase3_ms', '?')
             logger.debug(
-                f"batch_ingest: {fragments_ingested} fragments from {len(batch)} files "
+                f"batch_ingest: {fragments_ingested} fragments from "
+                f"{len(batch)} batch entries ({indexed} files) "
                 f"in {r.get('duration_ms', 0)}ms "
                 f"(P1={p1}ms P2={p2}ms P3={p3}ms, {r.get('duplicates', 0)} dups)"
             )
@@ -1667,6 +1687,10 @@ def _auto_index(
             # Older entroly_core without batch_ingest — graceful fallback
             logger.debug("batch_ingest unavailable, falling back to per-file ingest")
             try:
+                # A set, not a counter: `batch` holds one entry per chunk, so
+                # incrementing per entry counted chunks as files, the same
+                # overcount the batch path had.
+                indexed_files: set[str] = set()
                 for content, source, tokens in batch:
                     ingest_result = engine.ingest_fragment(
                         content=content, source=source,
@@ -1677,10 +1701,11 @@ def _auto_index(
                     # the live index and therefore cannot contribute to the
                     # baseline used by simulate/perf savings arithmetic.
                     if ingest_result.get("status") == "ingested":
-                        indexed += 1
+                        indexed_files.add(_logical_rel_path(source))
                         total_tokens += int(
                             ingest_result.get("token_count", tokens) or tokens
                         )
+                indexed = len(indexed_files)
             except Exception:
                 if force_snapshot is not None:
                     engine.restore_index_state(force_snapshot)
@@ -1691,16 +1716,19 @@ def _auto_index(
             raise
     else:
         try:
+            # Distinct files, not batch entries -- see the batch path above.
+            pure_python_files: set[str] = set()
             for content, source, tokens in batch:
                 ingest_result = engine.ingest_fragment(
                     content=content, source=source,
                     token_count=tokens, is_pinned=False,
                 )
                 if ingest_result.get("status") == "ingested":
-                    indexed += 1
+                    pure_python_files.add(_logical_rel_path(source))
                     total_tokens += int(
                         ingest_result.get("token_count", tokens) or tokens
                     )
+            indexed = len(pure_python_files)
         except Exception:
             if force_snapshot is not None:
                 engine.restore_index_state(force_snapshot)

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -3960,7 +3960,7 @@ def cmd_doctor(args):
                 checks_passed += 1
             else:
                 print(f"  {C.YELLOW}!{C.RESET} Config: weights sum={w_sum:.3f} (expected ~1.0)")
-                checks_passed += 1  # warning, not failure
+                checks_warned += 1
         except Exception as e:
             print(f"  {C.RED}x{C.RESET} Config error: {e}")
             checks_failed += 1
@@ -3990,9 +3990,10 @@ def cmd_doctor(args):
             age_hours = (_time.time() - newest) / 3600
             if age_hours < 24:
                 print(f"  {C.GREEN}+{C.RESET} Index fresh ({age_hours:.1f}h old)")
+                checks_passed += 1
             else:
                 print(f"  {C.YELLOW}!{C.RESET} Index stale ({age_hours:.0f}h old -- consider re-indexing)")
-            checks_passed += 1
+                checks_warned += 1
         else:
             print(f"  {C.GRAY}-{C.RESET} No index found (will be created on first run)")
             checks_passed += 1
@@ -4014,7 +4015,7 @@ def cmd_doctor(args):
                 checks_passed += 1
             elif drift < 0.3:
                 print(f"  {C.YELLOW}!{C.RESET} Weights drifted (drift={drift:.3f})")
-                checks_passed += 1  # warning, still usable
+                checks_warned += 1
             else:
                 # Advisory, not a broken install: heavy drift is produced by the
                 # supported `entroly autotune` doing its job, and the message
@@ -4056,8 +4057,23 @@ def cmd_doctor(args):
         checks_passed += 1
     except ImportError as e:
         print(f"  {C.YELLOW}!{C.RESET} Hallucination verifiers not available ({e})")
-        checks_passed += 1  # optional, not a failure
+        checks_warned += 1
 
+    # Invariant: the bucket a check is counted in matches the marker printed for
+    # it -- `+` and `-` are passed, `x` is failed, `!` is warned.
+    #
+    # Stated that way rather than as a sum: check 1b (the PATH shadow advisory)
+    # is deliberately outside checks_total, as its comment explains, so
+    # passed + failed + warned exceeds total by the number of such advisories.
+    # Every *counted* check still lands in exactly one bucket.
+    #
+    # Four warning branches used to print `!` and then increment checks_passed
+    # (config weights not summing to 1.0, a stale index, mild weight drift, and
+    # missing hallucination verifiers). Measured differentially: adding a bad
+    # tuning_config.json took the printed warnings from 1 to 2 while the summary
+    # stayed "8/8 checks passed, 1 warning(s)". An operator scanning the last
+    # line saw all-green while the body reported a problem, which is the
+    # false-green this split counter exists to prevent.
     summary = f"\n  {C.BOLD}{checks_passed}/{checks_total} checks passed"
     if checks_failed:
         summary += f", {C.RED}{checks_failed} failed{C.RESET}{C.BOLD}"

--- a/entroly/codec.py
+++ b/entroly/codec.py
@@ -203,7 +203,14 @@ class RecoveryStore:
             metadata={
                 "codec_recovery": True,
                 "codec_digest": digest,
-                "codec_byte_length": len(content.encode("utf-8")),
+                # `_to_bytes`, not a bare encode: this length is what
+                # `reference_for` rebuilds `RecoveryReference.byte_length` from
+                # across processes, and `verify` compares it against
+                # `_to_bytes(recovered)`. A bare encode both raised on content
+                # the reader deliberately admitted (cli_recover reads with
+                # surrogateescape) and disagreed with the value it is checked
+                # against.
+                "codec_byte_length": len(_to_bytes(content)),
                 "codec_item_count": int(item_count),
                 "codec_item_label": item_label,
                 "codec_note": note,

--- a/entroly/compression_mcp.py
+++ b/entroly/compression_mcp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 
 # These always-installed boundaries patch modules only after their public classes
@@ -89,9 +90,29 @@ def _safe_store_path(path_override: str, configured_path: str | None) -> Path:
             raise ValueError("override parent is not a directory")
         resolved_parent.relative_to(allowed_root)
         resolved = resolved_parent / override.name
+        # Resolving the parent leaves the final component symbolic. A link
+        # planted at that name -- live or dangling, since a dangling link is not
+        # reported by exists() -- puts the store wherever it points the moment it
+        # is opened. Containment has to be decided on the path that is used.
+        if resolved.is_symlink():
+            target = resolved.resolve(strict=False)
+            target.relative_to(allowed_root)
+            resolved = target
     except (OSError, RuntimeError, ValueError) as exc:
         raise ValueError("store_path_override escapes the configured recovery root") from exc
     return resolved
+
+
+# Store, lock, and ledger failures render the offending absolute path into their
+# message. That message is model-facing, and where this recovery store lives on
+# the operator's disk is not part of the retrieval answer.
+_ABSOLUTE_PATH_RE = re.compile(
+    r"""(?:[A-Za-z]:[\\/]|\\\\[^\s'"]|/[^\s'"/]+/)[^\s'"]*"""
+)
+
+
+def _redacted_error(error: Exception) -> str:
+    return _ABSOLUTE_PATH_RE.sub("<path>", str(error))[:500]
 
 
 def _error_payload(error: Exception, *, operation: str) -> str:
@@ -99,7 +120,7 @@ def _error_payload(error: Exception, *, operation: str) -> str:
         {
             "status": "error",
             "operation": operation,
-            "error": str(error)[:500],
+            "error": _redacted_error(error),
         },
         indent=2,
         ensure_ascii=False,
@@ -108,10 +129,9 @@ def _error_payload(error: Exception, *, operation: str) -> str:
 
 def create_compression_mcp_server(store_path: str | None = None):
     """Create a focused MCP server for scope-bound compressed-span retrieval."""
-    try:
-        from mcp.server.fastmcp import FastMCP
-    except ImportError:
-        raise RuntimeError("MCP SDK not installed. Install with: pip install mcp") from None
+    from .mcp_sdk import load_fastmcp
+
+    FastMCP = load_fastmcp()
 
     mcp = FastMCP(
         "entroly-compression",

--- a/entroly/compression_retrieval_store.py
+++ b/entroly/compression_retrieval_store.py
@@ -969,7 +969,7 @@ class CompressionRetrievalStore:
 
 
 def _estimate_tokens(text: str) -> int:
-    return max(1, len((text or "").encode("utf-8")) // 4)
+    return max(1, len(_exact_bytes(text or "")) // 4)
 
 
 def _count_o200k_tokens(text: str) -> int:
@@ -979,7 +979,7 @@ def _count_o200k_tokens(text: str) -> int:
         # A byte is a conservative upper bound for a tokenizer piece. Base
         # installs intentionally keep benchmark tokenizers optional, so this
         # path may return less context but can never violate the public cap.
-        return len(text.encode("utf-8"))
+        return len(_exact_bytes(text))
 
     return len(tiktoken.get_encoding("o200k_base").encode(text))
 
@@ -1142,8 +1142,32 @@ def _query_local_json_object(
     return best[4] if best[3] <= max_tokens else None
 
 
+def _exact_bytes(text: str) -> bytes:
+    """Exact bytes for text that may carry unpaired surrogates.
+
+    Content reaching this store is read with ``errors="surrogateescape"`` (see
+    ``cli_recover.cmd_compress``), so a byte that is not valid UTF-8 arrives as
+    a lone surrogate. ``surrogatepass`` round-trips those; a bare
+    ``encode("utf-8")`` raises on them, and ``errors="ignore"`` silently deletes
+    them.
+    """
+    return text.encode("utf-8", "surrogatepass")
+
+
 def _sha256_text(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()
+    """Content address over exact bytes.
+
+    NOT ``errors="ignore"``. That deleted every unencodable character before
+    hashing, so a file holding a raw non-UTF-8 byte addressed identically to the
+    same file with that byte removed. ``put`` short-circuits on a known
+    ``receipt_id`` and returns the item already stored, so the collision handed
+    back the WRONG original -- a silent integrity break in the one function the
+    recovery contract rests on.
+
+    ``surrogatepass`` is byte-identical to ``errors="ignore"`` for any text
+    without surrogates, so every content address already on disk is unchanged.
+    """
+    return hashlib.sha256(_exact_bytes(text)).hexdigest()
 
 
 def _short_hash(text: str) -> str:

--- a/entroly/compression_retrieval_store_safe.py
+++ b/entroly/compression_retrieval_store_safe.py
@@ -352,6 +352,14 @@ class CompressionRetrievalStore(_LegacyCompressionRetrievalStore):
         spans: list[dict[str, Any]],
         metadata=None,
     ):
+        # Loaded state is checked against _validate_identifier, so a span id the
+        # writer chose freely can make the shared store file unreadable for every
+        # scope that opens it afterwards. Validate at the boundary that accepts
+        # the id, not only at the one that later has no choice but to refuse it.
+        for raw in spans or ():
+            if not isinstance(raw, dict):
+                raise ValueError("exact spans must be objects")
+            _validate_identifier(str(raw.get("span_id", "")), name="span_id")
         stored = super().put_exact_spans(
             original_text=original_text,
             compressed_text=compressed_text,
@@ -399,6 +407,30 @@ class CompressionRetrievalStore(_LegacyCompressionRetrievalStore):
             optional=True,
         )
         return validated or f"auto:{uuid.uuid4().hex}"
+
+    def _record_retrieval(
+        self,
+        receipt_id: str,
+        span_id: str,
+        token_count: int,
+        *,
+        retrieval_id: str,
+    ) -> None:
+        """Debit the ledger under an id owned by this scope's record.
+
+        ``retrieval_id`` arrives verbatim from a recovery caller, while the
+        optimization ledger keys adjustments in a single process-wide namespace
+        shared by every store and workspace. Binding the caller's value to the
+        scope, receipt, and span that produced it keeps a chosen id from
+        claiming, colliding with, or denying another record's ledger row while
+        preserving per-span retry idempotency.
+        """
+        super()._record_retrieval(
+            receipt_id,
+            span_id,
+            token_count,
+            retrieval_id=f"{self.scope_hash}:{receipt_id}:{span_id}:{retrieval_id}",
+        )
 
     def _record_locked(
         self,

--- a/entroly/compression_retrieval_store_secure.py
+++ b/entroly/compression_retrieval_store_secure.py
@@ -9,6 +9,7 @@ all storage, locking, snapshot, and accounting logic in
 from __future__ import annotations
 
 import copy
+import logging
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -24,6 +25,8 @@ from .compression_retrieval_store_safe import (
     derive_recovery_scope,
     sanitize_recovery_metadata,
 )
+
+logger = logging.getLogger("entroly.compression_retrieval_store")
 
 
 def _public_item(item: StoredCompression | None) -> StoredCompression | None:
@@ -75,12 +78,41 @@ class CompressionRetrievalStore(_SafeCompressionRetrievalStore):
                 for span in item.spans:
                     token_count = _estimate_tokens(span.content)
                     for retrieval_id in span.retrieval_ids:
-                        self._record_retrieval(
-                            item.receipt_id,
-                            span.span_id,
-                            token_count,
-                            retrieval_id=retrieval_id,
-                        )
+                        self._backfill_retrieval(item, span, token_count, retrieval_id)
+
+    def _backfill_retrieval(
+        self,
+        item: StoredCompression,
+        span: StoredSpan,
+        token_count: int,
+        retrieval_id: str,
+    ) -> None:
+        """Replay one already-recorded retrieval into a freshly attached ledger.
+
+        This is reconciliation, not measurement. The store keeps the retrieval id
+        but not the token count that was debited for it, so the replay can only
+        offer an estimate; an excerpt retrieval debited the measured excerpt
+        instead. When the ledger already holds that authoritative row it rejects
+        the differing estimate as tampering, and letting that escape would make
+        every later construction of this store -- and therefore every recovery
+        tool call -- fail on state the store itself wrote.
+        """
+        try:
+            self._record_retrieval(
+                item.receipt_id,
+                span.span_id,
+                token_count,
+                retrieval_id=retrieval_id,
+            )
+        except ValueError as exc:
+            logger.warning(
+                "recovery ledger already holds retrieval %s for receipt %s span %s; "
+                "keeping the ledger's recorded debit (%s)",
+                retrieval_id,
+                item.receipt_id,
+                span.span_id,
+                exc,
+            )
 
     def _record_compression(self, item: StoredCompression) -> None:
         if self.optimization_ledger is None:

--- a/entroly/context_receipts/ingest.py
+++ b/entroly/context_receipts/ingest.py
@@ -169,7 +169,20 @@ def normalize_document_pairs(documents: object) -> list[tuple[str, str]]:
     fails before receipt generation can produce an auditable empty result.
     """
     pairs: list[tuple[str, str]] = []
-    if isinstance(documents, Mapping) or isinstance(documents, str | bytes):
+    if isinstance(documents, Mapping):
+        # A top-level mapping is ``{source_path: text}``. Discarding it was the
+        # one shape a caller could not detect went missing: a ``dict`` satisfies
+        # the declared ``Iterable`` by duck-typing, so ``ingest_documents({...})``
+        # built an index of zero chunks and the receipt then reported "No
+        # relevant chunks matched the query" -- blaming the query for input that
+        # was never ingested.
+        #
+        # ``sdk._normalize_receipt_documents`` already reads a top-level dict
+        # exactly this way, and that is the path the MCP tool uses, so the same
+        # documented input produced a full receipt through one entry point and
+        # an empty one through the other.
+        iterable = tuple(documents.items())
+    elif isinstance(documents, str | bytes):
         iterable = ()
     else:
         try:

--- a/entroly/context_receipts/receipts.py
+++ b/entroly/context_receipts/receipts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 import copy
 import math
+import re
 from dataclasses import asdict
 from typing import Any
 
@@ -72,6 +73,83 @@ def _compression_ratio(
 
 
 _REVIEW_ORDER = {"low": 0, "medium": 1, "high": 2}
+
+_OMITTED_RELEVANT_WARNING_RE = re.compile(
+    r"^(?:at least )?\d+ relevant chunk\(s\) were omitted"
+)
+
+
+def _omitted_listing_facts(
+    *,
+    selected_count: int,
+    total_chunks: int,
+    listed_omitted: int,
+    listed_relevant: int,
+) -> dict[str, Any]:
+    """Reconcile omitted-evidence counters against the index, not the listing.
+
+    ``omitted_context`` is a bounded top-N listing, so any count taken from it
+    saturates at that limit. Reporting the saturated value as
+    ``omitted_relevant_chunks`` -- and deriving ``omitted_evidence_pressure``
+    from it -- silently understates withheld evidence: a receipt that dropped
+    299 relevant chunks looks identical to one that dropped 20.
+
+    The listing is score-descending, so it *is* a complete census of relevant
+    omissions whenever it was not truncated, or whenever it already contains a
+    zero-score entry (everything positive was reached before the cut-off). Only
+    when neither holds is the count a lower bound, and then the pressure control
+    fails closed onto the exact omitted-chunk total instead of the saturated
+    count.
+    """
+    selected_count = max(0, _int_or_default(selected_count))
+    total_chunks = max(0, _int_or_default(total_chunks))
+    listed_omitted = max(0, _int_or_default(listed_omitted))
+    listed_relevant = max(0, _int_or_default(listed_relevant))
+
+    omitted_total = max(0, total_chunks - selected_count)
+    listing_truncated = omitted_total > listed_omitted
+    relevant_exact = (not listing_truncated) or listed_relevant < listed_omitted
+    upper_bound = listed_relevant if relevant_exact else omitted_total
+    pressure = min(1.0, upper_bound / max(1, selected_count + upper_bound))
+    return {
+        "omitted_chunks_total": omitted_total,
+        "omitted_context_listed": listed_omitted,
+        "omitted_context_listing_truncated": listing_truncated,
+        "omitted_relevant_chunks": listed_relevant,
+        "omitted_relevant_chunks_exact": relevant_exact,
+        "omitted_relevant_chunks_upper_bound": upper_bound,
+        "omission_pressure": round(pressure, 6),
+        "omission_pressure_basis": (
+            "exact_relevant_omitted_count"
+            if relevant_exact
+            else "upper_bound_truncated_omitted_listing"
+        ),
+    }
+
+
+def _omitted_relevant_warning(facts: Mapping[str, Any]) -> str | None:
+    listed_relevant = _int_or_default(facts.get("omitted_relevant_chunks"))
+    if listed_relevant <= 0:
+        return None
+    if facts.get("omitted_relevant_chunks_exact"):
+        return (
+            f"{listed_relevant} relevant chunk(s) were omitted; "
+            "inspect omitted_context."
+        )
+    return (
+        f"at least {listed_relevant} relevant chunk(s) were omitted "
+        f"({_int_or_default(facts.get('omitted_chunks_total'))} chunk(s) omitted in "
+        f"total); omitted_context lists only the "
+        f"{_int_or_default(facts.get('omitted_context_listed'))} highest-scoring."
+    )
+
+
+def _omission_pressure_band(pressure: float) -> str:
+    if pressure > 0.4:
+        return "high"
+    if pressure > 0.15:
+        return "medium"
+    return "low"
 
 
 def _max_review_level(current: str, candidate: str) -> str:
@@ -145,7 +223,7 @@ def _risk_summary(
     *,
     selected_count: int,
     selected_tokens: int,
-    omitted_relevant: int,
+    omitted_facts: Mapping[str, Any],
     dependencies: list,
     warnings: list[str],
     selection_certificate: dict[str, Any],
@@ -164,9 +242,7 @@ def _risk_summary(
         1, sum(chunk.token_count for chunk in index.chunks)
     )
     chunk_coverage = selected_count / max(1, total_chunks)
-    omission_pressure = min(
-        1.0, omitted_relevant / max(1, selected_count + omitted_relevant)
-    )
+    omission_pressure = _float_metric(omitted_facts.get("omission_pressure"))
     dependency_pressure = min(
         1.0, (unresolved + missing_dependency_warnings) / max(1, len(dependencies))
     )
@@ -191,7 +267,24 @@ def _risk_summary(
         "total_chunks": total_chunks,
         "chunk_coverage": round(chunk_coverage, 6),
         "token_coverage": round(token_coverage, 6),
-        "omitted_relevant_chunks": omitted_relevant,
+        "omitted_relevant_chunks": _int_or_default(
+            omitted_facts.get("omitted_relevant_chunks")
+        ),
+        "omitted_chunks_total": _int_or_default(
+            omitted_facts.get("omitted_chunks_total")
+        ),
+        "omitted_context_listed": _int_or_default(
+            omitted_facts.get("omitted_context_listed")
+        ),
+        "omitted_context_listing_truncated": bool(
+            omitted_facts.get("omitted_context_listing_truncated")
+        ),
+        "omitted_relevant_chunks_exact": bool(
+            omitted_facts.get("omitted_relevant_chunks_exact")
+        ),
+        "omitted_relevant_chunks_upper_bound": _int_or_default(
+            omitted_facts.get("omitted_relevant_chunks_upper_bound")
+        ),
         "unresolved_dependency_count": unresolved,
         "missing_dependency_warning_count": missing_dependency_warnings,
         "dependency_bundle_omission_count": dependency_bundle_omissions,
@@ -210,15 +303,80 @@ def _risk_summary(
             "dependency_bundle_fit": "omitted_due_to_budget"
             if dependency_bundle_omissions
             else "complete",
-            "omitted_evidence_pressure": "high"
-            if omission_pressure > 0.4
-            else "medium"
-            if omission_pressure > 0.15
-            else "low",
+            "omitted_evidence_pressure": _omission_pressure_band(omission_pressure),
+            "omitted_evidence_pressure_basis": str(
+                omitted_facts.get("omission_pressure_basis", "unknown")
+            ),
             "replayable_fingerprints": True,
             "local_no_llm_judgment": True,
         },
     }
+
+
+def _reconcile_omitted_counters(
+    risk_summary: dict[str, Any],
+    warnings: list[str],
+    receipt: ContextReceipt,
+    index: ContextIndex | None,
+) -> None:
+    """Rebase a native receipt's omitted-evidence counters onto the index.
+
+    The Rust selector caps ``omitted_context`` at the same listing limit as the
+    Python one and then counts that capped list, so its
+    ``omitted_relevant_chunks`` and ``omitted_evidence_pressure`` saturate
+    identically. This bridge is already the place where native receipts are
+    brought back onto the Python contract, so the reconciliation lives here and
+    applies to both engines.
+    """
+    selected_count = _int_or_default(
+        risk_summary.get("selected_chunks"), len(receipt.selected_context)
+    )
+    total_chunks = _int_or_default(risk_summary.get("total_chunks"))
+    if total_chunks <= 0 and index is not None:
+        total_chunks = len(index.chunks)
+    if total_chunks <= 0:
+        return
+    listed_omitted = len(receipt.omitted_context)
+    listed_relevant = sum(1 for item in receipt.omitted_context if item.score > 0)
+    facts = _omitted_listing_facts(
+        selected_count=selected_count,
+        total_chunks=total_chunks,
+        listed_omitted=listed_omitted,
+        listed_relevant=listed_relevant,
+    )
+    risk_summary.update(
+        {
+            "omitted_relevant_chunks": facts["omitted_relevant_chunks"],
+            "omitted_chunks_total": facts["omitted_chunks_total"],
+            "omitted_context_listed": facts["omitted_context_listed"],
+            "omitted_context_listing_truncated": facts[
+                "omitted_context_listing_truncated"
+            ],
+            "omitted_relevant_chunks_exact": facts["omitted_relevant_chunks_exact"],
+            "omitted_relevant_chunks_upper_bound": facts[
+                "omitted_relevant_chunks_upper_bound"
+            ],
+        }
+    )
+    controls = risk_summary.get("controls")
+    if not isinstance(controls, dict):
+        controls = {}
+        risk_summary["controls"] = controls
+    pressure = _float_metric(facts["omission_pressure"])
+    controls["omitted_evidence_pressure"] = _omission_pressure_band(pressure)
+    controls["omitted_evidence_pressure_basis"] = facts["omission_pressure_basis"]
+    if pressure > 0.25:
+        risk_summary["review_level"] = _max_review_level(
+            str(risk_summary.get("review_level", "low")), "medium"
+        )
+    corrected = _omitted_relevant_warning(facts)
+    warnings[:] = [
+        warning
+        for warning in warnings
+        if not _OMITTED_RELEVANT_WARNING_RE.match(warning)
+    ]
+    if corrected:
+        warnings.append(corrected)
 
 
 def attach_novelty_frontier(
@@ -253,6 +411,7 @@ def attach_novelty_frontier(
         omitted_text_by_chunk_id=omitted_text_by_chunk_id,
     )
     warnings = _warning_list(enriched.get("warnings", []))
+    _reconcile_omitted_counters(risk_summary, warnings, py_receipt, py_index)
     _apply_novelty_risk(risk_summary, novelty, warnings)
     enriched["warnings"] = list(dict.fromkeys(warnings))
 
@@ -305,16 +464,21 @@ def build_receipt(
     ranking_reasons = {rank.chunk_id: rank.reasons for rank in ranked}
     warning_candidates = list(selection.warnings)
     high_omitted = [item for item in selection.omitted if item.score > 0]
-    if high_omitted:
-        warning_candidates.append(
-            f"{len(high_omitted)} relevant chunk(s) were omitted; inspect omitted_context."
-        )
+    omitted_facts = _omitted_listing_facts(
+        selected_count=len(selection.selected),
+        total_chunks=len(index.chunks),
+        listed_omitted=len(selection.omitted),
+        listed_relevant=len(high_omitted),
+    )
+    omitted_warning = _omitted_relevant_warning(omitted_facts)
+    if omitted_warning:
+        warning_candidates.append(omitted_warning)
     warnings = list(dict.fromkeys(warning_candidates))
     risk_summary = _risk_summary(
         index,
         selected_count=len(selection.selected),
         selected_tokens=selected_tokens,
-        omitted_relevant=len(high_omitted),
+        omitted_facts=omitted_facts,
         dependencies=dependencies,
         warnings=warnings,
         selection_certificate=selection.certificate,
@@ -401,7 +565,11 @@ def markdown_report(receipt: ContextReceipt) -> str:
         f"- Certified relevance regret bound: {_float_metric(selection_objective.get('certified_regret_upper_bound')):.6f}",
         f"- Best omitted recovery bundle: {best_omitted.get('root_chunk_id', 'none')}",
         f"- Dependency bundles omitted: {_int_or_default(risk_summary.get('dependency_bundle_omission_count'))}",
-        f"- Omitted evidence pressure: {controls.get('omitted_evidence_pressure', 'unknown')}",
+        f"- Omitted evidence pressure: {controls.get('omitted_evidence_pressure', 'unknown')}"
+        f" (basis: {controls.get('omitted_evidence_pressure_basis', 'unknown')})",
+        f"- Chunks omitted in total: {_int_or_default(risk_summary.get('omitted_chunks_total'))}"
+        f"; listed in this receipt: {_int_or_default(risk_summary.get('omitted_context_listed'))}"
+        f"{'' if risk_summary.get('omitted_relevant_chunks_exact', True) else ' (relevant count is a lower bound)'}",
         f"- Novelty frontier pressure: {controls.get('novelty_frontier', 'unknown')}",
         f"- Novelty frontier action: {novelty_assessment.get('action', 'unknown')}",
         f"- Replayable fingerprints: {controls.get('replayable_fingerprints', False)}",

--- a/entroly/context_receipts/selection.py
+++ b/entroly/context_receipts/selection.py
@@ -21,6 +21,12 @@ from .retrieval import tokenize
 EXACT_CLOSED_SET_ROOT_LIMIT = 14
 _SCORE_EPSILON = 1e-9
 
+# ``omitted_context`` is a bounded, score-descending *listing*, not a census.
+# Anything that counts entries in that list saturates here; the Rust selector
+# (entroly-core/src/context_receipts.rs) hard-codes the same limit, so both
+# backends must reconcile counters against the index, never against the list.
+MAX_OMITTED_LISTED = 20
+
 
 class SelectionResult:
     def __init__(
@@ -165,7 +171,7 @@ def select_context(
     dependency_links: list[DependencyLink],
     *,
     token_budget: int,
-    max_omitted: int = 20,
+    max_omitted: int = MAX_OMITTED_LISTED,
 ) -> SelectionResult:
     token_budget = max(0, token_budget)
     chunks = {chunk.chunk_id: chunk for chunk in index.chunks}

--- a/entroly/mcp_sdk.py
+++ b/entroly/mcp_sdk.py
@@ -1,0 +1,102 @@
+"""Load the MCP server class, and explain accurately when it cannot be loaded.
+
+Every MCP entry point guarded ``from mcp.server.fastmcp import FastMCP`` with
+``except ImportError`` and reported "MCP SDK not installed. Install with: pip
+install mcp". That message is wrong in the case operators are most likely to
+hit, and its advice makes the failure permanent:
+
+``mcp`` 2.x renamed ``FastMCP`` to ``MCPServer`` and dropped the
+``mcp.server.fastmcp`` module, so importing it raises ``ModuleNotFoundError``
+(an ``ImportError`` subclass) even though the SDK *is* installed. The operator
+is then told to run ``pip install mcp``, which installs 2.x -- reproducing the
+exact failure they were trying to fix.
+
+``pyproject.toml`` pins ``mcp>=1.28.1,<2``, so a normal ``pip install entroly``
+resolves a working SDK. This module exists for everyone else: an environment
+where ``mcp`` was installed separately or upgraded past the pin. Failing closed
+is correct; failing closed with a false reason is not.
+
+This module deliberately imports nothing from ``entroly``. The package has an
+import cycle spanning ``entroly/__init__`` and the proxy stack, and a leaf with
+no internal imports cannot join it.
+"""
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+#: The pin declared in ``pyproject.toml``. ``test_mcp_sdk_guard`` asserts the
+#: two agree, so this string cannot drift into giving stale install advice.
+REQUIRED_SPEC = "mcp>=1.28.1,<2"
+
+
+def installed_version() -> str | None:
+    """Return the installed ``mcp`` version, or ``None`` when absent."""
+    try:
+        return version("mcp")
+    except PackageNotFoundError:
+        return None
+    except Exception:  # pragma: no cover - metadata backends vary
+        return None
+
+
+def _major(version: str) -> int | None:
+    try:
+        return int(version.split(".", 1)[0])
+    except (ValueError, AttributeError):
+        return None
+
+
+def unavailable_reason() -> str:
+    """Explain why the MCP SDK cannot be used, distinguishing the causes.
+
+    Three distinct states, three messages. Naming the 2.x rename
+    unconditionally would be the same defect this module exists to fix: when
+    ``mcp`` is installed at a supported version and the submodule is still
+    missing, the cause is a broken or partial install, and blaming a rename
+    that did not happen sends the operator to the wrong remedy.
+    """
+    found = installed_version()
+    if found is None:
+        return (
+            f"MCP SDK not installed. Install with: pip install '{REQUIRED_SPEC}'"
+        )
+
+    major = _major(found)
+    if major is not None and major >= 2:
+        return (
+            f"MCP SDK {found} is installed but does not provide "
+            f"'mcp.server.fastmcp'. Entroly requires {REQUIRED_SPEC}; mcp 2.x "
+            f"renamed FastMCP to MCPServer. "
+            f"Fix with: pip install '{REQUIRED_SPEC}'"
+        )
+
+    return (
+        f"MCP SDK {found} is installed and within {REQUIRED_SPEC}, but "
+        f"'mcp.server.fastmcp' could not be imported, so the install is "
+        f"incomplete or broken. "
+        f"Reinstall with: pip install --force-reinstall '{REQUIRED_SPEC}'"
+    )
+
+
+def load_fastmcp():
+    """Return the ``FastMCP`` class, or raise ``RuntimeError`` with the reason."""
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError:
+        raise RuntimeError(unavailable_reason()) from None
+    return FastMCP
+
+
+def load_context():
+    """Return the MCP ``Context`` class, or ``None`` when the SDK is unusable.
+
+    Used for type annotations at import time, where failing closed would break
+    importing the module at all. The server's ``create_mcp_server`` reports the
+    real error when a server is actually requested.
+    """
+    try:
+        from mcp.server.fastmcp import Context
+
+        return Context
+    except ImportError:
+        return None

--- a/entroly/native_status.py
+++ b/entroly/native_status.py
@@ -49,6 +49,23 @@ RELEASE_NATIVE_SYMBOLS = QCCR_SYMBOLS + (
     "py_compress_block",
 )
 
+# What `usable_core()` consumers dereference off the module it hands back.
+# `checkpoint.py` takes `ContextFragment` with no guard, so a core missing it
+# raises AttributeError at import time instead of using the pure-Python
+# fallback sitting in the very next branch. `engine.py` takes the other three.
+#
+# Feature-specific sets stay out on purpose. QCCR_SYMBOLS and
+# WORK_GRAPH_SYMBOLS are checked by the features that need them, via
+# `native_status(...)`; a core without QCCR should lose QCCR, not all native
+# acceleration. This tuple is the opposite case -- the symbols whose absence
+# leaves the process unable to use the core at all.
+CORE_SYMBOLS = (
+    "ContextFragment",
+    "EntrolyEngine",
+    "py_analyze_query",
+    "py_refine_heuristic",
+)
+
 
 @dataclass(frozen=True)
 class NativeStatus:
@@ -191,14 +208,33 @@ def usable_core() -> ModuleType | None:
 
     Cached: the answer cannot change within a process, and this sits on import
     paths that run per request.
+
+    "Incomplete" means missing any of ``CORE_SYMBOLS``. This used to call
+    ``native_status()`` with no required symbols, so ``missing_symbols`` was
+    always empty and the incomplete case could not be detected -- the promise
+    above was documented but not implemented. A core new enough to pass the
+    version gate but missing ``ContextFragment`` was handed to ``checkpoint.py``,
+    which dereferences it without a guard and raised ``AttributeError`` at
+    import time rather than falling back. That is not hypothetical: the comment
+    on ``WORK_GRAPH_SYMBOLS`` records a published core that satisfied the
+    minimum version while lacking a symbol.
     """
-    status = native_status()
+    status = native_status(CORE_SYMBOLS)
+    logger = logging.getLogger("entroly")
     if status.available and status.version_ok is False:
-        logging.getLogger("entroly").warning(
+        logger.warning(
             "entroly_core %s is below the %s this release requires; using the "
             "pure-Python engine. Rebuild with `cd entroly-core && maturin "
             "develop --release` to restore native acceleration.",
             status.version,
             MIN_ENTROLY_CORE_VERSION,
+        )
+    elif status.available and status.missing_symbols:
+        logger.warning(
+            "entroly_core %s is missing required symbols (%s); using the "
+            "pure-Python engine. Rebuild with `cd entroly-core && maturin "
+            "develop --release` to restore native acceleration.",
+            status.version,
+            ", ".join(status.missing_symbols),
         )
     return status.module if status.ok else None

--- a/entroly/path_safety.py
+++ b/entroly/path_safety.py
@@ -39,7 +39,18 @@ def resolve_dir_within(root: str | Path, candidate: str | Path = ".") -> Path | 
 
 
 def resolve_output_within(root: str | Path, candidate: str | Path) -> Path | None:
-    """Return an output file path only when its resolved parent remains inside ``root``."""
+    """Return an output file path only when it resolves inside ``root``.
+
+    The candidate is resolved whether or not it exists. Checking the parent and
+    then returning the unresolved candidate is not enough: ``Path.exists``
+    follows symlinks, so a link inside ``root`` whose target is missing reports
+    ``False`` and skips the containment check, while a write through it still
+    follows the link. Measured against a temporary tree, a dangling
+    ``root/link -> outside/target`` was returned as safe and the write landed in
+    ``outside``. A live symlink was already blocked, so only the dangling case
+    escaped -- which is the one an attacker plants, since the target not
+    existing yet is the point.
+    """
     try:
         root_path = Path(root).resolve(strict=True)
         candidate_path = Path(candidate)
@@ -47,10 +58,13 @@ def resolve_output_within(root: str | Path, candidate: str | Path) -> Path | Non
             candidate_path = root_path / candidate_path
         parent = candidate_path.parent.resolve(strict=True)
         parent.relative_to(root_path)
-        if candidate_path.exists():
-            resolved = candidate_path.resolve(strict=True)
-            resolved.relative_to(root_path)
-            return resolved if resolved.is_file() else None
+        # Non-strict: resolves symlinks and ``..`` as far as the path exists,
+        # which is what a write will follow, and tolerates a target that has
+        # not been created yet.
+        resolved = candidate_path.resolve()
+        resolved.relative_to(root_path)
     except (OSError, RuntimeError, ValueError):
         return None
-    return candidate_path
+    if candidate_path.exists() and not resolved.is_file():
+        return None
+    return resolved

--- a/entroly/ravs/beta_bounds.py
+++ b/entroly/ravs/beta_bounds.py
@@ -1,0 +1,127 @@
+"""Exact lower credible bound for a Beta posterior.
+
+RAVS routes a request to a cheaper model only when it is confident that model
+succeeds at the task. That confidence came from a normal approximation to the
+Beta posterior::
+
+    ci_lo = max(0.0, mean - 1.96 * std)
+
+A Beta is not symmetric, and this gate lives exactly where the approximation is
+worst: few observations and a mean close to 1. Measured against the exact
+quantile, the approximation overstates the bound in *every* configuration
+tested, and in three of them the difference is what opens the gate:
+
+    cell             mean-1.96s   exact 2.5%
+    n=10, 10/0         0.8367       0.7828
+    n=20, 19/1         0.8210       0.7892
+    n=35, 32/3         0.8073       0.7886
+
+against a ``ci_threshold`` of 0.80. The worst case is the smallest cell that can
+ever qualify -- ``min_samples`` observations with a perfect record -- so the
+overstatement is largest precisely where the evidence is thinnest.
+
+CLAUDE.md lists RAVS as fail-closed: "always routes to Opus when uncertain;
+never sacrifice correctness for cost". A bound that reports more confidence than
+the posterior holds fails open. This is the same defect the Jeffreys-prior
+comment in ``router.py`` describes one level up: that fixed the prior, this
+fixes the bound computed from it.
+
+Pure Python and dependency-free on purpose -- scipy is not a runtime dependency,
+and adding one to a routing path for a single quantile is not warranted.
+``entroly.engine._WilsonFeedbackTracker`` already uses a Wilson score bound
+rather than a naive one for the same reason; this brings RAVS in line.
+"""
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+
+__all__ = ["beta_cdf", "beta_lower_bound"]
+
+
+def _betacf(a: float, b: float, x: float) -> float:
+    """Continued fraction for the incomplete beta function (Lentz's method)."""
+    tiny = 1e-300
+    qab, qap, qam = a + b, a + 1.0, a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < tiny:
+        d = tiny
+    d = 1.0 / d
+    h = d
+    for m in range(1, 300):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + aa / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + aa / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < 1e-14:
+            break
+    return h
+
+
+def beta_cdf(x: float, alpha: float, beta: float) -> float:
+    """Regularised incomplete beta ``I_x(alpha, beta)`` = ``P(X <= x)``."""
+    if not (alpha > 0.0 and beta > 0.0):
+        raise ValueError("alpha and beta must be positive")
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    log_beta = math.lgamma(alpha) + math.lgamma(beta) - math.lgamma(alpha + beta)
+    # Use the reflected series where the continued fraction converges faster.
+    if x < (alpha + 1.0) / (alpha + beta + 2.0):
+        front = math.exp(alpha * math.log(x) + beta * math.log1p(-x) - log_beta)
+        return front * _betacf(alpha, beta, x) / alpha
+    front = math.exp(beta * math.log1p(-x) + alpha * math.log(x) - log_beta)
+    return 1.0 - front * _betacf(beta, alpha, 1.0 - x) / beta
+
+
+@lru_cache(maxsize=4096)
+def beta_lower_bound(alpha: float, beta: float, tail: float = 0.025) -> float:
+    """The ``tail`` quantile of ``Beta(alpha, beta)``.
+
+    With the default this is the lower end of a 95% equal-tailed credible
+    interval -- the interval the previous normal approximation was aiming at,
+    computed exactly instead of approximated.
+
+    Bisection on a monotone CDF, stopping at 1e-12. Each step evaluates a
+    continued fraction, so this is not free: measured at 836 us uncached on a
+    routing-sized posterior, against 0.32 us once cached. The arguments are
+    discrete (``alpha = 0.5 + passes``) and a cell is reused by every request
+    that lands in it, so the cache turns the amortised cost into a dict lookup.
+
+    Stopping at 1e-12 rather than at float precision: the full bisection
+    measured 1,464 us and changed no digit that matters, because the result is
+    only ever compared against a threshold.
+    """
+    if not (alpha > 0.0 and beta > 0.0):
+        return 0.0
+    if not (0.0 < tail < 1.0):
+        raise ValueError("tail must be in (0, 1)")
+
+    lo, hi = 0.0, 1.0
+    while hi - lo > 1e-12:
+        mid = (lo + hi) * 0.5
+        if mid <= lo or mid >= hi:  # exhausted float precision
+            break
+        if beta_cdf(mid, alpha, beta) < tail:
+            lo = mid
+        else:
+            hi = mid
+    return max(0.0, min(1.0, (lo + hi) * 0.5))

--- a/entroly/ravs/report.py
+++ b/entroly/ravs/report.py
@@ -27,6 +27,7 @@ import time
 from pathlib import Path
 from typing import Any, Iterator
 
+from .beta_bounds import beta_lower_bound
 from .events import (
     DECOMPOSITION_KINDS,
     HONEST_OUTCOME_TYPES,
@@ -319,10 +320,13 @@ def generate_report(
             entry["total_estimated_delta_usd"] / max(entry["comparisons"], 1), 6
         )
 
-    # ── Phase 4½: Bayesian cells (Empirical Bayes) ─────────────────────
-    # Per-cell Beta-Bernoulli posteriors with hierarchical pooling.
+    # ── Phase 4½: Bayesian cells (Jeffreys prior) ──────────────────────
+    # Per-cell Beta-Bernoulli posteriors, Beta(1/2, 1/2) prior.
     # Each cell = (tool_category) from hook-sourced events.
-    # Sparse cells borrow from the global prior via Empirical Bayes.
+    #
+    # No longer Empirical Bayes: sparse cells used to borrow from a prior
+    # pooled over the same log, which inflated thin cells rather than
+    # regularising them. See the prior block below.
 
     bayesian_cells: dict[str, dict[str, Any]] = {}
     _cell_counts: dict[str, dict[str, int]] = {}  # {cell: {pass: N, fail: N}}
@@ -344,15 +348,21 @@ def generate_report(
             elif value in failure_values:
                 cell["fail"] += 1
 
-    # Compute global prior (Empirical Bayes: pool across all cells)
-    total_pass = sum(c["pass"] for c in _cell_counts.values())
-    total_fail = sum(c["fail"] for c in _cell_counts.values())
-    total_obs = total_pass + total_fail
-    # Global success rate as prior mean; prior strength = 2 (weak prior)
-    global_mean = total_pass / max(total_obs, 1)
-    prior_strength = 2.0  # equivalent sample size of prior
-    alpha_0 = max(global_mean * prior_strength, 0.1)
-    beta_0 = max((1 - global_mean) * prior_strength, 0.1)
+    # Jeffreys prior, Beta(1/2, 1/2) -- the same prior `router.py` scores with.
+    #
+    # This used to fit the prior to the log it then scored: prior mean =
+    # global success rate, strength 2. `router.py` removed that and explains
+    # why ("a confidence bound whose prior is fitted to the evidence is not a
+    # confidence bound, and this one failed open"), but the report kept it, so
+    # the two disagreed about the same cell. On a log with no failures the old
+    # prior was alpha_0=2.0, beta_0=0.1 -- a prior mean of 0.952 before a single
+    # observation. Measured on a 2-pass cell: the report displayed
+    # P(success)=0.976 for a cell the router scores at 0.833.
+    #
+    # The report is what an operator reads to understand why routing did what it
+    # did, so it has to be the router's arithmetic, not a second opinion.
+    alpha_0 = 0.5
+    beta_0 = 0.5
 
     for cell_key, counts in _cell_counts.items():
         n = counts["pass"] + counts["fail"]
@@ -514,10 +524,10 @@ def format_report_text(report: dict[str, Any]) -> str:
         lines.append(f"  {'':30s}    NOT counterfactual truth.")
         lines.append("")
 
-    # Bayesian cells (Empirical Bayes per-tool posteriors)
+    # Bayesian cells (Jeffreys-prior per-tool posteriors)
     cells = report.get("bayesian_cells", {})
     if cells:
-        lines.append("  ── Bayesian Cells (Empirical Bayes) ──────────────────────")
+        lines.append("  ── Bayesian Cells (Jeffreys prior) ───────────────────────")
         prior = None
         for cell_key, cell in cells.items():
             n = cell.get("n", 0)
@@ -528,13 +538,14 @@ def format_report_text(report: dict[str, Any]) -> str:
             fails = cell.get("failures", 0)
             prior = cell.get("prior", {})
 
-            # Compute 95% CI via normal approximation of Beta
-            import math
-            ab = alpha + beta
-            var = (alpha * beta) / (ab * ab * (ab + 1)) if ab > 0 else 0
-            std = math.sqrt(var) if var > 0 else 0
-            ci_lo = max(0.0, mean - 1.96 * std)
-            ci_hi = min(1.0, mean + 1.96 * std)
+            # Exact 95% equal-tailed credible interval. This printed a normal
+            # approximation under a `95%CI=` label, which is a claim the numbers
+            # did not support -- the `max`/`min` clamps below were themselves a
+            # symptom, since a correct Beta interval cannot leave [0, 1].
+            # Same bound the router gates on, so the report and the decision
+            # agree.
+            ci_lo = beta_lower_bound(alpha, beta)
+            ci_hi = 1.0 - beta_lower_bound(beta, alpha)
 
             lines.append(
                 f"  {cell_key:25s}  n={n:3d}  "
@@ -543,7 +554,7 @@ def format_report_text(report: dict[str, Any]) -> str:
                 f"95%CI=[{ci_lo:.2f},{ci_hi:.2f}]"
             )
         if prior:
-            lines.append(f"  Prior: α₀={prior.get('alpha_0', '?')}, β₀={prior.get('beta_0', '?')} (hierarchical pool)")
+            lines.append(f"  Prior: α₀={prior.get('alpha_0', '?')}, β₀={prior.get('beta_0', '?')} (Jeffreys)")
         lines.append("")
 
     lines.append("  ══════════════════════════════════════════════════════════")

--- a/entroly/ravs/router.py
+++ b/entroly/ravs/router.py
@@ -56,6 +56,7 @@ from ..proxy_transform import (
     is_legacy_claude_3_model,
     strip_anthropic_unsupported_params,
 )
+from .beta_bounds import beta_lower_bound
 
 logger = logging.getLogger("entroly.ravs.router")
 
@@ -142,9 +143,14 @@ class GateStatus:
 
     # Metrics that must pass the gate
     decomposition_evidence_rate: float = 0.0    # target: >= 0.40
-    executor_coverage: float = 0.0              # target: >= 0.50
     shadow_success_rate: float = 0.0            # target: >= baseline - tolerance
     sample_size: int = 0                        # target: >= 50
+
+    # None means "not measured", which is the honest value today: no report
+    # field carries executor coverage, so `compute_gate_status` has nothing to
+    # read. It previously reported the gate's own *threshold* here, so the
+    # field always equalled 0.50 and read as a measurement of the fleet.
+    executor_coverage: float | None = None      # target: >= 0.50 (unenforced)
 
     # Model-specific readiness
     model_readiness: dict[str, bool] = field(default_factory=dict)
@@ -162,6 +168,13 @@ def compute_gate_status(
 
     Called offline (not per-request). Result is cached and used
     by the router for fast O(1) decisions.
+
+    ``min_executor_coverage`` is accepted but **not enforced**: it never appears
+    in ``checks``, and no report field carries executor coverage for it to be
+    compared against. It is kept so existing callers keep working, and named
+    here so the gap is visible rather than implied by a threshold that looks
+    active. Adding it as a real check would fail every gate until something
+    produces the metric, which would silently disable routing entirely.
     """
     total = report.get("total_requests", 0)
     decomp_rate = report.get("decomposition_evidence_rate", 0.0)
@@ -187,7 +200,11 @@ def compute_gate_status(
         passed=len(failed) == 0,
         reason="all gates passed" if not failed else f"failed: {', '.join(failed)}",
         decomposition_evidence_rate=decomp_rate,
-        executor_coverage=min_executor_coverage,  # from shadow data
+        # Read it if the report ever carries one; otherwise None for "not
+        # measured". This used to pass `min_executor_coverage`, so the field
+        # reported the gate's own threshold under a comment claiming it came
+        # "from shadow data" -- a constant presented as a measurement.
+        executor_coverage=report.get("executor_coverage"),
         shadow_success_rate=success_rate,
         sample_size=total,
         model_readiness=model_ready,
@@ -811,10 +828,13 @@ class BayesianRouter:
         alpha = cell.get("alpha", 1)
         beta = cell.get("beta", 1)
         mean = alpha / (alpha + beta) if (alpha + beta) > 0 else 0.5
-        ab = alpha + beta
-        var = (alpha * beta) / (ab * ab * (ab + 1)) if ab > 0 else 0
-        std = math.sqrt(var) if var > 0 else 0
-        ci_lo = max(0.0, mean - 1.96 * std)
+        # Exact quantile of the posterior, not `mean - 1.96 * std`. The normal
+        # approximation overstates the bound everywhere it was measured, and
+        # the overstatement is worst at the smallest qualifying cell: at
+        # `min_samples` observations with a perfect record it reported 0.8367
+        # where the posterior gives 0.7828, clearing a 0.80 threshold the
+        # evidence does not support. See `beta_bounds` for the measurements.
+        ci_lo = beta_lower_bound(alpha, beta)
 
         if n < self._min_samples:
             return RoutingDecision(

--- a/entroly/repository_intelligence/mcp.py
+++ b/entroly/repository_intelligence/mcp.py
@@ -79,10 +79,9 @@ def create_repository_mcp_server(
     cache_dir: str | os.PathLike[str] | None = None,
 ):
     """Create a workspace-fixed MCP server with no caller-controlled root."""
-    try:
-        from mcp.server.fastmcp import FastMCP
-    except ImportError:
-        raise RuntimeError("MCP SDK not installed. Install with: pip install mcp") from None
+    from ..mcp_sdk import load_fastmcp
+
+    FastMCP = load_fastmcp()
 
     service = RepositoryIntelligenceService(
         _configured_root(root),

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -445,13 +445,13 @@ def create_mcp_server(
     Uses the FastMCP SDK for automatic tool schema generation
     from Python type hints and docstrings.
     """
+    from .mcp_sdk import load_fastmcp
+
     try:
-        from mcp.server.fastmcp import FastMCP
-    except ImportError:
-        logger.error(
-            "MCP SDK not installed. Install with: pip install mcp"
-        )
-        raise RuntimeError("MCP SDK not installed. Install with: pip install mcp") from None
+        FastMCP = load_fastmcp()
+    except RuntimeError as exc:
+        logger.error(str(exc))
+        raise
 
     mcp = FastMCP(
         "entroly",
@@ -3494,80 +3494,116 @@ def create_mcp_server(
             context: The source context that was provided to the AI
             prompt: The original user prompt/query (helps calibrate verification)
         """
-        verification = {}
+        verification: dict[str, Any] = {}
+        # A signal that did not run contributes NO score. `None` here is
+        # distinct from 0.0: zero-filling a failed check is what turns a
+        # broken verifier into a machine that certifies everything.
+        risks: dict[str, float | None] = {
+            "witness": None, "ece": None, "epr": None, "spectral": None,
+        }
 
-        # 1. WITNESS: entity coverage gap
+        # 1. WITNESS: proof-carrying groundedness (the validated signal)
         try:
             from .witness import WitnessAnalyzer
             analyzer = WitnessAnalyzer()
             witness_result = analyzer.analyze(context or prompt, response)
+            # summary_score is GROUNDEDNESS (1.0 = fully grounded), so the
+            # risk contribution is its complement — the same convention
+            # entroly.sdk.detect_hallucination uses. Reading summary_score
+            # directly as a "gap" inverts the verdict.
+            groundedness = max(0.0, min(1.0, float(witness_result.summary_score)))
+            risks["witness"] = 1.0 - groundedness
             verification["witness"] = {
-                "entity_coverage_gap": round(witness_result.summary_score, 4),
+                "risk_score": round(risks["witness"], 4),
+                "groundedness": round(groundedness, 4),
                 "flagged_claims": [
-                    {"claim": c.text[:120], "score": round(c.score, 3)}
+                    {
+                        "claim": c.claim_text[:120],
+                        "risk": round(c.risk, 3),
+                        "label": c.label,
+                    }
                     for c in (witness_result.flagged() or [])[:10]
                 ],
-                "total_claims": witness_result.total_claims,
+                "total_claims": len(witness_result.certificates),
             }
         except Exception as e:
-            verification["witness"] = {"status": "unavailable", "reason": str(e)[:100]}
+            logger.warning("verify_response: WITNESS signal unavailable: %s", e)
+            verification["witness"] = {"status": "unavailable", "reason": str(e)[:200]}
 
         # 2. ECE: Fisher curvature (hedging/uncertainty detection)
         try:
             from .ravs.ece import EpistemicCascadeEngine
             ece = EpistemicCascadeEngine()
             ece_result = ece.evaluate(response)
+            risks["ece"] = float(ece_result.get("risk_score", 0))
             verification["ece"] = {
                 "curvature": round(ece_result.get("curvature", 0), 4),
                 "renyi_divergence": round(ece_result.get("renyi_divergence", 0), 4),
-                "risk_score": round(ece_result.get("risk_score", 0), 4),
+                "risk_score": round(risks["ece"], 4),
             }
         except Exception as e:
-            verification["ece"] = {"status": "unavailable", "reason": str(e)[:100]}
+            logger.warning("verify_response: ECE signal unavailable: %s", e)
+            verification["ece"] = {"status": "unavailable", "reason": str(e)[:200]}
 
         # 3. EPR: Entropy Production Rate
         try:
             from .ravs.epr import compute_epr
             epr_result = compute_epr(response)
+            risks["epr"] = float(epr_result.get("risk_score", 0))
             verification["epr"] = {
                 "entropy_production_rate": round(epr_result.get("epr", 0), 4),
-                "risk_score": round(epr_result.get("risk_score", 0), 4),
+                "risk_score": round(risks["epr"], 4),
             }
         except Exception as e:
-            verification["epr"] = {"status": "unavailable", "reason": str(e)[:100]}
+            logger.warning("verify_response: EPR signal unavailable: %s", e)
+            verification["epr"] = {"status": "unavailable", "reason": str(e)[:200]}
 
         # 4. Spectral: entity cross-similarity SVD
         try:
             from .ravs.spectral import compute_spectral_consistency
             spec_result = compute_spectral_consistency(response, context)
+            risks["spectral"] = float(spec_result.get("risk_score", 0))
             verification["spectral"] = {
                 "consistency": round(spec_result.get("consistency", 1.0), 4),
-                "risk_score": round(spec_result.get("risk_score", 0), 4),
+                "risk_score": round(risks["spectral"], 4),
             }
         except Exception as e:
-            verification["spectral"] = {"status": "unavailable", "reason": str(e)[:100]}
+            logger.warning("verify_response: spectral signal unavailable: %s", e)
+            verification["spectral"] = {"status": "unavailable", "reason": str(e)[:200]}
 
-        # 5. Fused risk score (same 4-signal fusion as proxy)
-        w_entity = 0.80
-        w_ece = 0.08
-        w_epr = 0.07
-        w_spectral = 0.05
-
-        entity_gap = verification.get("witness", {}).get("entity_coverage_gap", 0)
-        ece_risk = verification.get("ece", {}).get("risk_score", 0)
-        epr_risk = verification.get("epr", {}).get("risk_score", 0)
-        spec_risk = verification.get("spectral", {}).get("risk_score", 0)
-
+        # 5. Fused risk over the signals that ACTUALLY RAN.
+        #
+        # Fail-closed accounting. The previous fusion read each signal back
+        # out of `verification` with `.get("risk_score", 0)`, so a signal
+        # that raised was scored as ZERO risk — i.e. as positive evidence of
+        # safety. Because the whole cascade raised, every response scored
+        # fused_risk=0.0 and came back "pass / Accept — response appears
+        # well-grounded", including responses that contradict their context
+        # outright. Unavailable signals are now excluded from both numerator
+        # and denominator, and losing WITNESS — the primary, benchmark-
+        # validated signal — cannot yield a "pass".
+        weights = {"witness": 0.80, "ece": 0.08, "epr": 0.07, "spectral": 0.05}
+        scored = {k: v for k, v in risks.items() if v is not None}
+        unavailable = sorted(k for k, v in risks.items() if v is None)
+        denom = sum(weights[k] for k in scored)
         fused = (
-            w_entity * entity_gap
-            + w_ece * ece_risk
-            + w_epr * epr_risk
-            + w_spectral * spec_risk
+            sum(weights[k] * scored[k] for k in scored) / denom
+            if denom > 0.0
+            # Nothing ran at all: unknown is not safe.
+            else 1.0
         )
         fused = max(0.0, min(1.0, fused))
 
         # Verdict thresholds
-        if fused < 0.15:
+        if risks["witness"] is None:
+            verdict = "unverified"
+            recommendation = (
+                "Do NOT treat this response as verified — the primary WITNESS "
+                "groundedness signal did not run ("
+                + str(verification["witness"].get("reason", "unavailable"))
+                + "). No groundedness claim can be made."
+            )
+        elif fused < 0.15:
             verdict = "pass"
             recommendation = "Accept — response appears well-grounded"
         elif fused < 0.40:
@@ -3580,12 +3616,9 @@ def create_mcp_server(
         verification["fused_risk"] = round(fused, 4)
         verification["verdict"] = verdict
         verification["recommendation"] = recommendation
-        verification["signal_weights"] = {
-            "entity_coverage_gap": w_entity,
-            "ece_curvature": w_ece,
-            "epr_rate": w_epr,
-            "spectral_consistency": w_spectral,
-        }
+        verification["signals_scored"] = sorted(scored)
+        verification["signals_unavailable"] = unavailable
+        verification["signal_weights"] = {k: weights[k] for k in sorted(scored)}
 
         # ── Third-party verifier plugins (entroly.verifier entry points) ──
         # Additive observations with attribution. They never change the core

--- a/entroly/server.py
+++ b/entroly/server.py
@@ -3530,17 +3530,49 @@ def create_mcp_server(
             logger.warning("verify_response: WITNESS signal unavailable: %s", e)
             verification["witness"] = {"status": "unavailable", "reason": str(e)[:200]}
 
+        # Signals 2-4 are logprob- and entity-driven. This tool receives plain
+        # text, so each is called with its real API and then *asked whether it
+        # actually measured anything*. A signal that cannot measure is reported
+        # unavailable with the true reason and left out of the fusion below.
+        #
+        # These call sites had drifted out of API compatibility: `ece.evaluate`
+        # does not exist (it is `evaluate_uncertainty`), and EPRSignal and
+        # SpectralSignal are dataclasses, not dicts, so `.get(...)` raised.
+        # Every call therefore raised AttributeError and the old fusion counted
+        # the crash as zero risk. Repairing only the names would have been
+        # worse: measured on grounded vs fabricated text with no logprobs, ECE
+        # returns epistemic_uncertainty 0.0 for both, EPR reports
+        # has_logprobs=False with mean_entropy 0.0, and spectral returns a flat
+        # 0.5 because its entity extractor finds no response entities. Scoring
+        # those would inject a constant dressed as a measurement.
+        #
+        # `compute_spectral_consistency(context, response)` also had its
+        # arguments reversed here, which silently changes the result (0.2000 vs
+        # 0.5000 on the same pair) -- latent until someone "fixed" the names.
+
         # 2. ECE: Fisher curvature (hedging/uncertainty detection)
         try:
             from .ravs.ece import EpistemicCascadeEngine
-            ece = EpistemicCascadeEngine()
-            ece_result = ece.evaluate(response)
-            risks["ece"] = float(ece_result.get("risk_score", 0))
-            verification["ece"] = {
-                "curvature": round(ece_result.get("curvature", 0), 4),
-                "renyi_divergence": round(ece_result.get("renyi_divergence", 0), 4),
-                "risk_score": round(risks["ece"], 4),
-            }
+
+            ece_signal = EpistemicCascadeEngine().evaluate_uncertainty(
+                prompt or "", response
+            )
+            if ece_signal.epistemic_uncertainty > 0.0:
+                risks["ece"] = float(ece_signal.epistemic_uncertainty)
+                verification["ece"] = {
+                    "curvature": round(float(ece_signal.fisher_curvature), 4),
+                    "renyi_entropy": round(float(ece_signal.renyi_entropy), 4),
+                    "risk_score": round(risks["ece"], 4),
+                }
+            else:
+                verification["ece"] = {
+                    "status": "unavailable",
+                    "reason": (
+                        "requires token logprobs; from text alone every "
+                        "curvature term is zero and cannot separate grounded "
+                        "from fabricated"
+                    ),
+                }
         except Exception as e:
             logger.warning("verify_response: ECE signal unavailable: %s", e)
             verification["ece"] = {"status": "unavailable", "reason": str(e)[:200]}
@@ -3548,12 +3580,25 @@ def create_mcp_server(
         # 3. EPR: Entropy Production Rate
         try:
             from .ravs.epr import compute_epr
-            epr_result = compute_epr(response)
-            risks["epr"] = float(epr_result.get("risk_score", 0))
-            verification["epr"] = {
-                "entropy_production_rate": round(epr_result.get("epr", 0), 4),
-                "risk_score": round(risks["epr"], 4),
-            }
+
+            epr_signal = compute_epr(response)
+            if epr_signal.has_logprobs:
+                risks["epr"] = float(
+                    max(0.0, min(1.0, epr_signal.entity_bg_ratio))
+                )
+                verification["epr"] = {
+                    "mean_entropy": round(float(epr_signal.mean_entropy), 4),
+                    "entity_bg_ratio": round(float(epr_signal.entity_bg_ratio), 4),
+                    "risk_score": round(risks["epr"], 4),
+                }
+            else:
+                verification["epr"] = {
+                    "status": "unavailable",
+                    "reason": (
+                        "requires token logprobs, which this tool does not "
+                        "receive; entropy is undefined without them"
+                    ),
+                }
         except Exception as e:
             logger.warning("verify_response: EPR signal unavailable: %s", e)
             verification["epr"] = {"status": "unavailable", "reason": str(e)[:200]}
@@ -3561,12 +3606,28 @@ def create_mcp_server(
         # 4. Spectral: entity cross-similarity SVD
         try:
             from .ravs.spectral import compute_spectral_consistency
-            spec_result = compute_spectral_consistency(response, context)
-            risks["spectral"] = float(spec_result.get("risk_score", 0))
-            verification["spectral"] = {
-                "consistency": round(spec_result.get("consistency", 1.0), 4),
-                "risk_score": round(risks["spectral"], 4),
-            }
+
+            # (context, response) -- this order is load-bearing.
+            spec_signal = compute_spectral_consistency(context, response)
+            if spec_signal.n_ctx_entities > 0 and spec_signal.n_resp_entities > 0:
+                risks["spectral"] = float(
+                    max(0.0, min(1.0, 1.0 - spec_signal.score))
+                )
+                verification["spectral"] = {
+                    "consistency": round(float(spec_signal.score), 4),
+                    "max_similarity": round(float(spec_signal.max_sim), 4),
+                    "risk_score": round(risks["spectral"], 4),
+                }
+            else:
+                verification["spectral"] = {
+                    "status": "unavailable",
+                    "reason": (
+                        f"no comparable entities "
+                        f"(context={spec_signal.n_ctx_entities}, "
+                        f"response={spec_signal.n_resp_entities}); the score "
+                        f"is a floor constant, not a measurement"
+                    ),
+                }
         except Exception as e:
             logger.warning("verify_response: spectral signal unavailable: %s", e)
             verification["spectral"] = {"status": "unavailable", "reason": str(e)[:200]}

--- a/entroly/verification_engine.py
+++ b/entroly/verification_engine.py
@@ -370,18 +370,38 @@ class VerificationEngine:
 
             try:
                 checked = datetime.fromisoformat(last.replace("Z", "+00:00"))
-                hours = (now - checked).total_seconds() / 3600
-                if hours > self._freshness_hours:
-                    stale.append(StaleReport(
-                        claim_id=b.get("claim_id", ""),
-                        entity=b.get("entity", ""),
-                        status=b.get("status", ""),
-                        last_checked=last,
-                        hours_since=hours,
-                        confidence=b.get("confidence", 0),
-                    ))
             except (ValueError, TypeError):
-                pass
+                # An unparseable last_checked means the freshness check could
+                # not run. Swallowing it left the belief out of the stale list
+                # entirely, so check_belief reported status="verified" with no
+                # issues for a belief whose freshness was never established —
+                # a corrupt timestamp read as a clean bill of health. A check
+                # that cannot run is not a check that passed.
+                logger.warning(
+                    "VerificationEngine: belief %s has unparseable last_checked=%r; "
+                    "treating as stale",
+                    b.get("claim_id", ""), last,
+                )
+                stale.append(StaleReport(
+                    claim_id=b.get("claim_id", ""),
+                    entity=b.get("entity", ""),
+                    status=b.get("status", ""),
+                    last_checked=f"unparseable:{last}",
+                    hours_since=float('inf'),
+                    confidence=b.get("confidence", 0),
+                ))
+                continue
+
+            hours = (now - checked).total_seconds() / 3600
+            if hours > self._freshness_hours:
+                stale.append(StaleReport(
+                    claim_id=b.get("claim_id", ""),
+                    entity=b.get("entity", ""),
+                    status=b.get("status", ""),
+                    last_checked=last,
+                    hours_since=hours,
+                    confidence=b.get("confidence", 0),
+                ))
 
         return stale
 

--- a/entroly/verify_claims.py
+++ b/entroly/verify_claims.py
@@ -21,6 +21,7 @@ from entroly.ccr import (
     slice_recovery_content,
 )
 from entroly.config import EntrolyConfig
+from entroly.engine import naive_context_baseline
 from entroly.server import EntrolyEngine
 
 
@@ -92,8 +93,26 @@ def run(output: str | None = None, max_files: int = 120) -> int:
     # perfect score for having returned no context at all. `cmd_simulate`
     # already scores the identical event as 0.0%; two commands in one product
     # must not give opposite answers to "we returned nothing".
-    savings = (1 - used / tokens) * 100 if selected and tokens > 0 and used <= tokens else 0.0
-    print(f"  selected={len(selected)} tokens={used:,} savings={savings:.1f}% latency={optimize_ms:.1f}ms")
+    #
+    # The baseline has to match for the same reason. This divided by `tokens`,
+    # the whole indexed corpus, which credits every fragment that was never
+    # going to be sent -- the error `engine._honest_tokens_saved` documents.
+    # `cmd_simulate` measures against `min(total_tokens, 32_000)`, a context
+    # window someone might plausibly fill. Measured on this repository the two
+    # disagreed by more than ten points: verify-claims printed 99.4% against
+    # 769,339 corpus tokens while simulate reported 89.1%, and only simulate
+    # said what it was comparing against. Both are onboarding steps 1 and 2.
+    baseline = naive_context_baseline(tokens)
+    savings = (
+        (1 - used / baseline) * 100
+        if selected and baseline > 0 and used <= baseline
+        else 0.0
+    )
+    print(
+        f"  selected={len(selected)} tokens={used:,} "
+        f"savings={savings:.1f}% vs {baseline:,}-token baseline "
+        f"latency={optimize_ms:.1f}ms"
+    )
 
     # A deliberate no-match is not a failure. The engine refuses to return
     # files that share no term with the query rather than padding the budget
@@ -232,6 +251,10 @@ def run(output: str | None = None, max_files: int = 120) -> int:
         "total_tokens": tokens,
         "index_time_s": round(index_s, 3),
         "tokens_used": used,
+        # Report what the percentage is measured against. `cmd_simulate` emits
+        # `baseline_tokens` for the same reason: a saving without its baseline
+        # is not checkable, and the number moves by ten points depending on it.
+        "baseline_tokens": baseline,
         "savings_pct": round(savings, 1),
         "optimize_latency_ms": round(optimize_ms, 1),
         "recovery": {

--- a/entroly/work_graph_mcp_server.py
+++ b/entroly/work_graph_mcp_server.py
@@ -283,12 +283,9 @@ def register_work_graph_tools(mcp: Any) -> Any:
 
 
 def create_mcp_server():
-    try:
-        from mcp.server.fastmcp import FastMCP
-    except ImportError:
-        raise RuntimeError(
-            'MCP SDK not installed. Reinstall Entroly with `pip install "entroly"`.'
-        ) from None
+    from .mcp_sdk import load_fastmcp
+
+    FastMCP = load_fastmcp()
 
     mcp = FastMCP(
         "entroly-work-graph",

--- a/tests/test_context_byte_stability.py
+++ b/tests/test_context_byte_stability.py
@@ -1,0 +1,127 @@
+"""The injected context must be byte-identical for identical input.
+
+CLAUDE.md states the invariant: "Cache stability: prompt prefixes should remain
+byte-stable unless intentionally changed." Provider KV caches match an *exact*
+prefix, and ``CacheAligner`` only reuses a block when its SHA-256 is identical,
+so any instability silently costs the discount -- the request still succeeds, it
+just never hits cache. A non-reproducible selection also cannot be re-derived
+from a receipt.
+
+``EntrolyEngine.export_fragments`` iterated a Rust ``HashMap`` unsorted, and
+that list is what the default QCCR selector groups by "first-seen order". Score
+ties were therefore broken in HashMap iteration order, which Rust randomizes per
+map instance. Measured before the fix, with 12 fragments all scoring exactly
+1.0: the same set was selected every run, in a different order every run, so the
+bytes and the digest changed on every process start and between two engines in
+the same process.
+
+The sibling code path already guarded this -- ``lib.rs`` sorts its cogops
+candidate vector with a comment naming the same hazard -- but the default path
+did not.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+QUERY = "how does the payment refund processor validate a declined transaction"
+
+
+def _selected(monkeypatch) -> tuple[str, list[str], int]:
+    """Ingest a fixed corpus into a fresh engine and return (digest, sources, n).
+
+    A fresh ENTROLY_DIR per engine is required: otherwise the engine warm-starts
+    from a persisted index and the run measures the previous corpus.
+    """
+    monkeypatch.setenv("ENTROLY_DIR", tempfile.mkdtemp(prefix="bytestab_"))
+    from entroly.server import EntrolyEngine
+
+    engine = EntrolyEngine()
+
+    # All twelve are near-identical so they score equally -- ties are exactly
+    # the condition that exposed the ordering entropy. The trailing tag keeps
+    # them distinct enough to survive SimHash dedup; without it the corpus
+    # collapses and the test proves nothing.
+    for i in range(12):
+        engine.ingest_fragment(
+            content=(
+                "def validate_declined_transaction(payment, refund):\n"
+                "    if payment.status == 'declined':\n"
+                "        return refund.processor.validate(payment)\n"
+                f"    # tag hot_{i}_{i * 37 % 91}\n"
+            ),
+            source=f"file:pkg/hot_{i:02d}.py",
+            token_count=60,
+            is_pinned=False,
+        )
+
+    result = engine.optimize_context(token_budget=600, query=QUERY)
+    frags = result.get("selected_fragments") or result.get("selected") or []
+
+    def field(f, name):
+        return f.get(name, "") if isinstance(f, dict) else getattr(f, name, "")
+
+    sources = [field(f, "source") for f in frags]
+    blob = "\n".join(field(f, "content") for f in frags)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest(), sources, len(frags)
+
+
+def test_two_engines_produce_byte_identical_context(monkeypatch):
+    """Same corpus, same query, two engines -> identical bytes.
+
+    Rust reseeds ``HashMap`` per map instance, so two engines in one process is
+    enough to expose the entropy; it does not need separate processes.
+    """
+    digest_a, sources_a, n_a = _selected(monkeypatch)
+    digest_b, sources_b, n_b = _selected(monkeypatch)
+
+    # The fixture must actually have selected something under ties, or this
+    # asserts nothing.
+    assert n_a >= 2, f"only {n_a} fragment(s) selected; the fixture is not exercising ties"
+    assert n_a == n_b
+
+    assert sources_a == sources_b, (
+        "two engines selected the same fragments in a different order:\n"
+        f"  A: {[s.rsplit('/', 1)[-1] for s in sources_a]}\n"
+        f"  B: {[s.rsplit('/', 1)[-1] for s in sources_b]}"
+    )
+    assert digest_a == digest_b, (
+        f"identical input produced different context bytes: {digest_a} vs {digest_b}"
+    )
+
+
+def test_export_fragments_is_ordered(monkeypatch):
+    """The ordering contract, asserted where it is established.
+
+    ``export_fragments`` is the boundary the selector reads. Pinning the order
+    here localises a regression to this function rather than leaving it to
+    surface as a mysterious cache miss.
+    """
+    monkeypatch.setenv("ENTROLY_DIR", tempfile.mkdtemp(prefix="bytestab_ex_"))
+    from entroly.server import EntrolyEngine
+
+    engine = EntrolyEngine()
+    if not getattr(engine, "_use_rust", False):
+        pytest.skip("native engine unavailable; the Python path preserves dict order")
+
+    for i in range(25):
+        engine.ingest_fragment(
+            content=f"def fn_{i}():\n    return {i * 17 % 83}\n",
+            source=f"file:pkg/mod_{i:02d}.py",
+            token_count=20,
+            is_pinned=False,
+        )
+
+    ids = [dict(f)["fragment_id"] for f in engine._rust.export_fragments()]
+    assert ids, "export_fragments returned nothing"
+    assert ids == sorted(ids), (
+        "export_fragments returned fragments in unsorted (HashMap) order; the "
+        "default QCCR selector groups by first-seen order over this list, so "
+        f"ties inherit the entropy. First few: {ids[:5]}"
+    )

--- a/tests/test_doctor_check_accounting.py
+++ b/tests/test_doctor_check_accounting.py
@@ -1,0 +1,212 @@
+"""`entroly doctor`'s summary must agree with the markers it just printed.
+
+Four warning branches printed a yellow ``!`` and then incremented
+``checks_passed``: config weights not summing to 1.0, a stale index, mild
+weight drift, and missing hallucination verifiers. Measured differentially --
+one doctor run with a deliberately bad ``tuning_config.json`` and one without --
+the printed warnings went from 1 to 2 while the summary stayed
+``8/8 checks passed, 1 warning(s)``.
+
+An operator who reads only the last line saw all-green while the body reported a
+problem. cli.py's own comments call that the false green the split counter
+exists to prevent, so the rule is asserted here rather than left to review.
+
+The marker/bucket mapping is: ``+`` and ``-`` count as passed (``-`` is
+informational -- an absent proxy is not a fault), ``x`` failed, ``!`` warned.
+
+Note on isolation: ``doctor`` reads its tuning file from a fixed path inside the
+installed package (``cli.py`` uses ``Path(__file__).parent /
+"tuning_config.json"``), so the tests that need a bad config have to write
+there. Each guards with "skip if the file already exists", which keeps a real
+config safe and makes a concurrent run skip rather than clobber. It is not a
+substitute for running these serially under xdist.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TUNING = REPO_ROOT / "entroly" / "tuning_config.json"
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _run_doctor(tmp_state: Path) -> tuple[dict[str, int], int, int, int]:
+    env = dict(os.environ)
+    env["ENTROLY_DIR"] = str(tmp_state)
+    env["NO_COLOR"] = "1"
+    proc = subprocess.run(
+        [sys.executable, "-m", "entroly", "doctor"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(REPO_ROOT),
+        timeout=600,
+    )
+    clean = ANSI.sub("", proc.stdout)
+    # The banner above the report also uses these glyphs; the report starts at
+    # the "Entroly Doctor" header.
+    if "Entroly Doctor" not in clean:
+        pytest.skip(f"doctor did not produce a report:\n{proc.stdout}\n{proc.stderr}")
+    body = clean.split("Entroly Doctor", 1)[1]
+
+    summary_line = next(
+        (line for line in body.splitlines() if "checks passed" in line), None
+    )
+    assert summary_line, f"no summary line in doctor output:\n{body}"
+    body = body.split(summary_line)[0]
+
+    markers = {"+": 0, "-": 0, "x": 0, "!": 0}
+    for line in body.splitlines():
+        stripped = line.strip()
+        if len(stripped) > 1 and stripped[0] in markers and stripped[1] == " ":
+            markers[stripped[0]] += 1
+
+    counts = re.search(r"(\d+)/(\d+) checks passed", summary_line)
+    assert counts, summary_line
+    failed = re.search(r"(\d+) failed", summary_line)
+    warned = re.search(r"(\d+) warning", summary_line)
+    return (
+        markers,
+        int(counts.group(1)),
+        int(failed.group(1)) if failed else 0,
+        int(warned.group(1)) if warned else 0,
+    )
+
+
+def _assert_markers_match(markers, passed, failed, warned, label):
+    assert markers["!"] == warned, (
+        f"{label}: doctor printed {markers['!']} warning marker(s) but the "
+        f"summary counted {warned}; a printed warning is being reported as a "
+        f"pass"
+    )
+    assert markers["x"] == failed, (
+        f"{label}: printed {markers['x']} failure marker(s), summary says {failed}"
+    )
+    assert markers["+"] + markers["-"] == passed, (
+        f"{label}: printed {markers['+']} '+' and {markers['-']} '-' markers "
+        f"but the summary counted {passed} passed"
+    )
+
+
+def test_doctor_summary_matches_its_markers(tmp_path):
+    """Baseline: whatever this environment reports, the counts must agree."""
+    markers, passed, failed, warned = _run_doctor(tmp_path / "state")
+    assert sum(markers.values()) > 0, "doctor printed no check markers at all"
+    _assert_markers_match(markers, passed, failed, warned, "baseline")
+
+
+def test_a_forced_warning_is_counted_as_a_warning_not_a_pass(tmp_path):
+    """Non-vacuous: drive a warning branch instead of hoping for one.
+
+    The baseline test above passes trivially on a clean machine that produces no
+    warnings at all, which is exactly how this defect survived. This one creates
+    the condition.
+    """
+    if TUNING.exists():
+        pytest.skip("a real tuning_config.json is present; refusing to clobber it")
+
+    before = _run_doctor(tmp_path / "state_before")
+
+    TUNING.write_text(
+        json.dumps({"weights": {"relevance": 0.3, "entropy": 0.2}}),  # sums to 0.5
+        encoding="utf-8",
+    )
+    try:
+        after = _run_doctor(tmp_path / "state_after")
+    finally:
+        TUNING.unlink(missing_ok=True)
+
+    markers_b, _, _, warned_b = before
+    markers_a, passed_a, failed_a, warned_a = after
+
+    assert markers_a["!"] > markers_b["!"], (
+        "the bad tuning_config.json did not produce a new warning marker; "
+        f"before={markers_b} after={markers_a}"
+    )
+    _assert_markers_match(markers_a, passed_a, failed_a, warned_a, "forced warning")
+    assert warned_a > warned_b, (
+        f"an added warning did not raise the counted warnings ({warned_b} -> "
+        f"{warned_a}); it was absorbed into the pass count"
+    )
+
+
+@pytest.mark.parametrize(
+    "band,weights",
+    [
+        # Drift is sum(|w - default|) over recency .30, frequency .25,
+        # semantic .25, entropy .20. Each set sums to exactly 1.0 so the
+        # config-validity check still passes with a `+` and the only new marker
+        # comes from drift.
+        ("mild", {"recency": 0.36, "frequency": 0.19, "semantic": 0.25, "entropy": 0.20}),
+        ("heavy", {"recency": 0.60, "frequency": 0.10, "semantic": 0.10, "entropy": 0.20}),
+    ],
+)
+def test_weight_drift_is_counted_as_a_warning_not_a_pass(tmp_path, band, weights):
+    """Cover both drift branches, isolated from the other checks.
+
+    ``mild`` lands in ``[0.1, 0.3)`` (drift 0.12) and ``heavy`` above 0.3
+    (drift 0.60). They are separate branches with separate counters, and only
+    one of them was wrong -- so testing a single band let a mutation of the
+    other survive.
+    """
+    if TUNING.exists():
+        pytest.skip("a real tuning_config.json is present; refusing to clobber it")
+
+    before = _run_doctor(tmp_path / "state_before")
+
+    TUNING.write_text(json.dumps({"weights": weights}), encoding="utf-8")
+    try:
+        markers_a, passed_a, failed_a, warned_a = _run_doctor(tmp_path / "state_after")
+    finally:
+        TUNING.unlink(missing_ok=True)
+
+    assert markers_a["!"] > before[0]["!"], (
+        f"{band} drift did not produce a warning marker; "
+        f"before={before[0]} after={markers_a}"
+    )
+    _assert_markers_match(markers_a, passed_a, failed_a, warned_a, f"{band} drift")
+    assert warned_a > before[3], (
+        f"the {band} drift warning did not raise the counted warnings "
+        f"({before[3]} -> {warned_a})"
+    )
+
+
+def test_a_stale_index_is_counted_as_a_warning_not_a_pass(tmp_path):
+    """Cover a second warning branch, through a different mechanism.
+
+    Forcing only the config branch left the stale-index branch untested: a
+    mutation that reverted it to ``checks_passed += 1`` survived the rest of
+    this file. ``doctor`` resolves the index under ``ENTROLY_DIR``, so the
+    condition can be built directly.
+    """
+    fresh_state = tmp_path / "fresh"
+    (fresh_state / "checkpoints").mkdir(parents=True)
+    (fresh_state / "checkpoints" / "index.json").write_text("{}", encoding="utf-8")
+    before = _run_doctor(fresh_state)
+
+    stale_state = tmp_path / "stale"
+    (stale_state / "checkpoints").mkdir(parents=True)
+    stale_file = stale_state / "checkpoints" / "index.json"
+    stale_file.write_text("{}", encoding="utf-8")
+    two_days_ago = stale_file.stat().st_mtime - 48 * 3600
+    os.utime(stale_file, (two_days_ago, two_days_ago))
+
+    markers_a, passed_a, failed_a, warned_a = _run_doctor(stale_state)
+
+    assert markers_a["!"] > before[0]["!"], (
+        "a 48h-old index did not produce a warning marker; "
+        f"fresh={before[0]} stale={markers_a}"
+    )
+    _assert_markers_match(markers_a, passed_a, failed_a, warned_a, "stale index")
+    assert warned_a > before[3], (
+        f"the stale-index warning did not raise the counted warnings "
+        f"({before[3]} -> {warned_a})"
+    )

--- a/tests/test_index_file_count_honesty.py
+++ b/tests/test_index_file_count_honesty.py
@@ -1,0 +1,196 @@
+"""`files_indexed` must be a count of files, and must respect its own cap.
+
+The batch handed to ingest holds one entry per *chunk*: an oversized source file
+is split and appended as ``file:path``, ``file:path#1``, ``file:path#2``... so
+counting batch entries counts chunks. ``auto_index`` did exactly that, first via
+the Rust ``ingested`` count and then via ``len(batch)``.
+
+Measured on this repository before the fix, driving it through the command a new
+user is told to run first:
+
+    entroly verify-claims --max-files 10   ->   10 files
+    entroly verify-claims --max-files 20   ->   60 files
+    entroly verify-claims --max-files 120  ->  189 files
+
+The number is printed to users, returned by ``simulate``/``perf`` ``--json`` and
+``verify-claims``, and published as the headline of the CI dogfood evidence
+artifact, so it overstated coverage on every surface at once. It is also a claim
+that can be checked against the filesystem, which is the standard CLAUDE.md sets
+for benchmark honesty.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import entroly.auto_index as auto_index  # noqa: E402
+from entroly.auto_index import _logical_rel_path  # noqa: E402
+from entroly.server import EntrolyEngine  # noqa: E402
+
+
+def test_chunk_parts_collapse_to_one_file():
+    """The helper the count depends on, checked on the shapes it will see."""
+    assert _logical_rel_path("file:pkg/mod.py") == "file:pkg/mod.py"
+    assert _logical_rel_path("file:pkg/mod.py#1") == "file:pkg/mod.py"
+    assert _logical_rel_path("file:pkg/mod.py#12") == "file:pkg/mod.py"
+    # A '#' that is not a chunk marker belongs to the path and must survive.
+    assert _logical_rel_path("file:pkg/c#sharp.py") == "file:pkg/c#sharp.py"
+    assert _logical_rel_path("file:pkg/a#b.py#2") == "file:pkg/a#b.py"
+
+
+@pytest.fixture
+def repo_with_oversized_sources(tmp_path, monkeypatch):
+    """A project whose files land in the band that gets chunked.
+
+    Chunking is the mechanism that produced the overcount, so a fixture of small
+    files would pass against the broken implementation. The size has to sit
+    between the soft per-file budget (192 KiB, above which a source file is
+    chunked) and the hard ceiling (500 KiB, above which it is skipped outright).
+    An earlier version of this fixture used ~574 KiB files, which were skipped
+    rather than chunked -- the "was anything chunked?" assertion at the end of
+    this module is what caught it.
+    """
+    project = tmp_path / "project"
+    (project / "src").mkdir(parents=True)
+
+    # Every function body is unique, within and across files. SimHash dedup
+    # drops near-duplicates, so repeating one block would collapse a file's
+    # chunks back into a single fragment, and byte-identical files would
+    # collapse into one file -- either one silently undoes what this fixture
+    # exists to produce. Both were observed before the bodies were varied.
+    for i in range(3):
+        big_body = "\n".join(
+            f"def process_{i}_{n}(records):\n"
+            f"    total_{n} = {n * 7 + i}\n"
+            f"    for record in records:\n"
+            f"        total_{n} += record.value_{n} * {n % 97 + 3}\n"
+            f"    return total_{n} - {n * 13 % 101}\n"
+            for n in range(1800)
+        )
+        path = project / "src" / f"large_{i}.py"
+        path.write_text(big_body, encoding="utf-8")
+        size = path.stat().st_size
+        assert 192 * 1024 < size < 500 * 1024, (
+            f"fixture file is {size} bytes; it must exceed the 192 KiB soft "
+            "budget to be chunked but stay under the 500 KiB hard ceiling or "
+            "it is skipped instead"
+        )
+    for i in range(2):
+        (project / "src" / f"small_{i}.py").write_text(
+            f"def tiny_{i}():\n    return {i}\n", encoding="utf-8"
+        )
+
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    return project
+
+
+def _index(max_files: int, state_dir: Path, monkeypatch) -> dict:
+    """Index once with a *fresh* state directory.
+
+    Reusing one ``ENTROLY_DIR`` across calls makes the second call reload the
+    persisted index and return the cache path instead of indexing, so the run
+    silently measures the previous run's index rather than this cap.
+    """
+    monkeypatch.setenv("ENTROLY_DIR", str(state_dir))
+    previous = auto_index.MAX_FILES
+    auto_index.MAX_FILES = max_files
+    try:
+        return auto_index.auto_index(EntrolyEngine())
+    finally:
+        auto_index.MAX_FILES = previous
+
+
+def test_files_indexed_never_exceeds_the_cap(
+    repo_with_oversized_sources, tmp_path, monkeypatch
+):
+    """The cap is the user's explicit request; reporting past it is a false claim."""
+    for cap in (1, 2, 3, 5):
+        result = _index(cap, tmp_path / f"state_cap_{cap}", monkeypatch)
+        assert result["files_indexed"] <= cap, (
+            f"asked for at most {cap} files but reported "
+            f"{result['files_indexed']}; chunks of one file are being counted "
+            f"as separate files (fragments_ingested="
+            f"{result.get('fragments_ingested')})"
+        )
+
+
+def test_reloading_a_persisted_index_reports_files_not_chunks(
+    repo_with_oversized_sources, tmp_path, monkeypatch
+):
+    """The cache path counts too, and it counted chunks.
+
+    When a persisted index is already loaded, ``auto_index`` short-circuits and
+    derives ``files_indexed`` from the fragments in the engine rather than from a
+    fresh batch. That branch counted raw fragment sources, so a chunked file
+    contributed one "file" per chunk: measured at 68 files for a 5-file project.
+
+    It is reached by pointing a second engine at the same ``ENTROLY_DIR``, which
+    is the normal case -- every command after the first index.
+    """
+    state = tmp_path / "shared_state"
+
+    first = _index(20, state, monkeypatch)
+    assert first.get("status") != "skipped", (
+        "the first pass should build the index, not reload one"
+    )
+
+    second = _index(20, state, monkeypatch)
+    if second.get("status") != "skipped":
+        pytest.skip(
+            "the second pass rebuilt instead of reloading; cache path not exercised"
+        )
+
+    assert second["files_indexed"] == first["files_indexed"], (
+        f"the same index reports {first['files_indexed']} files when built and "
+        f"{second['files_indexed']} when reloaded; the reload path is counting "
+        "chunks as files"
+    )
+
+
+def test_files_indexed_matches_the_files_actually_in_the_index(
+    repo_with_oversized_sources,
+):
+    """Cross-check the reported count against the engine's own contents.
+
+    Scoped to distinct files on purpose. Whether a byte-identical duplicate
+    should count is a separate, pre-existing disagreement between the two ingest
+    paths: the pure-Python path counts only ``status == "ingested"`` and so
+    excludes duplicates, while the Rust ``batch_ingest`` path returns aggregate
+    counts only and cannot attribute duplicates back to a file. That is not what
+    this test is about, and mixing the two would make a failure ambiguous.
+    """
+    previous = auto_index.MAX_FILES
+    auto_index.MAX_FILES = 5
+    engine = EntrolyEngine()
+    try:
+        result = auto_index.auto_index(engine)
+    finally:
+        auto_index.MAX_FILES = previous
+
+    if engine._use_rust:
+        fragments = engine._rust.export_fragments()
+        sources = {f.get("source", "") for f in fragments if f.get("source")}
+    else:
+        sources = {
+            getattr(f, "source", "") for f in engine._fragments.values()
+        }
+        sources = {s for s in sources if s}
+
+    distinct_files = {_logical_rel_path(s) for s in sources}
+
+    assert result["files_indexed"] == len(distinct_files), (
+        f"reported {result['files_indexed']} files but the index holds "
+        f"{len(distinct_files)} distinct source files "
+        f"({len(sources)} fragment sources)"
+    )
+    # And the fixture must actually have exercised chunking, or this proves
+    # nothing about the defect.
+    assert len(sources) > len(distinct_files), (
+        "no file was chunked, so this fixture cannot distinguish a chunk count "
+        "from a file count; raise the file size"
+    )

--- a/tests/test_index_path_size_caps.py
+++ b/tests/test_index_path_size_caps.py
@@ -1,0 +1,112 @@
+"""The per-file size cap must treat a top-level directory like a nested one.
+
+`_max_bytes_for_path` grants source directories a larger budget (192 KiB rather
+than 50 KiB) because, as its docstring puts it, skipping real implementation
+files "creates false economy: the optimizer saves tokens but cannot select the
+code that actually answers the query".
+
+Both marker lists are written with surrounding slashes -- ``/src/``, ``/dist/``
+-- so that ``mysrc/`` does not match. But the paths passed in are
+workspace-relative and have no leading slash, so the markers only ever matched
+*nested* directories. Measured before the fix:
+
+    src/big.py          ->  50 KiB      pkg/src/big.py  -> 192 KiB
+    lib/big.py          ->  50 KiB      server/app.py   ->  50 KiB
+
+and the exclusion list failed the same way in reverse: ``dist/src/x.js`` matched
+``/src/`` but not ``/dist/``, so a generated file received the *larger* budget.
+
+A top-level ``src/`` is the most common project layout there is.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from entroly.auto_index import (  # noqa: E402
+    MAX_FILE_BYTES,
+    SOURCE_FILE_SOFT_MAX_BYTES,
+    _max_bytes_for_path,
+)
+
+
+@pytest.fixture(autouse=True)
+def _default_caps(monkeypatch):
+    """Pin the env these assertions are about.
+
+    ``_max_bytes_for_path`` returns ``MAX_FILE_BYTES`` immediately when
+    ``ENTROLY_MAX_FILE_BYTES`` is set -- an explicit override, and correct
+    behaviour. These tests are about the *default* rule, so they have to say so.
+
+    Not hypothetical: importing ``benchmarks/contextbench_floor.py`` used to set
+    that variable at module import, and ``tests/test_contextbench_runner_safety``
+    imports it. In a full-suite run every test after that point saw a
+    500,000-byte cap. These tests passed alone and failed in the suite, which is
+    how the leak was found.
+    """
+    monkeypatch.delenv("ENTROLY_MAX_FILE_BYTES", raising=False)
+    monkeypatch.delenv("ENTROLY_MAX_SOURCE_FILE_BYTES", raising=False)
+
+
+@pytest.mark.parametrize(
+    "top_level,nested",
+    [
+        ("src/big.py", "pkg/src/big.py"),
+        ("lib/big.py", "pkg/lib/big.py"),
+        ("core/big.py", "pkg/core/big.py"),
+        ("server/app.py", "pkg/server/app.py"),
+        ("worker/job.py", "pkg/worker/job.py"),
+        ("services/api.py", "pkg/services/api.py"),
+        ("packages/a/index.js", "repo/packages/a/index.js"),
+    ],
+)
+def test_depth_does_not_change_the_budget(top_level, nested):
+    """The same directory name must grant the same budget at any depth."""
+    assert _max_bytes_for_path(top_level) == _max_bytes_for_path(nested), (
+        f"{top_level} gets {_max_bytes_for_path(top_level)} bytes but "
+        f"{nested} gets {_max_bytes_for_path(nested)}; the marker only matches "
+        "when the directory is nested"
+    )
+    assert _max_bytes_for_path(top_level) == SOURCE_FILE_SOFT_MAX_BYTES
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "dist/src/x.js",
+        "build/src/x.js",
+        "generated/src/x.py",
+        "src/generated/x.py",
+        "pkg/dist/x.js",
+        "src/__snapshots__/x.js",
+    ],
+)
+def test_generated_output_never_gets_the_larger_budget(path):
+    """The exclusion list has to win over the source-directory list.
+
+    ``dist/src/x.js`` is the case that inverted: it matched ``/src/`` because the
+    marker appears mid-path, but missed ``/dist/`` because that one was at the
+    start.
+    """
+    assert _max_bytes_for_path(path) == MAX_FILE_BYTES, (
+        f"{path} was granted {_max_bytes_for_path(path)} bytes; generated "
+        "output must stay on the conservative cap"
+    )
+
+
+@pytest.mark.parametrize("path", ["mysrc/big.py", "resources/big.py", "srcs/big.py"])
+def test_the_slashes_still_do_their_job(path):
+    """Normalising must not turn the markers into bare substring matches."""
+    assert _max_bytes_for_path(path) == MAX_FILE_BYTES, (
+        f"{path} matched a source-directory marker it should not; the "
+        "surrounding slashes exist to prevent exactly this"
+    )
+
+
+def test_non_source_files_are_unaffected():
+    for path in ("src/README.md", "src/data.csv", "lib/notes.txt"):
+        assert _max_bytes_for_path(path) == MAX_FILE_BYTES

--- a/tests/test_mcp_sdk_guard.py
+++ b/tests/test_mcp_sdk_guard.py
@@ -1,0 +1,149 @@
+"""The MCP entry points must report why the SDK is unusable, not guess.
+
+Every MCP server factory used to guard its import with ``except ImportError``
+and report "MCP SDK not installed. Install with: pip install mcp". Both halves
+fail in the case operators actually hit:
+
+* ``mcp`` 2.x removed ``mcp.server.fastmcp`` (FastMCP was renamed MCPServer), so
+  the import raises ``ModuleNotFoundError`` while the SDK *is* installed -- the
+  message asserts something false.
+* ``pip install mcp`` resolves 2.x, so following the advice reinstalls the
+  version that does not work. The remedy makes the failure permanent.
+
+``pyproject.toml`` pins ``mcp>=1.28.1,<2``, so a normal install is unaffected.
+These tests cover the environments that are not normal installs.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from entroly import mcp_sdk  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_an_in_range_sdk_is_not_blamed_on_the_2x_rename(monkeypatch):
+    """Three states, three causes -- do not assert a cause that cannot apply.
+
+    When ``mcp`` is installed *within* the supported range and the submodule is
+    still missing, the install is broken. Blaming the 2.x rename there is the
+    same defect this module exists to fix, pointed the other way: it names a
+    cause that did not happen and sends the operator to the wrong remedy.
+    """
+    monkeypatch.setattr(mcp_sdk, "installed_version", lambda: "1.29.1")
+    message = mcp_sdk.unavailable_reason()
+
+    assert "1.29.1" in message
+    assert "not installed" not in message, message
+    assert "2.x" not in message, (
+        f"blamed the 2.x rename for an in-range install: {message}"
+    )
+    assert mcp_sdk.REQUIRED_SPEC in message
+
+
+def test_absent_sdk_and_incompatible_sdk_get_different_messages(monkeypatch):
+    monkeypatch.setattr(mcp_sdk, "installed_version", lambda: None)
+    absent = mcp_sdk.unavailable_reason()
+
+    monkeypatch.setattr(mcp_sdk, "installed_version", lambda: "2.1.1")
+    incompatible = mcp_sdk.unavailable_reason()
+
+    assert absent != incompatible
+    assert "2.x" in incompatible, incompatible
+
+    # The absent case may say "not installed"; the incompatible case may not,
+    # because it is untrue and sends the operator down the wrong path.
+    assert "not installed" in absent
+    assert "not installed" not in incompatible
+    assert "2.1.1" in incompatible, "the incompatible message must name what is installed"
+
+    # Both must give advice that actually resolves the failure, which means the
+    # pin -- never a bare `pip install mcp`, which resolves 2.x.
+    for message in (absent, incompatible):
+        assert mcp_sdk.REQUIRED_SPEC in message, message
+        assert not re.search(r"pip install ['\"]?mcp['\"]?(?![>=<~])", message), (
+            f"advice resolves to an incompatible major version: {message}"
+        )
+
+
+def _project_dependencies() -> list[str]:
+    """Extract ``[project].dependencies`` without tomllib.
+
+    ``requires-python`` is ``>=3.10`` and ``tomllib`` arrived in 3.11, so
+    skipping when it is missing would make this gate vacuous on the minimum
+    supported interpreter -- the one most likely to be running in CI's oldest
+    matrix leg. The array is scanned directly instead. Scoping to the array
+    matters: ``[project].keywords`` also contains a bare ``"mcp"``.
+    """
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    start = text.index("dependencies = [")
+    end = text.index("]", start)
+    return re.findall(r'"([^"]+)"', text[start:end])
+
+
+def test_required_spec_matches_the_pin_in_pyproject():
+    """A hardcoded spec that drifts from the pin gives stale install advice."""
+    deps = _project_dependencies()
+    assert deps, "failed to parse [project].dependencies"
+    pins = [d for d in deps if re.match(r"^mcp\b", d.strip())]
+
+    assert len(pins) == 1, f"expected exactly one mcp pin, found {pins}"
+    declared = pins[0].replace(" ", "")
+    assert declared == mcp_sdk.REQUIRED_SPEC, (
+        f"pyproject pins {declared!r} but mcp_sdk.REQUIRED_SPEC is "
+        f"{mcp_sdk.REQUIRED_SPEC!r}; the install advice would be stale"
+    )
+
+
+def test_no_entry_point_reintroduces_the_misleading_advice():
+    """Catch the next entry point that copies the old guard.
+
+    Four factories carried the same wrong message. Fixing them once does not
+    stop a fifth from being written, so assert the property over the tree
+    instead of over the four files that happened to have it.
+    """
+    offenders: list[str] = []
+    bare_advice = re.compile(r"pip install ['\"]?mcp['\"]?(?![>=<~\w-])")
+
+    for path in (REPO_ROOT / "entroly").rglob("*.py"):
+        if path.name == "mcp_sdk.py":
+            continue  # documents the anti-pattern in prose, by design
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):  # pragma: no cover
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if bare_advice.search(line):
+                rel = path.relative_to(REPO_ROOT).as_posix()
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "these lines advise `pip install mcp`, which resolves mcp 2.x and does "
+        "not provide mcp.server.fastmcp; use entroly.mcp_sdk.load_fastmcp():\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_load_fastmcp_raises_the_explained_reason(monkeypatch):
+    """The loader must fail closed, carrying the accurate reason."""
+    real_import = __import__
+
+    def blocked(name, *args, **kwargs):
+        if name == "mcp.server.fastmcp":
+            raise ModuleNotFoundError("No module named 'mcp.server.fastmcp'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", blocked)
+    monkeypatch.setattr(mcp_sdk, "installed_version", lambda: "2.1.1")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        mcp_sdk.load_fastmcp()
+
+    assert "2.1.1" in str(excinfo.value)
+    assert mcp_sdk.REQUIRED_SPEC in str(excinfo.value)

--- a/tests/test_native_core_gating.py
+++ b/tests/test_native_core_gating.py
@@ -138,6 +138,74 @@ def test_usable_core_refuses_a_below_minimum_core() -> None:
     )
 
 
+def test_usable_core_refuses_a_core_missing_the_symbols_its_callers_use() -> None:
+    """The gate documents "incomplete" -- it has to actually detect it.
+
+    ``usable_core`` called ``native_status()`` with no required symbols, so
+    ``missing_symbols`` was always empty and the incomplete branch could never
+    fire, while the docstring promised it did. A core new enough to pass the
+    version gate but missing ``ContextFragment`` was handed back, and
+    ``checkpoint.py`` -- which dereferences it with no guard -- raised
+    ``AttributeError`` at import time instead of using the pure-Python fallback
+    in the next branch.
+
+    Partially featured cores are not hypothetical: the comment on
+    ``WORK_GRAPH_SYMBOLS`` records published 1.0.78 passing the version check
+    while lacking a symbol.
+    """
+    probe = (
+        "import sys, types\n"
+        "import entroly_core as real\n"
+        "fake = types.ModuleType('entroly_core')\n"
+        "fake.__file__ = getattr(real, '__file__', '<t>')\n"
+        "for n in dir(real):\n"
+        "    if n != 'ContextFragment':\n"
+        "        try: setattr(fake, n, getattr(real, n))\n"
+        "        except Exception: pass\n"
+        "sys.modules['entroly_core'] = fake\n"
+        "import entroly.native_status as ns\n"
+        "ns.usable_core.cache_clear()\n"
+        "print('CORE=' + repr(ns.usable_core()))\n"
+        "import entroly.checkpoint as cp\n"
+        "print('FRAGMENT_MODULE=' + cp.ContextFragment.__module__)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, timeout=300
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "an incomplete core crashed instead of falling back:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+    assert "CORE=None" in result.stdout, (
+        f"usable_core() accepted a core missing ContextFragment:\n{result.stdout}"
+    )
+    assert "FRAGMENT_MODULE=entroly" in result.stdout, (
+        "checkpoint did not fall back to the Python ContextFragment:\n"
+        f"{result.stdout}"
+    )
+
+
+def test_core_symbols_are_present_in_the_engine_this_release_builds() -> None:
+    """Guard the other direction: the gate must not disable a healthy core.
+
+    ``CORE_SYMBOLS`` is a hard requirement, so a name that is misspelled or
+    renamed in the Rust core would silently drop the whole process to
+    pure-Python -- a large, quiet performance regression rather than a failure.
+    """
+    import entroly.native_status as ns
+
+    core = pytest.importorskip("entroly_core")
+    missing = [s for s in ns.CORE_SYMBOLS if not hasattr(core, s)]
+    assert not missing, (
+        f"CORE_SYMBOLS names symbols the built core does not export: {missing}. "
+        "Every process would fall back to pure-Python."
+    )
+    assert ns.usable_core() is not None, (
+        "a healthy core was refused by the capability gate"
+    )
+
+
 def test_engine_and_checkpoint_agree_on_the_core() -> None:
     """The two halves of the crash must reach the same verdict."""
     import entroly.checkpoint as checkpoint

--- a/tests/test_ravs_confidence_bound.py
+++ b/tests/test_ravs_confidence_bound.py
@@ -1,0 +1,238 @@
+"""RAVS must not claim more confidence than its posterior supports.
+
+The router routes a request to a cheaper model when the lower end of a 95%
+credible interval on that cell's success rate clears ``ci_threshold``. That
+bound was a normal approximation, ``mean - 1.96 * std``. A Beta is not
+symmetric, and the gate lives exactly where the approximation is worst: few
+observations, mean near 1.
+
+Measured against the exact quantile, the approximation overstates the bound in
+every configuration tested, and in three it is the difference between holding
+and routing:
+
+    cell             mean-1.96s   exact 2.5%
+    n=10, 10/0         0.8367       0.7828
+    n=20, 19/1         0.8210       0.7892
+    n=35, 32/3         0.8073       0.7886
+
+The worst case is the *smallest cell that can ever qualify* -- ``min_samples``
+observations with a perfect record -- so the overstatement is largest where the
+evidence is thinnest. CLAUDE.md lists RAVS as fail-closed ("always routes to
+Opus when uncertain; never sacrifice correctness for cost"); a bound that
+overstates fails open.
+
+``report.py`` had a second, independent version of the same problem: it kept the
+empirical-Bayes prior that ``router.py`` had already removed, so the report an
+operator reads to audit routing disagreed with the router that made the call.
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from entroly.ravs import report as ravs_report  # noqa: E402
+from entroly.ravs.beta_bounds import beta_cdf, beta_lower_bound  # noqa: E402
+from entroly.ravs.router import BayesianRouter, classify_archetype  # noqa: E402
+
+FLAGSHIP = "claude-sonnet-4-20250514"
+
+
+def _normal_lower(alpha: float, beta: float) -> float:
+    """The approximation that was in use, for comparison."""
+    ab = alpha + beta
+    mean = alpha / ab
+    var = (alpha * beta) / (ab * ab * (ab + 1))
+    return max(0.0, mean - 1.96 * math.sqrt(var))
+
+
+@pytest.mark.parametrize(
+    "alpha,beta,expected",
+    [
+        (1.0, 1.0, 0.025),                       # Uniform
+        (2.0, 1.0, math.sqrt(0.025)),            # CDF = x^2
+        (1.0, 2.0, 1 - math.sqrt(0.975)),        # CDF = 1-(1-x)^2
+        (3.0, 1.0, 0.025 ** (1 / 3)),            # CDF = x^3
+    ],
+)
+def test_bound_matches_closed_form_quantiles(alpha, beta, expected):
+    """Anchor the implementation on Betas whose quantiles are known exactly."""
+    assert beta_lower_bound(alpha, beta) == pytest.approx(expected, abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    "alpha,beta",
+    [(0.5, 0.5), (1.5, 0.5), (10.5, 0.5), (20.5, 1.5), (40.5, 3.5), (200.5, 9.5)],
+)
+def test_the_bound_is_actually_the_quantile(alpha, beta):
+    """It must invert the CDF, not approximate it."""
+    x = beta_lower_bound(alpha, beta)
+    assert beta_cdf(x, alpha, beta) == pytest.approx(0.025, abs=1e-9)
+    assert 0.0 <= x <= 1.0
+
+
+@pytest.mark.parametrize(
+    "passes,failures",
+    [(10, 0), (19, 1), (32, 3), (5, 0), (50, 2), (100, 7), (2, 0)],
+)
+def test_the_bound_is_never_more_optimistic_than_the_posterior(passes, failures):
+    """The regression that matters: never report above the exact quantile.
+
+    Failing closed means erring downward. The normal approximation errs upward,
+    which is what let thin cells route.
+    """
+    alpha, beta = 0.5 + passes, 0.5 + failures
+    exact = beta_lower_bound(alpha, beta)
+    approx = _normal_lower(alpha, beta)
+    assert exact <= approx + 1e-12, (
+        f"{passes}/{failures}: exact bound {exact:.4f} exceeds the normal "
+        f"approximation {approx:.4f}; the direction of the error has flipped"
+    )
+
+
+def test_the_smallest_qualifying_cell_does_not_route(monkeypatch):
+    """A perfect record at exactly `min_samples` must not clear the gate.
+
+    This is the concrete case the approximation got wrong: 10 passes, 0
+    failures gives 0.8367 approximated and 0.7828 exactly, against a 0.80
+    threshold.
+    """
+    router = BayesianRouter()
+    router.enabled = True
+
+    message = "rename this variable"
+    archetype = classify_archetype(message)
+    passes, failures = router._min_samples, 0
+    cell = {
+        "n": passes + failures,
+        "passes": passes,
+        "failures": failures,
+        "alpha": 0.5 + passes,
+        "beta": 0.5 + failures,
+        "posterior_mean": (0.5 + passes) / (1.0 + passes + failures),
+    }
+    monkeypatch.setattr(router, "_get_cells", lambda: {archetype: cell})
+
+    # The approximation would have cleared the threshold here.
+    assert _normal_lower(cell["alpha"], cell["beta"]) > router._ci_threshold
+    assert beta_lower_bound(cell["alpha"], cell["beta"]) < router._ci_threshold
+
+    decision = router.route(FLAGSHIP, message, _ignore_enabled=True)
+    assert decision.use_original, (
+        f"routed to a cheaper model on {passes}/{failures}: {decision.reason} "
+        f"(confidence={decision.confidence})"
+    )
+    assert "ci_low" in decision.reason, decision.reason
+
+
+def test_enough_evidence_still_routes(monkeypatch):
+    """Guard the other direction: the exact bound must not disable routing.
+
+    A gate that never opens is not fail-closed, it is broken, and would be
+    invisible except as a silent loss of every cost saving RAVS exists for.
+    """
+    router = BayesianRouter()
+    router.enabled = True
+
+    message = "rename this variable"
+    archetype = classify_archetype(message)
+    passes, failures = 200, 2
+    cell = {
+        "n": passes + failures,
+        "passes": passes,
+        "failures": failures,
+        "alpha": 0.5 + passes,
+        "beta": 0.5 + failures,
+        "posterior_mean": (0.5 + passes) / (1.0 + passes + failures),
+    }
+    monkeypatch.setattr(router, "_get_cells", lambda: {archetype: cell})
+
+    decision = router.route(FLAGSHIP, message, _ignore_enabled=True)
+    assert not decision.use_original, (
+        f"a 200/2 record did not route: {decision.reason}"
+    )
+    assert decision.recommended_model
+    assert decision.confidence >= router._ci_threshold
+
+
+def test_gate_status_does_not_report_its_own_threshold_as_a_measurement():
+    """A metric field must hold a measurement or say it has none.
+
+    ``compute_gate_status`` set ``executor_coverage=min_executor_coverage`` with
+    the comment "# from shadow data", so the reported coverage was always
+    exactly the gate's threshold (0.50) no matter what the fleet did, and read
+    as measured. Nothing produces executor coverage, so the honest value is
+    "not measured".
+    """
+    from entroly.ravs.router import compute_gate_status
+
+    base = {
+        "total_requests": 100,
+        "decomposition_evidence_rate": 0.9,
+        "success_rate": 0.9,
+    }
+
+    unmeasured = compute_gate_status(base)
+    assert unmeasured.executor_coverage is None, (
+        f"reported {unmeasured.executor_coverage} for a metric nothing "
+        "measured; None means 'not measured'"
+    )
+
+    # Changing the threshold must not change the reported metric.
+    shifted = compute_gate_status(base, min_executor_coverage=0.99)
+    assert shifted.executor_coverage == unmeasured.executor_coverage, (
+        "the reported coverage tracks the threshold, so it is the threshold"
+    )
+
+    # And a real value, if one ever appears, is passed through.
+    measured = compute_gate_status({**base, "executor_coverage": 0.73})
+    assert measured.executor_coverage == pytest.approx(0.73)
+
+
+def test_report_and_router_score_a_cell_with_the_same_prior(tmp_path):
+    """The audit surface must not contradict the decision it explains.
+
+    ``report.py`` kept an empirical-Bayes prior fitted to the log it scored --
+    the construction ``router.py`` removed and documents as failing open. On a
+    log with no failures that prior is Beta(2.0, 0.1), a mean of 0.952 before
+    any observation, and it displayed P(success)=0.976 for a 2-pass cell the
+    router scores at 0.833.
+    """
+    import json
+
+    log = tmp_path / "ravs.jsonl"
+    lines = []
+    for i in range(2):
+        rid = f"r{i}"
+        lines.append(
+            json.dumps(
+                {"kind": "trace", "request_id": rid, "timestamp": 1.0 + i,
+                 "tool": "test", "type": "request"}
+            )
+        )
+        lines.append(
+            json.dumps(
+                {"kind": "outcome", "request_id": rid, "timestamp": 2.0 + i,
+                 "event_type": "test_result", "value": "passed", "tool": "test"}
+            )
+        )
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    report = ravs_report.generate_report(log)
+    cells = report.get("bayesian_cells", {})
+    if not cells:
+        pytest.skip("no bayesian cells derived from the synthetic log")
+
+    for key, cell in cells.items():
+        implied_alpha_0 = cell["alpha"] - cell["passes"]
+        implied_beta_0 = cell["beta"] - cell["failures"]
+        assert implied_alpha_0 == pytest.approx(0.5, abs=1e-6), (
+            f"{key}: report prior alpha_0={implied_alpha_0}, router uses 0.5"
+        )
+        assert implied_beta_0 == pytest.approx(0.5, abs=1e-6), (
+            f"{key}: report prior beta_0={implied_beta_0}, router uses 0.5"
+        )

--- a/tests/test_recovery_fidelity_fuzz.py
+++ b/tests/test_recovery_fidelity_fuzz.py
@@ -1,0 +1,302 @@
+"""Byte-fidelity fuzz for the compress -> receipt -> recover round trip.
+
+Everything here asserts on BYTES. Text equality is not the contract: the
+promise is that what comes back out of the store is the same octets that went
+in, for content nobody would hand-write into a fixture.
+
+Three defects motivated this file, all on the path a file with one non-UTF-8
+byte takes through `entroly compress`:
+
+1. `entroly/codec.py` measured the stored length with a bare
+   ``content.encode("utf-8")``. `cli_recover.cmd_compress` reads every file
+   with ``errors="surrogateescape"`` on purpose, so a byte that is not valid
+   UTF-8 arrives as a lone surrogate and the bare encode raised -- turning a
+   10 KB tool-output capture into ``Error: 'utf-8' codec can't encode character
+   '\\udcff'``. `_to_bytes` in that same module exists precisely to stop this,
+   and its docstring says so.
+
+2. `compression_retrieval_store._estimate_tokens` had the same bare encode, and
+   it runs from `as_dict` during `_persist`, so the store could not even write
+   the receipt it had just built.
+
+3. `compression_retrieval_store._sha256_text` hashed with ``errors="ignore"``,
+   which DELETES unencodable characters before hashing. That made the store's
+   content address non-injective: a file holding a raw non-UTF-8 byte addressed
+   identically to the same file with that byte deleted. `put` returns the
+   already-stored item for a known ``receipt_id``, so the collision silently
+   handed back the wrong original.
+
+The existing suites did not catch any of these. `test_codec_abuse` does assert
+that no codec raises on a lone surrogate, but its payloads are a few dozen
+characters -- far too small for any codec to reach `RecoveryStore.put`, which
+is where all three defects live.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from entroly.codec import RecoveryStore, content_digest
+from entroly.compression_retrieval_store import _sha256_text
+from entroly.compression_retrieval_store_secure import CompressionRetrievalStore
+
+
+# --------------------------------------------------------------------------
+# Content classes. Every one varies line to line: identical repeated lines are
+# collapsed by dedup elsewhere in the stack, and a fixture that dedups away
+# certifies nothing.
+# --------------------------------------------------------------------------
+
+def _vary(template: str, n: int = 40) -> str:
+    return "".join(template.format(i=i) for i in range(n))
+
+
+CONTENT_CASES: dict[str, str] = {
+    # line terminators -- source bytes, not presentation
+    "lf": _vary("line {i} alpha bravo\n"),
+    "crlf": _vary("line {i} alpha bravo\r\n"),
+    "lone_cr": _vary("line {i} alpha bravo\r"),
+    "mixed_eol": _vary("line {i} a\r\nline {i} b\nline {i} c\r"),
+    "no_trailing_newline": _vary("line {i} alpha\n").rstrip("\n"),
+    "crlf_no_trailing": _vary("line {i} alpha\r\n").rstrip("\r\n"),
+    # characters str.splitlines() ALSO treats as line breaks. If any layer
+    # rebuilds content by splitting and rejoining on "\n" alone, these are the
+    # ones that get silently re-terminated.
+    "vertical_tab": _vary("line {i}\x0bcontinued {i}\n"),
+    "form_feed": _vary("line {i}\x0ccontinued {i}\n"),
+    "file_separators": _vary("line {i}\x1ca\x1db\x1ec\n"),
+    "next_line_u0085": _vary("line {i}continued {i}\n"),
+    "line_separator_u2028": _vary("line {i} continued {i}\n"),
+    "paragraph_sep_u2029": _vary("line {i} continued {i}\n"),
+    # degenerate sizes
+    "empty": "",
+    "one_char": "x",
+    "one_newline": "\n",
+    "one_cr": "\r",
+    "bom_only": "﻿",
+    # unicode where byte length != character count. Entropy in this codebase is
+    # measured on bytes; a char-vs-byte confusion shows up here first.
+    "bom_prefixed": "﻿" + _vary("line {i} after a byte order mark\n"),
+    "astral_emoji": _vary("line {i} \U0001f600\U0001f680\U0001f9ea tail\n"),
+    "combining_marks": _vary("line {i} é à̧ ȫ ñ\n"),
+    "rtl_marks": _vary("line {i} ‏‎‮ rev ‬ ؜ العربية\n"),
+    "zero_width_joiners": _vary(
+        "line {i} \U0001f468‍\U0001f469‍\U0001f467 "
+        "\U0001f3f3️‍\U0001f308\n"
+    ),
+    "cjk": _vary("line {i} 中文测试 日本語\n"),
+    "latin1_lookalike": _vary("line {i} " + "".join(chr(c) for c in range(0x80, 0x100)) + "\n"),
+    "nul_bytes": _vary("line {i}\x00middle\x00tail\n"),
+    # content shaped like the receipt's own machinery
+    "delimiter_lookalike": _vary(
+        'line {i} {{"omitted_spans": [{{"start_line": 1, "end_line": {i}}}]}} '
+        'sha256:deadbeef{i} "_entroly_scope_sha256" ccr:abc{i} '
+        "[... exact excerpt gap; retrieve full source by handle ...]\n"
+    ),
+    # one very long line
+    "megaline": "x" * (1024 * 1024 + 7),
+    # bytes that are not valid UTF-8 at all, decoded the way the CLI decodes
+    # them. This is the class every defect above lived in.
+    "invalid_utf8_single": (
+        _vary("line {i} alpha\n") + b"\xff".decode("utf-8", "surrogateescape") + "\n"
+    ),
+    "invalid_utf8_block": (
+        _vary("line {i} alpha\n")
+        + bytes(range(0xC0, 0xD0)).decode("utf-8", "surrogateescape")
+        + "\n"
+    ),
+    "invalid_utf8_interleaved": _vary(
+        "line {i} " + b"\x80\xfe".decode("utf-8", "surrogateescape") + " tail\n"
+    ),
+    # a genuine lone surrogate that surrogateescape cannot encode -- it is
+    # outside U+DC80..U+DCFF, so any fix must not simply swap one error handler
+    # for another.
+    "lone_high_surrogate": _vary("line {i} \ud800 tail\n"),
+}
+
+
+def _exact(text: str) -> bytes:
+    return text.encode("utf-8", "surrogatepass")
+
+
+@pytest.mark.parametrize("label", sorted(CONTENT_CASES))
+def test_recovery_store_round_trip_is_byte_exact(label, tmp_path: Path):
+    """put -> (fresh store object) reference_for -> recover returns the bytes.
+
+    The second store is deliberately a new instance over the same path: that is
+    the code path `entroly recover` takes in a separate process, and it
+    reconstructs the reference from the persisted receipt rather than from
+    in-process state.
+    """
+    text = CONTENT_CASES[label]
+    expected = _exact(text)
+
+    written = RecoveryStore(tmp_path / "recovery.json", scope_id="fuzz")
+    ref = written.put(text, item_count=1, note="fuzz")
+
+    reread = RecoveryStore(tmp_path / "recovery.json", scope_id="fuzz")
+    rebuilt = reread.reference_for(ref.digest)
+    assert rebuilt is not None, f"{label}: digest did not survive persistence"
+
+    recovered = reread.recover(rebuilt)
+    assert _exact(recovered) == expected, f"{label}: recovered bytes differ"
+
+
+@pytest.mark.parametrize("label", sorted(CONTENT_CASES))
+def test_recovery_reference_byte_length_matches_the_content(label, tmp_path: Path):
+    """`byte_length` is half of what `verify` authenticates -- it must be true.
+
+    Checking the digest alone would leave the length decorative, which is the
+    reason `RecoveryReference.verify` compares both.
+    """
+    text = CONTENT_CASES[label]
+    store = RecoveryStore(tmp_path / "recovery.json", scope_id="fuzz")
+    ref = store.put(text)
+    assert ref.byte_length == len(_exact(text))
+
+    reread = RecoveryStore(tmp_path / "recovery.json", scope_id="fuzz")
+    rebuilt = reread.reference_for(ref.digest)
+    assert rebuilt is not None
+    # Rebuilt from persisted metadata, so this is a different code path than
+    # the one above and has independently been wrong.
+    assert rebuilt.byte_length == len(_exact(text)), (
+        f"{label}: persisted byte_length {rebuilt.byte_length} "
+        f"!= {len(_exact(text))}"
+    )
+    assert rebuilt.verify(text)
+
+
+def test_content_digest_is_sha256_of_the_exact_bytes():
+    """The digest a receipt publishes has to be a digest of something real."""
+    for label, text in CONTENT_CASES.items():
+        expected = "sha256:" + hashlib.sha256(_exact(text)).hexdigest()
+        assert content_digest(text) == expected, label
+
+
+# --------------------------------------------------------------------------
+# The store's content address must be injective over its own input domain.
+# --------------------------------------------------------------------------
+
+_COLLIDING_PAIRS = [
+    # a raw non-UTF-8 byte vs. that byte simply not being there
+    ("alpha\n\udcff SECRET\nomega\n", "alpha\n SECRET\nomega\n"),
+    ("\udc80head\ntail\n", "head\ntail\n"),
+    # two DIFFERENT non-UTF-8 bytes
+    ("alpha\n\udcff\nomega\n", "alpha\n\udcfe\nomega\n"),
+    # a genuine lone surrogate vs. nothing
+    ("alpha\n\ud800\nomega\n", "alpha\n\nomega\n"),
+]
+
+
+@pytest.mark.parametrize("left,right", _COLLIDING_PAIRS)
+def test_store_content_address_separates_different_content(left, right):
+    """Different bytes must not share a content address.
+
+    ``errors="ignore"`` deleted every unencodable character before hashing, so
+    each of these pairs hashed identically. `put` returns the item already
+    stored for a known ``receipt_id``, and ``receipt_id`` is derived from this
+    hash -- so the collision was not cosmetic, it returned the wrong original.
+    """
+    assert left != right
+    assert _sha256_text(left) != _sha256_text(right)
+
+
+def test_put_does_not_alias_two_originals_that_differ_only_in_raw_bytes(tmp_path: Path):
+    """The end-to-end consequence of the address collision, on the real store."""
+    receipt = {
+        "original_tokens": 5,
+        "compressed_tokens": 0,
+        "omitted_spans": [
+            {"start_line": 1, "end_line": 3, "reason": "codec_original_source"}
+        ],
+    }
+    first = "alpha\n\udcff SECRET-A\nomega\n"
+    second = "alpha\n SECRET-A\nomega\n"
+
+    store = CompressionRetrievalStore(
+        tmp_path / "recovery.json", scope_id="fuzz", require_scope=True
+    )
+    stored_first = store.put(
+        original_text=first, compressed_text="", receipt=dict(receipt)
+    )
+    stored_second = store.put(
+        original_text=second, compressed_text="", receipt=dict(receipt)
+    )
+
+    assert stored_first.receipt_id != stored_second.receipt_id
+
+    back_first = store.get_span(stored_first.receipt_id, stored_first.spans[0].span_id)
+    back_second = store.get_span(
+        stored_second.receipt_id, stored_second.spans[0].span_id
+    )
+    assert back_first is not None and back_second is not None
+    assert _exact(back_first.content) == _exact(first)
+    assert _exact(back_second.content) == _exact(second)
+
+
+# --------------------------------------------------------------------------
+# The compress path proper: a codec has to be able to reach `put` at all.
+# --------------------------------------------------------------------------
+
+def _shell_capture(mutate_bytes) -> str:
+    """Tool output big enough for a codec to claim AND compress."""
+    lines = ["$ ./run-suite.sh --verbose"]
+    for i in range(200):
+        lines.append(
+            f"[{i:04d}] INFO worker-{i} handled rid={1000 + i} in {i % 97}ms ok"
+        )
+    lines += [
+        "FAILED tests/test_alpha.py::test_one - AssertionError: mismatch",
+        "3 passed",
+        "exit code 1",
+    ]
+    raw = ("\n".join(lines) + "\n").encode("utf-8")
+    return mutate_bytes(raw).decode("utf-8", "surrogateescape")
+
+
+@pytest.mark.parametrize(
+    "label,mutate",
+    [
+        ("clean", lambda b: b),
+        ("single_invalid_byte", lambda b: b.replace(b"worker-7 ", b"worker-\xff ", 1)),
+        (
+            "truncated_multibyte",
+            lambda b: b.replace(b"worker-9 ", b"worker-\xe4\xb8 ", 1),
+        ),
+        (
+            "latin1_block",
+            lambda b: b.replace(b"worker-11 ", bytes(range(0xC0, 0xD0)) + b" ", 1),
+        ),
+        ("crlf_and_invalid", lambda b: b.replace(b"\n", b"\r\n").replace(
+            b"worker-7 ", b"worker-\xff ", 1)),
+    ],
+)
+def test_compress_path_recovers_the_original_bytes(label, mutate, tmp_path: Path):
+    """Route real content through the registry and recover it byte-for-byte.
+
+    Not a unit test of one codec: `default_registry` picks the winner, and the
+    point is that whichever codec wins can still store and return the source.
+    Before the fix, `single_invalid_byte` raised UnicodeEncodeError here.
+    """
+    from entroly.codecs_builtin import default_registry
+
+    text = _shell_capture(mutate)
+    store = RecoveryStore(tmp_path / "recovery.json", scope_id="fuzz")
+    reps = default_registry(store).representations(text, source_id=f"capture-{label}")
+    assert reps, f"{label}: no codec claimed shell-shaped output"
+
+    recoverable = [r for r in reps if r.recovery is not None]
+    assert recoverable, f"{label}: no representation carried a recovery reference"
+
+    reread = RecoveryStore(tmp_path / "recovery.json", scope_id="fuzz")
+    for rep in recoverable:
+        rebuilt = reread.reference_for(rep.recovery.digest)
+        assert rebuilt is not None, f"{label}: {rep.representation_id} lost its digest"
+        recovered = reread.recover(rebuilt)
+        assert _exact(recovered) == _exact(text), (
+            f"{label}: {rep.representation_id} did not recover the source"
+        )
+        assert rep.source_sha256 == content_digest(text)

--- a/tests/test_reported_metric_honesty.py
+++ b/tests/test_reported_metric_honesty.py
@@ -175,3 +175,65 @@ def test_untruncated_listing_reports_an_exact_count(prefer_rust):
         f"{risk['omitted_relevant_chunks']} relevant chunk(s) were omitted; "
         "inspect omitted_context."
     )
+
+
+# ── Two normalisers, one documented input shape ───────────────────────────
+
+
+def test_both_document_normalisers_accept_the_same_shapes():
+    """A `{path: text}` mapping must ingest the same way through either door.
+
+    `sdk._normalize_receipt_documents` reads a top-level dict as
+    `{source_path: text}` — that is the path the MCP `create_context_receipt`
+    tool uses. `context_receipts.ingest.normalize_document_pairs` discarded a
+    Mapping outright, so the *same documented input* produced a full receipt
+    through one entry point and an empty one through the other.
+
+    A dict also satisfies the declared `Iterable[tuple[str, str]]` by
+    duck-typing, so `ingest_documents({...})` returned an index of zero chunks
+    without raising, and the receipt then reported "No relevant chunks matched
+    the query" — blaming the query for input that was never ingested.
+    """
+    from entroly.context_receipts.ingest import normalize_document_pairs
+    from entroly.sdk import _normalize_receipt_documents
+
+    shapes = {
+        "mapping": {"a.py": "def f():\n    return 1\n", "b.py": "def g():\n    return 2\n"},
+        "pairs": [("a.py", "def f():\n    return 1\n"), ("b.py", "def g():\n    return 2\n")],
+        "records": [
+            {"source_path": "a.py", "text": "def f():\n    return 1\n"},
+            {"source_path": "b.py", "text": "def g():\n    return 2\n"},
+        ],
+    }
+    for label, payload in shapes.items():
+        via_ingest = normalize_document_pairs(payload)
+        via_sdk = _normalize_receipt_documents(payload)
+        assert via_ingest == via_sdk, (
+            f"{label}: the two normalisers disagree — "
+            f"ingest={via_ingest!r} sdk={via_sdk!r}"
+        )
+        assert len(via_ingest) == 2, f"{label}: expected 2 documents, got {via_ingest!r}"
+
+
+def test_a_mapping_actually_reaches_the_index():
+    """The end the defect was visible from: chunks, not an empty receipt."""
+    from entroly.context_receipts.ingest import ingest_documents
+
+    docs = {
+        "src/a.py": "def refund_declined(payment):\n    return payment.validate()\n",
+        "src/b.py": "def widget(alpha, beta):\n    return alpha * beta\n",
+    }
+    index = ingest_documents(docs, chunk_tokens=40)
+    assert index.chunks, "a {path: text} mapping produced an empty index"
+    sources = {c.source_path for c in index.chunks}
+    assert sources == set(docs), f"ingested sources {sources} != {set(docs)}"
+
+
+def test_non_document_inputs_are_still_refused():
+    """The deliberate rejections must survive the mapping change."""
+    from entroly.context_receipts.ingest import normalize_document_pairs
+
+    assert normalize_document_pairs("not documents") == []
+    assert normalize_document_pairs(b"raw bytes") == []
+    # Malformed rows are skipped rather than raising — the documented contract.
+    assert normalize_document_pairs([("only-one",), 42, {"no": "usable keys"}]) == []

--- a/tests/test_reported_metric_honesty.py
+++ b/tests/test_reported_metric_honesty.py
@@ -1,0 +1,177 @@
+"""Reported-metric honesty: a receipt must not report a number it did not measure.
+
+``omitted_context`` is a bounded, score-descending *listing*. Counting entries
+in that listing yields a value that saturates at the listing cap, so a receipt
+that withheld 299 relevant chunks used to be indistinguishable from one that
+withheld 20 -- and the ``omitted_evidence_pressure`` control derived from that
+saturated count could read ``low`` while a clear majority of relevant evidence
+was withheld.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entroly.context_receipts import run_receipt_pipeline
+from entroly.context_receipts.selection import MAX_OMITTED_LISTED
+
+QUERY = "aardvark telemetry checkpoint"
+
+# Every document gets unique filler. Repeated content is collapsed by the
+# redundancy/dedup paths, which would silently shrink the corpus and make the
+# saturation impossible to observe.
+_FILLER = ("zebra", "mango", "quartz", "lantern", "gravel", "wombat", "syrup")
+
+
+def _relevant_doc(i: int) -> tuple[str, str]:
+    words = " ".join(f"{w}{i}_{j}" for j, w in enumerate(_FILLER))
+    return (
+        f"rel_{i:04d}.md",
+        f"# S{i} aardvark telemetry checkpoint\n"
+        f"aardvark telemetry checkpoint entry {i}\n{words}\n"
+        + " ".join(f"t{i}q{k}" for k in range(12)),
+    )
+
+
+def _irrelevant_doc(i: int) -> tuple[str, str]:
+    words = " ".join(f"{w}{i}_{j}x" for j, w in enumerate(_FILLER))
+    return (
+        f"irr_{i:04d}.md",
+        f"# U{i} unrelated bookkeeping\n"
+        f"nothing in record {i} concerns the query\n{words}\n"
+        + " ".join(f"u{i}q{k}" for k in range(12)),
+    )
+
+
+def _corpus(relevant: int, irrelevant: int = 0) -> list[tuple[str, str]]:
+    return [_relevant_doc(i) for i in range(relevant)] + [
+        _irrelevant_doc(i) for i in range(irrelevant)
+    ]
+
+
+def _band(pressure: float) -> str:
+    if pressure > 0.4:
+        return "high"
+    if pressure > 0.15:
+        return "medium"
+    return "low"
+
+
+def _receipt(documents, budget, prefer_rust):
+    return run_receipt_pipeline(
+        documents, query=QUERY, token_budget=budget, prefer_rust=prefer_rust
+    )
+
+
+def _omitted_warning(receipt) -> str:
+    matches = [w for w in receipt["warnings"] if "relevant chunk(s) were omitted" in w]
+    assert matches, f"no omitted-evidence warning in {receipt['warnings']}"
+    return matches[0]
+
+
+@pytest.mark.parametrize("prefer_rust", [True, False], ids=["rust", "python"])
+@pytest.mark.parametrize("documents", [60, 300])
+def test_omitted_evidence_count_does_not_saturate_at_the_listing_cap(
+    documents, prefer_rust
+):
+    receipt = _receipt(_corpus(documents), budget=90, prefer_rust=prefer_rust)
+    risk = receipt["risk_summary"]
+
+    # Mechanism guard: the fixture must actually overflow the listing, and no
+    # document may have been collapsed away before selection ran.
+    assert risk["total_chunks"] == documents
+    assert len(receipt["omitted_context"]) == MAX_OMITTED_LISTED
+    assert risk["omitted_context_listed"] == MAX_OMITTED_LISTED
+    assert risk["omitted_context_listing_truncated"] is True
+
+    # The count taken from the listing is a lower bound and must say so.
+    assert risk["omitted_relevant_chunks_exact"] is False
+    assert risk["omitted_chunks_total"] == documents - risk["selected_chunks"]
+    assert risk["omitted_relevant_chunks_upper_bound"] == risk["omitted_chunks_total"]
+
+    warning = _omitted_warning(receipt)
+    assert warning.startswith("at least "), warning
+    assert str(risk["omitted_chunks_total"]) in warning
+
+
+@pytest.mark.parametrize("prefer_rust", [True, False], ids=["rust", "python"])
+def test_omitted_evidence_scale_is_visible_across_two_corpus_sizes(prefer_rust):
+    """Two corpora that differ by 240 withheld chunks must not report the same."""
+    small = _receipt(_corpus(60), budget=90, prefer_rust=prefer_rust)["risk_summary"]
+    large = _receipt(_corpus(300), budget=90, prefer_rust=prefer_rust)["risk_summary"]
+
+    # Pre-fix, this was the *only* omitted-evidence quantity in the receipt and
+    # it read 20 for both corpora.
+    assert small["omitted_relevant_chunks"] == large["omitted_relevant_chunks"]
+    assert small["omitted_chunks_total"] != large["omitted_chunks_total"]
+    assert large["omitted_chunks_total"] - small["omitted_chunks_total"] == 240
+
+
+@pytest.mark.parametrize("prefer_rust", [True, False], ids=["rust", "python"])
+def test_omitted_evidence_pressure_fails_closed_when_the_listing_truncates(
+    prefer_rust,
+):
+    """The control must not read ``low`` while most relevant evidence is withheld."""
+    receipt = _receipt(_corpus(300), budget=3920, prefer_rust=prefer_rust)
+    risk = receipt["risk_summary"]
+    selected = risk["selected_chunks"]
+    listed_relevant = risk["omitted_relevant_chunks"]
+    true_omitted = risk["total_chunks"] - selected
+
+    # Mechanism guard: enough context fits that the *saturated* count would have
+    # produced a reassuring band, while the true withholding is severe.
+    assert risk["omitted_context_listing_truncated"] is True
+    assert risk["omitted_relevant_chunks_exact"] is False
+    saturated_band = _band(listed_relevant / (selected + listed_relevant))
+    true_band = _band(true_omitted / (selected + true_omitted))
+    assert saturated_band == "low"
+    assert true_band == "high"
+
+    controls = risk["controls"]
+    assert controls["omitted_evidence_pressure"] == "high"
+    assert (
+        controls["omitted_evidence_pressure_basis"]
+        == "upper_bound_truncated_omitted_listing"
+    )
+
+
+@pytest.mark.parametrize("prefer_rust", [True, False], ids=["rust", "python"])
+def test_relevant_count_stays_exact_when_the_listing_reaches_the_zero_score_tail(
+    prefer_rust,
+):
+    """Negative control: no fail-closed escalation when the count is provably complete.
+
+    The listing is score-descending, so a truncated listing that still contains
+    a zero-score entry has already passed every relevant omission.
+    """
+    receipt = _receipt(_corpus(10, irrelevant=60), budget=60, prefer_rust=prefer_rust)
+    risk = receipt["risk_summary"]
+
+    assert risk["total_chunks"] == 70
+    assert risk["omitted_context_listing_truncated"] is True
+    assert any(item["score"] <= 0 for item in receipt["omitted_context"])
+    assert risk["omitted_relevant_chunks_exact"] is True
+    assert (
+        risk["controls"]["omitted_evidence_pressure_basis"]
+        == "exact_relevant_omitted_count"
+    )
+    assert (
+        risk["omitted_relevant_chunks_upper_bound"] == risk["omitted_relevant_chunks"]
+    )
+    assert not _omitted_warning(receipt).startswith("at least ")
+
+
+@pytest.mark.parametrize("prefer_rust", [True, False], ids=["rust", "python"])
+def test_untruncated_listing_reports_an_exact_count(prefer_rust):
+    receipt = _receipt(_corpus(5), budget=90, prefer_rust=prefer_rust)
+    risk = receipt["risk_summary"]
+
+    assert risk["total_chunks"] == 5
+    assert len(receipt["omitted_context"]) < MAX_OMITTED_LISTED
+    assert risk["omitted_context_listing_truncated"] is False
+    assert risk["omitted_relevant_chunks_exact"] is True
+    assert risk["omitted_relevant_chunks"] == risk["omitted_chunks_total"]
+    assert _omitted_warning(receipt) == (
+        f"{risk['omitted_relevant_chunks']} relevant chunk(s) were omitted; "
+        "inspect omitted_context."
+    )

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -255,6 +255,40 @@ def test_project_scope_helpers_reject_parent_traversal(tmp_path):
     assert resolve_output_within(project, "../training.jsonl") is None
 
 
+def test_output_scope_rejects_dangling_symlink_out_of_project(tmp_path):
+    """A symlink whose target does not exist yet still redirects the write.
+
+    ``resolve_output_within`` guards every vault write and the MCP receipt
+    tool. It used to check containment only when ``candidate_path.exists()``,
+    and ``exists`` follows symlinks -- so a link pointing outside the project at
+    a target that had not been created reported ``False``, skipped the check,
+    and was returned as safe. Writing through the returned path then landed
+    outside the project. A *live* symlink was already blocked, which is why this
+    needs its own case: the escape is only reachable while the target is
+    missing, which is exactly how it would be planted.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    dangling = project / "dangling.jsonl"
+    try:
+        dangling.symlink_to(outside / "not_created_yet.jsonl")
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    assert not dangling.exists()  # the condition that used to skip the check
+    assert resolve_output_within(project, "dangling.jsonl") is None
+    assert resolve_output_within(project, dangling) is None
+
+    # A dangling link that stays inside the project is still a legitimate
+    # output target -- the rule is containment, not "no symlinks".
+    inside_link = project / "inside.jsonl"
+    inside_link.symlink_to(project / "later.jsonl")
+    assert resolve_output_within(project, "inside.jsonl") == (project / "later.jsonl").resolve()
+
+
 def test_skill_benchmark_rejects_parent_traversal(tmp_path):
     vault = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
     vault.ensure_structure()

--- a/tests/test_verify_claims_baseline_honesty.py
+++ b/tests/test_verify_claims_baseline_honesty.py
@@ -1,0 +1,138 @@
+"""`verify-claims` must measure savings against the same baseline as `simulate`.
+
+Onboarding tells a new user to run `entroly verify-claims` (step 1) and then
+`entroly simulate` (step 2). `cmd_simulate` measures against
+``min(total_tokens, 32_000)`` -- a context window someone might plausibly fill --
+and reports ``baseline_tokens`` alongside the percentage. `verify-claims`
+divided by the entire indexed corpus instead, which credits every fragment that
+was never going to be sent; ``engine._honest_tokens_saved`` documents that as the
+error its own baseline helper exists to prevent.
+
+Measured on this repository before the fix: verify-claims printed 99.4% against
+769,339 corpus tokens while simulate reported 89.1% for the same repo, and only
+simulate disclosed what it compared against.
+
+CLAUDE.md's benchmark-honesty rule is that a claim carries its baseline, so
+these assert both halves: the right baseline, and that it is reported.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from entroly.engine import naive_context_baseline  # noqa: E402
+from entroly.verify_claims import run as run_verify_claims  # noqa: E402
+
+
+@pytest.fixture
+def tiny_repo(tmp_path, monkeypatch):
+    """A small project so the pass indexes quickly."""
+    src = tmp_path / "proj"
+    (src / "pkg").mkdir(parents=True)
+    for i in range(4):
+        (src / "pkg" / f"module_{i}.py").write_text(
+            "\n".join(
+                [
+                    f'"""Module {i} of the main module structure."""',
+                    f"def handler_{i}(payload):",
+                    f"    # explain the main module structure for {i}",
+                    "    total = 0",
+                    "    for item in payload:",
+                    "        total += item",
+                    "    return total",
+                    "",
+                ]
+                * 12
+            ),
+            encoding="utf-8",
+        )
+    monkeypatch.chdir(src)
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    return src
+
+
+def _report(tmp_path, tiny_repo) -> dict:
+    out = tmp_path / "verification.json"
+    run_verify_claims(output=str(out), max_files=8)
+    assert out.exists(), "verify-claims wrote no report"
+    return json.loads(out.read_text(encoding="utf-8"))
+
+
+def test_savings_are_measured_against_the_capped_baseline(tmp_path, tiny_repo):
+    report = _report(tmp_path, tiny_repo)
+
+    total = report["total_tokens"]
+    expected = naive_context_baseline(total)
+
+    assert "baseline_tokens" in report, (
+        "the report states a savings percentage without saying what it is "
+        "measured against"
+    )
+    assert report["baseline_tokens"] == expected, (
+        f"baseline is {report['baseline_tokens']} but naive_context_baseline"
+        f"({total}) is {expected}; dividing by the whole corpus credits "
+        "fragments that were never going to be sent"
+    )
+
+
+def test_the_reported_percentage_matches_the_reported_baseline(tmp_path, tiny_repo):
+    """The number and its stated baseline have to be the same calculation."""
+    report = _report(tmp_path, tiny_repo)
+
+    used = report["tokens_used"]
+    baseline = report["baseline_tokens"]
+    stated = report["savings_pct"]
+
+    if used == 0 or baseline == 0:
+        assert stated == 0.0, "selecting nothing is not a saving"
+        return
+
+    recomputed = round((1 - used / baseline) * 100, 1)
+    assert stated == pytest.approx(recomputed, abs=0.1), (
+        f"reported {stated}% but {used} tokens against a {baseline}-token "
+        f"baseline is {recomputed}%"
+    )
+    assert 0.0 <= stated <= 100.0, f"savings of {stated}% is not a proportion"
+
+
+def test_the_two_onboarding_commands_share_one_baseline_rule(tmp_path, tiny_repo):
+    """Guard the specific divergence: corpus total vs capped window.
+
+    If ``verify-claims`` regressed to dividing by ``total_tokens``, this catches
+    it whenever the corpus exceeds the cap -- so the fixture is padded past
+    32,000 tokens to make the two rules give different answers.
+    """
+    # Unique bodies: repeating one block makes every chunk a near-duplicate of
+    # the last, and SimHash dedup collapses them, leaving a corpus far under the
+    # cap. Measured with a repeated block: 2,038 tokens instead of tens of
+    # thousands, which silently skipped this test.
+    for f in range(6):
+        (tiny_repo / "pkg" / f"bulk_{f}.py").write_text(
+            "\n".join(
+                f"def bulk_{f}_{n}(records):\n"
+                f"    total_{n} = {n * 7 + f}\n"
+                f"    for record in records:\n"
+                f"        total_{n} += record.value_{n} * {n % 89 + 3}\n"
+                f"    return total_{n} - {n * 17 % 103}\n"
+                for n in range(500)
+            ),
+            encoding="utf-8",
+        )
+
+    report = _report(tmp_path, tiny_repo)
+    total = report["total_tokens"]
+    if total <= 32_000:
+        pytest.skip(f"corpus is only {total} tokens; the two rules agree here")
+
+    assert report["baseline_tokens"] == 32_000, (
+        f"corpus is {total} tokens but the baseline is "
+        f"{report['baseline_tokens']}; the cap was not applied"
+    )
+    assert report["baseline_tokens"] != total, (
+        "the baseline is the whole corpus again"
+    )

--- a/tests/test_witness_fail_closed_audit.py
+++ b/tests/test_witness_fail_closed_audit.py
@@ -228,3 +228,59 @@ def test_parseable_timestamps_still_classify_correctly(engine_and_beliefs):
 
     assert engine.check_belief("c_fresh")["status"] == "verified"
     assert engine.check_belief("c_old")["status"] == "needs_attention"
+
+
+# ── Signals 2-4: correct API, and a reason that is true ────────────────────
+
+
+def test_unavailable_signals_report_a_true_reason_not_an_attribute_error():
+    """A signal that cannot measure must say why, accurately.
+
+    All three of ECE/EPR/spectral had drifted out of API compatibility --
+    `ece.evaluate` does not exist (it is `evaluate_uncertainty`), and EPRSignal
+    and SpectralSignal are dataclasses, not dicts, so `.get(...)` raised. The
+    reported reason was therefore an AttributeError string, which reads as a
+    trivial code bug rather than the real situation: these signals need token
+    logprobs or extractable entities, and this tool receives plain text.
+    """
+    from entroly.ravs.ece import EpistemicCascadeEngine
+    from entroly.ravs.epr import compute_epr
+    from entroly.ravs.spectral import compute_spectral_consistency
+
+    # The real APIs exist under these names.
+    assert hasattr(EpistemicCascadeEngine, "evaluate_uncertainty")
+    assert not hasattr(EpistemicCascadeEngine, "evaluate"), (
+        "an `evaluate` method appeared; re-check which one verify_response calls"
+    )
+
+    # They return dataclasses, so `.get` is not available -- the original bug.
+    epr = compute_epr("some response text")
+    assert not hasattr(epr, "get")
+    assert hasattr(epr, "has_logprobs")
+
+    spec = compute_spectral_consistency("ctx", "resp")
+    assert not hasattr(spec, "get")
+    assert hasattr(spec, "n_ctx_entities") and hasattr(spec, "score")
+
+
+def test_spectral_argument_order_is_context_then_response():
+    """`compute_spectral_consistency(context, response)` is not symmetric.
+
+    verify_response passed them reversed. Measured on one pair the two orders
+    gave 0.2000 and 0.5000, so the swap silently changed the number -- latent
+    only because the call was raising before it could be used.
+    """
+    from entroly.ravs.spectral import compute_spectral_consistency
+
+    context = (
+        "The RefundProcessor validates DeclinedTransaction objects and "
+        "PaymentGateway.charge calls StripeAdapter.submit."
+    )
+    response = "ZylophaneScheduler reconciles ParallelUniverseBatch records."
+
+    forward = compute_spectral_consistency(context, response)
+    reversed_ = compute_spectral_consistency(response, context)
+    assert (forward.n_ctx_entities, forward.n_resp_entities) != (
+        reversed_.n_ctx_entities,
+        reversed_.n_resp_entities,
+    ), "the two orders are indistinguishable here; pick a pair that separates them"

--- a/tests/test_witness_fail_closed_audit.py
+++ b/tests/test_witness_fail_closed_audit.py
@@ -1,0 +1,230 @@
+"""Fail-closed audit for the groundedness/verification surface.
+
+CLAUDE.md trust invariant: "Fail-closed verification: WITNESS, RAVS, and
+native-status checks must degrade safely, not silently claim confidence."
+
+These tests pin the property that a check which did not run is never
+reported as a check that passed. Two regressions are covered:
+
+1. `verify_response` (MCP tool, entroly/server.py) read every signal back
+   out of its own result dict with `.get("risk_score", 0)`. Each signal was
+   raising an AttributeError, so each was scored as ZERO risk — i.e. as
+   positive evidence of safety — and every response, including fabricated
+   ones, came back `fused_risk=0.0, verdict="pass"`.
+
+2. `VerificationEngine._check_staleness` swallowed a `ValueError` from an
+   unparseable `last_checked`, so `check_belief` returned status="verified"
+   with no issues for a belief whose freshness was never established.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import textwrap
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from entroly.vault import VaultConfig, VaultManager
+from entroly.verification_engine import VerificationEngine
+
+
+# ── 1. verify_response must not certify what it did not check ────────
+
+CONTEXT = "The build fails when the incremental cache is enabled."
+FABRICATED = "The build is orchestrated by the Zylophane quantum scheduler at 4400 THz."
+
+
+def _call_verify_response(monkeypatch, tmp_path, **kwargs) -> dict:
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "entroly"))
+    from entroly.server import create_mcp_server
+
+    mcp, _engine = create_mcp_server()
+
+    async def _run():
+        return await mcp.call_tool("verify_response", kwargs)
+
+    out = asyncio.run(_run())
+    raw = out[0][0].text if isinstance(out, tuple) else out[0].text
+    return json.loads(raw)
+
+
+def test_verify_response_flags_a_fabricated_response(monkeypatch, tmp_path):
+    """A response with no support in context must not come back "pass"."""
+    report = _call_verify_response(
+        monkeypatch, tmp_path, response=FABRICATED, context=CONTEXT
+    )
+    assert report["verdict"] != "pass", report
+    assert report["fused_risk"] > 0.15, report
+
+
+def test_verify_response_witness_signal_actually_runs(monkeypatch, tmp_path):
+    """The primary WITNESS signal must produce a score, not an exception.
+
+    Guards the attribute contract between server.py and witness.py:
+    WitnessResult exposes `certificates`/`summary_score` and Certificate
+    exposes `claim_text`/`risk`/`label` — not `total_claims`/`text`/`score`.
+    """
+    report = _call_verify_response(
+        monkeypatch, tmp_path, response=FABRICATED, context=CONTEXT
+    )
+    witness = report["witness"]
+    assert "status" not in witness, f"WITNESS did not run: {witness}"
+    assert "witness" in report["signals_scored"], report["signals_scored"]
+    assert 0.0 <= witness["risk_score"] <= 1.0
+
+
+def test_verify_response_witness_risk_is_complement_of_groundedness(
+    monkeypatch, tmp_path
+):
+    """Polarity guard: summary_score is groundedness, risk is 1 - it.
+
+    Feeding summary_score straight into the 0.80-weighted risk term
+    inverts the tool — a perfectly grounded response scores ~0.8 risk.
+    """
+    report = _call_verify_response(
+        monkeypatch, tmp_path, response=CONTEXT, context=CONTEXT
+    )
+    witness = report["witness"]
+    assert "status" not in witness, f"WITNESS did not run: {witness}"
+    assert witness["risk_score"] == pytest.approx(
+        1.0 - witness["groundedness"], abs=1e-4
+    )
+    # A verbatim restatement of the context is grounded -> low risk.
+    assert witness["risk_score"] < 0.15, witness
+    assert report["verdict"] == "pass", report
+
+
+def test_verify_response_unavailable_signal_is_not_scored_as_zero_risk(
+    monkeypatch, tmp_path
+):
+    """A raising signal must be excluded, never zero-filled.
+
+    Zero-filling is the fail-open: it makes "the check crashed" arithmetically
+    identical to "the check found no risk".
+    """
+    import entroly.ravs.epr as epr_mod
+
+    def _boom(*a, **k):
+        raise RuntimeError("epr exploded")
+
+    monkeypatch.setattr(epr_mod, "compute_epr", _boom)
+
+    report = _call_verify_response(
+        monkeypatch, tmp_path, response=FABRICATED, context=CONTEXT
+    )
+    assert "epr" in report["signals_unavailable"], report
+    assert "epr" not in report["signals_scored"], report
+    assert "epr" not in report["signal_weights"], report
+    # The broken signal must not have dragged the fused risk toward safe.
+    assert report["verdict"] != "pass", report
+
+
+def test_verify_response_without_witness_cannot_return_pass(monkeypatch, tmp_path):
+    """Losing the primary groundedness signal must block a "pass" verdict."""
+    import entroly.witness as witness_mod
+
+    class _Broken:
+        def __init__(self, *a, **k):
+            raise RuntimeError("witness engine unavailable")
+
+    monkeypatch.setattr(witness_mod, "WitnessAnalyzer", _Broken)
+
+    report = _call_verify_response(
+        monkeypatch, tmp_path, response=CONTEXT, context=CONTEXT
+    )
+    assert report["witness"]["status"] == "unavailable", report
+    assert report["verdict"] == "unverified", report
+    assert report["verdict"] != "pass"
+    assert "witness" in report["signals_unavailable"], report
+    assert "not" in report["recommendation"].lower()
+
+
+def test_verify_response_with_no_working_signal_reports_maximum_risk(
+    monkeypatch, tmp_path
+):
+    """If nothing ran, unknown is not safe."""
+    import entroly.witness as witness_mod
+
+    class _Broken:
+        def __init__(self, *a, **k):
+            raise RuntimeError("witness engine unavailable")
+
+    monkeypatch.setattr(witness_mod, "WitnessAnalyzer", _Broken)
+
+    report = _call_verify_response(
+        monkeypatch, tmp_path, response=FABRICATED, context=CONTEXT
+    )
+    if not report["signals_scored"]:
+        assert report["fused_risk"] == 1.0, report
+    assert report["verdict"] != "pass", report
+
+
+# ── 2. A belief whose freshness check could not run is not "verified" ──
+
+
+def _write_belief(beliefs_dir, name: str, claim_id: str, last_checked: str) -> None:
+    beliefs_dir.mkdir(parents=True, exist_ok=True)
+    (beliefs_dir / f"{name}.md").write_text(
+        textwrap.dedent(
+            f"""\
+            ---
+            claim_id: {claim_id}
+            entity: {name}
+            status: verified
+            confidence: 0.9
+            last_checked: {last_checked}
+            sources:
+              - {name}.py:1
+            ---
+
+            The {name} module does the thing.
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def engine_and_beliefs(tmp_path):
+    vault = VaultManager(VaultConfig(base_path=str(tmp_path / "vault")))
+    vault.ensure_structure()
+    return VerificationEngine(vault), vault.config.path / "beliefs"
+
+
+@pytest.mark.parametrize(
+    "bad_timestamp",
+    ["not-a-timestamp", "2024-13-45T99:99:99+00:00", "yesterday", "0"],
+)
+def test_unparseable_last_checked_is_not_reported_verified(
+    engine_and_beliefs, bad_timestamp
+):
+    engine, beliefs_dir = engine_and_beliefs
+    _write_belief(beliefs_dir, "corrupt", "c_corrupt", bad_timestamp)
+
+    result = engine.check_belief("c_corrupt")
+    assert result["status"] != "verified", result
+    assert result["issues"], result
+
+
+def test_unparseable_last_checked_appears_in_the_stale_report(engine_and_beliefs):
+    engine, beliefs_dir = engine_and_beliefs
+    _write_belief(beliefs_dir, "corrupt", "c_corrupt", "not-a-timestamp")
+
+    report = engine.full_verification_pass()
+    assert report.total_beliefs_checked == 1
+    assert [s.claim_id for s in report.stale_beliefs] == ["c_corrupt"], report.stale_beliefs
+
+
+def test_parseable_timestamps_still_classify_correctly(engine_and_beliefs):
+    """The fix must not turn every belief stale."""
+    engine, beliefs_dir = engine_and_beliefs
+    now = datetime.now(timezone.utc)
+    _write_belief(beliefs_dir, "fresh", "c_fresh", now.isoformat())
+    _write_belief(
+        beliefs_dir, "old", "c_old", (now - timedelta(days=30)).isoformat()
+    )
+
+    assert engine.check_belief("c_fresh")["status"] == "verified"
+    assert engine.check_belief("c_old")["status"] == "needs_attention"

--- a/tests/test_work_graph_mcp_server.py
+++ b/tests/test_work_graph_mcp_server.py
@@ -12,6 +12,18 @@ def test_transport_json_is_deterministic():
 
 
 def test_mcp_dependency_is_lazy(monkeypatch):
+    """Importing this module must not require the SDK; building a server may.
+
+    The failure is raised from ``create_mcp_server``, not at import time.
+
+    This asserted the literal "MCP SDK not installed", which is only true when
+    the SDK is absent. Here it is installed and only the submodule is blocked,
+    and reporting "not installed" would send the operator to reinstall a
+    package they already have. The message is now chosen from the actual state,
+    so the assertion checks the state this test creates.
+    """
+    from entroly.mcp_sdk import installed_version
+
     real_import = builtins.__import__
 
     def blocked(name, *args, **kwargs):
@@ -20,8 +32,16 @@ def test_mcp_dependency_is_lazy(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", blocked)
-    with pytest.raises(RuntimeError, match="MCP SDK not installed"):
+
+    with pytest.raises(RuntimeError) as excinfo:
         server.create_mcp_server()
+
+    message = str(excinfo.value)
+    assert "MCP SDK" in message, message
+    if installed_version() is not None:
+        assert "not installed" not in message, (
+            f"the SDK is installed; the error claims otherwise: {message}"
+        )
 
 
 def _fake_fastmcp(monkeypatch):


### PR DESCRIPTION
Ten defects found by dogfooding. Each was reproduced before it was fixed and mutation-verified after — the defect reintroduced, the new test confirmed to fail, then restored. They share one shape: **a value produced in one regime and consumed in another.**

## Trust and verification

**`verify_response` could only ever answer "pass".** All four fused signals had drifted out of API compatibility; each `except` recorded `{"status": "unavailable"}`, and the fusion then read the scores back out with `.get("risk_score", 0)` — zero-filling a crashed check as *zero risk*. Measured, every input scored identically:

| input | before | after |
|---|---|---|
| grounded restatement | risk 0.0, pass | risk 0.0023, pass |
| **fabricated text** | risk 0.0, **pass** | risk **1.0, flag** |

A second defect compounded it: `entity_coverage_gap = witness_result.summary_score`, but `summary_score` is *groundedness* (1.0 = grounded) fed as the 0.80-weighted *risk* term. Repairing only the attribute names would have inverted every verdict. Signals now record `None`, weights renormalise over signals that actually ran, and no working signal yields risk 1.0.

**RAVS fails open.** Routing gated on `mean - 1.96*std`, a normal approximation to a Beta posterior, used exactly where it is worst — few observations, mean near 1:

| cell | approximation | exact 2.5% |
|---|---|---|
| n=10, 10/0 | 0.8367 | **0.7828** |
| n=20, 19/1 | 0.8210 | **0.7892** |
| n=35, 32/3 | 0.8073 | **0.7886** |

Against a 0.80 threshold, and the worst case is the *smallest cell that can ever qualify*. New `entroly/ravs/beta_bounds.py` computes the exact quantile (validated against four closed forms; 836 µs uncached, 0.32 µs cached).

**The audit surface contradicted the decision engine.** `ravs/report.py` still carried the empirical-Bayes prior `router.py` had already removed and documented as failing open — it displayed `P(success)=0.976` for a cell the router scores at `0.833`, with a prior mean of 0.952 before any observation. Both now use Jeffreys and the exact interval.

**A belief whose freshness check crashed was reported verified.** `_check_staleness` swallowed an unparseable `last_checked`, so the belief never entered the stale list.

**`usable_core()` documented a check it never performed** — it promised to refuse an "incomplete" core but passed no required symbols, so a core missing `ContextFragment` reached `checkpoint.py`, which dereferences it unguarded, and raised `AttributeError` at import instead of falling back.

## Integrity and containment

**Two different files could share one content address.** `_sha256_text` hashed with `errors="ignore"`, which *deletes* unencodable bytes, so a file containing a raw non-UTF-8 byte addressed identically to the same file without it. `put()` short-circuits on a known `receipt_id` and returned the wrong original. Now hashes exact bytes; byte-identical for content without surrogates, so every address already on disk still resolves.

**A dangling symlink escaped the project root.** `resolve_output_within` checked containment only when the path existed — and `Path.exists()` follows symlinks, returning `False` for a broken link. Verified on a real tree: the returned path was reported safe and the write landed outside the root. A *live* symlink was already blocked, so only the dangling case escaped, which is the one that would be planted.

## Determinism and accounting

**The injected context was not byte-stable.** `export_fragments` iterated a `HashMap` unsorted; that list feeds the default QCCR selector, which groups by first-seen order, so score ties resolved in per-instance HashMap order. Twelve fragments all scoring 1.0 selected the same set every run in a different order — so the bytes and their SHA-256 changed on every process start, defeating the provider prefix caching this project exists to align. The sibling cogops path already sorted for exactly this reason.

**`files_indexed` counted chunks, not files** — `--max-files 120` reported 189, `--max-files 20` reported 60.

**`doctor` reported a false green** — four branches printed a yellow `!` then incremented the pass counter. Adding a warning took printed warnings 1 → 2 while the summary stayed `8/8 checks passed, 1 warning(s)`.

**The two onboarding steps disagreed** — `verify-claims` measured savings against the whole 769,339-token corpus (99.4%) while `simulate` used a 32,000-token cap (89.1%), and only `simulate` disclosed its baseline.

## Also

The MCP entry points reported "MCP SDK not installed" when it *was* installed but incompatible, advising `pip install mcp` — which reinstalls the broken version. Now version-aware across three states. And two benchmarks mutated `os.environ` at **import** time; a test imports them, so thousands of subsequent tests silently ran against a 500 KB file cap instead of the real rules.

## Verification

4,622 passed / 58 skipped. The two remaining failures are pre-existing and caused by untracked local files not in this branch (a gitignored stale `entroly-wasm/pkg/package.json`, and an untracked marketing draft) — both were confirmed to fail with all of this work stashed.

Rust: engine 599 passed, core 114 passed, `clippy -D warnings` clean on both. `ruff` clean.

Twelve new test files pin these invariants. `witness.py` labelling a *contradiction* "grounded" on the default no-NLI path (7/10 minimal-edit contradictions) is a model-design gap that is **not** fixed here — it is now visible rather than silently absorbed into a passing verdict.
