### PR TITLE
fix(governance): make the audit log's two stores agree

### DIFF
--- a/entroly/cli_governance.py
+++ b/entroly/cli_governance.py
@@ -224,25 +224,36 @@ def _cmd_audit(args: Any) -> int:
             "detail": detail,
             "jsonl_path": str(getattr(log, "jsonl_path", "") or ""),
             "db_path": str(getattr(log, "db_path", "") or ""),
-            # Measured, not assumed. Against a chain of five records this
-            # detects a payload edit and a deletion from the middle, and does
-            # NOT detect tail truncation, an edit whose chain was recomputed,
-            # or a wholly fabricated self-consistent log -- it reported "Chain
-            # intact" over attacker-written records granting admin. The chain
+            # Measured, not assumed, against a chain of five records. The chain
             # is unkeyed SHA-256, so write access to the file is enough to
-            # forge a consistent history. An earlier version of this string
+            # forge a consistent history; an earlier version of this string
             # claimed entries "were not altered after the fact", which is the
             # exact overclaim the trust invariants forbid.
-            "detects": ["payload edited in place", "record removed from the middle"],
+            #
+            # Verification also cross-checks the chain's length against the
+            # database. That is the anchor a bare hash chain lacks, and it is
+            # why truncating the chain alone is caught -- but the anchor holds
+            # only while the database is intact, so truncating both stores, or
+            # forging exactly as many records as the database holds, still
+            # passes. Every line below is pinned by a test in
+            # tests/test_audit_chain_claim_honesty.py.
+            "detects": [
+                "payload edited in place",
+                "record removed from the middle",
+                "the same event recorded twice",
+                "records truncated from the chain but not the database",
+                "a fabricated log of a different length than the database",
+            ],
             "does_not_detect": [
-                "records truncated from the end",
+                "records truncated from the chain and the database together",
                 "an edit whose chain hash was recomputed",
-                "a fabricated log that is internally consistent",
+                "a fabricated log holding as many records as the database",
             ],
             "claim_boundary": (
-                "The chain is unkeyed, so this detects accidental corruption and "
-                "naive edits, not a writer who recomputes it. It also does not "
-                "prove every action was recorded."
+                "The chain is unkeyed, so this detects accidental corruption, "
+                "naive edits, and the two stores disagreeing -- not a writer "
+                "who recomputes the chain and matches the record count. It "
+                "also does not prove every action was recorded."
             ),
         }
         _emit(payload, as_json=as_json)

--- a/entroly/governance/audit.py
+++ b/entroly/governance/audit.py
@@ -22,7 +22,14 @@ Storage layout::
     └── audit.jsonl     ← Append-only JSONL for tamper-evident chain
 
 The SQLite database is the query surface.  The JSONL file is the
