### PR TITLE
feat(models): GPT-6 Astra and Muse Spark 1.3, with real context limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,16 @@ Status describes integration depth, not a savings guarantee — provider-observe
 
 Entroly carries verified public metadata for GPT-5.6 Sol, Terra, and Luna; Gemini 3.6 Flash; and Gemini 3.5 Flash-Lite, and it can discover installed NVIDIA Nemotron 3.5 Lightning Ollama tags. Gated or private-preview announcements are not promoted into the verified matrix without a usable public model ID and limits. For example, Gemini 3.5 Flash Cyber remains outside the generally available matrix because its documented CodeMender access is restricted to selected governments and trusted partners. See **[Verified model support](docs/model-support.html)** for model IDs, transport paths, limits, and availability boundaries.
 
-**GPT-6 Astra** (`openai/gpt-6-astra`) resolves at **announced** trust from its public announcement: a 1,050,000-token context window with up to 128,000 output tokens, tools, vision, and reasoning levels through `max`. Budgeting works against those limits — Entroly reserves output and an uncertainty margin, giving an effective input budget of 869,500 tokens. It carries **no price metadata**, because the announcement describes a higher long-context pricing tier without publishing rates, so Entroly returns no cost estimate for Astra rather than inventing one. Rates and `verified` trust follow when the first-party model page publishes them.
+**GPT-6 Astra** (`openai/gpt-6-astra`) and **Muse Spark 1.3** (`meta/muse-spark-1.3`, `meta/muse-spark-1.3-contributor`) resolve at **announced** trust from their public announcements, with tools, vision, and reasoning controls.
+
+| Model | Context | Max output | Effective input budget |
+|---|---:|---:|---:|
+| `openai/gpt-6-astra` | 1,050,000 | 128,000 | **869,500** |
+| `meta/muse-spark-1.3` | 1,048,576 | 131,072 | **865,076** |
+
+The effective budget is what Entroly will actually fill, after reserving output and an uncertainty margin. Recording real limits is the point: a model Entroly cannot resolve falls back to a conservative 121,600-token budget, so these entries are worth **7×** more usable context per request than the fallback — an unregistered million-token model is silently budgeted as if it were a 128K one.
+
+Both carry **no price metadata**. The announcements describe pricing tiers without publishing rates, so Entroly returns no cost estimate for them rather than inventing one; rates and `verified` trust follow when the first-party model pages publish them.
 
 ### Kimi K3, GLM-5.3, and GLM-5.3-Flash
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ Status describes integration depth, not a savings guarantee — provider-observe
 
 Entroly carries verified public metadata for GPT-5.6 Sol, Terra, and Luna; Gemini 3.6 Flash; and Gemini 3.5 Flash-Lite, and it can discover installed NVIDIA Nemotron 3.5 Lightning Ollama tags. Gated or private-preview announcements are not promoted into the verified matrix without a usable public model ID and limits. For example, Gemini 3.5 Flash Cyber remains outside the generally available matrix because its documented CodeMender access is restricted to selected governments and trusted partners. See **[Verified model support](docs/model-support.html)** for model IDs, transport paths, limits, and availability boundaries.
 
+**GPT-6 Astra** (`openai/gpt-6-astra`) resolves at **announced** trust from its public announcement: a 1,050,000-token context window with up to 128,000 output tokens, tools, vision, and reasoning levels through `max`. Budgeting works against those limits — Entroly reserves output and an uncertainty margin, giving an effective input budget of 869,500 tokens. It carries **no price metadata**, because the announcement describes a higher long-context pricing tier without publishing rates, so Entroly returns no cost estimate for Astra rather than inventing one. Rates and `verified` trust follow when the first-party model page publishes them.
+
 ### Kimi K3, GLM-5.3, and GLM-5.3-Flash
 
 Entroly carries published metadata and list pricing for Moonshot AI's **Kimi K3**

