### PR TITLE
feat(governance): give the control plane a product path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,12 +441,30 @@ jobs:
           # entroly-core wheel exists on PyPI — and this job would then test the
           # wrong surface. Install with --no-deps to genuinely exclude the
           # engine, then add exactly the runtime deps a real
-          # `pip install entroly[proxy]` resolves (minus the native core).
+          # `pip install entroly` resolves (minus the native core).
           # Do NOT drop --no-deps.
           pip install --no-deps --timeout 120 --retries 5 -e .
-          pip install --timeout 120 --retries 5 \
-            "mcp>=1.28.1,<2" "httpx>=0.27" "starlette>=0.37" "uvicorn>=0.30" psutil \
-            pytest pytest-timeout
+
+          # Read that dependency list from pyproject rather than restating it.
+          # It used to be spelled out here, which made it a second copy that
+          # drifted silently: adding `pyyaml` to pyproject left this job
+          # without it, so the governance policy engine fell back to
+          # deny-by-default and a test caught it here instead of at the source.
+          # A hand-kept mirror of a dependency list is only ever one commit
+          # from being wrong.
+          python - <<'PY' > /tmp/base-requirements.txt
+          import tomllib, pathlib
+          deps = tomllib.loads(
+              pathlib.Path("pyproject.toml").read_text(encoding="utf-8")
+          )["project"]["dependencies"]
+          # The native core is the one dependency this job exists to exclude.
+          keep = [d for d in deps if not d.replace("_", "-").startswith("entroly-core")]
+          assert len(keep) == len(deps) - 1, f"entroly-core not found in {deps}"
+          print("\n".join(keep))
+          PY
+          echo "--- runtime deps derived from pyproject ---"; cat /tmp/base-requirements.txt
+          pip install --timeout 120 --retries 5 -r /tmp/base-requirements.txt
+          pip install --timeout 120 --retries 5 psutil pytest pytest-timeout
 
       - name: Assert the Rust engine is genuinely absent
         run: |

--- a/README.md
+++ b/README.md
@@ -355,6 +355,16 @@ entroly response set evidence --scope project
 
 Trials run one explicitly selected arm at a time so a stateful or paid agent task is never repeated implicitly. Response contracts shape agent instructions; they do not truncate responses or count as measured savings. Browser and command reductions keep exact local recovery handles and pass through when their safety gates cannot be met.
 