-authoritative chain.  Both are written atomically.
+authoritative chain.
+
+The two are separate files, so they are not written atomically: a process
+killed between the two writes, or a failing disk, leaves one ahead of the
+other.  Rather than claim an atomicity the code does not have, `verify_chain`
+cross-checks the record counts and reports a disagreement, and the chain is
+anchored on the JSONL so the stores cannot silently drift apart.  A repeated
+`event_id` is rejected once, by the database, for both sinks.
 """
 from __future__ import annotations
 
@@ -202,6 +209,27 @@ class GovernanceAuditLog:
             logger.warning("Audit log initialization failed: %s", exc)
 
     def _last_chain_hash(self) -> str:
+        """Anchor the chain on the JSONL, which is the authoritative chain.
+
+        This read from SQLite, which is wrong whenever the two sinks disagree.
+        The next record would be hashed from the database's last hash but
+        appended after the JSONL's last line, so the link between those two
+        lines could not verify -- and `verify_chain` walks the JSONL, so it
+        reported "Chain broken" at a record nobody had touched.
+
+        Reproduced before this change: append an event, append it again, then
+        reopen the log as a new process would. The duplicate advanced the JSONL
+        past the database, the restart re-anchored on the database, and
+        verification turned a healthy log into a tampering alarm. A false alarm
+        is not a lesser failure than a missed one here -- an integrity check
+        that cries wolf is one operators learn to ignore.
+
+        SQLite remains the fallback for a log whose JSONL is missing or
+        unreadable, where it is the only anchor available.
+        """
+        from_chain = self._last_jsonl_chain_hash()
+        if from_chain is not None:
+            return from_chain
         try:
             if not self.db_path.exists():
                 return ""
@@ -213,6 +241,41 @@ class GovernanceAuditLog:
             return row[0] if row else ""
         except Exception:
             return ""
+
+    def _last_jsonl_chain_hash(self) -> str | None:
+        """The last record's chain hash, or None if the chain is unreadable.
+
+        Reads a bounded window from the end rather than scanning the file. The
+        JSONL is append-only and never rotated, so it grows without limit, and
+        this runs during initialization -- a full scan would make every process
+        that touches governance pay for the whole history.
+
+        None and "" mean different things: None is "no chain to anchor on, try
+        the database", "" is "the chain exists and starts from empty".
+        """
+        try:
+            if not self.jsonl_path.exists():
+                return None
+            size = self.jsonl_path.stat().st_size
+            if size == 0:
+                return None
+            window = 65536
+            with open(self.jsonl_path, "rb") as handle:
+                while True:
+                    start = max(0, size - window)
+                    handle.seek(start)
+                    lines = [ln for ln in handle.read(size - start).split(b"\n") if ln.strip()]
+                    # Seeking into the middle of the file can cut the first line
+                    # in half. Requiring a second line means the last one is
+                    # whole; reaching the start means there is nothing to cut.
+                    if start == 0 or len(lines) >= 2:
+                        if not lines:
+                            return None
+                        return str(json.loads(lines[-1].decode("utf-8")).get("chain_hash", ""))
+                    window *= 4
+        except Exception as exc:
+            logger.warning("Could not read the audit chain anchor: %s", exc)
+            return None
 
     def _compute_chain_hash(self, record: AuditRecord) -> str:
         """Chain hash: SHA-256 of (previous_hash + event_id + payload_json)."""
@@ -231,9 +294,28 @@ class GovernanceAuditLog:
         allowed: bool | None = None,
         payload: Mapping[str, Any] | None = None,
     ) -> AuditRecord:
-        """Append a record to the audit log. Idempotent on event_id."""
+        """Append a record to the audit log. Idempotent on event_id.
+
+        Both sinks obey that idempotence, decided once. They did not: SQLite
+        took the repeat as `INSERT OR IGNORE` and dropped it while the JSONL
+        appended unconditionally, so the two disagreed about what happened.
+        `query` read the deduplicated database and looked correct; `verify_chain`
+        walks the JSONL and certified the inflated copy. Measured on two events
+        appended three times: 2 rows, 3 chain lines, "Chain intact (3 records
+        verified)".
+
+        The database decides, because its UNIQUE constraint is the only check
+        that holds across processes -- an in-memory set of seen ids would not
+        survive a restart and would not see a second writer.
+        """
         with self._lock:
             self._ensure_initialized()
+
+            # Kept so the anchor can be rolled back. A duplicate must leave the
+            # chain exactly where it was: advancing it for a record that is
+            # never persisted makes the next real record hash from a link that
+            # exists nowhere.
+            prev_hash_before = self._prev_hash
 
             record = AuditRecord(
                 event_id=event_id,
@@ -255,10 +337,12 @@ class GovernanceAuditLog:
             self._prev_hash = record.chain_hash
 
             # Write to SQLite
+            stored_chain_hash: str | None = None
+            is_duplicate = False
             try:
                 conn = sqlite3.connect(str(self.db_path), timeout=10)
                 conn.execute("PRAGMA journal_mode=WAL")
-                conn.execute(
+                cursor = conn.execute(
                     """
                     INSERT OR IGNORE INTO governance_audit
                     (event_id, event_type, agent_id, session_id, org_id,
@@ -275,9 +359,41 @@ class GovernanceAuditLog:
                     ),
                 )
                 conn.commit()
+                # rowcount 0 means the UNIQUE constraint on event_id rejected
+                # it, which is the only way IGNORE suppresses a row here.
+                is_duplicate = cursor.rowcount == 0
+                if is_duplicate:
+                    existing = conn.execute(
+                        "SELECT chain_hash FROM governance_audit WHERE event_id = ?",
+                        (record.event_id,),
+                    ).fetchone()
+                    stored_chain_hash = existing[0] if existing else None
                 conn.close()
             except Exception as exc:
