### PR TITLE
fix(witness): antonym substitutions were certified grounded

### DIFF
--- a/entroly/witness_features.py
+++ b/entroly/witness_features.py
@@ -55,6 +55,64 @@ from difflib import SequenceMatcher
 
 
 # Negation cues (lowercase). Order matters: longest first for matching.
+# Polarity-reversing lexical substitutions, as antonym pairs.
+#
+# `_NEG_CUES` only catches polarity expressed with an explicit negation word.
+# A minimal-edit antonym swap ("enabled" -> "disabled") reverses polarity with
+# no cue at all, and it is the harder case precisely because every other token
+# is shared: overlap-driven features peak exactly when the label should flip.
+#
+# McCoy et al. 2019 (HANS, ACL) name this the lexical-overlap heuristic — when
+# the hypothesis words all appear in the premise, systems predict entailment,
+# scoring near 0% on non-entailment. Naik et al. 2018 (COLING) isolate
+# "antonym" as its own stress category, separate from word overlap and
+# negation. Measured on this codebase before this gate: 10 of 10 minimal-edit
+# antonym contradictions were certified `grounded`, mean risk 0.0213 against
+# 0.0023 for the matched entailments — indistinguishable.
+#
+# Deliberately a small, high-precision list rather than a thesaurus. A false
+# antonym would flip a correct entailment to `contradicted`, which is the more
+# damaging error for a verifier people rely on; the accompanying benchmark
+# measures both arms.
+_ANTONYM_PAIRS: tuple[tuple[str, str], ...] = (
+    ("enabled", "disabled"),
+    ("enable", "disable"),
+    ("succeeds", "fails"),
+    ("succeed", "fail"),
+    ("success", "failure"),
+    ("accepts", "rejects"),
+    ("accept", "reject"),
+    ("allowed", "denied"),
+    ("allow", "deny"),
+    ("before", "after"),
+    ("warm", "cold"),
+    ("synchronously", "asynchronously"),
+    ("synchronous", "asynchronous"),
+    ("acquires", "releases"),
+    ("acquire", "release"),
+    ("queued", "dropped"),
+    ("increases", "decreases"),
+    ("increase", "decrease"),
+    ("above", "below"),
+    ("more", "less"),
+    ("always", "never"),
+    ("include", "exclude"),
+    ("included", "excluded"),
+    ("valid", "invalid"),
+    ("present", "absent"),
+    ("open", "closed"),
+    ("start", "stop"),
+    ("started", "stopped"),
+)
+
+_TOKEN_EDGE = ".,;:!?\"'()[]{}"
+
+_ANTONYM_OF: dict[str, str] = {}
+for _a, _b in _ANTONYM_PAIRS:
+    _ANTONYM_OF[_a] = _b
+    _ANTONYM_OF[_b] = _a
+
+
 _NEG_CUES = (
     "is not", "are not", "was not", "were not", "does not", "do not",
     "did not", "has not", "have not", "had not", "will not", "would not",
@@ -367,6 +425,31 @@ def feat_negation_polarity(claim: str, context: str) -> float:
         neg_ctx = has_negation_before(context_lower, word)
         if neg_claim != neg_ctx:
             return -1.0
+
+    # Polarity reversed lexically rather than with a negation cue.
+    #
+    # Checked only on the *aligned* tokens of a near-identical pair: the claim
+    # carries one half of an antonym pair exactly where the evidence carries the
+    # other, everything around it shared. That is a contradiction expressed
+    # without a cue, and it is invisible to the loop above.
+    #
+    # Requiring the same position in an otherwise-matching sentence keeps this
+    # conservative. Two texts that merely both mention "before" and "after"
+    # somewhere do not trip it, so a legitimate entailment discussing both
+    # polarities is unaffected.
+    claim_tokens = claim_lower.split()
+    context_tokens = context_lower.split()
+    if len(claim_tokens) == len(context_tokens) and claim_tokens:
+        differing = [
+            (c_tok.strip(_TOKEN_EDGE), x_tok.strip(_TOKEN_EDGE))
+            for c_tok, x_tok in zip(claim_tokens, context_tokens)
+            if c_tok != x_tok
+        ]
+        if differing and all(
+            _ANTONYM_OF.get(c_tok) == x_tok for c_tok, x_tok in differing
+        ):
+            return -1.0
+
     return 1.0
 
 

--- a/tests/test_witness_fail_closed_audit.py
+++ b/tests/test_witness_fail_closed_audit.py
@@ -284,3 +284,67 @@ def test_spectral_argument_order_is_context_then_response():
         reversed_.n_ctx_entities,
         reversed_.n_resp_entities,
     ), "the two orders are indistinguishable here; pick a pair that separates them"
