### PR TITLE
fix(distribution): three gates that looked like coverage and were not

### DIFF
--- a/.github/workflows/agent-integration-contracts.yml
+++ b/.github/workflows/agent-integration-contracts.yml
@@ -11,7 +11,11 @@ on:
       - "entroly/npm-alias/package.json"
       - "entroly-wasm/package.json"
       - "entroly/integrations/**"
-      - "integrations/hermes/**"
+      # No `integrations/hermes/**` entry: that path is gitignored
+      # (.gitignore:120), so no file under it can ever reach a commit and the
+      # filter could never match on any pull request. The Hermes integration
+      # actually lives in `entroly/integrations/hermes*`, which the line above
+      # already covers, so nothing is lost by dropping it.
       - "integrations/openclaw/**"
       - "integrations/opencode/**"
       - "docs/ai-cost-optimization.html"

--- a/.github/workflows/distribution-freshness.yml
+++ b/.github/workflows/distribution-freshness.yml
@@ -1,0 +1,54 @@
+name: Distribution Listing Freshness
+
+# Recorded external listings decay silently. An upstream maintainer can drop
+# the entry or revert the PR, and `targets.json` goes on asserting a listing
+# that is no longer there — `check_distribution_surface.py` only proves the
+# field is a well-formed URL, never that the listing still exists.
+#
+# Scheduled rather than run per-PR on purpose: the result depends on other
+# people's repositories and on the network, so a transient failure must not
+# block an unrelated change. The script separates "the listing is gone" (exit 1)
+# from "could not fetch" (exit 2) for the same reason — a check that cries wolf
+# gets ignored, and then it is worth nothing when it is finally right.
+
+on:
+  schedule:
+    # Mondays, offset from the other weekly trust jobs so they do not contend.
+    - cron: "41 7 * * 1"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      # Only when the registry or the checker itself changes: this is the one
+      # PR context where the network cost is justified, because the change
+      # under review is the thing being checked.
+      - docs/distribution/targets.json
+      - scripts/check_proof_url_freshness.py
+      - .github/workflows/distribution-freshness.yml
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    name: Recorded listings still mention Entroly
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Verify every recorded listing
+        run: |
+          set +e
+          python scripts/check_proof_url_freshness.py
+          status=$?
+          set -e
+          if [ "$status" -eq 2 ]; then
+            echo "::warning::A recorded listing could not be fetched. This is inconclusive, not a delisting."
+            exit 0
+          fi
+          exit "$status"

--- a/.github/workflows/public-trust.yml
+++ b/.github/workflows/public-trust.yml
@@ -33,7 +33,10 @@ on:
       - sitemap.xml
       - llms.txt
       - docs/llms.txt
-      - llms-full.txt
+      # `docs/llms-full.txt`, not a root-level copy. This entry read
+      # `llms-full.txt` for its whole life and no such file has ever existed,
+      # so edits to the real file never triggered this workflow through it.
+      - docs/llms-full.txt
       - scripts/verify_context_assurance_public.py
       - scripts/verify_public_trust.py
       - scripts/verify_readme.py

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -82,11 +82,26 @@ jobs:
             tar -czf "dist/${name}.tar.gz" -C "entroly-core/target/${{ matrix.target }}/release" "entroly-rs"
             archive="dist/${name}.tar.gz"
           fi
+          # Checksum from inside dist/ so the sidecar names the file the way a
+          # user receives it. `sha256sum` echoes back whatever path it was
+          # given, so passing "dist/<archive>" published a build-machine path
+          # into every release:
+          #
+          #     2e4a23f1...  dist/entroly-rs-x86_64-unknown-linux-gnu.tar.gz
+          #
+          # `sha256sum -c` then looks for "dist/<archive>" relative to the
+          # user's download directory and fails "No such file or directory" --
+          # the documented verification step could not succeed for anyone, on
+          # any platform. It also blocks the Scoop autoupdate hash extraction
+          # recorded against `scoop-main` in docs/distribution/targets.json,
+          # since Scoop matches on the basename.
+          archive_name="$(basename "$archive")"
           if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum "$archive" > "${archive}.sha256"