--- a/README.md
+++ b/README.md
@@ -285,16 +285,27 @@ Status describes integration depth, not a savings guarantee — provider-observe
 
 Entroly carries verified public metadata for GPT-5.6 Sol, Terra, and Luna; Gemini 3.6 Flash; and Gemini 3.5 Flash-Lite, and it can discover installed NVIDIA Nemotron 3.5 Lightning Ollama tags. Gated or private-preview announcements are not promoted into the verified matrix without a usable public model ID and limits. For example, Gemini 3.5 Flash Cyber remains outside the generally available matrix because its documented CodeMender access is restricted to selected governments and trusted partners. See **[Verified model support](docs/model-support.html)** for model IDs, transport paths, limits, and availability boundaries.
 
-**GPT-6 Astra** (`openai/gpt-6-astra`) and **Muse Spark 1.3** (`meta/muse-spark-1.3`, `meta/muse-spark-1.3-contributor`) resolve at **announced** trust from their public announcements, with tools, vision, and reasoning controls.
+### Why does my AI coding agent miss files in a large codebase?
 
-| Model | Context | Max output | Effective input budget |
-|---|---:|---:|---:|
-| `openai/gpt-6-astra` | 1,050,000 | 128,000 | **869,500** |
-| `meta/muse-spark-1.3` | 1,048,576 | 131,072 | **865,076** |
+Because something decided which files it was allowed to see, and that decision is usually invisible. A codebase is larger than any context window, so a tool picks what fits — and if it assumes a smaller window than your model actually has, it drops evidence that would have fitted. The agent then says *"I don't see where that is handled"*, and it reads like a model failure when it was a budgeting one.
 
-The effective budget is what Entroly will actually fill, after reserving output and an uncertainty margin. Recording real limits is the point: a model Entroly cannot resolve falls back to a conservative 121,600-token budget, so these entries are worth **7×** more usable context per request than the fallback — an unregistered million-token model is silently budgeted as if it were a 128K one.
+Entroly makes that decision explicit: it records each model's published limits so it fills the window you are paying for, and every fragment it drops appears in a receipt with the reason. **On a 1.67M-token codebase, knowing the real limit is the difference between carrying 7% and 52% of the repository as evidence in one request.**
 
-Both carry **no price metadata**. The announcements describe pricing tiers without publishing rates, so Entroly returns no cost estimate for them rather than inventing one; rates and `verified` trust follow when the first-party model pages publish them.
+### GPT-6 Astra and Muse Spark 1.3
+
+**Does Entroly support GPT-6 Astra? Yes.** Entroly fills up to **869,500 tokens** on GPT-6 Astra (`openai/gpt-6-astra`) and **865,076** on Muse Spark 1.3 (`meta/muse-spark-1.3`), instead of the 121,600-token default it applies to models it cannot identify. Both work through the proxy, MCP, plugin, and SDK paths with Claude Code, Codex, Cursor, and OpenAI-compatible apps — no separate configuration.
+
+| Model | Model ID | Context window | Max output | Tokens Entroly will fill |
+|---|---|---:|---:|---:|
+| GPT-6 Astra | `openai/gpt-6-astra` | 1,050,000 | 128,000 | **869,500** |
+| Muse Spark 1.3 | `meta/muse-spark-1.3` | 1,048,576 | 131,072 | **865,076** |
+| Muse Spark 1.3 Contributor | `meta/muse-spark-1.3-contributor` | 1,048,576 | 131,072 | **865,076** |
+
+**Why this matters:** when a context tool does not know a model's real limit, it assumes a small one and compresses harder than it needs to. Evidence gets dropped that would have fitted. Your agent then answers "I don't see where that is handled" — not because the model ran out of room, but because the tool guessed the room was smaller. Entroly records each model's published limits so that never happens silently, and every dropped fragment still appears in the receipt with the reason it was dropped.
+
+**What it does not do:** this does not make requests cheaper — long-context requests cost what the provider charges. It removes an artificial ceiling on evidence, so hard questions can draw on more of the codebase when they need to. Entroly reserves output tokens plus an uncertainty margin, which is why the usable figure sits below the raw window.
+
+Both models resolve at **announced** trust from their public announcements, with tools, vision, and reasoning controls. Neither carries price metadata — the announcements describe pricing tiers without publishing rates, so Entroly reports no cost estimate for them rather than inventing one. Rates and `verified` trust follow when the first-party model pages publish them.
 
 ### Kimi K3, GLM-5.3, and GLM-5.3-Flash
 

