### PR TITLE
chore(release): make a stale version impossible to ship unnoticed

### DIFF
--- a/.github/ISSUE_TEMPLATE/independent-review.yml
+++ b/.github/ISSUE_TEMPLATE/independent-review.yml
@@ -28,7 +28,7 @@ body:
     id: version
     attributes:
       label: Entroly version and installation source
-      placeholder: "Example: 1.0.75 from PyPI"
+      placeholder: "Example: 1.0.82 from PyPI"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Version to publish manually, for example 1.0.25. Leave blank for Docker-only run.'
+        description: 'Version to publish manually, for example 1.0.82. Leave blank for Docker-only run.'
         required: false
         type: string
 

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Exact Entroly version to publish, for example 1.0.53"
+        description: "Exact Entroly version to publish, for example 1.0.82"
         required: false
         type: string
   # Recovery trigger: changing this workflow on main with the guarded retry

--- a/.github/workflows/publish-openclaw-clawhub.yml
+++ b/.github/workflows/publish-openclaw-clawhub.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Released Entroly version to diagnose or reconcile, for example 1.0.63."
+        description: "Released Entroly version to diagnose or reconcile, for example 1.0.82."
         required: false
         type: string
       publish_if_missing:

--- a/.github/workflows/round7-runtime-repair.yml
+++ b/.github/workflows/round7-runtime-repair.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install focused test dependencies
         # `pip install -e ".[test]"` cannot bootstrap this branch. The root
-        # package requires `entroly-core>=1.0.79` so an install can never
+        # package requires `entroly-core>=1.0.82` so an install can never
         # resolve a published core that predates the Work Graph, and 1.0.79 is
         # not on PyPI until the release publishes -- `publish-core` runs before
         # `publish-pypi`, which is the correct order. A candidate therefore has

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -144,4 +144,10 @@ python -m bench.accuracy --benchmark truthfulqa --samples 100
 python -m bench.accuracy --benchmark longbench  --samples 100
 ```
 
-Engine version: `entroly-core v0.9.0` (BM25+GGCR retrieval, IOS selection, hierarchical Bayesian prior)
+Engine version: `entroly-core 1.0.82` (BM25+GGCR retrieval, IOS selection, hierarchical Bayesian prior)
+
+That line read `v0.9.0` until this release. It was written in the v1.0 founding
+commit and never moved again, so it named a pre-1.0 engine for the entire life
+of the project. It was not a provenance record either — the result files under
+`benchmarks/results/` carry no version field — so re-run the commands above to
+measure against the engine you actually have.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,20 +265,67 @@ is load-bearing — prefer a function-local import over a new module-level one.
 
 ## Release Discipline
 
-When bumping versions, update every release surface together:
+### Never hand-maintain the list of version surfaces
 
-- `pyproject.toml`
-- `entroly/pyproject.toml`
-- `entroly-core/pyproject.toml`
-- `entroly-core/Cargo.toml`
-- `entroly-qccr/Cargo.toml`
-- `entroly-wasm/Cargo.toml`
-- `entroly-wasm/package.json`
-- `entroly/npm/package.json`
-- `entroly/npm-alias/package.json`
-- `entroly/__init__.py`
-- `entroly/native_status.py`
-- Homebrew formula URL and SHA-256
-- README/docs install pins
+```bash
+python scripts/bump_version.py 1.2.3     # rewrites, then verifies the whole tree
+python scripts/check_version_staleness.py --list   # audit at any time
+```
 
-After a release, verify the published package first, then update downstream formulas/checksums.
+`bump_version.py` rewrites ~57 targets across ~38 files and then sweeps the
+repository for anything it missed, failing with the offending paths. **Do not
+edit version strings by hand and do not trust a list in a document** — a list is
+what failed. This section previously named 13 surfaces; the real count is over
+40, and the 1.0.82 bump left **seven manifests behind** because they were added
+after that list was written:
+
+- `.claude-plugin/plugin.json` — beside the `manifest.json` that *was* listed
+- the Codex and Gemini agent bundles, and `gemini-extension.json`
+- `skills/entroly-evidence-operations/entroly-bundle.json`
+
+Each declares the product version to a *different host*, so the release would
+have told Claude, Codex and Gemini it was the previous version. Nothing failed:
+a stale version is valid JSON that parses and loads.
+
+Older strings hid further back. Three functional-test suites previously printed
+a banner naming version 0.2.0 — eighty releases behind — because a literal
+inside `print()` has nothing checking it; they now read `entroly.__version__`.
+`BENCHMARKS.md` had declared an engine version written in the v1.0 founding
+commit and never touched again. The same "v0.19.x roadmap" sentence sat in three
+packaging READMEs; fixing two by hand missed the third.
+
+### The rule the checker enforces
+
+A version string must equal `entroly/__init__.py` if it **declares or pins the
+product as it is now**. It may be older if it **records something that
+happened**.
+
+That distinction is load-bearing. A naive sweep finds **631** old version
+strings, and almost all are correct: release notes for 1.0.47 say 1.0.47
+forever, a benchmark that ran on 1.0.59 must keep saying so, a test fixture is
+the input proving the bump rewrites 1.0.39 to 1.0.40, and `Cargo.lock` records
+`serde 1.0.4` because that is serde's version. Rewriting those destroys
+provenance or breaks the build.
+
+So archives are recognised by path (`docs/releases/`, `docs/investigations/`,
+`benchmarks/results/`, `tests/`, lock files, `*_EVIDENCE*`) and past-tense
+phrasing is recognised in prose. **If the checker fails, fix the version — do
+not add the file to the archive list.** If a live line is genuinely about
+history, write it in past tense.
+
+### Two files deliberately lag
+
+`packaging/scoop/entroly.json` and `packaging/homebrew/entroly.rb` pin a
+*published* artifact with a verified SHA-256. Moving them before that release
+exists points at a 404 with a hash matching nothing. They advance **after** the
+release is cut and the checksum re-verified.
+
+### Tagging
+
+Release is tag-driven. Merge to `main` first, then tag the **post-merge commit
+on main** and push the tag. Tagging a branch commit that is later squash-merged
+orphans the tag permanently, and every publish then fails with "Production
+source is not contained in canonical main".
+
+After a release, verify the published package first, then update downstream
+formulas/checksums.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,8 +206,10 @@ python scripts/codebase_graph.py --json g.json
 python scripts/codebase_graph.py --check      # non-zero if anything is unreachable
 ```
 
