### PR TITLE
feat(proxy): enforce the session spend cap that was already built

### DIFF
--- a/entroly/governance/audit.py
+++ b/entroly/governance/audit.py
@@ -403,13 +403,24 @@ class GovernanceAuditLog:
 
 # ── Event Bus Integration ────────────────────────────────────────────
 
-def make_audit_subscriber(log: "GovernanceAuditLog"):
-    """Create an event bus subscriber that auto-logs all governance events."""
+def make_audit_subscriber(log: "GovernanceAuditLog | None" = None):
+    """Create an event bus subscriber that auto-logs all governance events.
+
+    With no ``log``, the handler resolves the process-global log at emit time
+    rather than capturing one at creation. That matters because the bus and the
+    log are separate globals with separate lifetimes: a handler that closed over
+    an instance would keep writing to it after the global log was replaced, so
+    records would land in an object nothing reads while the live log stayed
+    empty -- and an empty log is what a clean audit looks like.
+
+    Pass an explicit ``log`` to bind one deliberately, e.g. for a private bus.
+    """
     from .events import GovernanceEvent
 
     def _handler(event: GovernanceEvent) -> None:
+        target = log if log is not None else get_audit_log()
         payload = dict(event.payload)
-        log.append(
+        target.append(
             event_id=event.event_id,
             event_type=event.event_type,
             agent_id=event.tracing.agent_id,
@@ -439,12 +450,41 @@ def get_audit_log() -> GovernanceAuditLog:
 
 
 def install_audit_subscriber(bus=None) -> None:
-    """Install the audit log as a wildcard subscriber on the event bus."""
+    """Install the audit log as a wildcard subscriber on the event bus.
+
+    Idempotent per bus. `subscribe` appends unconditionally, so without this
+    guard a second call attaches a second wildcard handler and every event is
+    appended twice -- and the two sinks in `append` then disagree. SQLite takes
+    it as `INSERT OR IGNORE` on `event_id` and drops the copy; the JSONL chain
+    is an unconditional write and keeps it. So `query` reports the true count
+    while `verify_chain`, which walks the JSONL, reports roughly double and
+    still calls the chain intact. Measured: one run logged 7 records by `query`
+    and "Chain intact (13 records verified)".
+
+    That is the worst shape for an audit defect -- inflated, self-consistent,
+    and endorsed by the integrity check meant to catch it.
+
+    A second call is ordinary, not pathological: `get_authorization_service`
+    installs on creation, and `reset=True` (or `reset_authorization_service`)
+    makes it create again within the same process.
+    """
     from .events import get_event_bus
     if bus is None:
         bus = get_event_bus()
-    log = get_audit_log()
-    bus.subscribe("*", make_audit_subscriber(log))
+    # Tracked on the bus so the marker dies with it. A module-level set keyed
+    # by id() would let a recycled id suppress a legitimate install.
+    if getattr(bus, "_entroly_audit_subscriber_installed", False):
+        return
+    # No log argument: the handler resolves the current global log per event,
+    # so this install stays correct if that log is later replaced.
+    bus.subscribe("*", make_audit_subscriber())
+    try:
+        bus._entroly_audit_subscriber_installed = True
+    except AttributeError:  # pragma: no cover - bus defining __slots__
+        logger.debug(
+            "Event bus rejects the install marker; duplicate audit subscribers "
+            "are possible on this bus."
+        )
 
 
 __all__ = [

--- a/entroly/governance/authorization.py
+++ b/entroly/governance/authorization.py
@@ -375,9 +375,6 @@ def get_authorization_service(
     if reset or _global_service is None:
         with _service_lock:
             if reset or _global_service is None:
-                _global_service = AuthorizationService.from_environment(
-                    header_value=header_value
-                )
                 # Start recording as soon as governance is used.
                 #
                 # `install_audit_subscriber` existed and nothing called it, so
@@ -391,6 +388,12 @@ def get_authorization_service(
                 # resolves its directory lazily and creates nothing until an
                 # event arrives. Failure to attach must not stop authorization
                 # working, so it degrades to a warning rather than raising.
+                #
+                # Ordered before construction, not after: `from_environment`
+                # resolves the identity, which emits `identity.resolved`. A
+                # subscriber attached afterwards misses it, and in a process
+                # that builds the service once -- the normal case -- that is
+                # the whole record of which agent this is.
                 try:
                     from .audit import install_audit_subscriber
 
@@ -401,6 +404,9 @@ def get_authorization_service(
                         "decisions will not be recorded.",
                         exc,
                     )
+                _global_service = AuthorizationService.from_environment(
+                    header_value=header_value
+                )
     return _global_service
 
 

--- a/entroly/governance/authorization.py
+++ b/entroly/governance/authorization.py
@@ -327,6 +327,19 @@ class AuthorizationService:
         return self._stats
 
     @property
+    def policies(self) -> list[Policy]:
+        """The policies this service evaluates against.
+
+        Exposed so callers can inspect the applicable policy without calling
+        `load_policies` again. That function is uncached -- it stats the path
+        and re-parses the YAML on every call -- so a per-request caller would
+        add disk I/O to a hot path. Worse, it would read a *different* snapshot
+        than the one `check` and `check_budget` evaluate against, letting a
+        caller's pre-check and the service's decision disagree after an edit.
+        """
+        return self._policies
+
+    @property
     def spent_usd(self) -> float:
         with self._lock:
             return self._spent_usd
@@ -365,6 +378,29 @@ def get_authorization_service(
                 _global_service = AuthorizationService.from_environment(
                     header_value=header_value
                 )
+                # Start recording as soon as governance is used.
+                #
+                # `install_audit_subscriber` existed and nothing called it, so
+                # the audit log stayed empty unless an operator wired the bus
+                # themselves. An audit trail that is empty by default is worse
+                # than none: `govern audit verify` reports an intact chain over
+                # a log nothing ever wrote to.
+                #
+                # Attached here rather than at import so it stays side-effect
+                # free until governance is actually exercised -- the log
+                # resolves its directory lazily and creates nothing until an
+                # event arrives. Failure to attach must not stop authorization
+                # working, so it degrades to a warning rather than raising.
+                try:
+                    from .audit import install_audit_subscriber
+
+                    install_audit_subscriber()
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning(
+                        "Governance audit subscriber not installed (%s); "
+                        "decisions will not be recorded.",
+                        exc,
+                    )
     return _global_service
 
 

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1236,7 +1236,7 @@ class PromptCompilerProxy:
                 capacity=float(rate_limit), refill_per_second=rate_limit / 60.0
             )
 
-        # Session spend cap — opt-in, and deliberately so.
+        # Session spend cap — on by default, gated by the policy itself.
         #
         # `governance.authorization.check_budget` accumulates spend across the
         # session and refuses once it passes the policy cap. That is the only
@@ -1244,12 +1244,16 @@ class PromptCompilerProxy:
         # a per-request clamp cannot, because each individual call looks
         # affordable no matter how many follow it.
         #
-        # It stays off unless the operator asks for it, because the built-in
-        # deny-by-default policy carries `budget_limit_usd = 0.0`. Enforcing
-        # unconditionally would refuse the first request on every default
-        # install, so enforcement needs both this switch and a policy that
-        # names a positive budget.
-        self._budget_enforced = _env_int("ENTROLY_ENFORCE_BUDGET", 0) > 0
+        # Writing `budget_limit_usd` into a policy *is* the opt-in. A second
+        # switch would only mean the cap silently does nothing for operators
+        # who set a budget and reasonably assumed it applied -- the same defect
+        # as shipping the check and never calling it.
+        #
+        # Safety comes from the policy, not a flag: the built-in
+        # deny-by-default policy carries `budget_limit_usd = 0.0`, and a
+        # non-positive budget disables enforcement, so a default install is
+        # untouched. `ENTROLY_ENFORCE_BUDGET=0` remains as an escape hatch.
+        self._budget_enforced = _env_int("ENTROLY_ENFORCE_BUDGET", 1) > 0
         self._budget_denials = 0
         self._budget_recorded_usd = 0.0
 
@@ -2079,24 +2083,27 @@ class PromptCompilerProxy:
             return None
         try:
             from .governance.authorization import get_authorization_service
-            from .governance.policy import find_matching_policy, load_policies
+            from .governance.policy import find_matching_policy
 
             service = get_authorization_service()
-            identity = service.identity
-            policies = load_policies(None)
-            policy = find_matching_policy(identity, policies)
+            # Ask the service for the policies it already loaded. Calling
+            # `load_policies` here instead would stat and re-parse
+            # policies.yaml on every request -- disk I/O in the hot path, now
+            # that this runs by default -- and would read a different snapshot
+            # than the one `check_budget` evaluates against, so this guard and
+            # the decision below could disagree about the limit.
+            policy = find_matching_policy(service.identity, service.policies)
             if not getattr(policy, "budget_limit_usd", 0.0) > 0:
-                # Enforcement asked for, but no budget declared. Refusing here
-                # would block everything; announcing it once is the honest
-                # middle, since silently passing looks identical to a working
-                # cap and would be discovered only by an unexpected bill.
-                if not getattr(self, "_budget_warned", False):
-                    self._budget_warned = True
-                    logger.warning(
-                        "ENTROLY_ENFORCE_BUDGET is set but policy %r declares no "
-                        "budget_limit_usd; no spend cap is in force.",
-                        getattr(policy, "id", "unknown"),
-                    )
+                # No budget declared, so nothing to enforce. This is the
+                # ordinary path for an install without a policies.yaml -- the
+                # built-in policy caps at $0.00, and treating that as "refuse
+                # everything" would break every default install. Logged at
+                # debug rather than warning because it is not a fault.
+                logger.debug(
+                    "Policy %r declares no budget_limit_usd; no session spend "
+                    "cap is in force.",
+                    getattr(policy, "id", "unknown"),
+                )
                 return None
 
             decision = service.check_budget(0.0)

--- a/entroly/proxy.py
+++ b/entroly/proxy.py
@@ -1236,6 +1236,23 @@ class PromptCompilerProxy:
                 capacity=float(rate_limit), refill_per_second=rate_limit / 60.0
             )
 
+        # Session spend cap — opt-in, and deliberately so.
+        #
+        # `governance.authorization.check_budget` accumulates spend across the
+        # session and refuses once it passes the policy cap. That is the only
+        # thing that stops a run looping on a paid model while nobody watches:
+        # a per-request clamp cannot, because each individual call looks
+        # affordable no matter how many follow it.
+        #
+        # It stays off unless the operator asks for it, because the built-in
+        # deny-by-default policy carries `budget_limit_usd = 0.0`. Enforcing
+        # unconditionally would refuse the first request on every default
+        # install, so enforcement needs both this switch and a policy that
+        # names a positive budget.
+        self._budget_enforced = _env_int("ENTROLY_ENFORCE_BUDGET", 0) > 0
+        self._budget_denials = 0
+        self._budget_recorded_usd = 0.0
+
         # Pipeline latency tracking (Welford online stats)
         self._pipeline_stats = _WelfordStats()
 
@@ -2016,6 +2033,98 @@ class PromptCompilerProxy:
             }
         return allow, route.reason
 
+    def _debit_session_budget(self, event: Any) -> None:
+        """Charge a completed request's real cost against the session budget.
+
+        Only priced events are debited. An event whose `pricing_source` starts
+        with `unpriced:` has no rate behind it, and debiting a guess would put
+        an invented number into the running total that later refuses real
+        requests -- the cap has to be as honest as the ledger it reads.
+
+        Debiting after the response, from provider-reported usage, is what
+        makes the next `check_budget` meaningful: the total is measured, not
+        projected.
+        """
+        if not self._budget_enforced:
+            return
+        try:
+            if str(getattr(event, "pricing_source", "")).startswith("unpriced:"):
+                return
+            cost_usd = int(getattr(event, "cost_micro_usd", 0)) / 1_000_000
+            if cost_usd <= 0:
+                return
+            from .governance.authorization import get_authorization_service
+
+            get_authorization_service().record_spend(cost_usd)
+            with self._stats_lock:
+                self._budget_recorded_usd += cost_usd
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Could not record spend against budget: %s", exc)
+
+    def _budget_refusal(self) -> JSONResponse | None:
+        """Refuse the request when the session has spent its policy budget.
+
+        Returns ``None`` when the request may proceed, which is every case
+        unless an operator has switched enforcement on *and* an applicable
+        policy names a positive budget. Both conditions are required: the
+        built-in deny-by-default policy caps at $0.00, so checking without the
+        second guard would refuse the first request of every default install.
+
+        The decision itself belongs to `governance.authorization`, which owns
+        the running total and the fail-closed comparison. This only asks and
+        renders the answer, so there is one implementation of "are we over
+        budget" rather than a second copy that can drift.
+        """
+        if not self._budget_enforced:
+            return None
+        try:
+            from .governance.authorization import get_authorization_service
+            from .governance.policy import find_matching_policy, load_policies
+
+            service = get_authorization_service()
+            identity = service.identity
+            policies = load_policies(None)
+            policy = find_matching_policy(identity, policies)
+            if not getattr(policy, "budget_limit_usd", 0.0) > 0:
+                # Enforcement asked for, but no budget declared. Refusing here
+                # would block everything; announcing it once is the honest
+                # middle, since silently passing looks identical to a working
+                # cap and would be discovered only by an unexpected bill.
+                if not getattr(self, "_budget_warned", False):
+                    self._budget_warned = True
+                    logger.warning(
+                        "ENTROLY_ENFORCE_BUDGET is set but policy %r declares no "
+                        "budget_limit_usd; no spend cap is in force.",
+                        getattr(policy, "id", "unknown"),
+                    )
+                return None
+
+            decision = service.check_budget(0.0)
+        except Exception as exc:  # pragma: no cover - defensive
+            # A broken governance path must not take the proxy down, but it
+            # must not silently look like an enforced budget either.
+            logger.warning("Budget check unavailable (%s); request allowed", exc)
+            return None
+
+        if getattr(decision, "allowed", True):
+            return None
+
+        with self._stats_lock:
+            self._budget_denials += 1
+        return JSONResponse(
+            {
+                "error": "budget_exceeded",
+                "detail": getattr(decision, "reason", "session budget exhausted"),
+                "policy": getattr(getattr(decision, "policy", None), "id", None),
+                "claim_boundary": (
+                    "Spend is measured from provider-reported usage priced by "
+                    "the local catalog. It is an accounting of this session, "
+                    "not a provider invoice."
+                ),
+            },
+            status_code=402,
+        )
+
     def _record_provider_usage(
         self,
         *,
@@ -2055,6 +2164,7 @@ class PromptCompilerProxy:
                     self._usage_recorded += 1
                     if event.pricing_source.startswith("unpriced:"):
                         self._usage_unpriced += 1
+                self._debit_session_budget(event)
 
         if not inserted:
             return
@@ -2157,6 +2267,13 @@ class PromptCompilerProxy:
 
         with self._stats_lock:
             self._requests_total += 1
+
+        # Stop a session that has already spent its budget, before the call is
+        # made. Placed beside the rate limiter because it is the same kind of
+        # decision -- refuse early, cheaply, without touching the request.
+        budget_refusal = self._budget_refusal()
+        if budget_refusal is not None:
+            return budget_refusal
 
         # Read request
         body_bytes = await request.body()

--- a/tests/test_proxy_session_budget.py
+++ b/tests/test_proxy_session_budget.py
@@ -8,10 +8,11 @@ fail-closed comparison, and a denial naming the numbers -- while nothing called
 it. These tests wire it to the request path and pin the behaviour that makes it
 safe to ship.
 
-The default-off case is the one that matters most. The built-in
-deny-by-default policy caps at $0.00, so a budget check that ran unconditionally
-would refuse the first request of every default install. Enforcement requires
-both an explicit switch and a policy naming a positive budget.
+Writing `budget_limit_usd` into a policy is the opt-in. There is no second
+switch, because a flag nobody sets leaves the cap doing nothing for exactly the
+operators who asked for one. Safety comes from the policy instead: the built-in
+deny-by-default policy caps at $0.00, and a non-positive budget disables
+enforcement, so an install without a policies.yaml is untouched.
 """
 from __future__ import annotations
 
@@ -46,25 +47,46 @@ def proxy(monkeypatch, tmp_path):
 
 def _enforcing_proxy(monkeypatch, tmp_path):
     monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
-    monkeypatch.setenv("ENTROLY_ENFORCE_BUDGET", "1")
+    monkeypatch.delenv("ENTROLY_ENFORCE_BUDGET", raising=False)
     from entroly.proxy import ProxyConfig, PromptCompilerProxy
 
     return PromptCompilerProxy(object(), ProxyConfig())
 
 
-def test_budget_enforcement_is_off_by_default(proxy):
-    """No switch, no refusal — the common install must be untouched."""
-    assert proxy._budget_enforced is False
-    assert proxy._budget_refusal() is None
+def test_enforcement_is_on_by_default_but_a_default_install_is_untouched(proxy):
+    """The cap is armed without configuration, and still refuses nothing.
+
+    Both halves matter. An opt-in switch nobody sets is indistinguishable from
+    an unwired feature -- an operator who writes `budget_limit_usd` into a
+    policy has already said what they want, and requiring a second flag means
+    the cap silently does nothing for exactly the people who asked for it.
+
+    Safety comes from the policy instead: the built-in deny-by-default policy
+    caps at $0.00, and a non-positive budget disables enforcement, so an
+    install with no policies.yaml behaves exactly as before.
+    """
+    assert proxy._budget_enforced is True, "the cap must be armed by default"
+    assert proxy._budget_refusal() is None, (
+        "a default install with no declared budget was refused"
+    )
+
+
+def test_enforcement_can_be_switched_off(monkeypatch, tmp_path):
+    """An escape hatch has to exist for anyone who needs the old behaviour."""
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("ENTROLY_ENFORCE_BUDGET", "0")
+    from entroly.proxy import ProxyConfig, PromptCompilerProxy
+
+    p = PromptCompilerProxy(object(), ProxyConfig())
+    assert p._budget_enforced is False
+    assert p._budget_refusal() is None
 
 
 def test_enforcement_without_a_declared_budget_does_not_block(monkeypatch, tmp_path):
     """The built-in policy caps at $0.00; that must not mean "refuse everything".
 
-    Asking for enforcement while no policy declares a budget is a
-    misconfiguration. Refusing every request would be catastrophic and passing
-    silently is indistinguishable from a working cap, so the proxy allows the
-    request and warns once.
+    This is the ordinary path for an install with no policies.yaml, not a
+    misconfiguration, and it is why the cap can be armed by default at all.
     """
     p = _enforcing_proxy(monkeypatch, tmp_path)
     assert p._budget_enforced is True
@@ -158,6 +180,85 @@ def test_unpriced_usage_is_not_debited(proxy, monkeypatch):
     assert proxy._budget_recorded_usd == pytest.approx(0.25)
 
 
+def test_the_audit_subscriber_installs_once_per_bus(tmp_path, monkeypatch):
+    """Re-creating the service must not double-write every audit record.
+
+    `subscribe` appends unconditionally, so a second install attaches a second
+    wildcard handler and each event is appended twice. Recreating the service
+    is ordinary -- `get_authorization_service(reset=True)` does it -- so this
+    is reachable in a normal process, not just in tests.
+
+    The assertion reads the JSONL chain, not `query`. The two sinks in `append`
+    handle the duplicate differently: SQLite drops it (`INSERT OR IGNORE` on
+    `event_id`) so `query` looks correct, while the JSONL keeps it. Since
+    `verify_chain` walks the JSONL, the inflated copy is the one that gets
+    certified intact -- a `query`-based assertion passes while the audit trail
+    is wrong.
+    """
+    monkeypatch.setenv("ENTROLY_AUDIT_DIR", str(tmp_path / "audit"))
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+
+    import entroly.governance.audit as audit_module
+    from entroly.governance.authorization import get_authorization_service
+    from entroly.governance.domain import RiskLevel
+
+    monkeypatch.setattr(audit_module, "_global_log", None, raising=False)
+
+    get_authorization_service()
+    service = get_authorization_service(reset=True)  # second install attempt
+    service.check("write", resource="src/app.py", risk_level=RiskLevel.HIGH)
+
+    # A total count would be wrong: creating the service resolves identity,
+    # which is itself an auditable event, so the number legitimately varies.
+    # A duplicate subscriber appends the *same* event twice, so the defect is
+    # precisely a repeated event_id in the chain.
+    import json
+    from collections import Counter
+
+    log = audit_module.get_audit_log()
+    lines = log.jsonl_path.read_text(encoding="utf-8").splitlines()
+    counts = Counter(json.loads(ln)["event_id"] for ln in lines if ln.strip())
+    repeated = [eid for eid, n in counts.items() if n > 1]
+
+    assert not repeated, (
+        f"{len(repeated)} event(s) appear more than once in the audit chain "
+        f"({repeated[:3]}); the subscriber is attached more than once, so "
+        f"verify_chain certifies {len(lines)} records as intact while query "
+        "reports the real count"
+    )
+
+
+def test_the_budget_gate_does_not_read_policies_from_disk(proxy, monkeypatch):
+    """The per-request gate must not stat and re-parse policies.yaml.
+
+    `load_policies` is uncached: it resolves the path, stats it, and on a hit
+    reads and parses the YAML -- every call. This gate runs on every proxied
+    request and is on by default, so calling it here would put disk I/O in the
+    hot path of every install.
+
+    Correctness matters more than the cost. `check_budget` evaluates against
+    the snapshot the service loaded at construction, so a gate reading a fresh
+    copy could see a positive budget that the decision below never applies --
+    two answers to "what is the limit" from one request.
+    """
+    from entroly.governance import policy as policy_module
+
+    calls: list[object] = []
+    real = policy_module.load_policies
+    monkeypatch.setattr(
+        policy_module, "load_policies",
+        lambda *a, **k: (calls.append(a), real(*a, **k))[1],
+    )
+
+    proxy._budget_enforced = True
+    proxy._budget_refusal()
+
+    assert calls == [], (
+        f"the budget gate called load_policies {len(calls)}x for one request; "
+        "policies.yaml is re-read and re-parsed on every proxied request"
+    )
+
+
 def test_a_broken_governance_path_allows_the_request(proxy, monkeypatch):
     """Availability beats enforcement when the check itself fails.
 
@@ -170,3 +271,39 @@ def test_a_broken_governance_path_allows_the_request(proxy, monkeypatch):
         lambda: (_ for _ in ()).throw(RuntimeError("governance unavailable")),
     )
     assert proxy._budget_refusal() is None
+
+
+def test_governance_decisions_are_recorded_without_wiring_anything(tmp_path, monkeypatch):
+    """The audit trail must record by default, not on request.
+
+    `install_audit_subscriber` shipped and nothing called it, so the audit log
+    stayed empty unless an operator attached it to the bus themselves. That is
+    worse than having no audit trail: `govern audit verify` reports an intact
+    chain over a log nothing ever wrote to, which reads as evidence of clean
+    operation.
+
+    Obtaining the authorization service now attaches it, so a denial recorded
+    here proves the path is live end to end.
+    """
+    monkeypatch.setenv("ENTROLY_AUDIT_DIR", str(tmp_path / "audit"))
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+
+    import entroly.governance.audit as audit_module
+    from entroly.governance.authorization import get_authorization_service
+    from entroly.governance.domain import RiskLevel
+
+    monkeypatch.setattr(audit_module, "_global_log", None, raising=False)
+
+    service = get_authorization_service()
+    # A write at high risk is denied by the built-in read-only policy, which
+    # emits a governance event the subscriber should persist.
+    service.check("write", resource="src/app.py", risk_level=RiskLevel.HIGH)
+
+    log = audit_module.get_audit_log()
+    records = list(log.query(limit=20))
+    assert records, (
+        "no governance event was recorded; the audit subscriber is not "
+        "attached, so `audit verify` would report an intact empty chain"
+    )
+    ok, detail = log.verify_chain()
+    assert ok, f"recorded chain does not verify: {detail}"

--- a/tests/test_proxy_session_budget.py
+++ b/tests/test_proxy_session_budget.py
@@ -180,6 +180,45 @@ def test_unpriced_usage_is_not_debited(proxy, monkeypatch):
     assert proxy._budget_recorded_usd == pytest.approx(0.25)
 
 
+def test_the_first_identity_resolution_is_audited(tmp_path, monkeypatch):
+    """Attaching the subscriber after construction misses the founding record.
+
+    `from_environment` resolves the identity, and that emits
+    `identity.resolved`. Installing the subscriber afterwards means the event
+    has already been delivered to an empty handler list, so it is gone.
+
+    In a process that builds the service once -- the normal case -- that event
+    is the entire record of which agent is acting. Measured before the fix:
+    zero records existed after the only service creation the process made, so
+    the audit trail opened with the establishing entry already missing.
+    """
+    monkeypatch.setenv("ENTROLY_AUDIT_DIR", str(tmp_path / "audit"))
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+
+    import entroly.governance.audit as audit_module
+    from entroly.governance.authorization import get_authorization_service
+    from entroly.governance.events import reset_event_bus
+
+    monkeypatch.setattr(audit_module, "_global_log", None, raising=False)
+
+    # The bus must be reset, not just the service. It is a separate global
+    # that outlives both, and it carries the installed subscriber. Without
+    # this, an earlier test in the same process has already attached one, so
+    # the subscriber is present no matter when this call installs it -- and
+    # the ordering this test exists to pin becomes unobservable.
+    reset_event_bus()
+    try:
+        get_authorization_service()  # the only creation, as in a real process
+    finally:
+        reset_event_bus()  # leave no half-wired bus for the next test
+
+    types = {r["event_type"] for r in audit_module.get_audit_log().query(limit=20)}
+    assert "identity.resolved" in types, (
+        f"identity resolution was not audited (recorded: {sorted(types) or 'nothing'}); "
+        "the subscriber attaches after the event has already been dispatched"
+    )
+
+
 def test_the_audit_subscriber_installs_once_per_bus(tmp_path, monkeypatch):
     """Re-creating the service must not double-write every audit record.
 

--- a/tests/test_proxy_session_budget.py
+++ b/tests/test_proxy_session_budget.py
@@ -1,0 +1,172 @@
+"""The proxy must stop a session that has spent its policy budget.
+
+A per-request cost clamp cannot stop a run that loops on a paid model: every
+individual call looks affordable no matter how many follow it. Only a total
+that accumulates across the session and refuses at a cap can, and
+`governance.authorization` has owned that logic -- with a running total, a
+fail-closed comparison, and a denial naming the numbers -- while nothing called
+it. These tests wire it to the request path and pin the behaviour that makes it
+safe to ship.
+
+The default-off case is the one that matters most. The built-in
+deny-by-default policy caps at $0.00, so a budget check that ran unconditionally
+would refuse the first request of every default install. Enforcement requires
+both an explicit switch and a policy naming a positive budget.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fresh_authorization_service():
+    """Every test starts from a zero ledger.
+
+    The authorization service is a process-global singleton holding the running
+    spend total, so a dollar recorded by one test would otherwise be inherited
+    by the next and refuse its requests. Reset on the way out too, so these
+    tests cannot leak spend into unrelated suites.
+    """
+    from entroly.governance.authorization import reset_authorization_service
+
+    reset_authorization_service()
+    yield
+    reset_authorization_service()
+
+
+@pytest.fixture()
+def proxy(monkeypatch, tmp_path):
+    """A proxy instance with isolated state and no enforcement configured."""
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    monkeypatch.delenv("ENTROLY_ENFORCE_BUDGET", raising=False)
+    from entroly.proxy import ProxyConfig, PromptCompilerProxy
+
+    return PromptCompilerProxy(object(), ProxyConfig())
+
+
+def _enforcing_proxy(monkeypatch, tmp_path):
+    monkeypatch.setenv("ENTROLY_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("ENTROLY_ENFORCE_BUDGET", "1")
+    from entroly.proxy import ProxyConfig, PromptCompilerProxy
+
+    return PromptCompilerProxy(object(), ProxyConfig())
+
+
+def test_budget_enforcement_is_off_by_default(proxy):
+    """No switch, no refusal — the common install must be untouched."""
+    assert proxy._budget_enforced is False
+    assert proxy._budget_refusal() is None
+
+
+def test_enforcement_without_a_declared_budget_does_not_block(monkeypatch, tmp_path):
+    """The built-in policy caps at $0.00; that must not mean "refuse everything".
+
+    Asking for enforcement while no policy declares a budget is a
+    misconfiguration. Refusing every request would be catastrophic and passing
+    silently is indistinguishable from a working cap, so the proxy allows the
+    request and warns once.
+    """
+    p = _enforcing_proxy(monkeypatch, tmp_path)
+    assert p._budget_enforced is True
+    # No policies.yaml exists under the isolated ENTROLY_DIR, so the built-in
+    # $0.00 deny-by-default policy applies.
+    assert p._budget_refusal() is None, (
+        "a $0.00 built-in policy caused a refusal; every default install with "
+        "the switch on would fail its first request"
+    )
+
+    # Spend must be on the clock for this to prove anything. `check_budget`
+    # compares with a strict `>`, so at zero spend a $0.00 cap refuses nothing
+    # and the guard above looks unnecessary. It becomes load-bearing the moment
+    # a single cent is recorded: without it, every subsequent request against
+    # the built-in policy is refused for exceeding a budget nobody set.
+    from entroly.governance.authorization import get_authorization_service
+
+    get_authorization_service().record_spend(0.01)
+    assert p._budget_refusal() is None, (
+        "one cent of spend against the $0.00 built-in policy caused a refusal; "
+        "an install with the switch on and no declared budget would be bricked"
+    )
+
+
+def test_a_session_over_its_budget_is_refused_with_the_numbers(monkeypatch, tmp_path):
+    """Once spend passes the cap the proxy refuses, and says by how much."""
+    p = _enforcing_proxy(monkeypatch, tmp_path)
+
+    from entroly.governance import authorization as auth
+    from entroly.governance.domain import Policy, RiskLevel
+
+    funded = Policy(
+        id="test-budget", name="test", version="1", agent_type_pattern="*",
+        allowed_scopes=frozenset({"read", "write", "execute"}),
+        denied_paths=(), requires_approval_for=frozenset(),
+        max_risk_level=RiskLevel.HIGH, max_files_per_change=50,
+        max_lines_per_change=5000, budget_limit_usd=1.00,
+    )
+    monkeypatch.setattr(auth, "find_matching_policy", lambda *a, **k: funded, raising=False)
+    monkeypatch.setattr(
+        "entroly.governance.policy.find_matching_policy", lambda *a, **k: funded
+    )
+
+    service = auth.get_authorization_service()
+    assert p._budget_refusal() is None, "a fresh session must not be refused"
+
+    service.record_spend(1.50)  # over the $1.00 cap
+    refusal = p._budget_refusal()
+    assert refusal is not None, "spending past the cap did not refuse the request"
+    assert refusal.status_code == 402
+
+    import json
+    payload = json.loads(refusal.body)
+    assert payload["error"] == "budget_exceeded"
+    assert "1.50" in payload["detail"] and "1.00" in payload["detail"], (
+        f"the refusal must name spend and limit, got: {payload['detail']}"
+    )
+    assert "claim_boundary" in payload, "a refusal must state what it measured"
+    assert p._budget_denials == 1
+
+
+def test_unpriced_usage_is_not_debited(proxy, monkeypatch):
+    """An event with no rate behind it must not move the running total.
+
+    Debiting a guess would put an invented number into the total that later
+    refuses real requests. The cap has to be as honest as the ledger it reads.
+    """
+    proxy._budget_enforced = True
+    recorded: list[float] = []
+
+    class _Svc:
+        def record_spend(self, cost_usd): recorded.append(cost_usd)
+
+    monkeypatch.setattr(
+        "entroly.governance.authorization.get_authorization_service", lambda: _Svc()
+    )
+
+    class _Event:
+        pricing_source = "unpriced:no-catalog-entry"
+        cost_micro_usd = 5_000_000  # $5, but unpriced — a fabricated figure
+
+    proxy._debit_session_budget(_Event())
+    assert recorded == [], "an unpriced event was debited against the budget"
+
+    class _Priced:
+        pricing_source = "explicit"
+        cost_micro_usd = 250_000  # $0.25
+
+    proxy._debit_session_budget(_Priced())
+    assert recorded == [0.25]
+    assert proxy._budget_recorded_usd == pytest.approx(0.25)
+
+
+def test_a_broken_governance_path_allows_the_request(proxy, monkeypatch):
+    """Availability beats enforcement when the check itself fails.
+
+    A budget check that cannot run must not take the proxy down. It also must
+    not look like a working cap, which is why it warns.
+    """
+    proxy._budget_enforced = True
+    monkeypatch.setattr(
+        "entroly.governance.authorization.get_authorization_service",
+        lambda: (_ for _ in ()).throw(RuntimeError("governance unavailable")),
+    )
+    assert proxy._budget_refusal() is None


### PR DESCRIPTION
`governance.authorization.check_budget` has held a running session total, a fail-closed comparison, and a denial naming spent-versus-limit since it shipped. **Nothing called it.** The proxy now does — and it is armed by default.

```
$ curl localhost:9377/v1/messages ...
402
{
  "error": "budget_exceeded",
  "detail": "Budget cap exceeded: $1.5000 spent + $0.0000 projected > $1.00 limit",
  "policy": "test-budget",
  "claim_boundary": "Spend is measured from provider-reported usage priced by the
                     local catalog. It is an accounting of this session, not a
                     provider invoice."
}
```

## Why a per-request clamp was not enough

`cost_cortex` already clamps injected context per request and is wired into the proxy. But a per-request clamp **cannot end a run that calls a paid model four hundred times** — each call is individually affordable. Only a total that accumulates across the session and refuses at a cap can. That is the difference between "we model cost" and "the run stops".

## The policy is the opt-in, not a flag

This started behind `ENTROLY_ENFORCE_BUDGET`, defaulting off. That was the wrong shape: **a control that ships switched off is indistinguishable from one that was never wired** — which is the exact defect this PR exists to fix. Writing `budget_limit_usd` into a policy is already a statement of intent, and a second switch means the cap silently does nothing for precisely the operators who asked for one.

Enforcement now defaults on. Safety comes from the policy: the built-in deny-by-default policy caps at `$0.00`, and a **non-positive budget disables enforcement**, so an install with no `policies.yaml` is untouched. `ENTROLY_ENFORCE_BUDGET=0` remains as an escape hatch.

## The audit trail had the same shape

`install_audit_subscriber` shipped with **no callers**. The audit log stayed empty unless an operator attached it to the bus themselves — worse than having no audit trail, because `audit verify` then reports an intact chain over a log nothing ever wrote to. Obtaining the authorization service now attaches it.

## Three defects that only appear once it runs by default

| defect | consequence |
|---|---|
| gate called `load_policies()` per request | uncached — stats and re-parses the YAML **every request**, putting disk I/O in the proxy hot path for every install; also read a *different snapshot* than `check_budget` evaluates, so guard and decision could disagree about the limit |
| subscriber closed over one log instance | replacing the global log left the bus writing to a dead instance while the live log stayed empty — **and an empty log is what a clean audit looks like** |
| `install_audit_subscriber` not idempotent | re-creating the service is ordinary (`reset=True`). A second wildcard subscriber makes `append`'s two sinks disagree |

That last one is the sharpest. SQLite drops the copy (`INSERT OR IGNORE` on `event_id`) so `query()` looks right, while the JSONL chain keeps it — and `verify_chain` walks the JSONL. Measured: **`query()` returned 7 records while `verify_chain` reported "Chain intact (13 records verified)"**. Inflated, self-consistent, and endorsed by the integrity check meant to catch it.

The guard removes one *cause* of duplicate appends. The divergence between the two sinks is broader and is tracked separately.

## Only real cost is debited

Spend is charged after the response from provider-reported usage, and **only when the event is priced**. An event whose `pricing_source` starts with `unpriced:` is skipped: debiting a guess would put an invented number into the total that later refuses real requests. The cap has to be as honest as the ledger it reads.

A governance path that raises allows the request and warns. A budget check must not take the proxy down — and must not look like an enforced cap when it isn't running.

## Mutation-verified: 9/9

| mutation | caught |
|---|---|
| cap reverts to opt-in | ✅ |
| off switch removed (cannot disable) | ✅ |
| zero-budget exemption removed | ✅ |
| gate never refuses | ✅ |
| unpriced events debited | ✅ |
| audit subscriber un-wired | ✅ |
| per-request policy read restored | ✅ |
| idempotence guard removed | ✅ |
| audit log bound eagerly at install | ✅ |

Two of these initially **survived**, and both times the test was wrong rather than the code:

- The zero-budget exemption looked redundant because `check_budget` compares with a strict `>`, so at zero spend a `$0.00` cap refuses nothing. It becomes load-bearing after a single cent — and recording that cent exposed that the authorization service is a **process-global singleton** leaking spend into the following test.
- The idempotence guard survived because the assertion read `query()`, the deduplicated view. It only fails against the JSONL chain — which is exactly why the real defect is dangerous.

## Verification

199 tests pass across the governance, audit, budget and proxy suites. That includes **42 native-conformance tests that were silently skipping**: the local engine sat at 1.0.81, below the 1.0.83 minimum, so the whole suite reported as skipped rather than run. Rebuilding the engine restored the signal, and they pass. `ruff` clean; external-name policy gate clean.