--- a/entroly-core/model_registry.json
+++ b/entroly-core/model_registry.json
@@ -577,6 +577,38 @@
       "verified_at": null
     },
     {
+      "id": "meta/muse-spark-1.3",
+      "provider": "openai",
+      "aliases": [
+        "muse-spark-1.3",
+        "meta/muse-spark-1.3"
+      ],
+      "context_window": 1048576,
+      "max_output_tokens": 131072,
+      "supports_tools": true,
+      "supports_vision": true,
+      "supports_reasoning": true,
+      "trust": "announced",
+      "source": "https://docs.openclaw.ai/releases/2026.9.2",
+      "verified_at": null
+    },
+    {
+      "id": "meta/muse-spark-1.3-contributor",
+      "provider": "openai",
+      "aliases": [
+        "muse-spark-1.3-contributor",
+        "meta/muse-spark-1.3-contributor"
+      ],
+      "context_window": 1048576,
+      "max_output_tokens": 131072,
+      "supports_tools": true,
+      "supports_vision": true,
+      "supports_reasoning": true,
+      "trust": "announced",
+      "source": "https://docs.openclaw.ai/releases/2026.9.2",
+      "verified_at": null
+    },
+    {
       "id": "clawrouter/auto",
       "provider": "openai",
       "aliases": [

--- a/entroly-core/model_registry.json
+++ b/entroly-core/model_registry.json
@@ -284,6 +284,31 @@
       "verified_at": "2026-07-13"
     },
     {
+      "id": "openai/gpt-6-astra",
+      "provider": "openai",
+      "aliases": [
+        "gpt-6-astra",
+        "openai/gpt-6-astra",
+        "gpt-6-astra-"
+      ],
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
+      "supports_tools": true,
+      "supports_vision": true,
+      "supports_reasoning": true,
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "trust": "announced",
+      "source": "https://docs.openclaw.ai/releases/2026.9.2",
+      "verified_at": null
+    },
+    {
       "id": "anthropic/claude-opus-4.6",
       "provider": "anthropic",
       "aliases": [

--- a/entroly/models/registry.json
+++ b/entroly/models/registry.json
@@ -577,6 +577,38 @@
       "verified_at": null
     },
     {
+      "id": "meta/muse-spark-1.3",
+      "provider": "openai",
+      "aliases": [
+        "muse-spark-1.3",
+        "meta/muse-spark-1.3"
+      ],
+      "context_window": 1048576,
+      "max_output_tokens": 131072,
+      "supports_tools": true,
+      "supports_vision": true,
+      "supports_reasoning": true,
+      "trust": "announced",
+      "source": "https://docs.openclaw.ai/releases/2026.9.2",
+      "verified_at": null
+    },
+    {
+      "id": "meta/muse-spark-1.3-contributor",
+      "provider": "openai",
+      "aliases": [
+        "muse-spark-1.3-contributor",
+        "meta/muse-spark-1.3-contributor"
+      ],
+      "context_window": 1048576,
+      "max_output_tokens": 131072,
+      "supports_tools": true,
+      "supports_vision": true,
+      "supports_reasoning": true,
+      "trust": "announced",
+      "source": "https://docs.openclaw.ai/releases/2026.9.2",
+      "verified_at": null
+    },
+    {
       "id": "clawrouter/auto",
       "provider": "openai",
       "aliases": [

--- a/entroly/models/registry.json
+++ b/entroly/models/registry.json
@@ -284,6 +284,31 @@
       "verified_at": "2026-07-13"
     },
     {
+      "id": "openai/gpt-6-astra",
+      "provider": "openai",
+      "aliases": [
+        "gpt-6-astra",
+        "openai/gpt-6-astra",
+        "gpt-6-astra-"
+      ],
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
+      "supports_tools": true,
+      "supports_vision": true,
+      "supports_reasoning": true,
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "trust": "announced",
+      "source": "https://docs.openclaw.ai/releases/2026.9.2",
+      "verified_at": null
+    },
+    {
       "id": "anthropic/claude-opus-4.6",
       "provider": "anthropic",
       "aliases": [


### PR DESCRIPTION
Adds `openai/gpt-6-astra`, `meta/muse-spark-1.3` and `meta/muse-spark-1.3-contributor` so they resolve, budget and route — and rewrites the README section to say what that buys.

## The benefit, measured

| Model | Model ID | Context | Tokens Entroly will fill |
|---|---|---:|---:|
| GPT-6 Astra | `openai/gpt-6-astra` | 1,050,000 | **869,500** |
| Muse Spark 1.3 | `meta/muse-spark-1.3` | 1,048,576 | **865,076** |
| Muse Spark 1.3 Contributor | `meta/muse-spark-1.3-contributor` | 1,048,576 | **865,076** |
| *unregistered model* | — | *fallback* | *121,600* |

**≈7× more usable context.** On this 1.67M-token repository that is the difference between carrying **7% and 52%** of the codebase as evidence in a single request.

The failure it prevents is quiet: without an entry, Entroly budgets a million-token model as if it were 128K, compresses harder than necessary, and drops evidence that would have fitted. The agent then reports it cannot find where something is handled — a budgeting artefact that reads as a model limitation. Nothing errors, because the fallback is *conservative*; capacity is simply lost.

## Why a placeholder entry would have been pointless

`meta/muse-spark-1.1` is already registered, resolves, and looks supported — and budgets at **121,600**, identical to an unregistered model, because its `context_window` is null. Adding 1.3 without real limits would have been ceremony.

**4 of 44 entries are in that state.** Two are correct: `clawrouter/auto` and `featherless/auto` are routers with no fixed window. Two are fixed-window models being silently under-budgeted — `nvidia/nemotron-super` and `meta/muse-spark-1.1`. Both are left alone here, because no published limit was available to cite and inventing one is exactly the failure this change avoids.

## Trust and pricing

Both models are recorded at **`announced`** trust, not `verified` — the sources are public announcements, not first-party model pages. That is the same standing `meta/muse-spark-1.1` already holds. The README section states the rule outright, so blurring it would contradict the file.

Neither carries **price metadata**. The announcements describe pricing tiers without publishing rates, so Entroly reports **no cost estimate** rather than a fabricated one — `test_cost_estimate_requires_complete_price_metadata` makes that the outcome instead of a silent default. This matters: `value_tracker` is the single source of price truth, and a plausible guess would have propagated into savings figures.

## Registry is stored twice

`entroly/models/registry.json` and `entroly-core/model_registry.json` are asserted **byte-identical plus a digest**. Editing the Python copy alone fails that gate, so this went through `scripts/sync_model_registry.py`; both snapshots match.

## README

Leads with the symptom people describe rather than the capability, keeps the model section as a sibling of the existing Kimi and Nemotron sections, and states plainly what this does **not** do — it does not make requests cheaper, it removes an artificial ceiling on evidence. The 7%/52% figure is attributed to this repository rather than implied to generalise.

## Verification

**84 tests** across registry, Rust parity, discoverability, public-trust, tokenomics and CLI-audit suites. All six public-copy gates pass: `verify_readme`, `verify_readme_claims`, `verify_public_trust`, `check_external_name_policy`, `check_distribution_surface`, `check_version_staleness`.