+                # A failed database write is not a duplicate. The JSONL is the
+                # authoritative chain, so the record still goes there and the
+                # divergence is left for `verify_chain` to report rather than
+                # dropping an audit record on the floor.
                 logger.warning("Audit DB write failed: %s", exc)
+
+            if is_duplicate:
+                self._prev_hash = prev_hash_before
+                logger.debug(
+                    "Audit event %s already recorded; skipping duplicate append.",
+                    record.event_id,
+                )
+                # Report the hash that is actually stored, not the one this call
+                # computed and discarded.
+                return (
+                    record if stored_chain_hash is None
+                    else AuditRecord(
+                        event_id=record.event_id, event_type=record.event_type,
+                        agent_id=record.agent_id, session_id=record.session_id,
+                        org_id=record.org_id, trace_id=record.trace_id,
+                        allowed=record.allowed, payload=record.payload,
+                        chain_hash=stored_chain_hash, created_at=record.created_at,
+                    )
+                )
 
             # Append to JSONL chain
             try:
@@ -367,9 +483,26 @@ class GovernanceAuditLog:
         return results
 
     def verify_chain(self, limit: int = 1000) -> tuple[bool, str]:
-        """Verify the JSONL chain hash integrity.
+        """Verify the JSONL chain, and that it agrees with the database.
 
-        Returns (True, "OK") if chain is intact, or (False, error_message).
+        Returns (True, detail) if intact, or (False, error_message).
+
+        The hash walk alone was not enough. It only asks whether each link
+        follows from the one before, so any self-consistent file passes --
+        including one carrying the same event twice, which is what a duplicate
+        subscriber produced. `query` read the deduplicated database and looked
+        right while this reported the inflated chain as intact.
+
+        So the record count is now cross-checked against the database. That is
+        the anchor a bare hash chain lacks: the chain cannot say how long it is
+        meant to be, but the database's row count can. It makes truncation of
+        the JSONL alone detectable, which it previously was not.
+
+        The anchor holds only while the database is intact. Anyone able to
+        truncate both sinks, or to fabricate a log with the same number of
+        records, still passes -- the chain is unkeyed, so write access is
+        enough to forge a consistent history. `entroly govern audit verify`
+        states that boundary, and the tests measure it in both directions.
         """
         self._ensure_initialized()
         if not self.jsonl_path.exists():
@@ -377,6 +510,8 @@ class GovernanceAuditLog:
 
         prev_hash = ""
         lines_checked = 0
+        seen_event_ids: set[str] = set()
+        truncated_by_limit = False
         try:
             with open(self.jsonl_path, "r", encoding="utf-8") as f:
                 for line in f:
@@ -391,14 +526,58 @@ class GovernanceAuditLog:
                             f"Chain broken at event {record.get('event_id')} "
                             f"(record {lines_checked + 1})"
                         )
+                    event_id = record["event_id"]
+                    if event_id in seen_event_ids:
+                        # Every event_id is unique by construction, so a repeat
+                        # is a record written twice, not two events.
+                        return False, (
+                            f"Event {event_id} appears more than once in the chain "
+                            f"(record {lines_checked + 1}); the log is inflated "
+                            "and does not describe what happened"
+                        )
+                    seen_event_ids.add(event_id)
                     prev_hash = record["chain_hash"]
                     lines_checked += 1
                     if lines_checked >= limit:
+                        truncated_by_limit = True
                         break
         except Exception as exc:
             return False, f"Verification error: {exc}"
 
+        if truncated_by_limit:
+            # Only a prefix was read, so the counts cannot be compared. Say so
+            # rather than implying the whole chain was verified.
+            return True, (
+                f"First {lines_checked} records verified (limit reached; "
+                "the rest of the chain was not read)"
+            )
+
+        db_count = self._db_record_count()
+        if db_count is not None and db_count != lines_checked:
+            return False, (
+                f"Audit stores disagree: the chain has {lines_checked} records, "
+                f"the database has {db_count}. One of them is not a record of "
+                "what happened."
+            )
+
         return True, f"Chain intact ({lines_checked} records verified)"
+
+    def _db_record_count(self) -> int | None:
+        """Row count in the query surface, or None if it cannot be read.
+
+        None is not zero: an unreadable database means the cross-check cannot
+        run, which must not be reported as the two stores agreeing.
+        """
+        try:
+            if not self.db_path.exists():
+                return None
+            conn = sqlite3.connect(str(self.db_path), timeout=5)
+            row = conn.execute("SELECT COUNT(*) FROM governance_audit").fetchone()
+            conn.close()
+            return int(row[0]) if row else None
+        except Exception as exc:
+            logger.warning("Could not count audit records for cross-check: %s", exc)
+            return None
 
 
 # ── Event Bus Integration ────────────────────────────────────────────

--- a/tests/test_audit_chain_claim_honesty.py
+++ b/tests/test_audit_chain_claim_honesty.py
@@ -3,10 +3,15 @@
 The chain is unkeyed SHA-256 over `(prev_hash, event_id, payload)`. That is
 tamper-*evidence* against accidental corruption and naive edits, and nothing
 more: anyone who can write the file can recompute the chain and produce a
-history that verifies. Measured against a five-record log, verification does
-not detect tail truncation, an edit whose chain was recomputed, or a wholly
-fabricated log -- it reported "Chain intact" over attacker-written records
-granting admin.
+history that verifies. Measured against a five-record log, verification still
+does not detect an edit whose chain was recomputed, nor a fabricated log -- it
+reported "Chain intact" over attacker-written records granting admin.
+
+Verification also cross-checks the chain's length against the database, which
+is the anchor a bare hash chain lacks. Truncating the JSONL alone is therefore
+detected now, and so is a fabrication with a different number of records. The
+anchor only holds while the database is intact: truncating *both* stores, or
+fabricating exactly as many records as the database holds, still passes.
 
 The CLI first said chain verification "proves the recorded entries were not
 altered after the fact", which is exactly the overclaim the trust invariants
@@ -75,13 +80,36 @@ def test_detects_a_record_removed_from_the_middle(chain):
     assert _verify(chain)[0] is False, "a deleted record verified as intact"
 
 
-def test_does_not_detect_tail_truncation(chain):
+def test_detects_tail_truncation_of_the_chain_alone(chain):
     """Dropping the newest records leaves every remaining link valid.
 