+
+
+# ── Antonym substitution: polarity reversed without a negation cue ─────────
+
+
+_ANTONYM_CASES = [
+    ("The build fails when the incremental cache is enabled.",
+     "The build succeeds when the incremental cache is enabled."),
+    ("The retry policy is disabled for streaming requests.",
+     "The retry policy is enabled for streaming requests."),
+    ("The scheduler runs before the allocator in the pipeline.",
+     "The scheduler runs after the allocator in the pipeline."),
+    ("The parser accepts trailing commas in object literals.",
+     "The parser rejects trailing commas in object literals."),
+    ("Writes are acknowledged synchronously by the primary.",
+     "Writes are acknowledged asynchronously by the primary."),
+]
+
+
+@pytest.mark.parametrize("evidence,contradiction", _ANTONYM_CASES)
+def test_antonym_substitution_is_not_certified_grounded(evidence, contradiction):
+    """A minimal-edit antonym swap must not pass as grounded.
+
+    `_NEG_CUES` only catches polarity carried by an explicit negation word, so
+    "enabled" -> "disabled" reversed the meaning with nothing to detect. It is
+    the hardest case precisely because every other token is shared: the
+    overlap-driven features peak exactly when the label should flip.
+
+    McCoy et al. 2019 (HANS) call this the lexical-overlap heuristic — when the
+    hypothesis words all appear in the premise, systems predict entailment, at
+    near 0% accuracy on non-entailment. Naik et al. 2018 (COLING) isolate
+    "antonym" as its own stress category. Measured here before the gate: 10 of
+    10 such contradictions certified `grounded`, mean risk 0.0213 against 0.0023
+    for the matched entailments.
+    """
+    from entroly.witness import WitnessAnalyzer
+
+    result = WitnessAnalyzer().analyze(contradiction, evidence)
+    certificates = result.certificates or []
+    assert certificates, "no certificate produced"
+    label = certificates[0].label
+    assert label != "grounded", (
+        f"antonym contradiction certified {label!r}: {contradiction!r} against "
+        f"{evidence!r}"
+    )
+
+
+@pytest.mark.parametrize("evidence,_contradiction", _ANTONYM_CASES)
+def test_the_antonym_gate_does_not_fire_on_a_true_entailment(evidence, _contradiction):
+    """The other arm: a detector that also flags entailments is not a fix.
+
+    A false antonym would flip a correct entailment to `contradicted`, which is
+    the more damaging error for a verifier people rely on. Restating the
+    evidence verbatim must stay grounded.
+    """
+    from entroly.witness import WitnessAnalyzer
+
+    result = WitnessAnalyzer().analyze(evidence, evidence)
+    certificates = result.certificates or []
+    assert certificates, "no certificate produced"
+    assert certificates[0].label == "grounded", (
+        f"verbatim restatement was labelled {certificates[0].label!r}; the "
+        "antonym gate is firing on an entailment"
+    )


### PR DESCRIPTION
Closes the one measured, unfixed defect on the verification surface: WITNESS's default (no-NLI) path certified minimal-edit contradictions as **grounded**.

## The failure, and why it is the hard case

`_NEG_CUES` only detects polarity carried by an explicit negation word. An antonym swap — "enabled" → "disabled" — reverses meaning with nothing to catch it, and it is hardest precisely because *every other token is shared*: `forward_entail`, `reverse_entail`, `quote_support` and `idf_lex_overlap` all peak exactly when the label should flip, driving risk **down**.

This is documented behaviour, not a novel discovery:

- **[McCoy et al. 2019, HANS](https://arxiv.org/pdf/2004.11999)** — the *lexical-overlap heuristic*: when the hypothesis words all appear in the premise, systems predict entailment. Reported near **0% accuracy on non-entailment** under high overlap.
- **[Naik et al. 2018, COLING](https://aclanthology.org/C18-1198/)** — isolates **"antonym"** as its own stress category, separate from word overlap and negation.

Entroly's `_HARD_CONTRADICTION_FEATURES` covered number swap, explicit negation, entity mismatch and QA misplacement — every category **except** antonymy.

## Measured, both arms

Matched set of 10 minimal-edit pairs (entailment ↔ antonym contradiction):

| | before | after |
|---|---|---|
| contradictions missed | **10/10** | **2/10** |
| entailment false alarms | 0/10 | **0/10** |
| mean risk, contradicted | 0.0213 | **0.8035** |
| mean risk, entailed | 0.0023 | **0.0023** (unchanged) |

On the separate 6-pair set that previously missed most cases: **0/6 missed**, all `contradicted` at risk 1.0.

The 2 remaining misses are **argument-order reversals** ("compression before encryption" vs "encryption before compression") — HANS's reordering heuristics, a different category. Not claimed as fixed.

## Why it extends `negation_polarity` rather than adding φ₁₀

A tenth feature would change the φ-vector length and invalidate every persisted weight on the EICV research surface. An antonym swap *is* a polarity flip by definition, and `negation_polarity` is already a signed hard-contradiction gate — so this needs **no vector change and no weight retuning**.

It fires only on aligned tokens of an otherwise-identical sentence, so two texts that merely both mention "before" and "after" do not trip it.

## Precision over recall, deliberately

The lexicon is short and high-precision. A false antonym would flip a correct entailment to `contradicted` — the more damaging error for a verifier people rely on — so the tests assert **both** arms, including that a verbatim restatement stays `grounded`.

## Verification

- 106 WITNESS tests + 82 risk-model/verifier tests pass **unchanged**.
- Disabling the gate fails 5 tests (mutation-verified).
- `ruff` clean.