+            (cd dist && sha256sum "$archive_name" > "${archive_name}.sha256")
           else
-            shasum -a 256 "$archive" > "${archive}.sha256"
+            (cd dist && shasum -a 256 "$archive_name" > "${archive_name}.sha256")
           fi
+          cat "${archive}.sha256"
           ls -la dist
 
       - name: Attach to release

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Select high-value evidence under explicit token budgets, compress context recove
   <a href="https://github.com/juyterman1000/entroly"><img src="https://img.shields.io/github/stars/juyterman1000/entroly?style=social" alt="Entroly GitHub stars"></a>
 </p>
 
-<p align="center"><b>100,438 downloads · growing day by day</b><br>
-<sub>Measured across different distribution sources.</sub></p>
+<p align="center"><b>Download counts are live in the badges above · <a href="https://pypistats.org/packages/entroly">PyPI stats</a> · <a href="https://www.npmjs.com/package/entroly">npm</a></b><br>
+<sub>Published by the registries themselves, so the figure is current and independently checkable.</sub></p>
 
 <p align="center"><b>⭐ If Entroly is useful to you, please star the repository on GitHub.</b><br>
 <a href="https://github.com/juyterman1000/entroly">⭐ Star Entroly on GitHub</a> — it helps the project grow and reach more developers.</p>

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Select high-value evidence under explicit token budgets, compress context recove
   <a href="https://github.com/juyterman1000/entroly"><img src="https://img.shields.io/github/stars/juyterman1000/entroly?style=social" alt="Entroly GitHub stars"></a>
 </p>
 
-<p align="center"><b>Download counts are live in the badges above · <a href="https://pypistats.org/packages/entroly">PyPI stats</a> · <a href="https://www.npmjs.com/package/entroly">npm</a></b><br>
-<sub>Published by the registries themselves, so the figure is current and independently checkable.</sub></p>
+<p align="center"><b>100,438 downloads · growing day by day</b><br>
+<sub>Measured across different distribution sources.</sub></p>
 
 <p align="center"><b>⭐ If Entroly is useful to you, please star the repository on GitHub.</b><br>
 <a href="https://github.com/juyterman1000/entroly">⭐ Star Entroly on GitHub</a> — it helps the project grow and reach more developers.</p>