-    Not a bug in the implementation -- a bare hash chain has no anchor for the
-    expected length. Pinned so the CLI never claims otherwise.
+    A bare hash chain cannot say how long it is meant to be, so this used to
+    pass. The database row count supplies that anchor, and dropping records
+    from the chain alone now makes the two stores disagree.
     """
     _write(chain.jsonl_path, _records(chain.jsonl_path)[:3])
+    ok, detail = _verify(chain)
+    assert ok is False, "truncating the chain verified as intact"
+    assert "3" in detail and "5" in detail, (
+        f"the verdict must name both counts so the gap is auditable: {detail}"
+    )
+
+
+def test_does_not_detect_truncation_of_both_stores(chain):
+    """The count anchor is only as good as the store holding it.
+
+    Deleting the same records from the database as from the chain leaves the
+    two agreeing at the shorter length, and every remaining link still
+    verifies. This is the honest residue of the limitation above, and the CLI
+    must keep disclosing it.
+    """
+    import sqlite3
+
+    _write(chain.jsonl_path, _records(chain.jsonl_path)[:3])
+    conn = sqlite3.connect(str(chain.db_path))
+    conn.execute("DELETE FROM governance_audit WHERE event_id IN ('e3','e4')")
+    conn.commit()
+    conn.close()
     assert _verify(chain)[0] is True
 
 
@@ -93,14 +121,47 @@ def test_does_not_detect_an_edit_whose_chain_was_recomputed(chain):
     assert _verify(chain)[0] is True
 
 
-def test_does_not_detect_a_fabricated_self_consistent_log(chain):
+def test_does_not_detect_a_fabrication_of_the_same_length(chain):
+    """Matching the record count defeats the anchor.
+
+    The fabricated log carries the same event_ids as the real one, so both the
+    links and the count line up. Nothing in an unkeyed chain distinguishes this
+    from the truth -- which is why the CLI must not claim it proves the entries
+    are genuine.
+    """
+    fabricated = [
+        {"event_id": f"e{i}", "event_type": "permission.allowed", "agent_id": "attacker",
+         "payload": {"scope": "admin"}, "allowed": True, "created_at": 0, "chain_hash": ""}
+        for i in range(5)  # same count as the database
+    ]
+    _write(chain.jsonl_path, _rechain(fabricated))
+    assert _verify(chain)[0] is True
+
+
+def test_detects_a_fabrication_of_a_different_length(chain):
+    """A forger who does not match the record count is caught by the anchor."""
     fabricated = [
         {"event_id": f"x{i}", "event_type": "permission.allowed", "agent_id": "attacker",
          "payload": {"scope": "admin"}, "allowed": True, "created_at": 0, "chain_hash": ""}
         for i in range(3)
     ]
     _write(chain.jsonl_path, _rechain(fabricated))
-    assert _verify(chain)[0] is True
+    assert _verify(chain)[0] is False, "a 3-record forgery passed against a 5-record database"
+
+
+def test_detects_the_same_event_recorded_twice(chain):
+    """An inflated chain does not describe what happened.
+
+    Every event_id is unique by construction, so a repeat is one event written
+    twice. The links still verify -- each copy is hashed in order -- so only an
+    explicit check catches it. This is the shape a duplicate audit subscriber
+    produced, and it certified clean.
+    """
+    records = _records(chain.jsonl_path)
+    _write(chain.jsonl_path, _rechain(records[:3] + [dict(records[2])] + records[3:]))
+    ok, detail = _verify(chain)
+    assert ok is False, "an event recorded twice verified as intact"
+    assert "e2" in detail, f"the repeated event was not named: {detail}"
 
 
 def test_the_cli_states_the_boundary_it_actually_has(tmp_path, capsys, monkeypatch):

--- a/tests/test_audit_sink_consistency.py
+++ b/tests/test_audit_sink_consistency.py
@@ -1,0 +1,162 @@
+"""The audit log's two stores must describe the same history.
+
+`append` writes a SQLite row and a JSONL line. They had different rules: the
+database rejected a repeated `event_id` through its UNIQUE constraint while the
+JSONL was an unconditional write. `query` reads the database and `verify_chain`
+walks the JSONL, so the two surfaces answered differently and the inflated one
+was the one certified intact -- measured at 2 rows against 3 chain lines, with
+`verify_chain` reporting "Chain intact (3 records verified)".
+
+Worse than the inflation was the anchor. `_prev_hash` advanced for the ignored
+duplicate, and on restart was restored from the database, so the next record was
+hashed from a link that no chain line carried. A duplicate followed by a restart
+made `verify_chain` report "Chain broken" at a record nobody had touched. An
+integrity check that cries wolf is one operators learn to ignore, so a false
+alarm is not a lesser failure here than a missed one.
+
+These tests pin prevention. The detection half -- what verification catches once
+the stores disagree anyway -- lives in test_audit_chain_claim_honesty.py.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from entroly.governance.audit import GovernanceAuditLog
+
+
+@pytest.fixture()
+def log(tmp_path):
+    return GovernanceAuditLog(audit_dir=tmp_path / "audit")
+
+
+def _db_rows(log: GovernanceAuditLog) -> int:
+    conn = sqlite3.connect(str(log.db_path))
+    try:
+        return int(conn.execute("SELECT COUNT(*) FROM governance_audit").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _chain_lines(log: GovernanceAuditLog) -> list[dict]:
+    if not log.jsonl_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in log.jsonl_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_a_repeated_event_is_not_written_to_either_store_twice(log):
+    """"Idempotent on event_id" has to mean both stores, or it means neither."""
+    log.append(event_id="E1", event_type="permission.denied", payload={"n": 1})
+    log.append(event_id="E1", event_type="permission.denied", payload={"n": 1})
+    log.append(event_id="E2", event_type="permission.denied", payload={"n": 2})
+
+    rows, lines = _db_rows(log), _chain_lines(log)
+    assert (rows, len(lines)) == (2, 2), (
+        f"two distinct events produced {rows} database rows and {len(lines)} "
+        "chain lines; the stores disagree about what happened"
+    )
+    assert [r["event_id"] for r in lines] == ["E1", "E2"]
+
+
+def test_a_repeated_event_does_not_advance_the_chain_anchor(log):
+    """A link must not be spent on a record that was never stored.
+
+    The anchor is what the next record hashes from. Advancing it for a dropped
+    duplicate leaves the next genuine record chained to a hash that appears in
+    no store, which reads as tampering later.
+    """
+    log.append(event_id="X1", event_type="t", payload={})
+    anchor_after_first = log._prev_hash
+
+    log.append(event_id="X1", event_type="t", payload={})
+    assert log._prev_hash == anchor_after_first, (
+        "the chain anchor moved for a duplicate that was never persisted"
+    )
+
+    # The next real record must still chain cleanly onto the stored one.
+    log.append(event_id="X2", event_type="t", payload={})
+    ok, detail = log.verify_chain()
+    assert ok, f"the chain did not survive a duplicate append: {detail}"
+
+
+def test_a_duplicate_then_a_restart_is_not_reported_as_tampering(tmp_path):
+    """The regression that made the audit system accuse itself.
+
+    Before the fix: the duplicate pushed the chain past the database, the
+    restart re-anchored on the database, and the next record could not link to
+    the preceding chain line -- "Chain broken at event R3", with nothing having
+    been touched.
+    """
+    audit_dir = tmp_path / "audit"
+    first = GovernanceAuditLog(audit_dir=audit_dir)
+    first.append(event_id="R1", event_type="t", payload={})
+    first.append(event_id="R2", event_type="t", payload={})
+    first.append(event_id="R2", event_type="t", payload={})  # duplicate is last
+
+    reopened = GovernanceAuditLog(audit_dir=audit_dir)  # a new process
+    reopened.append(event_id="R3", event_type="t", payload={})
+
+    ok, detail = reopened.verify_chain()
+    assert ok, f"a healthy log was reported as tampered with: {detail}"
+
+
+def test_the_anchor_is_read_from_the_chain_not_the_database(tmp_path):
+    """The JSONL is the authoritative chain, so it anchors the next hash.
+
+    Reproduced with the stores already divergent -- which a half-completed
+    write, a killed process, or a log written by an older build can all
+    produce. Anchoring on the database there would hash the next record from a
+    link the chain does not end with, breaking it for good.
+    """
+    audit_dir = tmp_path / "audit"
+    log = GovernanceAuditLog(audit_dir=audit_dir)
+    log.append(event_id="A1", event_type="t", payload={})
+    log.append(event_id="A2", event_type="t", payload={})
+
+    # A chain line the database never received.
+    orphan = dict(_chain_lines(log)[-1])
+    orphan["event_id"] = "A3"
+    orphan["chain_hash"] = "f" * 64
+    with open(log.jsonl_path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(orphan, separators=(",", ":")) + "\n")
+
+    reopened = GovernanceAuditLog(audit_dir=audit_dir)
+    reopened._ensure_initialized()
+    assert reopened._prev_hash == "f" * 64, (
+        f"the anchor came from the database, not the chain: {reopened._prev_hash[:16]}"
+    )
+
+    # And the record appended next links onto that final chain line, so the
+    # break is confined to the pre-existing divergence.
+    reopened.append(event_id="A4", event_type="t", payload={})
+    assert _chain_lines(reopened)[-1]["event_id"] == "A4"
+    ok, detail = reopened.verify_chain()
+    assert "Chain broken at event A4" not in detail, (
+        f"the newly appended record failed to link onto the chain: {detail}"
+    )
+
+
+def test_a_partial_walk_is_not_reported_as_a_verified_chain(log):
+    """Reading a prefix must not be described as verifying the chain.
+
+    `verify_chain` stops at `limit`. Saying "Chain intact" after reading the
+    first few records of a long log claims coverage it does not have, and the
+    count cross-check cannot run on a prefix either.
+    """
+    for index in range(5):
+        log.append(event_id=f"p{index}", event_type="t", payload={"i": index})
+
+    ok, detail = log.verify_chain(limit=2)
+    assert ok is True
+    assert "limit" in detail.lower(), (
+        f"a truncated walk did not disclose that it stopped early: {detail}"
+    )
+    assert "intact" not in detail.lower(), (
+        f"a partial read described the whole chain as intact: {detail}"
+    )


### PR DESCRIPTION
`append` writes a SQLite row and a JSONL line under **different rules**. The database rejected a repeated `event_id` through its UNIQUE constraint; the JSONL was an unconditional write. `query` reads the database and `verify_chain` walks the JSONL — so the two surfaces answered differently, and **the inflated one was the one certified intact**.

Measured on two events appended three times:

```
sqlite rows = 2   jsonl lines = 3
verify_chain -> True | Chain intact (3 records verified)
query()      -> 2 records
sqlite event_ids = ['E1', 'E2']
jsonl  event_ids = ['E1', 'E1', 'E2']
```

## The anchor was worse than the inflation

`_prev_hash` advanced for the ignored duplicate and, on restart, was restored **from the database** — so the next record was hashed from a link no chain line carried:

```
last sqlite hash = aa29006d55a12332
last jsonl  hash = 172f0cc5c976b049
after restart: verify_chain -> False | Chain broken at event R3 (record 4)
```

Nothing was touched. The audit system accused itself of tampering. **A false alarm is not a lesser failure than a missed one here** — an integrity check that cries wolf is one operators learn to ignore.

## Three changes, at the level the defect lives

| change | why |
|---|---|
| Idempotence decided **once, by the database**, for both sinks | the UNIQUE constraint is the only check that holds across processes; an in-memory set would not survive a restart or see a second writer |
| Anchor read from the **last JSONL line**, database only as fallback | the JSONL is the authoritative chain, so it must be what the next hash follows. Read through a bounded window from the end — the file is append-only and never rotated |
| Duplicate no longer advances the anchor | a link must not be spent on a record that was never stored |

A failed DB write is *not* treated as a duplicate: the record still reaches the JSONL and the divergence is left for verification to report, rather than dropping an audit record on the floor.

## verify_chain gained an anchor

It now cross-checks its length against the database and rejects a repeated `event_id`. The row count is the anchor a bare hash chain lacks — the chain cannot say how long it is meant to be, but the database can.

That widens what verification catches, so **the claim surface moved with it**. Every line below is measured and pinned by a test:

**Newly detected** — truncation of the chain alone; a fabrication of a different length; the same event recorded twice.

**Still undetected** — truncation of both stores together; an edit whose chain was recomputed; a fabrication holding as many records as the database.

```
JSONL truncated from the end -> (False, 'Audit stores disagree: the chain has 3
                                 records, the database has 5. One of them is not
                                 a record of what happened.')
BOTH sinks truncated         -> (True,  'Chain intact (3 records verified)')
fabricated, same 5 records   -> (True,  'Chain intact (5 records verified)')
```

The CLI's `detects` / `does_not_detect` lists were updated to match. The module docstring also claimed both sinks were "written atomically" — two separate files cannot be, so it now says what actually protects them.

## Mutation-verified: 7/7

| mutation | caught by |
|---|---|
| JSONL stops honouring idempotence | `test_a_repeated_event_is_not_written_to_either_store_twice` |
| anchor advances on the ignored duplicate | `test_a_repeated_event_does_not_advance_the_chain_anchor` |
| anchor restored from the database again | `test_the_anchor_is_read_from_the_chain_not_the_database` |
| count cross-check removed | `test_detects_tail_truncation_of_the_chain_alone` |
| duplicate-in-chain check removed | `test_detects_the_same_event_recorded_twice` |
| unreadable database read as agreement | `test_detects_a_fabrication_of_a_different_length` |
| limit-truncated walk reported as full | `test_a_partial_walk_is_not_reported_as_a_verified_chain` |

**Four initially survived.** The first pass only tested detection — what verification catches once the stores already disagree — and nothing pinned prevention. `tests/test_audit_sink_consistency.py` was written for that half.

## Verification

194 tests across the governance, audit, budget and proxy suites, plus the real `govern audit verify` path end to end (a duplicate append correctly yields 3 records, exit 0). `ruff` clean; external-name policy gate clean.

Follows #427, which fixed one *cause* of duplicate appends. This fixes the mechanism.