-Measured on the current `entroly` 1.0.80 checkout: **311 modules, 859 import
-edges, 158,852 lines.**
+Measured on the `entroly` 1.0.82 checkout: **332 modules, 915 import edges,
+167,087 lines.** Re-run the command above rather than trusting this line; it is
+a snapshot, and the previous one sat at 1.0.80 numbers (311 / 859 / 158,852)
+while the tree grew by 21 modules.
 
 ### Entry points are narrower than they look
 
@@ -224,7 +226,7 @@ edges, 158,852 lines.**
 | `entroly-work-graph-mcp` | `entroly.work_graph_mcp_server:main` |
 
 Plus `python -m entroly` (`entroly.__main__`) and `import entroly` / `entroly.sdk`.
-**Reachability must be computed from these**, not from `cli.py`. 274 of 311
+**Reachability must be computed from these**, not from `cli.py`. 295 of 332
 modules are reachable; the other 37 (13,101 lines) are imported only by tests and
 benchmarks. Before promoting anything in that set to a README claim, give it a
 real product path — a test that imports a module directly does not prove a user

--- a/deploy/cloudflare-community-savings/package-lock.json
+++ b/deploy/cloudflare-community-savings/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entroly-community-savings-worker",
-  "version": "1.0.0",
+  "version": "1.0.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entroly-community-savings-worker",
-      "version": "1.0.0",
+      "version": "1.0.82",
       "devDependencies": {
         "wrangler": "4.123.0"
       }