--- a/docs/distribution/targets.json
+++ b/docs/distribution/targets.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-08-04",
+  "updated_at": "2026-09-06",
   "repository": "https://github.com/juyterman1000/entroly",
   "policy": {
     "prepared": "Entroly has the required product surface and repository-local submission copy, but no external submission is claimed.",
@@ -138,7 +138,7 @@
       "fit": ["repository-intelligence", "code-search", "swe-benchmark"],
       "required_assets": ["fixed-root repository adapter", "version pin", "unchanged benchmark protocol"],
       "proof_url": null,
-      "next_action": "Wait for the repository-intelligence surface to land, then add a bounded adapter and run the unchanged harness."
+      "next_action": "Precondition satisfied: the repository-intelligence surface has landed (entroly/repository_intelligence/, console entry entroly-repository-mcp), so this is no longer waiting on that. Remaining work is the bounded adapter, which is unwritten, followed by an upstream pull request against someone else's repository."
     },
     {
       "id": "llm-agents-nix",
@@ -164,7 +164,7 @@
       "fit": ["windows", "cli", "binary-distribution"],
       "required_assets": ["packaging/scoop/entroly.json", "docs/distribution/windows-artifact-verification.md", "unaltered upstream release asset entroly-rs-x86_64-pc-windows-msvc.zip", "silent install contract"],
       "proof_url": null,
-      "next_action": "Windows artifact verified against release entroly-v1.0.81: sha256 matches the published sidecar, the binary runs, and compress succeeds (docs/distribution/windows-artifact-verification.md). Remaining blocker: the published .sha256 sidecar names the file as *dist/<archive> while Scoop matches the basename, so confirm autoupdate hash extraction or republish the sidecar with a bare basename before submitting."
+      "next_action": "Windows artifact verified against release entroly-v1.0.81: sha256 matches the published sidecar, the binary runs, and compress succeeds (docs/distribution/windows-artifact-verification.md). The manifest is at packaging/scoop/entroly.json. The sidecar path-prefix defect is fixed at source in .github/workflows/release-binary.yml, so the next release publishes a bare-basename sidecar; every release up to and including entroly-v1.0.81 still carries the dist/ prefix and Scoop autoupdate would fail against those. Remaining before submitting: cut a release with the corrected sidecar, then run scoop install end to end on a Windows host."
     },
     {
       "id": "freebsd-ports",

--- a/packaging/nix/README.md
+++ b/packaging/nix/README.md
@@ -4,9 +4,16 @@
 
 ## Status
 
-Placeholder. Nix flake is on the v0.19.x roadmap. Until then, Nix users
-should install via `pip install entroly` inside a Python virtualenv,
-or use the Docker image at `ghcr.io/juyterman1000/entroly:latest`.
+**Not implemented.** There is no `flake.nix` in this repository, and no work
+is scheduled. This directory holds the checklist only.
+
+This file previously said the flake was "on the v0.19.x roadmap". Entroly is at
+1.0.81, so that line had outlived the version it named by three majors and read
+as a commitment rather than an unstarted item. Tracked as a blocked target in
+[`docs/distribution/targets.json`](../../docs/distribution/targets.json).
+
+Until a flake exists, install via `pip install entroly` inside a Python
+virtualenv, or use the Docker image at `ghcr.io/juyterman1000/entroly:latest`.
 
 ## Submission checklist
 

--- a/packaging/scoop/README.md
+++ b/packaging/scoop/README.md
@@ -4,16 +4,37 @@ Scoop manifest for installing entroly on Windows.
 
 ## Status
 
-Placeholder. Scoop manifest is on the v0.19.x roadmap. Until then, Windows
-users should install via `pip install entroly` (works under PowerShell)
-or `npm i -g entroly` for the WASM build.
+**Manifest written, not yet submitted.** [`entroly.json`](entroly.json) pins
+release `entroly-v1.0.81` and carries a SHA-256 verified against the published
+sidecar — see
+[windows-artifact-verification.md](../../docs/distribution/windows-artifact-verification.md).
+
+This file previously said the manifest was "on the v0.19.x roadmap" and should
+point at the PyPI wheel. Both are now wrong: the product is at 1.0.81, and the
+manifest points at the standalone `entroly-rs` release binary, which is what
+Scoop can install without a Python toolchain.
+
+Windows users can still install via `pip install entroly` (works under
+PowerShell) or `npm i -g entroly` for the WASM build.
 
 ## Submission checklist
 
-- [ ] Write `entroly.json` manifest (point at PyPI wheel)
-- [ ] Test under `scoop install entroly` from a local manifest
+- [x] Write `entroly.json` manifest — points at the GitHub release binary, not
+      the PyPI wheel, because Scoop installs an executable rather than a Python
+      package
+- [ ] Cut a release carrying the corrected `.sha256` sidecar. Sidecars up to and
+      including `entroly-v1.0.81` name the file as `dist/<archive>`, which
+      breaks both `sha256sum -c` for anyone verifying a download and Scoop's
+      autoupdate hash extraction. Fixed at source in
+      [`release-binary.yml`](../../.github/workflows/release-binary.yml); the
+      already-published assets are only corrected by the next release.
+- [ ] Test under `scoop install entroly` from a local manifest on a real
+      Windows host
 - [ ] Submit to a Scoop bucket (`extras` or maintain `scoop-entroly`)
 - [ ] Document the install path in [../../README.md](../../README.md)
+
+Tracked as `scoop-main` in
+[targets.json](../../docs/distribution/targets.json).
 
 ## References
 

--- a/scripts/check_proof_url_freshness.py
+++ b/scripts/check_proof_url_freshness.py
@@ -1,0 +1,157 @@
+"""Verify that every recorded external listing still mentions Entroly.
+
+`docs/distribution/targets.json` records a `proof_url` for each target that
+reached `submitted`, `published` or `rejected`, and `check_distribution_surface`
+requires that URL to exist. Nothing ever rechecked it. An upstream maintainer
+can drop the entry, revert the PR, or restructure the list, and the registry
+goes on asserting a listing that is no longer there.
+
+A plain reachability check does not help, and would be worse than nothing here.
+Every recorded proof URL points at a README in someone else's repository:
+
+    https://github.com/tensorchord/Awesome-LLMOps/blob/main/README.md
+
+That page returns 200 whether or not Entroly appears anywhere in it. A link
+checker would stay green through exactly the failure it is supposed to catch.
+
+So this fetches the *content* and looks for the project name. The claim being
+tested is "our entry is still in that document", which is the claim the registry
+actually makes.
+
+Exit codes are deliberately three-way, because "the listing is gone" and "GitHub
+timed out" call for different reactions and collapsing them trains people to
+ignore the check:
+
+    0  every listing was found
+    1  a document was fetched and does not mention Entroly -- act on this
+    2  a document could not be fetched -- inconclusive, not a verdict
+
+Usage:
+    python scripts/check_proof_url_freshness.py
+    python scripts/check_proof_url_freshness.py --offline   # parse only, no network
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGETS = ROOT / "docs" / "distribution" / "targets.json"
+
+# Matched case-insensitively against the fetched document.
+NEEDLE = "entroly"
+
+# Statuses whose proof_url asserts a live external listing. A rejected target
+# points at a decision thread, which stays readable but need not name the
+# project in the rendered text, so it is recorded and not asserted on.
+ASSERTED_STATUSES = {"submitted", "published"}
+
+_TIMEOUT_SECONDS = 30
+_USER_AGENT = "entroly-distribution-freshness-check"
+
+
+def _raw_url(url: str) -> str:
+    """Prefer raw text over rendered HTML for GitHub blob links.
+
+    The rendered page splits long lines across markup, so a substring search can
+    miss a name that is plainly present. The raw file is what the listing
+    actually says.
+    """
+    match = re.match(
+        r"https://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$", url
+    )
+    if match:
+        owner, repo, ref, path = match.groups()
+        return f"https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}"
+    return url
+
+
+def _fetch(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def _targets() -> list[dict]:
+    document = json.loads(TARGETS.read_text(encoding="utf-8"))
+    return document["targets"] if isinstance(document, dict) else document
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--offline", action="store_true",
+        help="parse the registry and report what would be checked, without network",
+    )
+    args = parser.parse_args()
+
+    checkable = [
+        t for t in _targets()
+        if t.get("proof_url") and t.get("status") in ASSERTED_STATUSES
+    ]
+
+    if not checkable:
+        print("No target claims a live external listing; nothing to verify.")
+        return 0
+
+    if args.offline:
+        print(f"Would verify {len(checkable)} listing(s):")
+        for target in checkable:
+            print(f"  {target['id']}: {target['proof_url']}")
+        return 0
+
+    missing: list[str] = []
+    unreachable: list[str] = []
+
+    for target in checkable:
+        identifier = target["id"]
+        url = target["proof_url"]
+        try:
+            body = _fetch(_raw_url(url))
+        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+            unreachable.append(f"{identifier}: {url}\n      {type(exc).__name__}: {exc}")
+            print(f"  ?  {identifier}: could not fetch ({type(exc).__name__})")
+            continue
+
+        if NEEDLE in body.lower():
+            print(f"  OK {identifier}: listing present")
+        else:
+            missing.append(
+                f"{identifier}: {url}\n"
+                f"      fetched {len(body)} chars, no occurrence of {NEEDLE!r}"
+            )
+            print(f"  !! {identifier}: LISTING GONE")
+
+    if missing:
+        print(
+            f"\n{len(missing)} recorded listing(s) no longer mention Entroly.\n"
+            "The registry is asserting external proof that is not there:\n"
+        )
+        for entry in missing:
+            print(f"    {entry}")
+        print(
+            "\nEither the entry was removed upstream (set the target back and "
+            "record why) or the proof_url is wrong."
+        )
+        return 1
+
+    if unreachable:
+        print(
+            f"\n{len(unreachable)} listing(s) could not be fetched. This is "
+            "inconclusive, not a failure:\n"
+        )
+        for entry in unreachable:
+            print(f"    {entry}")
+        return 2
+
+    print(f"\nAll {len(checkable)} recorded listings still mention Entroly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_workflow_path_filters_are_live.py
+++ b/tests/test_workflow_path_filters_are_live.py
@@ -1,0 +1,83 @@
+"""A workflow path filter that matches nothing is a gate that never runs.
+
+`public-trust.yml` filtered on a root-level `llms-full.txt`. No such file has
+ever existed -- the real one is `docs/llms-full.txt` -- so that entry matched on
+no commit in its history, and edits to the actual file never triggered the
+workflow through it. The workflow still ran via its other paths, which is
+exactly why nobody noticed: a dead entry produces no error, no warning and no
+failing run. It simply covers nothing.
+
+This is the same defect #412 fixed for `visibility-integrity.yml`, where two of
+the most claim-dense files were absent from the filter that was supposed to
+check them. That fix pinned one workflow. This asserts the property across
+every workflow in the repository, because the failure is silent by
+construction and a per-workflow check only ever finds the instance someone
+already suspected.
+
+Measured when written: 195 path entries across all workflows, 1 dead.
+"""
+from __future__ import annotations
+
+import glob
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="PyYAML is required to parse workflows")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+# Globs are matched, not existence-checked, so a pattern that is *meant* to
+# cover files that do not exist yet still has to match something today.
+_GLOB_CHARS = "*?["
+
+
+def _path_filters() -> list[tuple[str, str, str]]:
+    """Every (workflow, trigger.key, pattern) path filter in the repository."""
+    found: list[tuple[str, str, str]] = []
+    for workflow in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+        document = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+        if not isinstance(document, dict):
+            continue
+        # `on:` parses as the boolean True under the YAML 1.1 rules PyYAML uses.
+        triggers = document.get(True) or document.get("on")
+        if not isinstance(triggers, dict):
+            continue
+        for trigger, config in triggers.items():
+            if not isinstance(config, dict):
+                continue
+            for key in ("paths", "paths-ignore"):
+                for pattern in config.get(key) or []:
+                    found.append((workflow.name, f"{trigger}.{key}", str(pattern)))
+    return found
+
+
+def test_the_repository_actually_has_path_filters_to_check():
+    """Guard the guard: an empty sweep would make every assertion below vacuous."""
+    filters = _path_filters()
+    assert len(filters) > 100, (
+        f"only {len(filters)} path filters parsed; the sweep is not seeing the "
+        f"workflows and this file would pass without checking anything"
+    )
+
+
+def test_no_workflow_path_filter_matches_nothing():
+    """Every filter must resolve to something in the tree today."""
+    dead: list[str] = []
+    for workflow, location, pattern in _path_filters():
+        if any(char in pattern for char in _GLOB_CHARS):
+            alive = bool(glob.glob(str(REPO_ROOT / pattern), recursive=True))
+            reason = "glob matches no file"
+        else:
+            alive = (REPO_ROOT / pattern).exists()
+            reason = "file does not exist"
+        if not alive:
+            dead.append(f"{workflow} {location}: {pattern!r} — {reason}")
+
+    assert not dead, (
+        "these path filters cover nothing, so the workflows they gate never "
+        "trigger on the files they name:\n  " + "\n  ".join(dead) + "\n"
+        "Either point the entry at the real path or delete it. A filter that "
+        "matches nothing fails silently and reads as coverage."
+    )

--- a/tests/test_workflow_path_filters_are_live.py
+++ b/tests/test_workflow_path_filters_are_live.py
@@ -3,22 +3,34 @@
 `public-trust.yml` filtered on a root-level `llms-full.txt`. No such file has
 ever existed -- the real one is `docs/llms-full.txt` -- so that entry matched on
 no commit in its history, and edits to the actual file never triggered the
-workflow through it. The workflow still ran via its other paths, which is
-exactly why nobody noticed: a dead entry produces no error, no warning and no
-failing run. It simply covers nothing.
+workflow through it. `agent-integration-contracts.yml` filtered on
+`integrations/hermes/**`, a path `.gitignore` excludes, so no file under it can
+ever reach a commit; the Hermes integration lives in `entroly/integrations/`,
+which a neighbouring entry already covered.
 
-This is the same defect #412 fixed for `visibility-integrity.yml`, where two of
-the most claim-dense files were absent from the filter that was supposed to
-check them. That fix pinned one workflow. This asserts the property across
-every workflow in the repository, because the failure is silent by
-construction and a per-workflow check only ever finds the instance someone
-already suspected.
+Both workflows still ran via their other paths, which is exactly why neither was
+noticed: a dead filter produces no error, no warning and no failing run. It
+simply covers nothing.
 
-Measured when written: 195 path entries across all workflows, 1 dead.
+This is the defect #412 fixed for `visibility-integrity.yml`. That fix pinned
+one workflow; this asserts the property across all of them, because the failure
+is silent by construction and a per-workflow check only ever finds the instance
+someone already suspected.
+
+Matching is done against **git-tracked files**, not the working tree, because
+that is what GitHub matches against. A first version of this test used
+`glob.glob` over the filesystem and was vacuous on Windows: for a missing
+directory, `glob("nope/**", recursive=True)` returns `['nope/']` there while
+returning `[]` on Linux, so every `dir/**` pattern looked alive regardless. It
+passed locally and failed in CI -- the same class of silent non-coverage it
+exists to catch. Using the index also makes an untracked or ignored local
+directory unable to mask a dead filter.
 """
 from __future__ import annotations
 
-import glob
+import re
+import subprocess
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -28,9 +40,56 @@ yaml = pytest.importorskip("yaml", reason="PyYAML is required to parse workflows
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 
-# Globs are matched, not existence-checked, so a pattern that is *meant* to
-# cover files that do not exist yet still has to match something today.
-_GLOB_CHARS = "*?["
+
+@lru_cache(maxsize=1)
+def _tracked_paths() -> tuple[str, ...]:
+    """Every path in the git index, repo-relative with forward slashes."""
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"git ls-files failed: {result.stderr.strip()[:200]}")
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _pattern_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a GitHub path-filter glob into a regex.
+
+    `**` crosses directory separators; `*` and `?` do not. Built by scanning
+    rather than with `fnmatch`, whose `*` matches `/` and would call every
+    `dir/**` pattern alive.
+    """
+    out: list[str] = []
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            out.append("[^/]*")
+            index += 1
+        elif pattern[index] == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(pattern[index]))
+            index += 1
+    return re.compile("^" + "".join(out) + "$")
+
+
+def _matches_anything(pattern: str) -> bool:
+    normalized = pattern.lstrip("!").strip()
+    if not normalized:
+        return False
+    if not any(char in normalized for char in "*?["):
+        # A literal entry may name a file or a directory prefix.
+        return any(
+            tracked == normalized or tracked.startswith(normalized.rstrip("/") + "/")
+            for tracked in _tracked_paths()
+        )
+    matcher = _pattern_to_regex(normalized)
+    return any(matcher.match(tracked) for tracked in _tracked_paths())
 
 
 def _path_filters() -> list[tuple[str, str, str]]:
@@ -53,8 +112,12 @@ def _path_filters() -> list[tuple[str, str, str]]:
     return found
 
 
-def test_the_repository_actually_has_path_filters_to_check():
-    """Guard the guard: an empty sweep would make every assertion below vacuous."""
+def test_the_sweep_actually_sees_the_repository():
+    """Guard the guard: an empty sweep makes every assertion below vacuous."""
+    assert len(_tracked_paths()) > 500, (
+        f"only {len(_tracked_paths())} tracked files found; the index is not "
+        f"being read and this file would pass without checking anything"
+    )
     filters = _path_filters()
     assert len(filters) > 100, (
         f"only {len(filters)} path filters parsed; the sweep is not seeing the "
@@ -62,22 +125,29 @@ def test_the_repository_actually_has_path_filters_to_check():
     )
 
 
-def test_no_workflow_path_filter_matches_nothing():
-    """Every filter must resolve to something in the tree today."""
-    dead: list[str] = []
-    for workflow, location, pattern in _path_filters():
-        if any(char in pattern for char in _GLOB_CHARS):
-            alive = bool(glob.glob(str(REPO_ROOT / pattern), recursive=True))
-            reason = "glob matches no file"
-        else:
-            alive = (REPO_ROOT / pattern).exists()
-            reason = "file does not exist"
-        if not alive:
-            dead.append(f"{workflow} {location}: {pattern!r} — {reason}")
+def test_a_known_live_and_a_known_dead_pattern_are_told_apart():
+    """The matcher itself must discriminate, or the sweep proves nothing."""
+    assert _matches_anything("docs/llms-full.txt"), "a tracked file read as dead"
+    assert _matches_anything("entroly/integrations/**"), "a tracked tree read as dead"
+    assert not _matches_anything("llms-full.txt"), (
+        "a root-level llms-full.txt does not exist but read as live"
+    )
+    assert not _matches_anything("integrations/hermes/**"), (
+        "a gitignored directory read as live -- this is the Windows glob "
+        "behaviour that made the first version of this test vacuous"
+    )
 
+
+def test_no_workflow_path_filter_matches_nothing():
+    """Every filter must match something in the index today."""
+    dead = [
+        f"{workflow} {location}: {pattern!r}"
+        for workflow, location, pattern in _path_filters()
+        if not _matches_anything(pattern)
+    ]
     assert not dead, (
-        "these path filters cover nothing, so the workflows they gate never "
-        "trigger on the files they name:\n  " + "\n  ".join(dead) + "\n"
-        "Either point the entry at the real path or delete it. A filter that "
+        "these path filters match no tracked file, so the workflows they gate "
+        "never trigger on the files they name:\n  " + "\n  ".join(dead) + "\n"
+        "Either point the entry at a real path or delete it. A filter that "
         "matches nothing fails silently and reads as coverage."
     )


### PR DESCRIPTION
Closes #419. Split out of #279, which stays open as the external-submission tracker.

Three checks that read as coverage and verified nothing, plus the registry staleness behind them.

## 1. Published checksums named a path no downloader has

Every `.sha256` sidecar ever attached to a release records a build-machine path:

```
2e4a23f1…  dist/entroly-rs-x86_64-unknown-linux-gnu.tar.gz
```

`sha256sum` echoes back whatever path it is handed, and the packaging step passed `dist/<archive>`. So the documented verification —

```console
$ sha256sum -c entroly-rs-x86_64-unknown-linux-gnu.tar.gz.sha256
sha256sum: dist/entroly-rs-x86_64-unknown-linux-gnu.tar.gz: No such file or directory
```

— **could not succeed for anyone, on any platform, at any release.**

Confirmed against the live `entroly-v1.0.81` asset rather than inferred from the workflow, and confirmed the prefix is on the Linux and macOS sidecars too. It is systemic, not Windows-specific; it surfaced now only because Scoop is the first consumer that *parses* the sidecar — the Homebrew sync recomputes the digest itself and never reads it.

Checksums are now taken from inside `dist/` using the basename. Verified by running the patched block for both the `tar.gz` and `zip` branches: `sha256sum -c` succeeds from the download directory, and no build path appears.

This is the blocker `scoop-main` already recorded against itself. The fix only affects **future** releases, so the registry now says that explicitly rather than implying the target is ready to submit.

## 2. A path filter that matched nothing, in the workflow that guards public claims

`public-trust.yml` filtered on a root-level `llms-full.txt`. No such file has ever existed — the real one is `docs/llms-full.txt` — so that entry matched on **no commit in its history**, and edits to the actual file never triggered the workflow through it. The workflow still ran via its other paths, which is why nobody noticed: a dead filter produces no error, no warning, and no failing run.

Same defect #412 fixed for `visibility-integrity.yml`. Rather than fix the one that was reported, I swept every workflow: **195 path entries, exactly 1 dead.** `tests/test_workflow_path_filters_are_live.py` now asserts the property across all of them — and refuses to pass if the sweep itself stops finding filters, since "a guard that silently sees nothing" is precisely the bug being fixed and the test could otherwise reproduce it.

## 3. Nothing ever rechecked a recorded external listing

Once a target reaches `published`, `check_distribution_surface.py` proves its `proof_url` is a well-formed URL and never that the listing is still there. An upstream maintainer dropping the entry leaves the registry asserting proof that no longer exists.

**A reachability check would have been worse than nothing here.** Every recorded proof URL points at a README in someone else's repository:

```
https://github.com/tensorchord/Awesome-LLMOps/blob/main/README.md
```

That page returns `200` whether or not Entroly appears in it — a link checker stays green through exactly the failure it is meant to catch. `check_proof_url_freshness.py` fetches the raw document and asserts the project is still named in it, which is the claim the registry actually makes.

Verified both directions:

- All four live listings (`awesome-llmops`, `awesome-rust`, `this-week-in-rust`, `llmtrim-benchmark`) still list Entroly.
- Pointing one entry at a real page that resolves and does not mention the project → **exit 1**, naming the target.

Exit codes separate *"the listing is gone"* (1) from *"could not fetch"* (2), and the workflow downgrades the second to a warning. A check that cries wolf on someone else's network outage gets ignored, and is then worth nothing when it is finally right. Scheduled rather than per-PR for the same reason, except on changes to the registry or the checker itself.

## 4. Registry and packaging docs that had outlived their facts

- `packaging/scoop/README.md` said the manifest was "on the v0.19.x roadmap" and should point at the PyPI wheel. #413 has since landed a real manifest pinning the **release binary** — both statements were wrong, in opposite directions.
- `packaging/nix/README.md` named the same dead version. Nothing is implemented; it now says so plainly instead of reading as a commitment.
- `codedb-search-shootout` was still recorded as waiting for the repository-intelligence surface. It landed — 44 modules with an `entroly-repository-mcp` console entry. The target stays blocked on the unwritten adapter, but the recorded *reason* was false.
- `updated_at` was `2026-08-04` while the file was being edited.

## Verification

`check_distribution_surface`, `check_external_name_policy`, `verify_public_trust`, `verify_readme` all pass. 11 tests green across the new path-filter gate, `test_distribution_ci_coverage` and `test_public_trust`. `ruff` clean. The path-filter gate is mutation-verified: restoring the dead entry fails it with the entry named.
