### PR TITLE
fix(release): the publish probes failed on healthy releases

### DIFF
--- a/.github/workflows/entroly-publish.yml
+++ b/.github/workflows/entroly-publish.yml
@@ -494,6 +494,14 @@ jobs:
     timeout-minutes: 15
     env:
       RELEASE_VERSION: ${{ needs.release-metadata.outputs.version }}
+      # The assertion below looks for the literal "Entroly v<version>" in the
+      # banner, and `entroly-wasm/js/cli.js:40` builds that banner as
+      # `${C.CYAN}${C.BOLD}  Entroly${C.RESET} v${VERSION}` -- the reset lands
+      # *between* the name and the version, so with colour on the literal never
+      # appears and `grep -F` cannot match no matter how long it retries. The
+      # CLI honours NO_COLOR (cli.js:30), which collapses the codes to empty
+      # strings and makes the banner say what the assertion expects.
+      NO_COLOR: '1'
     steps:
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -519,8 +527,16 @@ jobs:
               probe_dir="$(mktemp -d)"
               output="$probe_dir/help.txt"
               error="$probe_dir/error.txt"
+              # Strip ANSI before matching as well as setting NO_COLOR. The
+              # banner colours the product name separately from the version, so
+              # a single stray escape between them makes `grep -F` fail on a
+              # perfectly good release -- and it fails identically on every
+              # retry, which reads as a registry problem rather than a broken
+              # assertion. Belt and braces, because this gate reported red for
+              # two releases while the packages were fine.
               if (cd "$probe_dir" && "$@" > "$output" 2> "$error") \
-                   && grep -Fq "Entroly v${RELEASE_VERSION}" "$output"; then
+                   && sed -r 's/\x1B\[[0-9;]*[A-Za-z]//g' "$output" \
+                        | grep -Fq "Entroly v${RELEASE_VERSION}"; then
                 cat "$output"
                 rm -rf "$probe_dir"
                 return 0
@@ -546,7 +562,11 @@ jobs:
     needs: [release-metadata, publish-pypi]
     if: needs.release-metadata.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Comfortably above the 900s probe budget plus runner setup, so the budget
+    # is what ends this job. A job timeout kills it mid-retry with no
+    # explanation; the budget prints how long it waited and how many attempts
+    # it made, which is the difference between a usable failure and a puzzle.
+    timeout-minutes: 25
     env:
       RELEASE_VERSION: ${{ needs.release-metadata.outputs.version }}
     steps:
@@ -562,23 +582,44 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # One wall-clock budget shared by every runner, not 20 attempts each.
+          #
+          # This job starts seconds after the upload finishes -- measured at 7s
+          # for 1.0.83 -- and the old budget of 20 attempts x 15s gave PyPI five
+          # minutes to serve the new version from the `/simple/` index that pip
+          # resolves against. That was not enough: the probe failed 20/20 on a
+          # correctly published release, and the same job succeeded in 21s when
+          # it ran again half an hour later. So the release was fine and the
+          # gate was wrong, which is the worst way for a gate to fail.
+          #
+          # A shared deadline rather than per-runner attempts means the first
+          # probe absorbs the propagation wait and the rest return immediately,
+          # so the ceiling does not multiply as runners are added.
+          PROBE_DEADLINE=$(( $(date +%s) + ${PROBE_BUDGET_SECONDS:-900} ))
+
           probe_python_runner() {
             local label="$1"
             shift
             local output="$RUNNER_TEMP/${label}-output.txt"
-            for attempt in $(seq 1 20); do
+            local attempt=0
+            while :; do
+              attempt=$(( attempt + 1 ))
               if "$@" > "$output" 2>&1 \
                    && grep -Fq "$RELEASE_VERSION" "$output"; then
                 cat "$output"
                 return 0
               fi
-              echo "$label could not run entroly==${RELEASE_VERSION} (attempt $attempt/20)." >&2
-              cat "$output" >&2 || true
-              if [[ "$attempt" != 20 ]]; then
-                sleep 15
+              local remaining=$(( PROBE_DEADLINE - $(date +%s) ))
+              if (( remaining <= 0 )); then
+                echo "$label still could not run entroly==${RELEASE_VERSION} after ${PROBE_BUDGET_SECONDS:-900}s and ${attempt} attempts." >&2
+                cat "$output" >&2 || true
+                return 1
               fi
+              echo "$label could not run entroly==${RELEASE_VERSION} (attempt ${attempt}, ${remaining}s of budget left)." >&2
+              cat "$output" >&2 || true
+              sleep 15
             done
-            return 1
           }
 
           # pipx 1.16 defaults to a new-release cooldown and auto-selects uv

--- a/tests/test_release_surface.py
+++ b/tests/test_release_surface.py
@@ -247,6 +247,37 @@ def test_homebrew_formula_targets_release_sdist() -> None:
     assert f'sha256 "{HOMEBREW_FORMULA_SHA256}"' in text
 
 