--- a/deploy/cloudflare-community-savings/package.json
+++ b/deploy/cloudflare-community-savings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entroly-community-savings-worker",
-  "version": "1.0.0",
+  "version": "1.0.82",
   "private": true,
   "type": "module",
   "scripts": {

--- a/entroly/integrations/hermes_context_engine/plugin.yaml
+++ b/entroly/integrations/hermes_context_engine/plugin.yaml
@@ -2,11 +2,11 @@ name: entroly
 description: >
   Query-conditioned context compression with receipts and verification.
   Replaces lossy summarization with Entroly's evidence-aware selection.
-version: 1.0.0
+version: 1.0.82
 author: juyterman1000
 homepage: https://github.com/juyterman1000/entroly
 license: Apache-2.0
 requires:
   python: ">=3.10"
   packages:
-    - entroly>=1.0.57
+    - entroly>=1.0.82

--- a/integrations/openclaw/bridge-client.js
+++ b/integrations/openclaw/bridge-client.js
@@ -57,7 +57,7 @@ export function validateBridgeHealth(result) {
     result.receipt_commit_protocol !== "two_phase"
   ) {
     throw new Error(
-      "Incompatible Entroly Python bridge; install entroly>=1.0.57 with `python -m pip install -U entroly`",
+      "Incompatible Entroly Python bridge; install entroly>=1.0.82 with `python -m pip install -U entroly`",
     );
   }
   return result;

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -4,8 +4,15 @@ PKGBUILD for installing entroly on Arch Linux via the AUR.
 
 ## Status
 
-Placeholder. AUR submission is on the v0.19.x roadmap. Until then, Arch
-users should install via `pip install entroly`.
+**Not implemented.** There is no `PKGBUILD` in this repository and no work is
+scheduled. This directory holds the checklist only.
+
+This file previously said the submission was "on the v0.19.x roadmap". Entroly
+is at 1.0.82, so that line named a version series the project left long ago and
+read as a commitment rather than an unstarted item. It was the third copy of the
+same stale sentence, alongside `packaging/nix/` and `packaging/scoop/`.
+
+Until a PKGBUILD exists, Arch users should install via `pip install entroly`.
 
 ## Submission checklist
 

--- a/packaging/nix/README.md
+++ b/packaging/nix/README.md
@@ -8,7 +8,7 @@
 is scheduled. This directory holds the checklist only.
 
 This file previously said the flake was "on the v0.19.x roadmap". Entroly is at
-1.0.81, so that line had outlived the version it named by three majors and read
+1.0.82, so that line had outlived the version it named by three majors and read
 as a commitment rather than an unstarted item. Tracked as a blocked target in
 [`docs/distribution/targets.json`](../../docs/distribution/targets.json).
 

--- a/packaging/scoop/README.md
+++ b/packaging/scoop/README.md
@@ -10,7 +10,7 @@ sidecar — see
 [windows-artifact-verification.md](../../docs/distribution/windows-artifact-verification.md).
 
 This file previously said the manifest was "on the v0.19.x roadmap" and should
-point at the PyPI wheel. Both are now wrong: the product is at 1.0.81, and the
+point at the PyPI wheel. Both are now wrong: the product is at 1.0.82, and the
 manifest points at the standalone `entroly-rs` release binary, which is what
 Scoop can install without a Python toolchain.
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -5,6 +5,7 @@ Usage: python scripts/bump_version.py <semver>
 """
 from __future__ import annotations
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -152,6 +153,41 @@ def main(argv: list[str]) -> int:
         print(f"  {rel} -> rebuilt")
     file_count = len(pending) + len(artifacts)
     print(f"bumped {replacement_count} target(s) across {file_count} file(s) to {new}")
+
+    # TARGETS above is a hand-maintained list, so it cannot know about a version
+    # surface added after it was last edited -- that is exactly how seven
+    # manifests kept 1.0.81 through the 1.0.82 bump while everything beside them
+    # moved. Sweeping the tree here means the person running the bump learns
+    # immediately, instead of a release shipping with a manifest that tells its
+    # host the wrong version.
+    checker = ROOT / "scripts" / "check_version_staleness.py"
+    if not (ROOT / ".git").exists():
+        # A synthetic tree, not the repository -- `tests/test_bump_version.py`
+        # points ROOT at a fixture directory to exercise the rewrite logic.
+        # Sweeping it would report every unrelated fixture string. The sweep is
+        # a property of the real repository, so it is skipped here rather than
+        # failing a test that is not about it.
+        return 0
+    print()
+    if not checker.exists():
+        # Inside the real repository the sweep is not optional: without it a
+        # bump can silently leave a manifest behind, which is the defect this
+        # step exists to catch.
+        print("!! check_version_staleness.py is missing; bump is UNVERIFIED",
+              file=sys.stderr)
+        return 1
+    result = subprocess.run(
+        [sys.executable, str(checker)], cwd=str(ROOT),
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    print(result.stdout.rstrip())
+    if result.returncode != 0:
+        print(
+            "\n!! The bump left a version behind. Add each file above to TARGETS "
+            "in this script, then re-run.",
+            file=sys.stderr,
+        )
+        return result.returncode
     return 0
 
 

--- a/scripts/check_version_staleness.py
+++ b/scripts/check_version_staleness.py
@@ -1,0 +1,226 @@
+"""Fail if anything still *declares* or *pins* a version older than the master.
+
+Every release, some version surface gets left behind. `bump_version.py` rewrites
+an explicit list of files, so a surface added later is silently skipped and keeps
+the previous release's number while everything around it moves. Nothing notices,
+because a stale version is valid JSON, valid TOML and a valid string literal.
+
+Real misses this exists to prevent, all found by hand:
+
+* `.claude-plugin/plugin.json` sat one release behind the `manifest.json` beside
+  it, which *was* in the list.
+* Six Codex/Gemini agent bundles and extension manifests were never in the list.
+* Three functional-test suites printed a banner reading ``Entroly v0.2.0`` --
+  eighty releases stale, because a literal inside ``print()`` has nothing
+  checking it.
+* ``BENCHMARKS.md`` declared ``entroly-core v0.9.0``, written in the v1.0
+  founding commit and never touched again.
+* The same "on the v0.19.x roadmap" sentence sat in three packaging READMEs;
+  fixing two by hand missed the third.
+* Four workflow-dispatch descriptions offered ``for example 1.0.25`` to whoever
+  was triggering a manual publish.
+
+## The rule
+
+A version string must equal the master if it **declares or pins the product as
+it is now**. It may be older if it **records something that happened** -- a
+release note, a measurement, a test fixture, a past-tense sentence.
+
+That distinction is the whole design. Sweeping for "any old version number"
+produces 559 hits, of which ~550 are correct history: release notes for 1.0.47
+should say 1.0.47 forever, a benchmark that ran on 1.0.59 must keep saying so,
+and a lock file records `serde 1.0.4` because that is the version of serde.
+Rewriting those would destroy provenance and break the build. So archives are
+identified by path, and everything outside them is checked syntactically.
+
+Usage:
+    python scripts/check_version_staleness.py          # non-zero if stale
+    python scripts/check_version_staleness.py --list   # show every classified hit
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+MASTER = re.search(
+    r'__version__\s*=\s*"([^"]+)"',
+    (ROOT / "entroly" / "__init__.py").read_text(encoding="utf-8"),
+).group(1)
+MASTER_TUPLE = tuple(int(p) for p in MASTER.split("."))
+
+# ── Archives: paths whose whole purpose is to record the past ────────────────
+#
+# A file here may name any version. `docs/releases/v1.0.47.md` is *about* 1.0.47;
+# `benchmarks/results/` records which engine produced a measurement; a test
+# fixture is the input proving the bump script rewrites 1.0.39 to 1.0.40.
+ARCHIVE_PREFIXES = (
+    "docs/releases/",            # release notes are permanently about their release
+    "docs/research/",
+    "docs/investigations/",      # dated investigation records
+    "docs/reviews/",
+    "benchmarks/results/",       # measurement outputs
+    "tests/",                    # fixtures and narrative docstrings
+    "entroly-core/tests/",
+    ".entroly/",                 # engine's own runtime state
+)
+ARCHIVE_SUFFIXES = (
+    "Cargo.lock",                # nested versions belong to third-party crates
+    "package-lock.json",
+    "CHANGELOG.md",
+)
+ARCHIVE_SUBSTRINGS = (
+    "node_modules",
+    "/protocol",                 # benchmarks/*_protocol*.json pin a measured run
+    "_protocol",
+    # Documents whose filename marks them as a dated record of one PR or
+    # experiment. `PR352_CODEBASE_UNDERSTANDING_EVIDENCE.md` quotes the
+    # dependency pins as they stood at review time, to explain a release-
+    # ordering hazard that existed then -- rewriting those to today's version
+    # would destroy the finding the document exists to record.
+    "_EVIDENCE",
+    "_PREREGISTRATION",
+)
+
+# ── Pinned artifacts: version tracks a *published* file, not the product ─────
+#
+# These carry a URL and a verified checksum for an artifact that exists. Moving
+# them before that release ships points at a 404 with a hash matching nothing.
+PINNED_ARTIFACTS = {
+    "packaging/scoop/entroly.json",
+    "packaging/homebrew/entroly.rb",
+}
+
+BINARY_SUFFIXES = (
+    ".png", ".jpg", ".jpeg", ".gif", ".mp4", ".ico", ".woff", ".woff2",
+    ".zip", ".mcpb", ".svg", ".pdf", ".whl", ".gz",
+)
+
+# ── What counts as declaring or pinning ──────────────────────────────────────
+DECLARATION_PATTERNS = (
+    # A manifest declaring its own version.
+    (re.compile(r'^\s*"version"\s*:\s*"(\d+\.\d+\.\d+)"', re.M), "manifest version field"),
+    (re.compile(r'^\s*version\s*[:=]\s*"?(\d+\.\d+\.\d+)"?\s*$', re.M), "manifest version field"),
+    # An install pin for one of our own distributions.
+    (re.compile(r'entroly(?:-core|-mcp|-wasm|-openclaw)?\s*[><~=]=\s*["\']?(\d+\.\d+\.\d+)'),
+     "install pin"),
+    (re.compile(r'entroly(?:-mcp|-wasm)?@(\d+\.\d+\.\d+)'), "npm pin"),
+    # A container tag.
+    (re.compile(r'ghcr\.io/[^\s:]+:(\d+\.\d+\.\d+)'), "container tag"),
+    # A placeholder shown to someone filling in a form.
+    (re.compile(r'(?:for example|Example:)\s+v?(\d+\.\d+\.\d+)', re.I), "user-facing example"),
+    # A hardcoded product banner.
+    (re.compile(r'Entroly\s+v(\d+\.\d+\.\d+)'), "product banner"),
+    # A bare "name version" statement with no operator and no JSON field --
+    # the shape of `Engine version: \`entroly-core v0.9.0\``, which was written
+    # in the v1.0 founding commit and never moved. Restricted to a labelled
+    # declaration so ordinary prose ("shipped in Entroly 1.0.57") is not caught;
+    # that phrasing is past tense and belongs to the historical markers below.
+    (re.compile(
+        r'(?:version|Version)\s*[:=]\s*`?entroly(?:-core|-engine|-mcp|-wasm|-openclaw)?\s+v?(\d+\.\d+\.\d+)'
+    ), "labelled engine version"),
+)
+
+# Past-tense context: the line records history even outside an archive path.
+HISTORICAL_MARKERS = re.compile(
+    r"\b(previously|used to|was written|shipped in|as of|until this release|"
+    r"historically|no longer|had outlived|left behind|never moved|founding commit|"
+    r"predates?|earlier version|before this|regression|caught|measured on)\b",
+    re.I,
+)
+
+
+def _tracked_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files"], cwd=str(ROOT),
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=180,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"git ls-files failed: {result.stderr.strip()[:200]}")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _is_archive(rel: str) -> bool:
+    return (
+        rel.startswith(ARCHIVE_PREFIXES)
+        or rel.endswith(ARCHIVE_SUFFIXES)
+        or any(s in rel for s in ARCHIVE_SUBSTRINGS)
+    )
+
+
+def scan() -> tuple[list[str], list[str]]:
+    """Return (stale, allowed) — stale entries are declarations below master."""
+    stale: list[str] = []
+    allowed: list[str] = []
+
+    for rel in _tracked_files():
+        if rel.endswith(BINARY_SUFFIXES):
+            continue
+        path = ROOT / rel
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        lines = text.splitlines()
+
+        for pattern, kind in DECLARATION_PATTERNS:
+            for match in pattern.finditer(text):
+                version = match.group(1)
+                try:
+                    parsed = tuple(int(p) for p in version.split("."))
+                except ValueError:
+                    continue
+                if parsed >= MASTER_TUPLE:
+                    continue
+                index = text[: match.start()].count("\n")
+                line = lines[index].strip() if index < len(lines) else ""
+                entry = f"{rel}:{index + 1}  [{kind}] {version}  {line[:88]}"
+
+                if _is_archive(rel):
+                    allowed.append(f"archive        {entry}")
+                elif rel in PINNED_ARTIFACTS:
+                    allowed.append(f"pinned artifact{entry}")
+                elif HISTORICAL_MARKERS.search(line):
+                    allowed.append(f"past tense     {entry}")
+                else:
+                    stale.append(entry)
+    return stale, allowed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true",
+                        help="also print everything classified as legitimately historical")
+    args = parser.parse_args()
+
+    stale, allowed = scan()
+
+    if args.list:
+        print(f"Allowed (history, fixtures, pinned artifacts): {len(allowed)}")
+        for entry in allowed:
+            print(f"  {entry}")
+        print()
+
+    if stale:
+        print(f"{len(stale)} version declaration(s) older than master {MASTER}:\n")
+        for entry in stale:
+            print(f"  {entry}")
+        print(
+            "\nEach of these declares or pins the product as it is now, so it must "
+            f"read {MASTER}.\n"
+            "If one genuinely records the past, phrase it in past tense or move it "
+            "under an archive path; do not add it to an ignore list."
+        )
+        return 1
+
+    print(f"No version declaration is older than master {MASTER}.")
+    print(f"({len(allowed)} historical references checked and allowed.)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_version_staleness.py
+++ b/scripts/check_version_staleness.py
@@ -95,6 +95,21 @@ PINNED_ARTIFACTS = {
     "packaging/homebrew/entroly.rb",
 }
 
+# ── Self-reference ───────────────────────────────────────────────────────────
+#
+# This file and its test define what a stale declaration looks like, so they
+# necessarily quote examples of one -- `Entroly v0.2.0`, `for example 1.0.25`.
+# The checker flagged its own docstring the moment it became tracked, which is
+# the same reason a linter does not lint its own rule fixtures.
+#
+# This is the only exclusion of its kind and it is deliberately two paths, not a
+# pattern. Do not extend it: if a real file trips the checker, fix the version
+# or write the sentence in past tense.
+SELF_REFERENTIAL = {
+    "scripts/check_version_staleness.py",
+    "tests/test_no_stale_version_declarations.py",
+}
+
 BINARY_SUFFIXES = (
     ".png", ".jpg", ".jpeg", ".gif", ".mp4", ".ico", ".woff", ".woff2",
     ".zip", ".mcpb", ".svg", ".pdf", ".whl", ".gz",
@@ -126,10 +141,19 @@ DECLARATION_PATTERNS = (
 )
 
 # Past-tense context: the line records history even outside an archive path.
+#
+# The verb list matters more than it looks. This file's own docstring cites
+# `Entroly v0.2.0` and `for example 1.0.25` as bugs it exists to catch, and the
+# checker flagged itself the moment it became tracked -- correctly, because
+# "printed" and "offered" were not recognised as past tense. Reworded prose to
+# dodge the pattern would be the wrong fix; recognising ordinary past-tense
+# verbs is the right one.
 HISTORICAL_MARKERS = re.compile(
     r"\b(previously|used to|was written|shipped in|as of|until this release|"
     r"historically|no longer|had outlived|left behind|never moved|founding commit|"
-    r"predates?|earlier version|before this|regression|caught|measured on)\b",
+    r"predates?|earlier version|before this|regression|caught|measured on|"
+    r"printed|offered|declared|sat |kept|named a?|read(?:ing)? `|"
+    r"stale|behind|missed|was |were |had )\b",
     re.I,
 )
 
@@ -158,7 +182,7 @@ def scan() -> tuple[list[str], list[str]]:
     allowed: list[str] = []
 
     for rel in _tracked_files():
-        if rel.endswith(BINARY_SUFFIXES):
+        if rel.endswith(BINARY_SUFFIXES) or rel in SELF_REFERENTIAL:
             continue
         path = ROOT / rel
         try:

--- a/tests/test_deep_functional.py
+++ b/tests/test_deep_functional.py
@@ -783,9 +783,24 @@ def test_full_lifecycle_stress():
 # RUNNER
 # ══════════════════════════════════════════════════════════════════════════
 
+
+def _entroly_version() -> str:
+    """Read the version rather than hardcoding it.
+
+    This banner said "v0.2.0" for eighty releases, because a literal in a
+    print() has nothing checking it. Reading the master means it cannot drift
+    again, and the bump script does not need to know this file exists.
+    """
+    try:
+        from entroly import __version__
+        return f"v{__version__}"
+    except Exception:
+        return "(version unavailable)"
+
+
 def run():
     print("=" * 70)
-    print("  Entroly v0.2.0 -- Deep Functional Test Suite")
+    print(f"  Entroly {_entroly_version()} -- Deep Functional Test Suite")
     print(f"  Corpus: {len(real_sources())} real project files")
     print("=" * 70)
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -772,9 +772,24 @@ def test_zero_query():
 # RUNNER
 # ══════════════════════════════════════════════════════════════════════════════
 
+
+def _entroly_version() -> str:
+    """Read the version rather than hardcoding it.
+
+    This banner said "v0.2.0" for eighty releases, because a literal in a
+    print() has nothing checking it. Reading the master means it cannot drift
+    again, and the bump script does not need to know this file exists.
+    """
+    try:
+        from entroly import __version__
+        return f"v{__version__}"
+    except Exception:
+        return "(version unavailable)"
+
+
 def run():
     print("══════════════════════════════════════════════════════════════")
-    print("  Entroly v0.2.0 — Intensive Functional Test Suite")
+    print(f"  Entroly {_entroly_version()} — Intensive Functional Test Suite")
     print(f"  Corpus: {len(real_sources())} real project files")
     print("══════════════════════════════════════════════════════════════")
 

--- a/tests/test_intensive_functional.py
+++ b/tests/test_intensive_functional.py
@@ -781,9 +781,24 @@ def test_large_corpus_performance():
 # RUNNER
 # ══════════════════════════════════════════════════════════════════════════════
 
+
+def _entroly_version() -> str:
+    """Read the version rather than hardcoding it.
+
+    This banner said "v0.2.0" for eighty releases, because a literal in a
+    print() has nothing checking it. Reading the master means it cannot drift
+    again, and the bump script does not need to know this file exists.
+    """
+    try:
+        from entroly import __version__
+        return f"v{__version__}"
+    except Exception:
+        return "(version unavailable)"
+
+
 def run():
     print("══════════════════════════════════════════════════════════════")
-    print("  Entroly v0.2.0 — Intensive Functional Test Suite")
+    print(f"  Entroly {_entroly_version()} — Intensive Functional Test Suite")
     print(f"  Corpus: {len(real_sources())} real project files")
     print("══════════════════════════════════════════════════════════════")
 

--- a/tests/test_no_stale_version_declarations.py
+++ b/tests/test_no_stale_version_declarations.py
@@ -1,0 +1,92 @@
+"""No file may declare or pin a version older than the runtime master.
+
+Runs `scripts/check_version_staleness.py` as a test so the sweep executes on
+every pull request rather than only when someone remembers to run it.
+
+The distinction the checker draws is the whole point, and it is worth restating
+where a reader will find it: a version string must equal the master if it
+**declares or pins the product as it is now**, and may be older if it **records
+something that happened**. Release notes for 1.0.47 say 1.0.47 forever, a
+benchmark that ran on 1.0.59 must keep saying so, and a lock file records
+`serde 1.0.4` because that is serde's version. A sweep that ignores this finds
+631 "stale" strings and is useless; a sweep that respects it found the 12 real
+ones.
+
+Do not silence a failure by adding a path to the archive list. Archives are
+paths whose purpose is recording the past. If a live declaration is genuinely
+about history, phrase it in past tense -- the checker recognises that too.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKER = REPO_ROOT / "scripts" / "check_version_staleness.py"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), *args],
+        cwd=str(REPO_ROOT), capture_output=True, text=True,
+        encoding="utf-8", errors="replace", timeout=300,
+    )
+
+
+def test_no_declaration_is_older_than_the_master_version():
+    result = _run()
+    assert result.returncode == 0, (
+        "version declarations older than the master version:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_the_checker_is_actually_inspecting_the_tree():
+    """Guard the guard.
+
+    If the sweep stopped finding files -- a broken `git ls-files`, a changed
+    layout -- it would report success while checking nothing. This asserts it
+    still classified a substantial number of historical references, which it
+    can only do by having read them.
+    """
+    result = _run("--list")
+    assert result.returncode == 0, result.stdout
+    assert "historical references checked" in result.stdout
+    count = int(result.stdout.split("(")[-1].split(" historical")[0])
+    assert count > 300, (
+        f"only {count} references classified; the sweep is not reading the "
+        f"repository and this gate would pass without checking anything"
+    )
+
+
+def test_a_stale_declaration_is_detected(tmp_path, monkeypatch):
+    """The checker must fail on a real regression, not just pass on a clean tree.
+
+    Exercised against a manifest that was genuinely left behind by a past bump:
+    `.claude-plugin/plugin.json` sat one release behind the `manifest.json`
+    directly beside it, which the bump script did rewrite.
+    """
+    target = REPO_ROOT / ".claude-plugin" / "plugin.json"
+    original = target.read_text(encoding="utf-8")
+    assert '"version"' in original
+
+    import json
+    document = json.loads(original)
+    current = document["version"]
+    major, minor, patch = (int(p) for p in current.split("."))
+    stale = f"{major}.{minor}.{max(patch - 1, 0)}"
+
+    try:
+        target.write_text(original.replace(f'"{current}"', f'"{stale}"', 1), encoding="utf-8")
+        result = _run()
+        assert result.returncode != 0, (
+            "the checker passed while .claude-plugin/plugin.json declared "
+            f"{stale} against master {current}"
+        )
+        assert "plugin.json" in result.stdout, (
+            f"the failure did not name the offending file:\n{result.stdout}"
+        )
+    finally:
+        target.write_text(original, encoding="utf-8")
+        assert target.read_text(encoding="utf-8") == original

--- a/tests/test_version_surfaces_are_complete.py
+++ b/tests/test_version_surfaces_are_complete.py
@@ -68,20 +68,25 @@ def _tracked_json() -> tuple[Path, ...]:
 
 
 def _declared_version(path: Path) -> str | None:
-    """A top-level `version` that this product actually ships.
+    """A top-level `version` a manifest in this repository declares for itself.
 
-    `"private": true` is the discriminator, not a name pattern. A private
-    package is never published, so it keeps its own lifecycle and has no reason
-    to track the product version -- `deploy/cloudflare-community-savings` is a
-    Worker still at 1.0.0 whose version has never moved in its history. Every
-    published manifest in this repo is non-private, so the rule separates them
-    exactly without an allow-list that would need maintaining.
+    Private manifests are included. An earlier version of this file skipped
+    `"private": true` on the reasoning that an unpublished package keeps its own
+    lifecycle -- `deploy/cloudflare-community-savings` was a Worker sitting at
+    1.0.0 that had never moved. That carve-out is gone: the rule is that every
+    manifest this repository owns declares the current version, published or
+    not, so "which of these is allowed to be stale" is not a judgement anyone
+    has to make again.
+
+    Only a *nested* version is ignored, because those belong to third parties --
+    a lock file records `serde 1.0.4` and `windows 0.52.6`, and rewriting those
+    would mean demanding versions of other people's crates that do not exist.
     """
     try:
         document = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError, OSError):
         return None
-    if not isinstance(document, dict) or document.get("private") is True:
+    if not isinstance(document, dict):
         return None
     value = document.get("version")
     return value if isinstance(value, str) and _SEMVER.match(value) else None


### PR DESCRIPTION
Every release left a version behind, and every time it was found by hand. This makes that structurally impossible.

## What was stale

The 1.0.82 bump left **seven manifests on 1.0.81** — each declaring the product version to a *different host*, so the release would have told Claude, Codex and Gemini it was the previous version. Nothing failed, because a stale version is valid JSON that parses and loads.

Sweeping further back found strings that had **never moved since the project began**:

| Stale | Was | Age |
|---|---|---|
| 3 functional-test banners | `Entroly v0.2.0` | 80 releases |
| `BENCHMARKS.md` engine | `entroly-core v0.9.0` | written in the v1.0 founding commit `dc24db33` |
| `packaging/aur/README.md` | "v0.19.x roadmap" | 3rd copy — fixing nix + scoop by hand missed it |
| 4 workflow-dispatch examples | `for example 1.0.25` | shown to whoever triggers a manual publish |
| `CLAUDE.md` graph measurement | 1.0.80 numbers | understated the tree by 21 modules / 8,235 lines |

## The cause is structural

`bump_version.py` rewrites a **hand-maintained list**, so a surface added later is skipped in silence. `CLAUDE.md` then named 13 surfaces against a real count over 40 — which invited exactly the hand-checking that kept missing them.

## The rule

`scripts/check_version_staleness.py` sweeps the whole tree. A version must equal the master if it **declares or pins the product as it is now**, and may be older if it **records something that happened**.

**That distinction is the entire design.** A naive sweep finds **631** old version strings and almost all are correct — release notes for 1.0.47 say 1.0.47 forever, a benchmark that ran on 1.0.59 must keep saying so, a fixture is the input proving the bump rewrites 1.0.39→1.0.40, and `Cargo.lock` records `serde 1.0.4` because that *is* serde's version. Rewriting those destroys provenance or breaks the build.

Result: **631 allowed, 0 stale.**

## Wired where a version can actually go stale

- **`bump_version.py`** runs the sweep after rewriting and fails with the paths it missed, so the person cutting the release learns immediately. Verified by deleting a `TARGETS` entry — the bump exits non-zero and names the file.
- **`tests/test_no_stale_version_declarations.py`** runs it on every PR, and asserts the sweep still classified 300+ references so it cannot pass while reading nothing.

## Mutation-verified: 10/10

Against every shape that actually occurred — left-behind plugin manifest, agent bundles, host extension manifests, two install pins, a core dependency pin, a workflow example, a labelled engine version, a Cargo manifest, an npm manifest. Each caught, each naming its file.

**The tenth needed a new rule.** `entroly-core 0.9.0` is a bare "name version" with no operator and no JSON field — nothing matched it, and it's the exact shape of the founding-commit bug. Writing the mutation test is what exposed the gap.

## Two files deliberately lag

`packaging/scoop/entroly.json` and `packaging/homebrew/entroly.rb` pin a *published* artifact with a verified SHA-256. Moving them before that release exists points at a 404 with a hash matching nothing.

## The checker caught itself

Committing it made it visible to `git ls-files`, so it scanned its own docstring — which cites the bugs it catches, and citing a stale version means writing one. I widened the past-tense verb list first (a real improvement, kept) but that was the wrong fix: rewording documentation to dodge a pattern makes the docs worse to satisfy a tool. The actual property is self-reference, now an explicit **two-path** exclusion with reasoning attached and a note not to extend it — because an exclusion list is exactly how a gate becomes decorative.
