### PR TITLE
feat(distribution): verify the released Windows binary and add a Scoop manifest

### DIFF
--- a/docs/distribution/targets.json
+++ b/docs/distribution/targets.json
@@ -162,9 +162,9 @@
       "target_url": "https://github.com/ScoopInstaller/Main",
       "submission_url": "https://github.com/ScoopInstaller/Main/pulls",
       "fit": ["windows", "cli", "binary-distribution"],
-      "required_assets": ["stable Windows artifact", "checksum", "autoupdate manifest", "silent install contract"],
+      "required_assets": ["packaging/scoop/entroly.json", "docs/distribution/windows-artifact-verification.md", "unaltered upstream release asset entroly-rs-x86_64-pc-windows-msvc.zip", "silent install contract"],
       "proof_url": null,
-      "next_action": "Publish and verify a stable Windows CLI artifact before submitting a Scoop manifest."
+      "next_action": "Windows artifact verified against release entroly-v1.0.81: sha256 matches the published sidecar, the binary runs, and compress succeeds (docs/distribution/windows-artifact-verification.md). Remaining blocker: the published .sha256 sidecar names the file as *dist/<archive> while Scoop matches the basename, so confirm autoupdate hash extraction or republish the sidecar with a bare basename before submitting."
     },
     {
       "id": "freebsd-ports",

--- a/docs/distribution/windows-artifact-verification.md
+++ b/docs/distribution/windows-artifact-verification.md
@@ -1,0 +1,104 @@
+# Windows artifact verification
+
+Status: prepared, not submitted.
+
+Evidence that the released Windows CLI artifact is a stable, self-contained
+binary — the precondition the Scoop Main entry in
+[`targets.json`](targets.json) was blocked on.
+
+Everything below was executed against the **published release asset**, not a
+local build. Commands and raw output are recorded so the result is reproducible
+rather than asserted.
+
+- Release: `entroly-v1.0.81`
+- Asset: `entroly-rs-x86_64-pc-windows-msvc.zip` (1,285,828 bytes)
+- Host: Windows 11, x86_64
+- Date: 2026-09-05
+
+## 1. Download and checksum
+
+```
+gh release download entroly-v1.0.81 \
+  --pattern "entroly-rs-x86_64-pc-windows-msvc.zip*"
+```
+
+Published sidecar `entroly-rs-x86_64-pc-windows-msvc.zip.sha256`:
+
+```
+d7d0a92eb90318f2316071c2bf8356d2cadd2c28feffc793591079475aa97894 *dist/entroly-rs-x86_64-pc-windows-msvc.zip
+```
+
+Recomputed locally:
+
+```
+computed: d7d0a92eb90318f2316071c2bf8356d2cadd2c28feffc793591079475aa97894
+size    : 1285828 bytes
+```
+
+**Match.**
+
+## 2. Archive contents
+
+```
+   2885120  entroly-rs.exe
+```
+
+One file, no installer, no side directories. Extract-and-run.
+
+## 3. The binary runs
+
+```
+> entroly-rs.exe --version
+entroly-rs 1.0.81
+
+> entroly-rs.exe --help
+Single-binary context compressor — no Python runtime required.
+exit code: 0
+```
+
+The reported version matches the release tag and the repository version.
+
+## 4. It does the thing it claims
+
+```
+> entroly-rs.exe compress --budget 120 sample.py
+input bytes: 7786
+output bytes: 445
+exit code: 0
+```
+
+Output is well-formed source text, not a truncation artifact.
+
+## 5. Silent install contract
+
+Scoop installs a `bin` entry by extracting the archive and shimming the
+executable. This artifact satisfies that contract without special handling:
+
+- no installer, no MSI, no elevation prompt, no interactive step;
+- a single self-contained `.exe`; nothing is written outside the extraction
+  directory at install time;
+- no Python runtime, no PATH mutation performed by the artifact itself;
+- uninstall is removal of the extracted directory — the binary installs nothing
+  elsewhere. Runtime state is created only when a command is run, under
+  `ENTROLY_DIR`, and is user data rather than install state.
+
+## 6. Not verified here
+
+Recorded so the gap is visible instead of implied:
+
+- **Autoupdate hash extraction is unverified.** The manifest resolves the hash
+  from `$url.sha256`, and the published sidecar names the file as
+  `*dist/entroly-rs-x86_64-pc-windows-msvc.zip`. Scoop matches a hash line
+  against the *basename*, so the `dist/` prefix may defeat extraction and force
+  a fallback. Scoop is not installed on the verification host, so this was not
+  exercised. Resolve before submitting: either confirm Scoop's fallback handles
+  the prefix, or publish the sidecar with a bare basename.
+- **`scoop install` end-to-end** — not run, same reason.
+- **32-bit and ARM64 Windows** — no such asset is published; the manifest
+  declares `64bit` only.
+
+## Manifest
+
+[`packaging/scoop/entroly.json`](../../packaging/scoop/entroly.json), pinned to
+the verified URL and hash above, with `checkver` on the `entroly-v<version>`
+tag format this project uses.

--- a/packaging/scoop/entroly.json
+++ b/packaging/scoop/entroly.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.0.81",
+    "description": "Single-binary context compressor for AI coding agents. Knapsack-optimal token budgeting with auditable receipts; no Python runtime required.",
+    "homepage": "https://github.com/juyterman1000/entroly",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/juyterman1000/entroly/releases/download/entroly-v1.0.81/entroly-rs-x86_64-pc-windows-msvc.zip",
+            "hash": "d7d0a92eb90318f2316071c2bf8356d2cadd2c28feffc793591079475aa97894"
+        }
+    },
+    "bin": "entroly-rs.exe",
+    "checkver": {
+        "github": "https://github.com/juyterman1000/entroly",
+        "regex": "entroly-v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/juyterman1000/entroly/releases/download/entroly-v$version/entroly-rs-x86_64-pc-windows-msvc.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Refs #279 (Phase 4 — maintained package channels).

The Scoop Main entry was `blocked` on *"Publish and verify a stable Windows CLI artifact before submitting a Scoop manifest."* The artifact already exists — `entroly-rs-x86_64-pc-windows-msvc.zip` on release `entroly-v1.0.81` — but nothing recorded whether it works, so the blocker could not be retired on evidence.

## Verified against the published asset (not a local build)

Windows 11, x86_64:

| Check | Result |
|---|---|
| sha256 vs published sidecar | `d7d0a92e…97894` — **match** |
| archive contents | one self-contained `entroly-rs.exe`, no installer |
| `--version` | `entroly-rs 1.0.81` — matches release tag and repo |
| `compress --budget 120` | 7,786 bytes → **445**, exit code 0 |

Output was well-formed source, not a truncation artifact. The binary needs no Python runtime, which is what makes it a legitimate Scoop candidate rather than a pip wrapper.

## Added

- **`packaging/scoop/entroly.json`** — pinned to the verified URL and hash, `bin: entroly-rs.exe`, `checkver` on this project's `entroly-v<version>` tag format, `autoupdate` resolving the hash from `$url.sha256`.
- **`docs/distribution/windows-artifact-verification.md`** — the commands and raw output, so the claim is reproducible instead of asserted. Includes the silent-install contract (extract-and-run, no elevation, no PATH mutation, uninstall = remove the directory).

## Status stays `blocked` — deliberately

The published `.sha256` sidecar names the file as:

```
d7d0a92e…97894 *dist/entroly-rs-x86_64-pc-windows-msvc.zip
```

Scoop matches a hash line against the **basename**, so the `dist/` prefix may defeat extraction and force a fallback. Scoop is not installed on the verification host, so this was not exercised — and `scoop install` end-to-end was not run for the same reason.

`next_action` now names that narrower blocker instead of the one that is satisfied. Marking this `prepared` would assert a readiness the evidence does not support, and would also fail the surface check, which requires every `required_assets` entry of a `prepared` target to exist as a file.

Resolution is one of: confirm Scoop's fallback tolerates the prefix, or publish the sidecar with a bare basename.

## Verification

`check_distribution_surface.py` and `check_external_name_policy.py` both pass. Distribution tests: 22 passed. The single failure in the local run is a pre-existing one caused by an untracked working-tree file (`marketing/launch/new_targets_strategy.md`) that is not part of this branch and does not exist in CI.

`targets.json` was edited surgically (2 insertions, 2 deletions) to preserve the file's inline-array formatting — a `json.dumps` round-trip reflowed 168 lines and was reverted.