+def _assert_probe_retries_and_is_bounded(probe: str, name: str) -> None:
+    """A publish probe must tolerate propagation without hanging forever.
+
+    Both halves matter. Without retries the probe races the registry index and
+    fails on a healthy release -- measured: the PyPI probe starts 7s after
+    upload and once failed 20/20 in five minutes, then passed in 21s when rerun
+    half an hour later. Without a bound it could hang until the job timeout
+    kills it with no explanation.
+
+    Asserted as a property rather than a literal loop. This previously pinned
+    `for attempt in $(seq 1 20)`, which passes only for a count-based loop, so
+    replacing it with an equivalent wall-clock deadline failed the test while
+    preserving everything the test exists to protect. A gate that encodes one
+    implementation blocks a better one wearing the same guarantees.
+
+    Caller keeps its own `npm view` / `pypi.org/pypi/` assertions: a probe must
+    exercise the real installer path, because registry metadata can lead the
+    tarball and CDN.
+    """
+    retries = "sleep " in probe and ("$(seq 1 " in probe or "while :" in probe)
+    assert retries, (
+        f"{name} does not retry; it will fail whenever the registry index lags "
+        f"behind a correct publish"
+    )
+    bounded = "$(seq 1 " in probe or "PROBE_DEADLINE" in probe
+    assert bounded, (
+        f"{name} retries without a bound; it can only end by hitting the job "
+        f"timeout, which reports nothing about what it was waiting for"
+    )
+
+
 def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> None:
     text = (ROOT / ".github/workflows/entroly-publish.yml").read_text(
         encoding="utf-8"
@@ -273,12 +304,12 @@ def test_release_workflow_sanitizes_version_once_and_probes_live_artifacts() -> 
     npm_runner_probe = text.split("  probe-npm-runners:", 1)[1].split(
         "  probe-python-runners:", 1
     )[0]
-    assert "for attempt in $(seq 1 20)" in npm_runner_probe
+    _assert_probe_retries_and_is_bounded(npm_runner_probe, "probe-npm-runners")
     assert "npm view" not in npm_runner_probe
     python_runner_probe = text.split("  probe-python-runners:", 1)[1].split(
         "  probe-npm-openclaw:", 1
     )[0]
-    assert "for attempt in $(seq 1 20)" in python_runner_probe
+    _assert_probe_retries_and_is_bounded(python_runner_probe, "probe-python-runners")
     assert "pypi.org/pypi/" not in python_runner_probe
     assert "oven-sh/setup-bun@v2" in text
     assert "pipx==1.16.7 uv==0.12.7" in text


### PR DESCRIPTION
Both post-publish probes reported failure while the packages were **correctly published**, so the pipeline showed red on a good release twice running. They were red for two different reasons — and only one of them was a budget.

## npm was never a timing problem

`probe-npm-runners` asserts the literal `Entroly v<version>` in the CLI banner. `entroly-wasm/js/cli.js:40` builds that banner as:

```js
`${C.CYAN}${C.BOLD}  Entroly${C.RESET} v${VERSION} — ...`
```

The reset lands **between** the name and the version, so with colour on that literal does not exist in the output and `grep -F` cannot match it. **Twenty retries or two hundred fail identically.**

Confirmed from the 1.0.83 job log — npx printed a perfectly good banner and the probe still called it a failure:

```
npx could not run entroly@1.0.83 (attempt 1/20).
[38;5;45m[1m  Entroly[0m v1.0.83 — information-theoretic context optimization
```

Reproduced locally against the real CLI:

| | raw grep | ANSI-stripped |
|---|---|---|
| **colour** | **FAIL** ← the shipped probe | PASS |
| **NO_COLOR** | PASS | PASS |

Fixed **twice over**, because this gate was silently asserting nothing across at least two releases: `NO_COLOR` is set (the CLI honours it at `cli.js:30`) *and* the comparison strips ANSI before matching, so a future colour path that ignores `NO_COLOR` can't quietly break it again.

## PyPI was a genuine budget

The job starts seconds after upload — measured at **7s** for 1.0.83 — and allowed 20 attempts × 15s, giving PyPI's `/simple/` index (what `pip` resolves against) five minutes to serve the new version.

```
16:32:58  PyPI upload completes
16:33:05  probe starts            ← 7s later
16:38:18  probe gives up          ← 20/20 failed
```

The same job **passed in 21 seconds** when it ran again half an hour later. The release was fine; the deadline was too short.

Attempts are now a single **wall-clock budget shared by every runner**, default `900s`. A shared deadline means the first probe absorbs the propagation wait and the rest return immediately, so the ceiling doesn't multiply as runners are added. The failure message now reports how long it waited and how many attempts it made, and `timeout-minutes` moves to 25 so the *budget* ends the job rather than an opaque timeout killing it mid-retry.

## Why this matters beyond the noise

A release gate that reports red on healthy releases trains people to ignore it — and the npm one wasn't merely noisy, it was **incapable of passing**. It would not have caught a genuinely broken npm package either.

## Verification

- YAML parses; all **four** probe scripts pass `bash -n`.
- The deadline loop exits non-zero with its budget and attempt count (exercised with a 3s budget against a failing command).
- The banner assertion passes under both colour settings once stripped.
