### PR TITLE
test(native): skip the incomplete-core probe when there is no core

### DIFF
--- a/tests/test_native_core_gating.py
+++ b/tests/test_native_core_gating.py
@@ -153,6 +153,13 @@ def test_usable_core_refuses_a_core_missing_the_symbols_its_callers_use() -> Non
     ``WORK_GRAPH_SYMBOLS`` records published 1.0.78 passing the version check
     while lacking a symbol.
     """
+    # "Incomplete" presupposes a core to be incomplete. On the pure-Python
+    # fallback surface there is no `entroly_core` at all, which
+    # `test_usable_core_refuses_a_below_minimum_core` and the engine/checkpoint
+    # agreement test already cover — and the probe below would abort on its own
+    # import, which this test would then read as the crash it is looking for.
+    pytest.importorskip("entroly_core")
+
     probe = (
         "import sys, types\n"
         "import entroly_core as real\n"


### PR DESCRIPTION
`main` is currently red on **Pure-Python Fallback (base `pip install entroly`, no Rust engine)**. This restores it.

`test_usable_core_refuses_a_core_missing_the_symbols_its_callers_use` builds a deliberately incomplete core in a subprocess, and that probe opens with `import entroly_core`. The pure-Python fallback job installs entroly *without* the Rust engine, so the probe aborts on its own import and the test reads the non-zero exit as the crash it was looking for:

```
FAILED tests/test_native_core_gating.py::test_usable_core_refuses_a_core_missing_the_symbols_its_callers_use
  - Failed: an incomplete core crashed instead of falling back:
    ModuleNotFoundError: No module named 'entroly_core'
```

Everything else in that job passed: `1 failed, 4287 passed, 223 skipped, 1 xfailed`.

"Incomplete" presupposes a core to be incomplete. The absent-core case is already covered by `test_usable_core_refuses_a_below_minimum_core` and `test_engine_and_checkpoint_agree_on_the_core`, so this skips instead — matching the `importorskip` its sibling `test_core_symbols_are_present_in_the_engine_this_release_builds` already uses.

Verified both ways locally:
- with the native core present: `7 passed`