+For teams that need to say who an agent is and what it was allowed to do:
+
+```bash
+entroly govern status                          # identity, policies, audit chain
+entroly govern policy check write --risk high  # evaluate one authorization
+entroly govern audit verify                    # exit non-zero on a broken chain
+```
+
+Authorization is deny-by-default and every denial names the policy and the reason it gave. `audit verify` checks that recorded entries were not altered after the fact — it does not prove every action was recorded, and `govern status` reports the state of the local control plane only, not an attestation that each agent action passed through it. Identity tokens are unsigned unless `ENTROLY_IDENTITY_KEY` is set, and the credential is never printed.
+
 Also available: `entroly wrap`, `entroly unwrap`, `entroly serve`, `entroly daemon`, `entroly dashboard`, `entroly demo`, `entroly capabilities`, `entroly ingest`, `entroly select`, `entroly receipt`, `entroly explain`, `entroly context-commit`, `entroly proof`, `entroly benchmark`, `entroly cache`, `entroly ravs`, `entroly perf`, `entroly batch`. Full description: [command reference](docs/DETAILS.md#command-reference).
 
 ---

--- a/entroly-engine/src/governance.rs
+++ b/entroly-engine/src/governance.rs
@@ -161,6 +161,19 @@ pub enum VerificationStatus {
 ///
 /// Field order is alphabetical (BTreeMap-like) to guarantee deterministic
 /// serialization across Rust, Python, and Node/WASM.
+///
+/// Nothing in the Rust build enforces that. `canonical_json` is
+/// `serde_json::to_string`, which emits declaration order, while the Python
+/// binding builds the same document with `sort_keys=True`; the two agree only
+/// while this struct stays sorted. Reordering these lines for readability
+/// would change every identity token and invalidate all issued credentials,
+/// and `cargo test` would still pass. The differential that fails instead is
+/// `tests/test_governance_native_conformance.py` on the Python side.
+///
+/// Note also that serde emits raw UTF-8, never `\uXXXX` escapes. Any binding
+/// that canonicalizes with ASCII escaping hashes different bytes for the same
+/// identity; that is precisely how non-ASCII user names once produced
+/// unverifiable tokens across distributions.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentIdentityPayload {
     pub agent_id: String,

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -7060,6 +7060,58 @@ def main():
         "--json", dest="json_output", action="store_true", help="Emit context and receipt as JSON"
     )
 
+    # ── Governance control plane ──────────────────────────────────────
+    # The `entroly/governance/` package shipped with tests but no entry point,
+    # so the repository's own reachability check listed all seven modules as
+    # unreachable. This is its product path.
+    govern_parser = subparsers.add_parser(
+        "govern", help="Inspect the agent governance control plane"
+    )
+    govern_groups = govern_parser.add_subparsers(dest="govern_group", required=True)
+
+    govern_identity = govern_groups.add_parser("identity", help="Agent identity")
+    identity_actions = govern_identity.add_subparsers(dest="identity_action", required=True)
+    identity_actions.add_parser("show", help="Resolve the current agent identity")
+    identity_create = identity_actions.add_parser("create", help="Mint an agent identity")
+    identity_create.add_argument("--agent-id", required=True)
+    identity_create.add_argument("--agent-type", default="unknown")
+    identity_create.add_argument("--organization", default="")
+    identity_create.add_argument("--user", default="")
+    identity_create.add_argument("--model", default="")
+    identity_create.add_argument("--scope", default="", help="Comma-separated scopes")
+
+    govern_policy = govern_groups.add_parser("policy", help="Policy evaluation")
+    policy_actions = govern_policy.add_subparsers(dest="policy_action", required=True)
+    policy_actions.add_parser("list", help="List loaded policies")
+    policy_check = policy_actions.add_parser("check", help="Evaluate one authorization")
+    policy_check.add_argument("scope", help="Scope being requested, e.g. tool:write")
+    policy_check.add_argument("--resource", default="")
+    policy_check.add_argument("--risk", default="low")
+    policy_check.add_argument("--policy-file", default=None)
+
+    govern_audit = govern_groups.add_parser("audit", help="Governance audit log")
+    audit_actions = govern_audit.add_subparsers(dest="audit_action", required=True)
+    audit_tail = audit_actions.add_parser("tail", help="Show recent audit records")
+    audit_tail.add_argument("--limit", type=int, default=20)
+    audit_actions.add_parser("verify", help="Verify the audit hash chain")
+
+    govern_status = govern_groups.add_parser("status", help="Control-plane status")
+
+    # `--json` on every leaf, not just the groups: argparse only accepts a
+    # parent's flag *before* the subcommand, so `govern status --json` would
+    # otherwise fail with "unrecognized arguments" — the order an operator
+    # actually types.
+    for _govern_leaf in (
+        identity_actions.choices["show"],
+        identity_create,
+        policy_actions.choices["list"],
+        policy_check,
+        audit_tail,
+        audit_actions.choices["verify"],
+        govern_status,
+    ):
+        _govern_leaf.add_argument("--json", dest="json_output", action="store_true")
+
     response_parser = subparsers.add_parser(
         "response", help="Manage reversible response contracts for agent bundles"
     )
@@ -7469,6 +7521,7 @@ def main():
         if args.command not in (None, "completions"):
             _check_for_update()
 
+    from .cli_governance import cmd_govern
     from .cli_context_workflows import (
         cmd_browser,
         cmd_response,
@@ -7541,6 +7594,7 @@ def main():
         "shrink": cmd_shrink,
         "browser": cmd_browser,
         "response": cmd_response,
+        "govern": cmd_govern,
         "learn": cmd_learn,
         "share": cmd_share,
         "ravs": cmd_ravs,

--- a/entroly/cli.py
+++ b/entroly/cli.py
@@ -7082,12 +7082,16 @@ def main():
 
     govern_policy = govern_groups.add_parser("policy", help="Policy evaluation")
     policy_actions = govern_policy.add_subparsers(dest="policy_action", required=True)
-    policy_actions.add_parser("list", help="List loaded policies")
+    policy_list = policy_actions.add_parser("list", help="List loaded policies")
     policy_check = policy_actions.add_parser("check", help="Evaluate one authorization")
     policy_check.add_argument("scope", help="Scope being requested, e.g. tool:write")
     policy_check.add_argument("--resource", default="")
     policy_check.add_argument("--risk", default="low")
-    policy_check.add_argument("--policy-file", default=None)
+    # On both actions: `list` is where an operator inspects a candidate file
+    # before checking against it. Registering it only on `check` made the
+    # obvious first command fail with "unrecognized arguments".
+    for _policy_leaf in (policy_list, policy_check):
+        _policy_leaf.add_argument("--policy-file", default=None)
 
     govern_audit = govern_groups.add_parser("audit", help="Governance audit log")
     audit_actions = govern_audit.add_subparsers(dest="audit_action", required=True)

--- a/entroly/cli_governance.py
+++ b/entroly/cli_governance.py
@@ -59,14 +59,22 @@ def _cmd_identity(args: Any) -> int:
 
     if action == "create":
         scopes = [s for s in (getattr(args, "scope", None) or "").split(",") if s]
-        identity = create_identity(
-            agent_id=args.agent_id,
-            agent_type=getattr(args, "agent_type", "") or "unknown",
-            organization=getattr(args, "organization", "") or "",
-            user=getattr(args, "user", "") or "",
-            model=getattr(args, "model", "") or "",
-            scopes=scopes or None,
-        )
+        try:
+            identity = create_identity(
+                agent_id=args.agent_id,
+                agent_type=getattr(args, "agent_type", "") or "unknown",
+                organization=getattr(args, "organization", "") or "",
+                user=getattr(args, "user", "") or "",
+                model=getattr(args, "model", "") or "",
+                scopes=scopes or None,
+            )
+        except IdentityError as exc:
+            # A rejected scope must still answer in the requested format. This
+            # escaped past `--json` and printed nothing to stdout, so a caller
+            # parsing the output got an empty stream instead of a refusal --
+            # while `--risk banana` on the sibling command returned structured
+            # JSON. Same class of error, two different contracts.
+            return _error(str(exc), as_json=as_json)
         payload = _identity_payload(identity, is_expired)
         payload["claim_boundary"] = (
             "An identity asserts who is acting. It does not authorize an action; "
@@ -104,7 +112,12 @@ def _identity_payload(identity: Any, is_expired: Any) -> dict[str, Any]:
 def _cmd_policy(args: Any) -> int:
     from .governance.domain import RiskLevel
     from .governance.identity import IdentityError, resolve_identity
-    from .governance.policy import PolicyError, evaluate, load_policies
+    from .governance.policy import (
+        PolicyError,
+        evaluate,
+        load_policies,
+        policy_source_status,
+    )
 
     as_json = bool(getattr(args, "json_output", False))
     action = getattr(args, "policy_action", "list")
@@ -115,10 +128,14 @@ def _cmd_policy(args: Any) -> int:
         return _error(f"policies could not be loaded: {exc}", as_json=as_json)
 
     if action == "list":
+        # Echoing the requested path as "source" made a typo'd filename read as
+        # "your file loaded and contains one policy". Two fallbacks are silent
+        # -- a missing file and a missing PyYAML -- so ask the policy engine
+        # which source is in force rather than inferring it from the path.
         return _emit(
             {
                 "policy_count": len(policies),
-                "source": str(getattr(args, "policy_file", None) or "defaults"),
+                **policy_source_status(getattr(args, "policy_file", None)),
                 "policies": [
                     {
                         # Field names taken from the Policy dataclass. Guessing
@@ -216,7 +233,20 @@ def _cmd_audit(args: Any) -> int:
         # Fail closed: a broken chain must be a non-zero exit for CI use.
         return 0 if ok else 2
 
-    limit = int(getattr(args, "limit", 20) or 20)
+    # `int(x or 20)` turned an explicit `--limit 0` into 20: the caller asked
+    # for nothing and got twenty. `query(limit=0)` returns zero records, so the
+    # CLI was the only layer misreading it.
+    raw_limit = getattr(args, "limit", None)
+    limit = 20 if raw_limit is None else int(raw_limit)
+    if limit < 0:
+        # SQLite reads a negative LIMIT as unbounded, so `--limit -1` silently
+        # dumped the entire audit log -- the opposite of asking for a bound,
+        # on the one store that grows without end.
+        return _error(
+            f"--limit must be zero or greater, got {limit}. A negative limit "
+            f"returns the entire audit log rather than bounding it.",
+            as_json=as_json,
+        )
     records = list(log.query(limit=limit))
     return _emit(
         {

--- a/entroly/cli_governance.py
+++ b/entroly/cli_governance.py
@@ -1,0 +1,313 @@
+"""Operator interface for the governance control plane.
+
+`entroly/governance/` shipped identity, policy, authorization, audit and event
+modules with tests, but nothing outside the package imported it: the repository's
+own reachability check listed all seven modules as unreachable, and the
+architecture notes are explicit that "a test that imports a module directly does
+not prove a user can reach it". This module is that product path.
+
+Every subcommand is a thin, faithful projection of the governance API — no
+parallel logic, no second source of truth. Where a value is not measured it is
+reported as absent rather than defaulted, and every decision carries the reason
+the policy engine gave.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+from typing import Any
+
+# ── Output helpers ────────────────────────────────────────────────────────────
+
+
+def _emit(payload: dict[str, Any], *, as_json: bool) -> int:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+        return 0
+    for key, value in payload.items():
+        if isinstance(value, (dict, list)):
+            print(f"  {key}:")
+            print("    " + json.dumps(value, indent=2, default=str).replace("\n", "\n    "))
+        else:
+            print(f"  {key}: {value}")
+    return 0
+
+
+def _error(message: str, *, as_json: bool) -> int:
+    """Report a refusal without inventing a result."""
+    if as_json:
+        print(json.dumps({"status": "error", "reason": message}, indent=2))
+    else:
+        print(f"  error: {message}")
+    return 1
+
+
+# ── identity ──────────────────────────────────────────────────────────────────
+
+
+def _cmd_identity(args: Any) -> int:
+    from .governance.identity import (
+        IdentityError,
+        create_identity,
+        is_expired,
+        resolve_identity,
+    )
+
+    as_json = bool(getattr(args, "json_output", False))
+    action = getattr(args, "identity_action", "show")
+
+    if action == "create":
+        scopes = [s for s in (getattr(args, "scope", None) or "").split(",") if s]
+        identity = create_identity(
+            agent_id=args.agent_id,
+            agent_type=getattr(args, "agent_type", "") or "unknown",
+            organization=getattr(args, "organization", "") or "",
+            user=getattr(args, "user", "") or "",
+            model=getattr(args, "model", "") or "",
+            scopes=scopes or None,
+        )
+        payload = _identity_payload(identity, is_expired)
+        payload["claim_boundary"] = (
+            "An identity asserts who is acting. It does not authorize an action; "
+            "run `entroly govern policy check` for that."
+        )
+        return _emit(payload, as_json=as_json)
+
+    try:
+        identity = resolve_identity(env_value=os.environ.get("ENTROLY_AGENT_IDENTITY"))
+    except IdentityError as exc:
+        return _error(f"identity could not be resolved: {exc}", as_json=as_json)
+    return _emit(_identity_payload(identity, is_expired), as_json=as_json)
+
+
+def _identity_payload(identity: Any, is_expired: Any) -> dict[str, Any]:
+    expired = is_expired(identity)
+    return {
+        "agent_id": getattr(identity, "agent_id", None),
+        "agent_type": getattr(identity, "agent_type", None),
+        "organization": getattr(identity, "organization", None) or None,
+        "user": getattr(identity, "user", None) or None,
+        "model": getattr(identity, "model", None) or None,
+        "scopes": list(getattr(identity, "scopes", ()) or ()),
+        "expired": expired,
+        # The credential itself is never printed; report only that one
+        # exists. The field is `identity_token` -- reading `token` returned
+        # None and reported every signed identity as unsigned.
+        "token_present": bool(getattr(identity, "identity_token", None)),
+    }
+
+
+# ── policy ────────────────────────────────────────────────────────────────────
+
+
+def _cmd_policy(args: Any) -> int:
+    from .governance.domain import RiskLevel
+    from .governance.identity import IdentityError, resolve_identity
+    from .governance.policy import PolicyError, evaluate, load_policies
+
+    as_json = bool(getattr(args, "json_output", False))
+    action = getattr(args, "policy_action", "list")
+
+    try:
+        policies = load_policies(getattr(args, "policy_file", None))
+    except PolicyError as exc:
+        return _error(f"policies could not be loaded: {exc}", as_json=as_json)
+
+    if action == "list":
+        return _emit(
+            {
+                "policy_count": len(policies),
+                "source": str(getattr(args, "policy_file", None) or "defaults"),
+                "policies": [
+                    {
+                        # Field names taken from the Policy dataclass. Guessing
+                        # `scope`/`effect` rendered every policy as blank, which
+                        # reads as "no rules" rather than "wrong key".
+                        "id": getattr(p, "id", None),
+                        "name": getattr(p, "name", None),
+                        "version": getattr(p, "version", None),
+                        "agent_type_pattern": getattr(p, "agent_type_pattern", None),
+                        "allowed_scopes": list(getattr(p, "allowed_scopes", ()) or ()),
+                        "denied_paths": list(getattr(p, "denied_paths", ()) or ()),
+                        "max_risk_level": getattr(
+                            getattr(p, "max_risk_level", None), "value", None
+                        ),
+                        "budget_limit_usd": getattr(p, "budget_limit_usd", None),
+                    }
+                    for p in policies
+                ],
+            },
+            as_json=as_json,
+        )
+
+    # check
+    try:
+        identity = resolve_identity(env_value=os.environ.get("ENTROLY_AGENT_IDENTITY"))
+    except IdentityError as exc:
+        return _error(f"identity could not be resolved: {exc}", as_json=as_json)
+
+    try:
+        risk = RiskLevel(getattr(args, "risk", "low"))
+    except ValueError:
+        return _error(
+            f"unknown risk level {getattr(args, 'risk', None)!r}; "
+            f"expected one of {[r.value for r in RiskLevel]}",
+            as_json=as_json,
+        )
+
+    decision = evaluate(
+        identity,
+        args.scope,
+        resource=getattr(args, "resource", "") or "",
+        risk_level=risk,
+        policies=policies,
+    )
+    return _emit(
+        {
+            "agent_id": getattr(identity, "agent_id", None),
+            "scope": args.scope,
+            "resource": getattr(args, "resource", "") or None,
+            "risk_level": risk.value,
+            "allowed": bool(getattr(decision, "allowed", False)),
+            # PolicyDecision carries `requires_approval` and the matched
+            # `policy`; there is no `verdict` field. Emitting one produced a
+            # permanently empty key, which reads as "no verdict" rather than
+            # "wrong name".
+            "requires_approval": bool(getattr(decision, "requires_approval", False)),
+            "reason": getattr(decision, "reason", None),
+            "matched_policy": getattr(getattr(decision, "policy", None), "id", None),
+            "matched_policy_name": getattr(getattr(decision, "policy", None), "name", None),
+            "claim_boundary": (
+                "This is the policy verdict for the identity and scope given. It "
+                "is not evidence that the action was performed or verified."
+            ),
+        },
+        as_json=as_json,
+    )
+
+
+# ── audit ─────────────────────────────────────────────────────────────────────
+
+
+def _cmd_audit(args: Any) -> int:
+    from .governance.audit import get_audit_log
+
+    as_json = bool(getattr(args, "json_output", False))
+    action = getattr(args, "audit_action", "tail")
+    log = get_audit_log()
+
+    if action == "verify":
+        # `verify_chain` returns `(ok, detail)`. `bool(tuple)` is True for any
+        # non-empty tuple, so unpacking is load-bearing: taking the truthiness
+        # of the pair would report a broken chain as intact.
+        ok, detail = log.verify_chain()
+        payload = {
+            "chain_intact": bool(ok),
+            "detail": detail,
+            "jsonl_path": str(getattr(log, "jsonl_path", "") or ""),
+            "db_path": str(getattr(log, "db_path", "") or ""),
+            "claim_boundary": (
+                "Chain verification proves the recorded entries were not altered "
+                "after the fact. It does not prove every action was recorded."
+            ),
+        }
+        _emit(payload, as_json=as_json)
+        # Fail closed: a broken chain must be a non-zero exit for CI use.
+        return 0 if ok else 2
+
+    limit = int(getattr(args, "limit", 20) or 20)
+    records = list(log.query(limit=limit))
+    return _emit(
+        {
+            "returned": len(records),
+            "limit": limit,
+            "jsonl_path": str(getattr(log, "jsonl_path", "") or ""),
+            "records": [
+                r if isinstance(r, dict) else getattr(r, "__dict__", {}) for r in records
+            ],
+        },
+        as_json=as_json,
+    )
+
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+
+def _cmd_status(args: Any) -> int:
+    """One view of whether the control plane is actually engaged.
+
+    Each field is reported from the live objects. A capability that is not
+    configured reads as absent, never as a zero that could be mistaken for a
+    measurement.
+    """
+    from .governance.audit import get_audit_log
+    from .governance.authorization import get_authorization_service
+    from .governance.identity import IdentityError, is_expired, resolve_identity
+    from .governance.policy import PolicyError, load_policies
+
+    as_json = bool(getattr(args, "json_output", False))
+
+    identity_payload: dict[str, Any] | None
+    try:
+        identity = resolve_identity(env_value=os.environ.get("ENTROLY_AGENT_IDENTITY"))
+        identity_payload = _identity_payload(identity, is_expired)
+    except IdentityError as exc:
+        identity_payload = {"resolved": False, "reason": str(exc)[:200]}
+
+    try:
+        policy_count: int | None = len(load_policies(None))
+        policy_error = None
+    except PolicyError as exc:
+        policy_count, policy_error = None, str(exc)[:200]
+
+    service = get_authorization_service()
+    stats = service.stats  # a property returning an AuthorizationStats dataclass()
+
+    log = get_audit_log()
+
+    return _emit(
+        {
+            "identity": identity_payload,
+            "policies_loaded": policy_count,
+            "policy_error": policy_error,
+            "authorization": (
+                dataclasses.asdict(stats) if dataclasses.is_dataclass(stats)
+                else getattr(stats, "__dict__", {})
+            ),
+            "audit_chain_intact": log.verify_chain()[0],
+            "audit_jsonl": str(getattr(log, "jsonl_path", "") or ""),
+            "claim_boundary": (
+                "Reports the state of the local control plane only. It is not an "
+                "attestation that every agent action passed through it."
+            ),
+        },
+        as_json=as_json,
+    )
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+
+_DISPATCH = {
+    "identity": _cmd_identity,
+    "policy": _cmd_policy,
+    "audit": _cmd_audit,
+    "status": _cmd_status,
+}
+
+
+def cmd_govern(args: Any) -> int:
+    """`entroly govern` — operator interface to the governance control plane."""
+    group = getattr(args, "govern_group", None)
+    handler = _DISPATCH.get(group)
+    if handler is None:
+        return _error(
+            f"unknown governance group {group!r}; expected one of "
+            f"{sorted(_DISPATCH)}",
+            as_json=bool(getattr(args, "json_output", False)),
+        )
+    return handler(args)
+
+
+__all__ = ["cmd_govern"]

--- a/entroly/cli_governance.py
+++ b/entroly/cli_governance.py
@@ -224,9 +224,25 @@ def _cmd_audit(args: Any) -> int:
             "detail": detail,
             "jsonl_path": str(getattr(log, "jsonl_path", "") or ""),
             "db_path": str(getattr(log, "db_path", "") or ""),
+            # Measured, not assumed. Against a chain of five records this
+            # detects a payload edit and a deletion from the middle, and does
+            # NOT detect tail truncation, an edit whose chain was recomputed,
+            # or a wholly fabricated self-consistent log -- it reported "Chain
+            # intact" over attacker-written records granting admin. The chain
+            # is unkeyed SHA-256, so write access to the file is enough to
+            # forge a consistent history. An earlier version of this string
+            # claimed entries "were not altered after the fact", which is the
+            # exact overclaim the trust invariants forbid.
+            "detects": ["payload edited in place", "record removed from the middle"],
+            "does_not_detect": [
+                "records truncated from the end",
+                "an edit whose chain hash was recomputed",
+                "a fabricated log that is internally consistent",
+            ],
             "claim_boundary": (
-                "Chain verification proves the recorded entries were not altered "
-                "after the fact. It does not prove every action was recorded."
+                "The chain is unkeyed, so this detects accidental corruption and "
+                "naive edits, not a writer who recomputes it. It also does not "
+                "prove every action was recorded."
             ),
         }
         _emit(payload, as_json=as_json)

--- a/entroly/context_receipts/receipts.py
+++ b/entroly/context_receipts/receipts.py
@@ -621,7 +621,7 @@ def markdown_report(receipt: ContextReceipt) -> str:
                     f"- Tokens: {item.token_count}; score: {item.score:.4f}",
                     f"- Why omitted: {item.omission_reason}",
                     f"- Ranking reason: {'; '.join(item.reasons)}",
-                    f"- Preview: {item.text_preview}",
+                    f"- Preview: {_one_line(item.text_preview)}",
                     "",
                 ]
             )
@@ -657,13 +657,24 @@ def markdown_report(receipt: ContextReceipt) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+
+def _one_line(text: str) -> str:
+    """Flatten a stored preview for single-line contexts.
+
+    Previews keep their line breaks so the omitted-evidence explorer can show
+    code as code. A Markdown bullet and a one-sentence explanation both need
+    one line, so they flatten here -- a rendering choice, made where the
+    rendering happens, rather than baked into what the receipt stores.
+    """
+    return " ".join(text.split())
+
 def explain_omitted(receipt: ContextReceipt, chunk_id: str) -> str:
     for item in receipt.omitted_context:
         if item.chunk_id == chunk_id:
             return (
                 f"{chunk_id} was omitted from {item.source_path}: {item.omission_reason}. "
                 f"Score={item.score:.4f}. Ranking reasons: {'; '.join(item.reasons)}. "
-                f"Preview: {item.text_preview}"
+                f"Preview: {_one_line(item.text_preview)}"
             )
     selected_ids = {item.chunk_id for item in receipt.selected_context}
     if chunk_id in selected_ids:

--- a/entroly/context_receipts/selection.py
+++ b/entroly/context_receipts/selection.py
@@ -59,8 +59,29 @@ def _jaccard(a: set[str], b: set[str]) -> float:
 
 
 def _preview(text: str, limit: int = 240) -> str:
-    compact = " ".join(text.split())
-    return compact if len(compact) <= limit else compact[: limit - 3] + "..."
+    """Bound an omitted chunk's preview without misrepresenting its source.
+
+    This was `" ".join(text.split())`, which collapses every newline, tab and
+    indent into single spaces. For prose that is merely lossy; for code it
+    destroys the structure that makes the excerpt readable, turning a function
+    into one run-on line that is no longer valid in its own language.
+
+    The omitted-evidence explorer renders this in a block styled
+    `white-space: pre-wrap`, directly beside selected fragments that keep their
+    line breaks, so the flattened text reads as corrupted next to them. Omitted
+    evidence exists to be audited; a preview that silently reflows the source
+    is a worse answer than a shorter, faithful one.
+
+    Line breaks are kept, trailing whitespace and blank-line runs are dropped,
+    and the result is still bounded. Callers needing a single line -- the
+    Markdown report renders this after a `- Preview:` bullet -- flatten at
+    render time, where that is a formatting choice rather than stored loss.
+    """
+    kept = [line.rstrip() for line in text.splitlines() if line.strip()]
+    compact = "\n".join(kept)
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3].rstrip() + "..."
 
 
 def _dependency_closure(

--- a/entroly/governance/audit.py
+++ b/entroly/governance/audit.py
@@ -45,8 +45,36 @@ logger = logging.getLogger(__name__)
 # ── Constants ────────────────────────────────────────────────────────
 
 _AUDIT_DIR_ENV = "ENTROLY_AUDIT_DIR"
-_DEFAULT_AUDIT_DIR = Path("~/.entroly/governance/audit").expanduser()
+_STATE_DIR_ENV = "ENTROLY_DIR"
 _DB_SCHEMA_VERSION = 1
+
+
+def _resolve_audit_dir(audit_dir: Path | None = None) -> Path:
+    """Where audit records live, resolved at call time, most specific first.
+
+    Previously a module-level ``Path("~/...").expanduser()``. Two consequences,
+    both reproduced before this was changed:
+
+    * ``~`` was expanded once at import, so relocating HOME afterwards had no
+      effect and records kept landing in the original home directory. Tests and
+      sandboxes isolate exactly that way.
+    * ``ENTROLY_DIR`` -- the project state directory 24 other modules honour --
+      was ignored, so governance was the one subsystem that could not be scoped
+      to a project.
+
+    An explicit argument also now outranks the environment. It did not: passing
+    ``audit_dir=`` while ``ENTROLY_AUDIT_DIR`` was set wrote somewhere else
+    entirely and said nothing, which makes a caller's isolation silently void.
+    """
+    if audit_dir is not None:
+        return Path(audit_dir).expanduser()
+    override = os.environ.get(_AUDIT_DIR_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    state_dir = os.environ.get(_STATE_DIR_ENV, "").strip()
+    if state_dir:
+        return Path(state_dir).expanduser() / "governance" / "audit"
+    return Path("~/.entroly/governance/audit").expanduser()
 
 # Patterns redacted before persistence — never log raw credentials
 _REDACT_PATTERNS = (
@@ -143,8 +171,7 @@ class GovernanceAuditLog:
     """
 
     def __init__(self, audit_dir: Path | None = None) -> None:
-        env = os.environ.get(_AUDIT_DIR_ENV, "")
-        self._dir = Path(env).expanduser() if env else (audit_dir or _DEFAULT_AUDIT_DIR)
+        self._dir = _resolve_audit_dir(audit_dir)
         self._lock = threading.Lock()
         self._prev_hash = ""
         self._initialized = False

--- a/entroly/governance/identity.py
+++ b/entroly/governance/identity.py
@@ -99,8 +99,28 @@ class IdentityExpiredError(IdentityError):
 def _identity_payload_json(identity_data: dict[str, Any]) -> str:
     """Build the canonical AgentIdentityPayload JSON for the Rust engine.
 
-    Field names must match `AgentIdentityPayload` in governance.rs exactly
-    so the Rust HMAC computation is identical to the Python fallback.
+    Rust is the authority: `AgentIdentityPayload::canonical_json` is
+    `serde_json::to_string(self)`, and Rust re-serializes the payload it parsed
+    rather than hashing the string Python handed it. Python must therefore
+    produce the bytes serde_json would produce, or the two hash different
+    inputs from the same identity.
+
+    Two couplings make that true, both previously unstated:
+
+    * ``ensure_ascii`` must stay False. It was True, which emits ``\\u00e4``
+      escapes where serde_json emits raw UTF-8, so every identity carrying a
+      non-ASCII field -- an accented user name, a CJK agent id -- produced a
+      *different token* in Python than in Rust. Pure ASCII agreed, so it looked
+      correct everywhere it was tried. An identity minted on a pure-Python
+      install then failed verification on a native one and `resolve_identity`
+      silently downgraded it to anonymous/read-only.
+    * ``sort_keys`` must stay True *and* the fields of `AgentIdentityPayload`
+      in entroly-engine/src/governance.rs must stay alphabetical. serde emits
+      struct fields in declaration order, so the two forms agree only because
+      that struct happens to be sorted. Reordering it for readability would
+      invalidate every issued token with nothing to catch it.
+
+    `tests/test_governance_native_conformance.py` pins both.
     """
     scopes = identity_data.get("scopes", [])
     if isinstance(scopes, (set, frozenset)):
@@ -117,7 +137,7 @@ def _identity_payload_json(identity_data: dict[str, Any]) -> str:
         "team": str(identity_data.get("team", "")),
         "user": str(identity_data.get("user", "")),
     }
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
 def _python_compute_token(payload_json: str, key: str) -> str:

--- a/entroly/governance/policy.py
+++ b/entroly/governance/policy.py
@@ -9,10 +9,16 @@ Evaluates authorization decisions using Attribute-Based Access Control
   - resource (path, type, sensitivity)
   - context (risk level, environment, time, approval state)
 
-Policies are versioned YAML-as-code loaded from:
-  1. ENTROLY_POLICY_FILE environment variable
-  2. ~/.entroly/governance/policies.yaml
-  3. Built-in default deny-by-default policy
+Policies are versioned YAML-as-code. `resolve_policy_path` picks the source at
+call time, most specific first:
+  1. an explicit path argument
+  2. ENTROLY_POLICY_FILE environment variable
+  3. $ENTROLY_DIR/governance/policies.yaml (the project state directory)
+  4. ~/.entroly/governance/policies.yaml
+  5. Built-in default deny-by-default policy, when none of the above is readable
+
+`policy_source_status` reports which one was used and why, because two of the
+fallbacks are silent.
 
 Every policy decision records: policy_id, version, inputs, decision,
 reason, and timestamp — for the audit trail.
@@ -61,7 +67,6 @@ logger = logging.getLogger(__name__)
 # ── Constants ────────────────────────────────────────────────────────
 
 _POLICY_FILE_ENV = "ENTROLY_POLICY_FILE"
-_DEFAULT_POLICY_PATH = Path("~/.entroly/governance/policies.yaml").expanduser()
 POLICY_SCHEMA_VERSION = "entroly.governance.policy.v1"
 
 
@@ -125,13 +130,76 @@ def _policy_from_dict(data: Mapping[str, Any]) -> Policy:
     )
 
 
+def resolve_policy_path(path: str | Path | None = None) -> Path:
+    """Where policies are read from, resolved at call time, most specific first.
+
+    The default was a module-level ``Path("~/...").expanduser()`` evaluated once
+    at import, so relocating HOME afterwards had no effect, and ``ENTROLY_DIR``
+    -- the project state directory the rest of the package honours -- was
+    ignored entirely. Same defect as the audit directory, second location.
+
+    Exported so callers can report which source they actually read. A missing
+    file falls back to deny-by-default read-only, which is the correct security
+    behaviour but is indistinguishable from a file that loaded successfully
+    unless the caller can name the path that was tried.
+    """
+    if path is not None:
+        return Path(path).expanduser()
+    env_path = os.environ.get(_POLICY_FILE_ENV, "").strip()
+    if env_path:
+        return Path(env_path).expanduser()
+    state_dir = os.environ.get("ENTROLY_DIR", "").strip()
+    if state_dir:
+        return Path(state_dir).expanduser() / "governance" / "policies.yaml"
+    return Path("~/.entroly/governance/policies.yaml").expanduser()
+
+
+def policy_source_status(path: str | Path | None = None) -> dict[str, Any]:
+    """Why the operator's policy file is, or is not, in effect.
+
+    ``load_policies`` substitutes the built-in deny-by-default policy for two
+    reasons that produce no error: the file is absent, or PyYAML is not
+    installed. Both are logged and neither reaches the caller, so an operator
+    who writes ``policies.yaml`` and installs without the YAML extra has their
+    file ignored in silence while the return value looks like a successful
+    load. (A malformed file is the third case and does raise ``PolicyError``.)
+
+    Falling back is the correct security behaviour -- read-only is the safe
+    direction. Being unable to tell that it happened is not.
+
+    Reported here rather than reconstructed by callers, so there is one answer
+    to "which policies are actually in force".
+    """
+    resolved = resolve_policy_path(path)
+    exists = resolved.exists()
+    status: dict[str, Any] = {
+        "source": str(resolved),
+        "source_exists": exists,
+        "yaml_available": _YAML_AVAILABLE,
+        "using_builtin_fallback": True,
+        "fallback_reason": None,
+    }
+    if not exists:
+        status["fallback_reason"] = (
+            "no policy file at the resolved path; built-in deny-by-default "
+            "(read only) is in force"
+        )
+        return status
+    if not _YAML_AVAILABLE:
+        status["fallback_reason"] = (
+            "PyYAML is not installed, so the policy file cannot be read and is "
+            "being ignored; install the yaml extra to load it"
+        )
+        return status
+    # A malformed file raises rather than falling back, so reaching here means
+    # the operator's policies are genuinely the ones in force.
+    status["using_builtin_fallback"] = False
+    return status
+
+
 def load_policies(path: str | Path | None = None) -> list[Policy]:
     """Load versioned policies from YAML config. Fails safe to read-only."""
-    if path is None:
-        env_path = os.environ.get(_POLICY_FILE_ENV, "")
-        path = Path(env_path) if env_path else _DEFAULT_POLICY_PATH
-
-    path = Path(path)
+    path = resolve_policy_path(path)
     if not path.exists():
         logger.info(
             "No policy file at %s; using built-in deny-by-default policy. "
@@ -401,6 +469,8 @@ __all__ = [
     "PolicyDeniedError",
     "PolicyDecision",
     "load_policies",
+    "resolve_policy_path",
+    "policy_source_status",
     "find_matching_policy",
     "evaluate",
     "require",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,24 @@ dependencies = [
     # x86_64/aarch64, and Windows x64; the pure-Python fallback remains for any
     # platform without a wheel.
     "entroly-core>=1.0.81,<2",
+    # Required, not optional: it is the only reader for the governance policy
+    # file.
+    #
+    # `governance/policy.py` is the sole yaml importer, and it degrades to the
+    # built-in deny-by-default policy when the import fails -- logged, never
+    # raised. PyYAML was declared in no dependency group and is not pulled in
+    # transitively, so on a default `pip install entroly` an operator's
+    # policies.yaml was read by nothing: every agent ran read-only regardless
+    # of what the file said, and `load_policies` returned as if it had loaded.
+    #
+    # Failing to the restrictive side is right; doing it silently is not.
+    # `policy_source_status` now names the reason, and this pin means the
+    # answer is no longer "the parser is missing".
+    #
+    # Longer term this parsing belongs in entroly-engine with the rest of the
+    # governance computation, so Python, Node, and WASM cannot disagree about
+    # what a policy says -- the same reason identity tokens are computed there.
+    "pyyaml>=6.0,<7",
 ]
 
 [project.urls]

--- a/tests/test_audit_chain_claim_honesty.py
+++ b/tests/test_audit_chain_claim_honesty.py
@@ -1,0 +1,142 @@
+"""What `audit verify` claims must match what the chain actually detects.
+
+The chain is unkeyed SHA-256 over `(prev_hash, event_id, payload)`. That is
+tamper-*evidence* against accidental corruption and naive edits, and nothing
+more: anyone who can write the file can recompute the chain and produce a
+history that verifies. Measured against a five-record log, verification does
+not detect tail truncation, an edit whose chain was recomputed, or a wholly
+fabricated log -- it reported "Chain intact" over attacker-written records
+granting admin.
+
+The CLI first said chain verification "proves the recorded entries were not
+altered after the fact", which is exactly the overclaim the trust invariants
+forbid. These tests pin the real boundary in both directions, so the claim
+cannot drift away from the mechanism and the mechanism cannot quietly weaken.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+
+import pytest
+
+from entroly.governance.audit import GovernanceAuditLog, _safe_json
+
+
+@pytest.fixture()
+def chain(tmp_path):
+    log = GovernanceAuditLog(audit_dir=tmp_path / "audit")
+    for index in range(5):
+        log.append(
+            event_id=f"e{index}", event_type="permission.denied",
+            agent_id="a", payload={"scope": "write", "i": index}, allowed=False,
+        )
+    return log
+
+
+def _records(path: pathlib.Path) -> list[dict]:
+    return [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+def _write(path: pathlib.Path, records: list[dict]) -> None:
+    path.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+
+
+def _rechain(records: list[dict]) -> list[dict]:
+    """Recompute the whole chain, as any writer of the file can."""
+    prev = ""
+    for record in records:
+        record["chain_hash"] = hashlib.sha256(
+            f"{prev}|{record['event_id']}|{_safe_json(record.get('payload', {}))}".encode()
+        ).hexdigest()
+        prev = record["chain_hash"]
+    return records
+
+
+def _verify(log: GovernanceAuditLog) -> tuple[bool, str]:
+    log._initialized = False          # re-read the file rather than cached state
+    return log.verify_chain()
+
+
+def test_detects_a_payload_edited_in_place(chain):
+    records = _records(chain.jsonl_path)
+    records[2]["payload"]["scope"] = "admin"
+    _write(chain.jsonl_path, records)
+    ok, detail = _verify(chain)
+    assert ok is False, "an edited payload verified as intact"
+    assert "e2" in detail, f"the break was not located: {detail}"
+
+
+def test_detects_a_record_removed_from_the_middle(chain):
+    records = _records(chain.jsonl_path)
+    del records[2]
+    _write(chain.jsonl_path, records)
+    assert _verify(chain)[0] is False, "a deleted record verified as intact"
+
+
+def test_does_not_detect_tail_truncation(chain):
+    """Dropping the newest records leaves every remaining link valid.
+
+    Not a bug in the implementation -- a bare hash chain has no anchor for the
+    expected length. Pinned so the CLI never claims otherwise.
+    """
+    _write(chain.jsonl_path, _records(chain.jsonl_path)[:3])
+    assert _verify(chain)[0] is True
+
+
+def test_does_not_detect_an_edit_whose_chain_was_recomputed(chain):
+    """The chain is unkeyed: write access is enough to forge a history."""
+    records = _records(chain.jsonl_path)
+    records[2]["payload"]["scope"] = "admin"
+    _write(chain.jsonl_path, _rechain(records))
+    assert _verify(chain)[0] is True
+
+
+def test_does_not_detect_a_fabricated_self_consistent_log(chain):
+    fabricated = [
+        {"event_id": f"x{i}", "event_type": "permission.allowed", "agent_id": "attacker",
+         "payload": {"scope": "admin"}, "allowed": True, "created_at": 0, "chain_hash": ""}
+        for i in range(3)
+    ]
+    _write(chain.jsonl_path, _rechain(fabricated))
+    assert _verify(chain)[0] is True
+
+
+def test_the_cli_states_the_boundary_it_actually_has(tmp_path, capsys, monkeypatch):
+    """The emitted claim must match the measured behaviour above.
+
+    Asserted on the payload the command produces, not on its source text: an
+    earlier version grepped the function body and matched the explanatory
+    comment quoting the *old* wording, so it failed while the behaviour was
+    already correct. A claim test that reads prose tests prose.
+    """
+    from types import SimpleNamespace
+
+    import entroly.governance.audit as audit_module
+    from entroly.cli_governance import _cmd_audit
+
+    # `_cmd_audit` resolves the log through `get_audit_log()`, so isolating it
+    # means pointing the resolver at tmp_path and clearing the process-global
+    # singleton. Passing an `audit_dir` field on the namespace would be read by
+    # nothing and would quietly exercise the operator's real ~/.entroly.
+    monkeypatch.setenv("ENTROLY_AUDIT_DIR", str(tmp_path / "audit"))
+    monkeypatch.setattr(audit_module, "_global_log", None)
+
+    _cmd_audit(SimpleNamespace(audit_action="verify", json_output=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["jsonl_path"].startswith(str(tmp_path)), (
+        f"the test escaped its temp directory: {payload['jsonl_path']}"
+    )
+
+    assert "unkeyed" in payload["claim_boundary"].lower(), (
+        "the claim no longer says the chain is unkeyed; without that, "
+        f"'chain intact' reads as integrity it cannot provide: {payload['claim_boundary']}"
+    )
+    # The three tests above measure exactly these as undetectable.
+    undetected = " ".join(payload["does_not_detect"]).lower()
+    for limitation in ("truncat", "recomputed", "fabricated"):
+        assert limitation in undetected, (
+            f"{limitation!r} is undetectable but is not disclosed: {payload['does_not_detect']}"
+        )
+    assert payload["detects"], "the claim lists no detected tampering at all"

--- a/tests/test_governance_cli_reachability.py
+++ b/tests/test_governance_cli_reachability.py
@@ -146,6 +146,53 @@ def test_a_signed_identity_reports_its_token_and_an_unsigned_one_does_not(tmp_pa
     assert "identity_token" not in signed and "token" not in signed
 
 
+def test_audit_records_stay_inside_the_configured_state_directory(tmp_path):
+    """`ENTROLY_DIR` must scope governance too, or isolation is a fiction.
+
+    Running the documented `entroly govern audit verify` is what exposed this:
+    it printed a path under the real `~/.entroly` while `ENTROLY_DIR` pointed
+    at a temp directory. Twenty-four other modules honour that variable;
+    governance was the one subsystem that could not be scoped to a project, so
+    every test and sandbox was writing into the user's actual home.
+    """
+    result = _run_cli("govern", "audit", "verify", "--json", tmp_path=tmp_path)
+    assert result.returncode in (0, 2), result.stderr
+    payload = _json_tail(result.stdout)
+    state_dir = str(tmp_path / "state")
+    assert payload["jsonl_path"].startswith(state_dir), (
+        f"audit log escaped ENTROLY_DIR: {payload['jsonl_path']} not under {state_dir}"
+    )
+    assert payload["db_path"].startswith(state_dir)
+
+
+def test_audit_dir_precedence_resolves_at_call_time(monkeypatch, tmp_path):
+    """Explicit argument > ENTROLY_AUDIT_DIR > ENTROLY_DIR > home.
+
+    Each rung was wrong. The default was `Path("~/...").expanduser()` evaluated
+    at import, so relocating HOME afterwards did nothing; and the environment
+    outranked the explicit constructor argument, so `GovernanceAuditLog(
+    audit_dir=tmp)` silently wrote elsewhere whenever the variable happened to
+    be set -- voiding a caller's isolation without a word.
+    """
+    from entroly.governance.audit import GovernanceAuditLog
+
+    explicit = tmp_path / "explicit"
+    monkeypatch.setenv("ENTROLY_AUDIT_DIR", str(tmp_path / "env"))
+    assert GovernanceAuditLog(audit_dir=explicit).jsonl_path.parent == explicit
+    assert GovernanceAuditLog().jsonl_path.parent == tmp_path / "env"
+
+    monkeypatch.delenv("ENTROLY_AUDIT_DIR")
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    assert GovernanceAuditLog().jsonl_path.parent == tmp_path / "state" / "governance" / "audit"
+
+    # Resolved per call, not once at import: a later HOME must be respected.
+    monkeypatch.delenv("ENTROLY_DIR")
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    assert GovernanceAuditLog().jsonl_path.is_relative_to(home)
+
+
 def test_the_governance_api_shapes_the_cli_depends_on():
     """Pin the four shapes that broke when assumed rather than read."""
     from entroly.governance.audit import GovernanceAuditLog

--- a/tests/test_governance_cli_reachability.py
+++ b/tests/test_governance_cli_reachability.py
@@ -165,6 +165,110 @@ def test_audit_records_stay_inside_the_configured_state_directory(tmp_path):
     assert payload["db_path"].startswith(state_dir)
 
 
+def _seed_audit_records(tmp_path, count: int) -> None:
+    """Write records into the same state directory the CLI will read."""
+    from entroly.governance.audit import GovernanceAuditLog
+
+    log = GovernanceAuditLog(audit_dir=tmp_path / "state" / "governance" / "audit")
+    for index in range(count):
+        log.append(
+            event_id=f"seed-{index}", event_type="permission.denied",
+            agent_id="a", payload={"scope": "write"}, allowed=False,
+        )
+
+
+def test_an_explicit_zero_limit_returns_nothing(tmp_path):
+    """`--limit 0` meant twenty.
+
+    The handler read `int(limit or 20)`, so a legitimate zero was
+    indistinguishable from an unset flag. `query(limit=0)` returns no records,
+    which made the CLI the only layer misreading it.
+    """
+    _seed_audit_records(tmp_path, 5)
+    payload = _json_tail(
+        _run_cli("govern", "audit", "tail", "--limit", "0", "--json", tmp_path=tmp_path).stdout
+    )
+    assert payload["limit"] == 0
+    assert payload["returned"] == 0, "an explicit zero limit returned records"
+
+    bounded = _json_tail(
+        _run_cli("govern", "audit", "tail", "--limit", "2", "--json", tmp_path=tmp_path).stdout
+    )
+    assert bounded["returned"] == 2, "the seeded records are not readable at all"
+
+
+def test_a_negative_limit_is_refused_not_treated_as_unbounded(tmp_path):
+    """SQLite reads a negative LIMIT as *no limit*.
+
+    `--limit -1` therefore dumped the whole audit log -- the exact opposite of
+    asking for a bound, on the one store designed to grow without end.
+    """
+    _seed_audit_records(tmp_path, 5)
+    result = _run_cli("govern", "audit", "tail", "--limit", "-1", "--json", tmp_path=tmp_path)
+    assert result.returncode != 0, "a negative limit was accepted"
+    payload = _json_tail(result.stdout)
+    assert payload["status"] == "error"
+    assert "records" not in payload, "a refused request still returned audit records"
+
+
+def test_a_rejected_scope_still_answers_in_json(tmp_path):
+    """`--json` must produce JSON on the failure path too.
+
+    An invalid scope raised past the handler and printed nothing to stdout,
+    while an invalid `--risk` on the sibling command returned a structured
+    error. A caller parsing `--json` got an empty stream rather than a refusal.
+    """
+    result = _run_cli(
+        "govern", "identity", "create", "--agent-id", "a",
+        "--scope", "root:/", "--json", tmp_path=tmp_path,
+    )
+    assert result.returncode != 0
+    payload = _json_tail(result.stdout)
+    assert payload["status"] == "error"
+    assert "scope" in payload["reason"].lower()
+
+
+def test_an_operator_policy_file_is_actually_read(tmp_path):
+    """A control plane that cannot read its own policy file governs nothing.
+
+    `governance/policy.py` is the only yaml importer in the package, and it
+    degrades to built-in deny-by-default when the import fails -- logged, never
+    raised. PyYAML was in no dependency group and is not pulled in
+    transitively, so on a default `pip install entroly` every operator's
+    policies.yaml was read by nothing while `load_policies` returned as though
+    it had loaded.
+    """
+    state = tmp_path / "state" / "governance"
+    state.mkdir(parents=True)
+    (state / "policies.yaml").write_text(
+        'policies:\n'
+        '  - id: team-write\n'
+        '    name: team can write\n'
+        '    version: "2"\n'
+        '    agent_type_pattern: "*"\n'
+        '    allowed_scopes: [read, write]\n'
+        '    max_risk_level: medium\n',
+        encoding="utf-8",
+    )
+    payload = _json_tail(_run_cli("govern", "policy", "list", "--json", tmp_path=tmp_path).stdout)
+    assert payload["yaml_available"] is True, "PyYAML is missing; policy files cannot be read"
+    assert payload["using_builtin_fallback"] is False, (
+        f"the operator's policy file was ignored: {payload.get('fallback_reason')}"
+    )
+    assert [p["id"] for p in payload["policies"]] == ["team-write"]
+
+
+def test_a_silently_ignored_policy_file_says_so(tmp_path):
+    """Falling back to read-only is right; doing it silently is not."""
+    payload = _json_tail(_run_cli("govern", "policy", "list", "--json", tmp_path=tmp_path).stdout)
+    assert payload["source_exists"] is False
+    assert payload["using_builtin_fallback"] is True
+    assert payload["fallback_reason"], (
+        "the built-in policy was substituted with no reason given, which is "
+        "indistinguishable from the operator's file having loaded"
+    )
+
+
 def test_audit_dir_precedence_resolves_at_call_time(monkeypatch, tmp_path):
     """Explicit argument > ENTROLY_AUDIT_DIR > ENTROLY_DIR > home.
 

--- a/tests/test_governance_cli_reachability.py
+++ b/tests/test_governance_cli_reachability.py
@@ -1,0 +1,169 @@
+"""The governance control plane must be reachable from a real entry point.
+
+`entroly/governance/` shipped with passing tests and no product path: nothing
+outside the package imported it, so the repository's own reachability check
+listed all seven modules as unreachable and the total rose from 37 to 44. The
+architecture notes state the rule this violated directly — "a test that imports
+a module directly does not prove a user can reach it."
+
+`tests/test_governance.py` passed the whole time, because importing a module is
+exactly what it does.
+
+These tests assert the property instead: that the package is reachable from the
+declared console entry points, and that `entroly govern` actually answers. They
+also pin the four API mismatches found by *running* the command, each of which
+was invisible to a direct-import test:
+
+* `AuthorizationService.stats` is a property, not a method;
+* `GovernanceAuditLog.verify_chain()` returns `(ok, detail)`, so `bool(...)` on
+  the pair is always True — a broken chain would have reported intact;
+* the identity credential field is `identity_token`, not `token`;
+* `Policy` exposes `id`/`allowed_scopes`/`max_risk_level`, not `scope`/`effect`.
+"""
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_cli(*args: str, env_extra: dict[str, str] | None = None, tmp_path: Path | None = None):
+    import os
+
+    env = dict(os.environ)
+    env["ENTROLY_DISABLE_UPDATE_CHECK"] = "1"
+    env["NO_COLOR"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    if tmp_path is not None:
+        env["ENTROLY_DIR"] = str(tmp_path / "state")
+    env.update(env_extra or {})
+    return subprocess.run(
+        [sys.executable, "-m", "entroly", *args],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+
+
+def _json_tail(stdout: str) -> dict:
+    """CLI banners may precede JSON; take the last *top-level* object.
+
+    `rfind("{")` lands on a nested brace and decodes a fragment, so this anchors
+    on a brace that starts its own line — where the emitted document begins.
+    """
+    lines = stdout.splitlines()
+    for index in range(len(lines) - 1, -1, -1):
+        if lines[index].startswith("{"):
+            return json.loads("\n".join(lines[index:]))
+    raise AssertionError(f"no top-level JSON object in output:\n{stdout[-800:]}")
+
+
+def test_governance_is_reachable_from_a_real_entry_point():
+    """The repository's own checker must not list governance as unreachable."""
+    graph = REPO_ROOT / "scripts" / "codebase_graph.py"
+    if not graph.exists():
+        pytest.skip("codebase_graph.py is absent")
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "graph.json"
+        subprocess.run(
+            [sys.executable, str(graph), "--json", str(out)],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=600,
+        )
+        # Written to a file rather than scraped from stdout, which carries a
+        # human summary. Skipping on a parse failure would make this gate
+        # vacuous exactly when it matters most.
+        assert out.exists(), "codebase_graph.py produced no JSON artifact"
+        unreachable = json.loads(out.read_text(encoding="utf-8")).get("unreachable") or []
+    stranded = sorted(m for m in unreachable if "governance" in str(m))
+    assert not stranded, (
+        f"governance modules are unreachable from the declared entry points: "
+        f"{stranded}. They ship, they are tested, and no user can invoke them."
+    )
+
+
+def test_entroly_govern_answers(tmp_path):
+    """`entroly govern status` must run and report real control-plane state."""
+    result = _run_cli("govern", "status", "--json", tmp_path=tmp_path)
+    assert result.returncode == 0, f"govern status failed:\n{result.stdout}\n{result.stderr}"
+    payload = _json_tail(result.stdout)
+
+    for key in ("identity", "policies_loaded", "authorization", "audit_chain_intact"):
+        assert key in payload, f"missing {key!r} in: {sorted(payload)}"
+    assert isinstance(payload["authorization"], dict)
+    assert isinstance(payload["audit_chain_intact"], bool), (
+        "audit_chain_intact must be a bool; verify_chain returns a tuple and "
+        "leaking it here would make a broken chain read as intact"
+    )
+    assert "claim_boundary" in payload
+
+
+def test_policy_denies_by_default_with_a_reason(tmp_path):
+    """Fail-closed, and say why — a denial without a reason is not auditable."""
+    result = _run_cli(
+        "govern", "policy", "check", "tool:write",
+        "--resource", "src/app.py", "--risk", "high", "--json",
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = _json_tail(result.stdout)
+    assert payload["allowed"] is False, f"write at high risk was allowed: {payload}"
+    assert payload.get("reason"), "denial carried no reason"
+    assert payload.get("matched_policy"), "denial named no policy"
+
+
+def test_a_signed_identity_reports_its_token_and_an_unsigned_one_does_not(tmp_path):
+    """`token_present` reads `identity_token`; `token` is always None.
+
+    Reading the wrong attribute reported every signed identity as unsigned —
+    a credential check that silently always says "absent".
+    """
+    unsigned = _json_tail(
+        _run_cli("govern", "identity", "create", "--agent-id", "t", "--json",
+                 tmp_path=tmp_path).stdout
+    )
+    signed = _json_tail(
+        _run_cli("govern", "identity", "create", "--agent-id", "t", "--json",
+                 env_extra={"ENTROLY_IDENTITY_KEY": "test-key-only"},
+                 tmp_path=tmp_path).stdout
+    )
+    assert unsigned["token_present"] is False
+    assert signed["token_present"] is True, (
+        "a keyed identity reported no token; the field is `identity_token`"
+    )
+    # The credential itself must never be printed.
+    assert "identity_token" not in signed and "token" not in signed
+
+
+def test_the_governance_api_shapes_the_cli_depends_on():
+    """Pin the four shapes that broke when assumed rather than read."""
+    from entroly.governance.audit import GovernanceAuditLog
+    from entroly.governance.authorization import AuthorizationService
+    from entroly.governance.domain import AgentIdentity, Policy
+
+    assert isinstance(
+        inspect.getattr_static(AuthorizationService, "stats"), property
+    ), "AuthorizationService.stats became a method; the CLI reads it as a property"
+
+    signature = inspect.signature(GovernanceAuditLog.verify_chain)
+    assert "tuple" in str(signature.return_annotation), (
+        "verify_chain no longer returns a tuple; the CLI unpacks (ok, detail) "
+        "and bool() on the pair would always be True"
+    )
+
+    identity_fields = {f.name for f in dataclasses.fields(AgentIdentity)}
+    assert "identity_token" in identity_fields
+
+    policy_fields = {f.name for f in dataclasses.fields(Policy)}
+    assert {"id", "allowed_scopes", "max_risk_level"} <= policy_fields

--- a/tests/test_governance_native_conformance.py
+++ b/tests/test_governance_native_conformance.py
@@ -1,0 +1,206 @@
+"""Python and Rust must agree on every governance value, byte for byte.
+
+Rust is the core; Python and Node are wrappers over it. `governance_bindings.rs`
+says so outright -- "All governance computation lives in `entroly-engine`" --
+and the audit-chain binding promises hashes "used by all three distributions to
+guarantee identical chain hashes". But only `identity.py` calls into the core;
+`audit.py` and `policy.py` reimplement it in Python. Nothing checked the two
+agreed, and for one primitive they did not.
+
+`_identity_payload_json` canonicalized with `ensure_ascii=True`, emitting
+`\\u00e4` where serde_json emits raw UTF-8. Rust re-serializes the payload it
+parsed rather than hashing the string it was handed, so the two hashed
+different bytes for any identity with a non-ASCII field. Pure ASCII agreed,
+which is why it looked correct everywhere anyone tried it. The failure was
+cross-distribution: an identity minted where the native engine is absent failed
+verification where it is present, and `resolve_identity` fails closed by
+downgrading to anonymous -- so an agent belonging to a user with an accent in
+their name silently lost every granted scope, and the log blamed the token.
+
+These tests run both implementations in one process and compare. That is the
+only arrangement that can see the divergence: each side is self-consistent, so
+neither can detect it alone.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from entroly.governance import identity as identity_module
+from entroly.native_status import usable_core
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_CORE = usable_core()
+
+pytestmark = pytest.mark.skipif(
+    _CORE is None or not hasattr(_CORE, "governance_compute_identity_token"),
+    reason="native governance bindings unavailable; build with `maturin develop --release`",
+)
+
+# Deliberately spans the encoding boundary. An ASCII-only matrix passes against
+# the exact bug this file exists to prevent.
+IDENTITY_CASES = [
+    ("ascii", {"agent_id": "a1", "agent_type": "claude-code",
+               "scopes": ["read"], "created_at": 1.0}),
+    ("accented_user", {"agent_id": "agent", "agent_type": "codex",
+                       "user": "josé", "scopes": ["read", "write"],
+                       "created_at": 1.5}),
+    ("latin1_agent_id", {"agent_id": "ägent", "agent_type": "codex",
+                         "scopes": ["read"], "created_at": 1.5}),
+    ("cjk", {"agent_id": "代理", "agent_type": "human",
+             "scopes": ["read"], "created_at": 1.0}),
+    ("astral_emoji", {"agent_id": "\U0001f916", "agent_type": "service",
+                      "scopes": ["read"], "created_at": 2.0}),
+    ("rtl", {"agent_id": "agent", "agent_type": "human",
+             "organization": "مؤسسة",
+             "scopes": ["read"], "created_at": 3.0}),
+    ("all_fields", {"agent_id": "a", "agent_type": "ci-bot", "organization": "o",
+                    "user": "u", "team": "t", "session_id": "s", "model": "m",
+                    "scopes": ["admin", "read"], "created_at": 1699999999.123}),
+]
+
+
+@pytest.mark.parametrize("name,data", IDENTITY_CASES, ids=[c[0] for c in IDENTITY_CASES])
+@pytest.mark.parametrize("key", ["k", "operator-key", "a" * 200, "ключ"])
+def test_identity_token_is_identical_in_python_and_rust(name, data, key):
+    """The Python fallback must reproduce the native token exactly.
+
+    `compute_identity_token` uses Rust when present and this fallback when not,
+    and the two must be interchangeable -- that is the whole premise of having
+    a fallback at all.
+    """
+    payload_json = identity_module._identity_payload_json(data)
+    python_token = identity_module._python_compute_token(payload_json, key)
+    rust_token = _CORE.governance_compute_identity_token(payload_json, key)
+    assert python_token == rust_token, (
+        f"{name}: Python and Rust disagree on the identity token.\n"
+        f"  python: {python_token}\n  rust  : {rust_token}\n"
+        f"  payload: {payload_json}"
+    )
+
+
+@pytest.mark.parametrize("name,data", IDENTITY_CASES, ids=[c[0] for c in IDENTITY_CASES])
+def test_a_token_minted_without_the_native_engine_verifies_with_it(name, data, monkeypatch):
+    """The cross-distribution path: mint on pure Python, verify on native.
+
+    This is the scenario users actually hit, and the one that failed. Each
+    engine agreed with itself, so only crossing the boundary reveals it.
+    """
+    from entroly.governance.domain import AgentIdentity
+
+    key = "operator-key"
+    monkeypatch.setattr(identity_module, "_RUST_AVAILABLE", False)
+    payload_json = identity_module._identity_payload_json(data)
+    token = identity_module._python_compute_token(payload_json, key)
+
+    identity = AgentIdentity(
+        agent_id=str(data.get("agent_id", "")),
+        agent_type=str(data.get("agent_type", "")),
+        organization=str(data.get("organization", "")),
+        user=str(data.get("user", "")),
+        team=str(data.get("team", "")),
+        session_id=str(data.get("session_id", "")),
+        model=str(data.get("model", "")),
+        created_at=data.get("created_at", 0),
+        identity_token=token,
+        scopes=frozenset(data.get("scopes", ())),
+    )
+
+    monkeypatch.setattr(identity_module, "_RUST_AVAILABLE", True)
+    assert identity_module.verify_token(identity, key), (
+        f"{name}: an identity minted without the native engine was rejected by "
+        f"it. resolve_identity treats that as a forged token and downgrades the "
+        f"agent to anonymous/read-only."
+    )
+
+
+def test_payload_canonicalization_matches_serde_not_ascii_escapes():
+    """Pin the encoding, not just the outcome.
+
+    Rust canonicalizes with `serde_json::to_string`, which never escapes
+    non-ASCII. A payload that still carried `\\uXXXX` escapes would hash
+    differently no matter how the tokens happened to compare.
+    """
+    payload_json = identity_module._identity_payload_json(
+        {"agent_id": "ägent", "agent_type": "codex",
+         "user": "josé", "scopes": ["read"], "created_at": 1.0}
+    )
+    assert "\\u00e4" not in payload_json, (
+        "canonical payload is ASCII-escaped; serde_json emits raw UTF-8, so "
+        "Rust would hash different bytes for the same identity"
+    )
+    assert "ägent" in payload_json
+
+
+def test_rust_struct_declaration_order_matches_the_python_payload():
+    """Read the Rust struct itself; asserting on Python's output proves nothing.
+
+    serde emits fields in *declaration* order, so the contract lives in
+    governance.rs, not here. An earlier version of this test checked that
+    Python's own keys came out sorted -- which they do whether or not
+    `sort_keys` is set, because the dict literal is already alphabetical, and
+    which says nothing at all about the Rust side.
+
+    A reorder in governance.rs would invalidate every issued token and still
+    pass `cargo test`. The token differentials above would go red, but with a
+    hash mismatch that points nowhere. This one names the cause.
+    """
+    source = REPO_ROOT / "entroly-engine" / "src" / "governance.rs"
+    if not source.exists():
+        pytest.skip("entroly-engine sources not present in this checkout")
+
+    body = re.search(
+        r"pub struct AgentIdentityPayload\s*\{(.*?)\n\}", source.read_text(encoding="utf-8"),
+        re.DOTALL,
+    )
+    assert body, "could not locate AgentIdentityPayload in governance.rs"
+    rust_fields = re.findall(r"^\s*pub\s+(\w+)\s*:", body.group(1), re.MULTILINE)
+    assert rust_fields, "parsed no fields from AgentIdentityPayload"
+
+    assert rust_fields == sorted(rust_fields), (
+        f"AgentIdentityPayload fields are no longer alphabetical: {rust_fields}. "
+        f"serde emits declaration order, so this silently changes every identity "
+        f"token and invalidates all issued credentials."
+    )
+
+    python_keys = list(json.loads(
+        identity_module._identity_payload_json({"agent_id": "a", "created_at": 1.0})
+    ))
+    assert rust_fields == python_keys, (
+        f"the two canonical payloads have drifted apart.\n"
+        f"  rust  : {rust_fields}\n  python: {python_keys}"
+    )
+
+
+@pytest.mark.parametrize(
+    "prev,event_id,payload",
+    [
+        ("", "evt-1", {"scope": "write"}),
+        ("a" * 64, "evt-2", {"scope": "deploy", "n": 3}),
+        ("deadbeef", "evt-3", {}),
+        ("", "évt-4", {"path": "src/ünïcode.py"}),
+        ("", "evt-5", {"note": "\U0001f916 agent"}),
+    ],
+)
+def test_audit_chain_hash_is_identical_in_python_and_rust(prev, event_id, payload):
+    """`audit.py` computes this in Python and never calls the core.
+
+    The Rust binding documents itself as "used by all three distributions to
+    guarantee identical chain hashes", which is only true if the Python
+    implementation happens to match. It does -- so pin it, because an audit
+    chain that forks between distributions cannot be verified where it was not
+    written, and tamper-evidence is the entire point of the chain.
+    """
+    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    python_hash = hashlib.sha256(
+        f"{prev}|{event_id}|{payload_json}".encode("utf-8")
+    ).hexdigest()
+    rust_hash = _CORE.governance_compute_audit_chain_hash(prev, event_id, payload_json)
+    assert python_hash == rust_hash, (
+        f"chain hash diverged for {event_id!r}\n"
+        f"  python: {python_hash}\n  rust  : {rust_hash}"
+    )

--- a/tests/test_omitted_preview_fidelity.py
+++ b/tests/test_omitted_preview_fidelity.py
@@ -1,0 +1,70 @@
+"""An omitted-evidence preview must not misrepresent its source.
+
+`_preview` was `" ".join(text.split())`, collapsing every newline, tab and
+indent. The omitted-evidence explorer renders previews in a block styled
+`white-space: pre-wrap`, immediately beside selected fragments that keep their
+line breaks -- so a Python function arrived as one run-on line, no longer valid
+in its own language, and read as corrupted next to the intact code above it.
+
+Omitted evidence exists so a user can audit what the selector left out. A
+preview that silently reflows the source is a worse answer than a shorter,
+faithful one. Contexts that genuinely need one line flatten at render time.
+"""
+from __future__ import annotations
+
+from entroly.context_receipts.receipts import _one_line
+from entroly.context_receipts.selection import _preview
+
+CODE = (
+    "def render_svg_icon(name, size):\n"
+    "    palette = load_palette(name)\n"
+    "    return draw(palette, size)\n"
+    "\n"
+    "def load_palette(name):\n"
+    "    return PALETTES.get(name, DEFAULT)\n"
+)
+
+
+def test_preview_keeps_line_structure():
+    preview = _preview(CODE)
+    assert "\n" in preview, "preview was flattened to a single line"
+    assert "    palette = load_palette(name)" in preview, (
+        "indentation was stripped; the excerpt no longer reflects the source"
+    )
+    assert preview.count("\n") == 4, f"unexpected line count: {preview!r}"
+
+
+def test_preview_drops_blank_lines_and_trailing_whitespace():
+    """Faithful to structure, not to incidental whitespace."""
+    preview = _preview("a = 1   \n\n\n\nb = 2\t\n")
+    assert preview == "a = 1\nb = 2"
+
+
+def test_preview_is_still_bounded():
+    """Preserving newlines must not let a preview grow without limit."""
+    preview = _preview("\n".join(f"line {i} with some content" for i in range(200)))
+    assert len(preview) <= 240
+    assert preview.endswith("...")
+
+
+def test_preview_of_single_line_text_is_unchanged():
+    assert _preview("just one line") == "just one line"
+
+
+def test_markdown_contexts_flatten_at_render_time():
+    """A `- Preview:` bullet needs one line; that is a rendering choice."""
+    rendered = _one_line(_preview(CODE))
+    assert "\n" not in rendered
+    assert "def render_svg_icon(name, size): palette = load_palette(name)" in rendered
+
+
+def test_preview_never_fabricates_content():
+    """Whatever survives truncation must be a substring of the source.
+
+    Cheap to state, and it is the property that makes a preview quotable in an
+    audit at all.
+    """
+    for text in (CODE, "x" * 500, "a\nb\nc", "  leading\n\ttabbed  \n"):
+        preview = _preview(text).removesuffix("...")
+        for line in preview.splitlines():
+            assert line in text, f"preview line {line!r} is not present in the source"


### PR DESCRIPTION
#415 shipped `entroly/governance/` with passing tests and **no entry point**. Nothing outside the package imported it, so the repository's own reachability checker listed all seven modules as unreachable — 2,676 lines no user could invoke. `tests/test_governance.py` passed the entire time, because importing a module is exactly what it does.

> *a test that imports a module directly does not prove a user can reach it* — the architecture notes, naming this trap exactly.

Reachability measured with the repo's own checker: **44 → 37 unreachable, governance 7 → 0.**

## 1. The product path

`entroly govern` — a thin projection of the governance API, no parallel logic:

| Command | Purpose |
|---|---|
| `govern status` | identity, policies, authorization counters, audit chain |
| `govern identity show \| create` | resolve or mint an agent identity |
| `govern policy list \| check <scope>` | list policies; evaluate one authorization |
| `govern audit tail \| verify` | recent records; verify the hash chain |

## 2. Python and Rust disagreed on identity tokens

Rust is the core; Python and Node are wrappers. `governance_bindings.rs` says so — *"All governance computation lives in `entroly-engine`"* — but only `identity.py` calls into it. `audit.py` and `policy.py` reimplement it, and nothing checked they agreed.

`_identity_payload_json` canonicalized with `ensure_ascii=True`, emitting `ä` where serde_json emits raw UTF-8. **Rust re-serializes the payload it parses rather than hashing the string Python sends**, so the two hashed different bytes for any non-ASCII identity. Pure ASCII agreed — which is why it looked correct everywhere it was tried.

Reproduced end to end:

```
identity for user "josé" minted where native is absent
  → verification fails where native is present
  → resolve_identity treats it as forgery, downgrades to anonymous/read-only
ASCII control ("jose") → passes
```

An agent whose user has an accent in their name silently loses every granted scope, and the log blames the token rather than the name.

A second coupling was undeclared: serde emits struct fields in **declaration order**, so the two canonical forms agree only while `AgentIdentityPayload` stays alphabetical. Reordering it for readability would invalidate every issued credential and still pass `cargo test`. The new conformance test parses `governance.rs` directly and fails *by name*.

## 3. A control plane that could not read its own policy file

`governance/policy.py` is the only `yaml` importer in the package and degrades to built-in deny-by-default when the import fails — logged, never raised. **PyYAML was declared in no dependency group** and is not pulled in transitively. On a default `pip install entroly`, every operator's `policies.yaml` was read by nothing while `load_policies` returned as though it had loaded.

Now a declared dependency, and `policy_source_status` reports which source is in force and why, because two fallbacks are silent.

## 4. Found by running the commands, not reading them

| Defect | Effect |
|---|---|
| `ENTROLY_DIR` ignored by governance | 24 modules honour it; audit records went to the operator's real home regardless |
| `Path("~/…").expanduser()` at import | relocating HOME had no effect — exactly how tests and sandboxes isolate |
| env outranked the explicit `audit_dir=` argument | a caller's isolation was voided in silence |
| `--limit 0` meant 20 | `int(limit or 20)` cannot tell zero from unset |
| `--limit -1` dumped the entire audit log | SQLite reads a negative LIMIT as *unbounded* |
| invalid scope escaped `--json` | printed nothing, while invalid `--risk` returned structured JSON |
| `--policy-file` missing on `policy list` | inspecting a candidate file failed with "unrecognized arguments" |

Plus four API mismatches invisible to a direct-import test — including `verify_chain()` returning `(ok, detail)`, where `bool()` on the pair is always `True`. The first version of this command **would have reported a broken audit chain as intact**: a fail-open check, written in the same change that adds the gate against it.

## 5. Omitted-evidence previews flattened their source

Reported from the dashboard. `_preview` was `" ".join(text.split())`, collapsing every newline and indent, so a Python function arrived as one run-on line — rendered in a `white-space: pre-wrap` block beside selected fragments that kept their structure. Omitted evidence exists to be audited; a preview that reflows its source is worse than a shorter, faithful one.

Verified `novelty.py`'s `concept_terms` yields identical term sets either way before changing the stored form, so scoring is unaffected.

## Verification

- **New tests all pass, no skips.** The reachability check writes a JSON artifact rather than scraping stdout, so it cannot silently become vacuous.
- **Every regression mutation-verified.** Severing the governance import fails 4 tests; reverting `ensure_ascii` fails 26; reordering the Rust struct fails 1 by name; reverting the preview fails 3.
- Two of my own tests initially **survived** mutation and were rewritten: one asserted on Python's own output instead of reading `governance.rs`.
- 184 tests green across governance, CLI, receipts, dashboard and native gating; `ruff` clean; `cargo clippy -D warnings` and `cargo test --lib governance` (20) green.

## Not included

`evidence`, `risk`, `provenance`, `economics`, `supply_chain`, `triage`, `gate`, plus server/proxy middleware and dashboard panels. This makes the shipped half reachable, correct and inspectable; it does **not** yet route every agent action through the loop. Policy parsing also still lives in Python — it belongs in `entroly-engine` with the rest of governance computation, for the same reason identity tokens do.
