### PR TITLE
Make the plugin installable, and make channel presence a release surface

### DIFF
--- a/.claude-plugin/commands/entroly-first-run.md
+++ b/.claude-plugin/commands/entroly-first-run.md
@@ -1,0 +1,24 @@
+---
+description: Show what Entroly selected from this repository, what it omitted, and how to recover the omissions.
+---
+
+Show the user what Entroly does to their own repository, using their real code.
+
+1. Run `entroly compile` against the project's primary source directory, then
+   `entroly simulate` scoped to that directory.
+2. Report three things, in this order:
+   - **Selected** — the fragments that were kept, with their files.
+   - **Omitted** — the fragments that were left out, with their files. Name
+     them. Do not summarise them as a count.
+   - **Recovery** — for each omitted fragment, the content-addressed handle
+     that retrieves the exact original bytes. Demonstrate one live recovery.
+3. Close by inviting the user to pick any omitted fragment and recover it.
+
+Do not report a savings percentage, a compression ratio, or a token-reduction
+figure. The percentage is determined by the configured budget before selection
+runs, so it measures the budget rather than the selection. The claim worth
+making is that nothing was lost irrecoverably, and that claim is checkable in
+front of the user — which is the entire point.
+
+If the native engine is missing, say so plainly and state that selection has
+not been query-conditioned, rather than reporting a figure that looks earned.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "entroly",
+  "description": "Auditable context selection, exact recovery, and receipts for AI coding agents.",
+  "owner": {
+    "name": "juyterman1000",
+    "url": "https://github.com/juyterman1000"
+  },
+  "plugins": [
+    {
+      "name": "entroly",
+      "source": "./",
+      "description": "Evidence operations, auditable context selection, and exact recovery for AI coding agents.",
+      "version": "1.0.83",
+      "author": {
+        "name": "Entroly"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,15 @@
   "homepage": "https://github.com/juyterman1000/entroly",
   "repository": "https://github.com/juyterman1000/entroly",
   "license": "Apache-2.0",
-  "skills": "./skills/"
+  "skills": "./skills/",
+  "commands": "./.claude-plugin/commands/",
+  "mcpServers": {
+    "entroly": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/entroly-plugin-launch.mjs"],
+      "env": {
+        "ENTROLY_NO_DOCKER": "1"
+      }
+    }
+  }
 }

--- a/.github/workflows/publish-marketplaces.yml
+++ b/.github/workflows/publish-marketplaces.yml
@@ -1,0 +1,38 @@
+name: Verify marketplace presence
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily. A channel that dies between releases should not wait for the
+    # next release to be noticed -- Smithery was dead for months.
+    - cron: "17 6 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  presence:
+    runs-on: ubuntu-latest
+    # ADVISORY until one full release cycle has run green. To promote:
+    # delete `continue-on-error` from the probe step. Do not promote early --
+    # a gate that reddens a healthy release gets disabled, and a disabled
+    # gate is how Smithery stayed dead.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Probe every distribution channel
+        id: probe
+        continue-on-error: true
+        run: |
+          version="$(python -c "import re,pathlib;print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', pathlib.Path('entroly/__init__.py').read_text()).group(1))")"
+          python scripts/marketplace_presence.py --version "$version" --channel all
+
+      - name: Report
+        run: |
+          if [ "${{ steps.probe.outcome }}" = "failure" ]; then
+            echo "::warning::a distribution channel is not listing the current version"
+          fi

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -313,9 +313,14 @@ jobs:
         shell: bash
         run: |
           version="$(python -c "import json;print(json.load(open('server.json'))['version'])")"
+          # Match `present` explicitly rather than trusting the exit code. The
+          # checker exits 0 on UNKNOWN as well, because UNKNOWN must never block
+          # a release elsewhere -- but here UNKNOWN means we could not confirm
+          # the publish landed, which is a reason to keep polling, not to pass.
           for attempt in $(seq 1 60); do
             if python scripts/marketplace_presence.py \
-                 --version "$version" --channel mcp-registry; then
+                 --version "$version" --channel mcp-registry | tee /dev/stderr \
+                 | grep -q ': present -'; then
               exit 0
             fi
             sleep 10

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -312,50 +312,13 @@ jobs:
         if: steps.release_guard.outputs.should_publish == 'true'
         shell: bash
         run: |
-          python - <<'PY'
-          import json
-          import time
-          import urllib.parse
-          import urllib.request
-
-          name = 'io.github.juyterman1000/entroly'
-          repository = 'https://github.com/juyterman1000/entroly'
-          expected_packages = {('pypi', 'entroly'), ('npm', 'entroly-mcp')}
-          version = json.load(open('server.json', encoding='utf-8'))['version']
-          url = (
-              'https://registry.modelcontextprotocol.io/v0.1/servers?search='
-              + urllib.parse.quote(name, safe='')
-          )
-
-          for attempt in range(1, 61):
-              request = urllib.request.Request(
-                  url,
-                  headers={'User-Agent': 'entroly-canonical-mcp-publisher'},
-              )
-              with urllib.request.urlopen(request, timeout=30) as response:
-                  payload = json.load(response)
-
-              match = None
-              for item in payload.get('servers', []):
-                  server = item.get('server', item)
-                  if server.get('name') == name and server.get('version') == version:
-                      match = server
-                      break
-
-              if match is not None:
-                  repo = match.get('repository') or {}
-                  packages = {
-                      (package.get('registryType'), package.get('identifier'))
-                      for package in match.get('packages', [])
-                  }
-                  if repo.get('url') != repository:
-                      raise SystemExit('registry listing points to a non-canonical repository')
-                  if packages != expected_packages:
-                      raise SystemExit(f'registry package set is unexpected: {packages!r}')
-                  print(f'Verified exclusive canonical listing {name} {version}.')
-                  break
-
-              if attempt == 60:
-                  raise SystemExit(f'Registry listing for {name} {version} was not visible')
-              time.sleep(10)
-          PY
+          version="$(python -c "import json;print(json.load(open('server.json'))['version'])")"
+          for attempt in $(seq 1 60); do
+            if python scripts/marketplace_presence.py \
+                 --version "$version" --channel mcp-registry; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::registry did not list $version after 60 attempts"
+          exit 1

--- a/docs/superpowers/plans/2026-09-06-marketplace-wedge.md
+++ b/docs/superpowers/plans/2026-09-06-marketplace-wedge.md
@@ -1,0 +1,1128 @@
+# Marketplace Wedge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Entroly installable from the Claude Code plugin marketplace, prove its value on first run, and turn channel presence into a release surface that fails loudly when a channel goes dead.
+
+**Architecture:** Three parts. A marketplace manifest plus an `mcpServers` declaration makes the plugin installable at all. A Node launcher shim absorbs the absence of `uvx` so the plugin can never be silently inert. A presence checker — extracted from the polling gate that already works inside `publish-mcp-registry.yml` — probes every channel with three result states and blocks releases only for channels Entroly actually pushes to.
+
+**Tech Stack:** Python 3.10+ (stdlib only for the checker: `urllib`, `json`, `dataclasses`, `enum`), pytest, Node (for the launcher shim only), GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-marketplace-wedge-design.md`
+
+## Global Constraints
+
+- Canonical MCP server name: `io.github.juyterman1000/entroly`
+- Canonical repository URL: `https://github.com/juyterman1000/entroly`
+- Expected MCP package set: `{("pypi", "entroly"), ("npm", "entroly-mcp")}`
+- Marketplace name (users type this): `entroly`. Install command: `/plugin install entroly@entroly`
+- **No savings percentage in any user-facing plugin copy.** `saved = max(0, baseline - selected_tokens)` with `baseline = min(total_tokens, 32_000)` in `entroly/cli.py` pins the figure at ≥75% for a budget of 8,000 before selection runs. Task 6 adds a test that fails if one is reintroduced.
+- Version strings are never edited by hand. `scripts/bump_version.py` owns them; its repository-wide sweep is the backstop. `tests/test_version_surfaces_are_complete.py` asserts the property over every tracked file.
+- The presence checker uses the Python standard library only. It runs in CI before the package is installed.
+- Release is tag-driven: merge to `main`, then tag the post-merge commit on `main`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `.claude-plugin/marketplace.json` | **Create.** The file `/plugin marketplace add` reads. Without it there is no install path. |
+| `.claude-plugin/plugin.json` | **Modify.** Add `mcpServers` and `commands`. Schema is already correct; do not rewrite the rest. |
+| `scripts/entroly-plugin-launch.mjs` | **Create.** Resolves `uvx` → `npx` → `entroly` and execs the first that exists. One job: survive a machine without `uv`. |
+| `scripts/marketplace_presence.py` | **Create.** Given a channel and expected version, answers Present/Absent/Unknown. No publishing, no side effects. |
+| `.claude-plugin/commands/entroly-first-run.md` | **Create.** The first-run wedge: omissions shown with their recovery handles. |
+| `.github/workflows/publish-marketplaces.yml` | **Create.** Orchestration only. |
+| `.github/workflows/publish-mcp-registry.yml` | **Modify.** Replace the duplicated inline heredoc with a call to the shared checker. |
+| `scripts/bump_version.py` | **Modify.** Add `marketplace.json` to `TARGETS`. |
+| `tests/test_plugin_marketplace_manifest.py` | **Create.** Schema and identity assertions. |
+| `tests/test_plugin_launcher.py` | **Create.** Fallback-chain behavior. |
+| `tests/test_marketplace_presence.py` | **Create.** Adapter states against fixtures; MCP parity regression. |
+| `tests/test_first_run_copy.py` | **Create.** Guards the no-percentage rule. |
+
+Design note on plugin root: `marketplace.json` declares `"source": "./"`, so the plugin root is the repository root. MCP servers are therefore declared **inline in `plugin.json`** rather than in a root `.mcp.json` — a root `.mcp.json` would also be picked up as project MCP config by anyone opening the Entroly repo, which is a side effect nobody asked for. Commands live under `.claude-plugin/commands/` for the same reason: a root `commands/` directory in this repository would read as something else entirely.
+
+---
+
+### Task 1: Marketplace manifest and plugin MCP wiring
+
+Makes installation possible. Today it is not possible at all.
+
+**Files:**
+- Create: `.claude-plugin/marketplace.json`
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `scripts/bump_version.py:88` (add an entry beside the existing `.claude-plugin` targets)
+- Test: `tests/test_plugin_marketplace_manifest.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: marketplace name `entroly`; plugin name `entroly`; the MCP server command contract `node ${CLAUDE_PLUGIN_ROOT}/scripts/entroly-plugin-launch.mjs`, which Task 2 implements.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_plugin_marketplace_manifest.py`:
+
+```python
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
+
+
+def _json(path: str) -> dict:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def _master_version() -> str:
+    text = (ROOT / "entroly" / "__init__.py").read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+    assert match is not None, "no __version__ in entroly/__init__.py"
+    return match.group(1)
+
+
+def test_marketplace_manifest_has_required_fields() -> None:
+    manifest = _json(".claude-plugin/marketplace.json")
+
+    assert manifest["name"] == "entroly"
+    assert manifest["owner"]["name"] == "juyterman1000"
+    assert isinstance(manifest["plugins"], list) and manifest["plugins"]
+
+
+def test_marketplace_lists_the_plugin_at_the_master_version() -> None:
+    manifest = _json(".claude-plugin/marketplace.json")
+    entry = next(p for p in manifest["plugins"] if p["name"] == "entroly")
+
+    assert entry["source"] == "./"
+    assert entry["version"] == _master_version()
+
+
+def test_plugin_declares_the_launcher_shim_not_a_bare_runner() -> None:
+    plugin = _json(".claude-plugin/plugin.json")
+    server = plugin["mcpServers"]["entroly"]
+
+    # A bare `uvx` here is the silent-dead-plugin failure mode: MCP config has
+    # no fallback chain, so a machine without uv gets a plugin that starts
+    # nothing and reports nothing.
+    assert server["command"] == "node"
+    assert server["args"] == [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/entroly-plugin-launch.mjs"
+    ]
+    assert server["env"]["ENTROLY_NO_DOCKER"] == "1"
+
+
+def test_plugin_identity_matches_the_canonical_repository() -> None:
+    plugin = _json(".claude-plugin/plugin.json")
+
+    assert plugin["name"] == "entroly"
+    assert plugin["repository"] == CANONICAL_REPOSITORY
+    assert plugin["version"] == _master_version()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_plugin_marketplace_manifest.py -v`
+Expected: FAIL — `FileNotFoundError` for `.claude-plugin/marketplace.json`.
+
+- [ ] **Step 3: Create the marketplace manifest**
+
+Create `.claude-plugin/marketplace.json`. Replace `1.0.83` with the current value of `__version__` in `entroly/__init__.py` if it has moved:
+
+```json
+{
+  "name": "entroly",
+  "description": "Auditable context selection, exact recovery, and receipts for AI coding agents.",
+  "owner": {
+    "name": "juyterman1000",
+    "url": "https://github.com/juyterman1000"
+  },
+  "plugins": [
+    {
+      "name": "entroly",
+      "source": "./",
+      "description": "Evidence operations, auditable context selection, and exact recovery for AI coding agents.",
+      "version": "1.0.83",
+      "author": {
+        "name": "Entroly"
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Add `mcpServers` and `commands` to the plugin manifest**
+
+Modify `.claude-plugin/plugin.json`. Keep every existing key; add two:
+
+```json
+{
+  "name": "entroly",
+  "version": "1.0.83",
+  "description": "Evidence operations, auditable context selection, and exact recovery for AI coding agents.",
+  "author": {
+    "name": "Entroly"
+  },
+  "homepage": "https://github.com/juyterman1000/entroly",
+  "repository": "https://github.com/juyterman1000/entroly",
+  "license": "Apache-2.0",
+  "skills": "./skills/",
+  "commands": "./.claude-plugin/commands/",
+  "mcpServers": {
+    "entroly": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/entroly-plugin-launch.mjs"],
+      "env": {
+        "ENTROLY_NO_DOCKER": "1"
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Register the new version surface**
+
+Modify `scripts/bump_version.py`. Immediately after the `.claude-plugin/plugin.json` entry (line 91), add:
+
+```python
+    # The marketplace entry declares the plugin version to Claude Code's
+    # install UI. It is a third `.claude-plugin` surface; the sweep below
+    # would catch it, but catching it here means the bump never emits a
+    # warning in the first place.
+    (".claude-plugin/marketplace.json",
+        r'"version"\s*:\s*"[^"]+"', '"version": "{v}"'),
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pytest tests/test_plugin_marketplace_manifest.py tests/test_version_surfaces_are_complete.py -v --timeout=300`
+Expected: PASS. The version-surfaces test needs no new case — it asserts the property over every tracked file, so it covers `marketplace.json` the moment the file exists.
+
+- [ ] **Step 7: Validate the manifest with the real tool**
+
+Run: `claude plugin validate .`
+Expected: reports the `entroly` marketplace and the `entroly` plugin with no errors. If `claude` is unavailable in the environment, record that and rely on Step 6.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json .claude-plugin/plugin.json \
+        scripts/bump_version.py tests/test_plugin_marketplace_manifest.py
+git commit -m "feat(plugin): make Entroly installable from the plugin marketplace
+
+Without .claude-plugin/marketplace.json there is no install path at all --
+plugin.json alone is not discoverable. Declares mcpServers inline rather
+than in a root .mcp.json, which would otherwise apply to anyone who simply
+opens this repository.
+
+Co-Authored-By: juyterman1000 <208309368+juyterman1000@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: The launcher shim
+
+The plugin's MCP command points at this file. Until it exists, an installed plugin starts nothing.
+
+Written in Node because Claude Code ships a Node runtime, so `node` is present wherever the plugin is. `python3` is not a safe assumption on Windows, and `uvx` is precisely the thing we cannot assume.
+
+**Files:**
+- Create: `scripts/entroly-plugin-launch.mjs`
+- Test: `tests/test_plugin_launcher.py`
+
+**Interfaces:**
+- Consumes: the command contract from Task 1 — `node ${CLAUDE_PLUGIN_ROOT}/scripts/entroly-plugin-launch.mjs`.
+- Produces: an executable that either becomes an Entroly MCP stdio server or exits `1` after printing one actionable line to stderr.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_plugin_launcher.py`:
+
+```python
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = ROOT / "scripts" / "entroly-plugin-launch.mjs"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="the launcher is a Node script; node is absent in this environment",
+)
+
+
+def _run(env_path: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PATH"] = env_path
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["node", str(LAUNCHER)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+
+def test_reports_one_actionable_line_when_no_runner_exists(tmp_path: Path) -> None:
+    node_dir = str(Path(shutil.which("node")).parent)
+    result = _run(node_dir)
+
+    assert result.returncode == 1
+    # The failure mode this guards is a plugin that starts nothing and says
+    # nothing, which is indistinguishable from a broken install.
+    assert "entroly" in result.stderr.lower()
+    assert "uv" in result.stderr.lower()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fake PATH executables need .cmd shims on Windows",
+)
+def test_prefers_uvx_and_passes_the_expected_arguments(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "invoked.txt"
+    uvx = fake_bin / "uvx"
+    uvx.write_text(
+        '#!/bin/sh\nprintf "%s" "$*" > "{marker}"\nexit 0\n'.format(marker=marker),
+        encoding="utf-8",
+    )
+    uvx.chmod(0o755)
+
+    node_dir = str(Path(shutil.which("node")).parent)
+    result = _run(f"{fake_bin}{os.pathsep}{node_dir}")
+
+    assert result.returncode == 0
+    assert marker.read_text(encoding="utf-8") == "--from entroly entroly"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fake PATH executables need .cmd shims on Windows",
+)
+def test_falls_through_to_npx_when_uvx_is_absent(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "invoked.txt"
+    npx = fake_bin / "npx"
+    npx.write_text(
+        '#!/bin/sh\nprintf "npx %s" "$*" > "{marker}"\nexit 0\n'.format(marker=marker),
+        encoding="utf-8",
+    )
+    npx.chmod(0o755)
+
+    node_dir = str(Path(shutil.which("node")).parent)
+    result = _run(f"{fake_bin}{os.pathsep}{node_dir}")
+
+    assert result.returncode == 0
+    assert marker.read_text(encoding="utf-8") == "npx -y entroly@latest"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_plugin_launcher.py -v`
+Expected: FAIL — node reports `Cannot find module .../scripts/entroly-plugin-launch.mjs`.
+
+- [ ] **Step 3: Write the launcher**
+
+Create `scripts/entroly-plugin-launch.mjs`:
+
+```javascript
+#!/usr/bin/env node
+// Entroly plugin launcher.
+//
+// The plugin's MCP config cannot express a fallback chain: it names one
+// command, and if that command is missing the server never starts and the
+// user sees a plugin that is silently inert. So the config names this file,
+// and the fallback lives here.
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
+
+const CANDIDATES = [
+  { command: "uvx", args: ["--from", "entroly", "entroly"] },
+  { command: "npx", args: ["-y", "entroly@latest"] },
+  { command: "entroly", args: [] },
+];
+
+// Resolve against PATH ourselves rather than passing `shell: true`. With a
+// shell, a missing command exits 1 like any other failure, and the chain
+// cannot tell "not installed" from "installed and broken".
+function resolve(command) {
+  const extensions =
+    process.platform === "win32"
+      ? (process.env.PATHEXT || ".EXE;.CMD;.BAT").split(";")
+      : [""];
+  for (const dir of (process.env.PATH || "").split(delimiter)) {
+    if (!dir) continue;
+    for (const extension of extensions) {
+      const candidate = join(dir, command + extension);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+for (const candidate of CANDIDATES) {
+  const executable = resolve(candidate.command);
+  if (executable === null) continue;
+
+  const result = spawnSync(executable, candidate.args, {
+    stdio: "inherit",
+    env: { ...process.env, ENTROLY_NO_DOCKER: "1" },
+  });
+  process.exit(result.status === null ? 1 : result.status);
+}
+
+process.stderr.write(
+  "Entroly plugin: no runner found. Install uv (https://docs.astral.sh/uv/) " +
+    "or Node, or run `pip install -U entroly`, then restart Claude Code.\n",
+);
+process.exit(1);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_plugin_launcher.py -v`
+Expected: PASS (3 passed, or 1 passed / 2 skipped on Windows).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/entroly-plugin-launch.mjs tests/test_plugin_launcher.py
+git commit -m "feat(plugin): resolve a runner instead of assuming uvx exists
+
+MCP configuration names one command with no fallback, so naming uvx
+directly means a machine without uv gets a plugin that starts nothing and
+reports nothing. Resolves PATH directly rather than using a shell, because
+a shell collapses 'not installed' and 'installed and broken' into exit 1.
+
+Co-Authored-By: juyterman1000 <208309368+juyterman1000@users.noreply.github.com>"
+```
+
+---
+
+### Task 3: Presence checker with the MCP registry adapter
+
+Extraction, not invention. `publish-mcp-registry.yml` already polls the registry and asserts name, version, canonical repository URL, and exact package set — twice, as duplicated inline heredocs. This lifts that logic into one tested module.
+
+**Files:**
+- Create: `scripts/marketplace_presence.py`
+- Test: `tests/test_marketplace_presence.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `class Presence(str, Enum)` with members `PRESENT`, `ABSENT`, `UNKNOWN`
+  - `@dataclass(frozen=True) class Probe: channel: str; presence: Presence; detail: str`
+  - `def probe_mcp_registry(version: str, *, fetch: Fetch = _fetch_json) -> Probe`
+  - `Fetch = Callable[[str], dict]`
+  - Task 4 adds `probe_claude_marketplace` and `probe_smithery` with the same shape; Task 5 consumes `main()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_marketplace_presence.py`:
+
+```python
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from marketplace_presence import (  # noqa: E402
+    Presence,
+    probe_mcp_registry,
+)
+
+CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
+
+
+def _server(version: str, *, repository: str = CANONICAL_REPOSITORY, packages=None):
+    return {
+        "servers": [
+            {
+                "server": {
+                    "name": "io.github.juyterman1000/entroly",
+                    "version": version,
+                    "repository": {"url": repository, "source": "github"},
+                    "packages": packages
+                    if packages is not None
+                    else [
+                        {"registryType": "pypi", "identifier": "entroly"},
+                        {"registryType": "npm", "identifier": "entroly-mcp"},
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def test_present_when_the_released_version_is_listed() -> None:
+    probe = probe_mcp_registry("1.0.84", fetch=lambda url: _server("1.0.84"))
+
+    assert probe.presence is Presence.PRESENT
+    assert probe.channel == "mcp-registry"
+
+
+def test_absent_when_only_an_older_version_is_listed() -> None:
+    # The real skew this guards: the registry sat at 1.0.81 while the
+    # repository was at 1.0.83.
+    probe = probe_mcp_registry("1.0.84", fetch=lambda url: _server("1.0.81"))
+
+    assert probe.presence is Presence.ABSENT
+
+
+def test_absent_when_the_registry_returns_nothing() -> None:
+    probe = probe_mcp_registry("1.0.84", fetch=lambda url: {"servers": []})
+
+    assert probe.presence is Presence.ABSENT
+
+
+def test_unknown_when_the_payload_shape_is_unrecognised() -> None:
+    # Two API paths answered on 2026-09-06 (/v0 and /v0.1), so the schema is
+    # moving. A shape change must not redden a healthy release.
+    probe = probe_mcp_registry("1.0.84", fetch=lambda url: {"unexpected": True})
+
+    assert probe.presence is Presence.UNKNOWN
+
+
+def test_unknown_when_the_network_fails() -> None:
+    def explode(url: str) -> dict:
+        raise OSError("connection reset")
+
+    probe = probe_mcp_registry("1.0.84", fetch=explode)
+
+    assert probe.presence is Presence.UNKNOWN
+    assert "connection reset" in probe.detail
+
+
+def test_absent_when_the_listing_points_at_a_non_canonical_repository() -> None:
+    # Reproduces the workflow's ownership assertion: a listing under our name
+    # pointing somewhere else is a hijack, not a success.
+    probe = probe_mcp_registry(
+        "1.0.84",
+        fetch=lambda url: _server("1.0.84", repository="https://github.com/someone/else"),
+    )
+
+    assert probe.presence is Presence.ABSENT
+    assert "repository" in probe.detail
+
+
+def test_absent_when_the_package_set_is_unexpected() -> None:
+    # Reproduces the workflow's package-set assertion.
+    probe = probe_mcp_registry(
+        "1.0.84",
+        fetch=lambda url: _server(
+            "1.0.84",
+            packages=[{"registryType": "pypi", "identifier": "entroly"}],
+        ),
+    )
+
+    assert probe.presence is Presence.ABSENT
+    assert "package" in probe.detail
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_marketplace_presence.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'marketplace_presence'`.
+
+- [ ] **Step 3: Write the checker**
+
+Create `scripts/marketplace_presence.py`:
+
+```python
+"""Is Entroly actually listed on the channels it claims to ship through?
+
+Smithery held a correct `smithery.yaml` for months while its server page did
+not exist, and nothing reported it. The one channel that stayed live is the
+one a workflow verified. This module is that verification, generalised.
+
+Three result states, not two. `/v0/servers` and `/v0.1/servers` both answered
+on 2026-09-06, so the registry schema is moving; a checker that treats an
+unrecognised payload as failure turns a green release red for a reason that
+has nothing to do with Entroly. UNKNOWN is recorded and warned about. It
+never silently passes and it never blocks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+CANONICAL_NAME = "io.github.juyterman1000/entroly"
+CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
+EXPECTED_PACKAGES = {("pypi", "entroly"), ("npm", "entroly-mcp")}
+USER_AGENT = "entroly-canonical-mcp-publisher"
+
+Fetch = Callable[[str], dict]
+
+
+class Presence(str, Enum):
+    PRESENT = "present"
+    ABSENT = "absent"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Probe:
+    channel: str
+    presence: Presence
+    detail: str
+
+
+def _fetch_json(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def probe_mcp_registry(version: str, *, fetch: Fetch = _fetch_json) -> Probe:
+    channel = "mcp-registry"
+    url = (
+        "https://registry.modelcontextprotocol.io/v0.1/servers?search="
+        + urllib.parse.quote(CANONICAL_NAME, safe="")
+    )
+
+    try:
+        payload = fetch(url)
+    except Exception as error:  # noqa: BLE001 - any failure to reach is UNKNOWN
+        return Probe(channel, Presence.UNKNOWN, f"could not reach registry: {error}")
+
+    servers = payload.get("servers")
+    if not isinstance(servers, list):
+        return Probe(channel, Presence.UNKNOWN, "unrecognised payload: no server list")
+
+    for item in servers:
+        server = item.get("server", item)
+        if server.get("name") != CANONICAL_NAME:
+            continue
+        if server.get("version") != version:
+            continue
+
+        repository = (server.get("repository") or {}).get("url")
+        if repository != CANONICAL_REPOSITORY:
+            return Probe(
+                channel,
+                Presence.ABSENT,
+                f"listing claims a non-canonical repository: {repository!r}",
+            )
+
+        packages = {
+            (package.get("registryType"), package.get("identifier"))
+            for package in server.get("packages", [])
+        }
+        if packages != EXPECTED_PACKAGES:
+            return Probe(
+                channel,
+                Presence.ABSENT,
+                f"unexpected package set: {sorted(packages)!r}",
+            )
+
+        return Probe(channel, Presence.PRESENT, f"listed at {version}")
+
+    return Probe(channel, Presence.ABSENT, f"not listed at {version}")
+
+
+PROBES: dict[str, Callable[..., Probe]] = {
+    "mcp-registry": probe_mcp_registry,
+}
+
+# Channels Entroly publishes to block a release when absent. Channels that
+# index on their own schedule cannot: Smithery pulls from GitHub whenever it
+# chooses, so ABSENT there can be nobody's fault.
+BLOCKING = {"mcp-registry"}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--channel", default="all", choices=["all", *PROBES])
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    names = list(PROBES) if args.channel == "all" else [args.channel]
+    probes = [PROBES[name](args.version) for name in names]
+
+    if args.json:
+        print(json.dumps([probe.__dict__ for probe in probes], indent=2, default=str))
+    else:
+        for probe in probes:
+            policy = "blocking" if probe.channel in BLOCKING else "advisory"
+            print(f"{probe.channel} [{policy}]: {probe.presence.value} - {probe.detail}")
+
+    failed = [
+        probe
+        for probe in probes
+        if probe.presence is Presence.ABSENT and probe.channel in BLOCKING
+    ]
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_marketplace_presence.py -v`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Verify against the live registry**
+
+Run: `python scripts/marketplace_presence.py --version 1.0.83`
+Expected: prints `mcp-registry [blocking]: ...`. Either `present` or `absent` is a correct result here — the registry listed 1.0.81 while the repository was at 1.0.83 during the audit. Record which you saw.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/marketplace_presence.py tests/test_marketplace_presence.py
+git commit -m "feat(distribution): extract the registry presence gate into one module
+
+publish-mcp-registry.yml already asserts name, version, canonical repository
+and exact package set -- twice, as duplicated inline heredocs, for one
+channel. Lifts it into a tested module with three result states so a moving
+registry schema cannot redden a healthy release.
+
+Co-Authored-By: juyterman1000 <208309368+juyterman1000@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: Claude Code marketplace and Smithery adapters
+
+**Files:**
+- Modify: `scripts/marketplace_presence.py`
+- Test: `tests/test_marketplace_presence.py`
+
+**Interfaces:**
+- Consumes: `Presence`, `Probe`, `Fetch` from Task 3.
+- Produces: `probe_claude_marketplace(version, *, fetch=...) -> Probe` (channel `claude-marketplace`, blocking) and `probe_smithery(version, *, fetch=...) -> Probe` (channel `smithery`, advisory). Both registered in `PROBES`.
+
+The Claude marketplace is pull-based: GitHub `main` is the source of truth, so the probe reads the raw manifest. Smithery is also pull-based but on Smithery's schedule, so it is advisory — that distinction is what stops the gate from blocking releases forever.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_marketplace_presence.py`:
+
+```python
+from marketplace_presence import (  # noqa: E402
+    BLOCKING,
+    probe_claude_marketplace,
+    probe_smithery,
+)
+
+
+def _marketplace(version: str) -> dict:
+    return {
+        "name": "entroly",
+        "owner": {"name": "juyterman1000"},
+        "plugins": [{"name": "entroly", "source": "./", "version": version}],
+    }
+
+
+def test_claude_marketplace_present_when_raw_manifest_lists_the_version() -> None:
+    probe = probe_claude_marketplace("1.0.84", fetch=lambda url: _marketplace("1.0.84"))
+
+    assert probe.presence is Presence.PRESENT
+    assert probe.channel == "claude-marketplace"
+
+
+def test_claude_marketplace_absent_when_the_manifest_lags() -> None:
+    probe = probe_claude_marketplace("1.0.84", fetch=lambda url: _marketplace("1.0.83"))
+
+    assert probe.presence is Presence.ABSENT
+
+
+def test_claude_marketplace_unknown_when_the_manifest_is_unreachable() -> None:
+    def explode(url: str) -> dict:
+        raise OSError("404 not found")
+
+    probe = probe_claude_marketplace("1.0.84", fetch=explode)
+
+    assert probe.presence is Presence.UNKNOWN
+
+
+def test_smithery_absent_when_the_server_page_is_missing() -> None:
+    # The audited state on 2026-09-06: correct smithery.yaml, no server page.
+    def missing(url: str) -> dict:
+        raise OSError("HTTP Error 404: Not Found")
+
+    probe = probe_smithery("1.0.84", fetch=missing)
+
+    assert probe.presence is Presence.ABSENT
+
+
+def test_smithery_is_advisory_so_it_cannot_block_a_release() -> None:
+    # Smithery indexes from GitHub on its own schedule, so ABSENT there can
+    # be nobody's fault and must never stop a release.
+    assert "smithery" not in BLOCKING
+    assert "claude-marketplace" in BLOCKING
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_marketplace_presence.py -v`
+Expected: FAIL — `ImportError: cannot import name 'probe_claude_marketplace'`.
+
+- [ ] **Step 3: Add the adapters**
+
+In `scripts/marketplace_presence.py`, add these functions after `probe_mcp_registry`:
+
+```python
+RAW_MARKETPLACE_URL = (
+    "https://raw.githubusercontent.com/juyterman1000/entroly/main/"
+    ".claude-plugin/marketplace.json"
+)
+SMITHERY_URL = "https://smithery.ai/server/@juyterman1000/entroly"
+
+
+def probe_claude_marketplace(version: str, *, fetch: Fetch = _fetch_json) -> Probe:
+    channel = "claude-marketplace"
+
+    try:
+        payload = fetch(RAW_MARKETPLACE_URL)
+    except Exception as error:  # noqa: BLE001
+        return Probe(channel, Presence.UNKNOWN, f"could not read manifest: {error}")
+
+    plugins = payload.get("plugins")
+    if not isinstance(plugins, list):
+        return Probe(channel, Presence.UNKNOWN, "unrecognised manifest: no plugin list")
+
+    for plugin in plugins:
+        if plugin.get("name") != "entroly":
+            continue
+        if plugin.get("version") == version:
+            return Probe(channel, Presence.PRESENT, f"listed at {version}")
+        return Probe(
+            channel,
+            Presence.ABSENT,
+            f"manifest on main declares {plugin.get('version')!r}, not {version!r}",
+        )
+
+    return Probe(channel, Presence.ABSENT, "manifest does not list the entroly plugin")
+
+
+def _fetch_text(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return {"status": response.status}
+
+
+def probe_smithery(version: str, *, fetch: Fetch = _fetch_text) -> Probe:
+    channel = "smithery"
+
+    try:
+        payload = fetch(SMITHERY_URL)
+    except Exception as error:  # noqa: BLE001
+        # A 404 here is a real answer: the server page does not exist. That
+        # was the audited state while smithery.yaml sat correct in the repo.
+        if "404" in str(error):
+            return Probe(channel, Presence.ABSENT, "server page does not exist")
+        return Probe(channel, Presence.UNKNOWN, f"could not reach smithery: {error}")
+
+    if payload.get("status") == 200:
+        return Probe(channel, Presence.PRESENT, "server page exists")
+    return Probe(channel, Presence.UNKNOWN, f"unexpected status: {payload.get('status')}")
+```
+
+Then replace the `PROBES` dictionary:
+
+```python
+PROBES: dict[str, Callable[..., Probe]] = {
+    "mcp-registry": probe_mcp_registry,
+    "claude-marketplace": probe_claude_marketplace,
+    "smithery": probe_smithery,
+}
+```
+
+And replace `BLOCKING`:
+
+```python
+BLOCKING = {"mcp-registry", "claude-marketplace"}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_marketplace_presence.py -v`
+Expected: PASS (12 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/marketplace_presence.py tests/test_marketplace_presence.py
+git commit -m "feat(distribution): probe the marketplace and Smithery channels
+
+Smithery is advisory because it indexes from GitHub on its own schedule, so
+absence there can be nobody's fault and must not block a release. The
+marketplace manifest on main is the source of truth for the Claude Code
+channel, so that one blocks.
+
+Co-Authored-By: juyterman1000 <208309368+juyterman1000@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: Wire the checker into the workflows
+
+**Files:**
+- Create: `.github/workflows/publish-marketplaces.yml`
+- Modify: `.github/workflows/publish-mcp-registry.yml` (the two inline verification heredocs)
+
+**Interfaces:**
+- Consumes: `python scripts/marketplace_presence.py --version <v> [--channel <c>]`, exit `1` when a blocking channel is absent.
+- Produces: no Python interface.
+
+Per the spec's rollout, the new workflow runs **advisory-only for one full release cycle**. It must not gate a release before it has been observed green.
+
+- [ ] **Step 1: Replace the duplicated heredoc in the existing workflow**
+
+In `.github/workflows/publish-mcp-registry.yml`, replace the body of the `Verify exact registry ownership and listing` step (the ~60-line inline `python - <<'PY'` heredoc beginning around line 310) with:
+
+```yaml
+      - name: Verify exact registry ownership and listing
+        if: steps.release_guard.outputs.should_publish == 'true'
+        shell: bash
+        run: |
+          version="$(python -c "import json;print(json.load(open('server.json'))['version'])")"
+          for attempt in $(seq 1 60); do
+            if python scripts/marketplace_presence.py \
+                 --version "$version" --channel mcp-registry; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::registry did not list $version after 60 attempts"
+          exit 1
+```
+
+The retry loop is preserved deliberately: registry propagation is not instant, and the original polled sixty times for that reason.
+
+- [ ] **Step 2: Verify the existing regression tests still pass**
+
+Run: `pytest tests/test_mcp_registry_manifest.py -v`
+Expected: PASS. The manifest contract is unchanged; only the verification mechanism moved.
+
+- [ ] **Step 3: Create the advisory workflow**
+
+Create `.github/workflows/publish-marketplaces.yml`:
+
+```yaml
+name: Verify marketplace presence
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily. A channel that dies between releases should not wait for the
+    # next release to be noticed -- Smithery was dead for months.
+    - cron: "17 6 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  presence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Probe every distribution channel
+        id: probe
+        continue-on-error: true
+        run: |
+          version="$(python -c "import re,pathlib;print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', pathlib.Path('entroly/__init__.py').read_text()).group(1))")"
+          python scripts/marketplace_presence.py --version "$version" --channel all
+
+      - name: Report
+        run: |
+          if [ "${{ steps.probe.outcome }}" = "failure" ]; then
+            echo "::warning::a distribution channel is not listing the current version"
+          fi
+```
+
+`continue-on-error` plus a warning is the advisory mode the rollout requires. Task 5 Step 5 flips it after one clean cycle.
+
+- [ ] **Step 4: Validate the workflow files parse**
+
+Run: `python -c "import yaml,pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/publish-marketplaces.yml', '.github/workflows/publish-mcp-registry.yml']]; print('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 5: Record the promotion condition**
+
+Add this comment at the top of the `presence` job in `publish-marketplaces.yml`, directly under `runs-on`:
+
+```yaml
+    # ADVISORY until one full release cycle has run green. To promote:
+    # delete `continue-on-error` from the probe step. Do not promote early --
+    # a gate that reddens a healthy release gets disabled, and a disabled
+    # gate is how Smithery stayed dead.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/publish-marketplaces.yml .github/workflows/publish-mcp-registry.yml
+git commit -m "feat(ci): check every channel daily, not one channel at release
+
+Smithery was dead for months between releases, so a release-time-only check
+would not have caught it. Runs advisory until one clean cycle: a gate that
+reddens a healthy release gets disabled, and a disabled gate is the failure
+this is meant to prevent.
+
+Co-Authored-By: juyterman1000 <208309368+juyterman1000@users.noreply.github.com>"
+```
+
+---
+
+### Task 6: The first-run wedge
+
+A plugin that installs and shows nothing gets uninstalled. First run demonstrates the property competitors do not have: omitted evidence shown together with the handles that recover it.
+
+**Files:**
+- Create: `.claude-plugin/commands/entroly-first-run.md`
+- Test: `tests/test_first_run_copy.py`
+
+**Interfaces:**
+- Consumes: the `commands` path registered in Task 1.
+- Produces: the `/entroly-first-run` slash command.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_first_run_copy.py`:
+
+```python
+"""The first-run screen may not carry a savings percentage.
+
+`saved = max(0, baseline - selected_tokens)` with
+`baseline = min(total_tokens, 32_000)` in entroly/cli.py pins the figure at
+or above 75% for a budget of 8,000 before selection has run. It is budget
+arithmetic wearing the costume of a measurement, and a first-run screen is
+the widest possible distribution for it.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMAND = ROOT / ".claude-plugin" / "commands" / "entroly-first-run.md"
+
+PERCENTAGE = re.compile(r"\d{1,3}\s?%")
+
+
+def test_first_run_command_exists() -> None:
+    assert COMMAND.is_file()
+
+
+def test_first_run_copy_states_no_savings_percentage() -> None:
+    matches = PERCENTAGE.findall(COMMAND.read_text(encoding="utf-8"))
+
+    assert matches == [], f"first-run copy must not quote a percentage: {matches}"
+
+
+def test_first_run_copy_shows_recovery_handles() -> None:
+    text = COMMAND.read_text(encoding="utf-8").lower()
+
+    # The differentiator is not that context got smaller. It is that what
+    # was left out is named and recoverable.
+    assert "recover" in text
+    assert "omitted" in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_first_run_copy.py -v`
+Expected: FAIL — `assert False` on `COMMAND.is_file()`.
+
+- [ ] **Step 3: Write the command**
+
+Create `.claude-plugin/commands/entroly-first-run.md`:
+
+```markdown
+---
+description: Show what Entroly selected from this repository, what it omitted, and how to recover the omissions.
+---
+
+Show the user what Entroly does to their own repository, using their real code.
+
+1. Run `entroly compile` against the project's primary source directory, then
+   `entroly simulate` scoped to that directory.
+2. Report three things, in this order:
+   - **Selected** — the fragments that were kept, with their files.
+   - **Omitted** — the fragments that were left out, with their files. Name
+     them. Do not summarise them as a count.
+   - **Recovery** — for each omitted fragment, the content-addressed handle
+     that retrieves the exact original bytes. Demonstrate one live recovery.
+3. Close by inviting the user to pick any omitted fragment and recover it.
+
+Do not report a savings percentage, a compression ratio, or a token-reduction
+figure. The percentage is determined by the configured budget before selection
+runs, so it measures the budget rather than the selection. The claim worth
+making is that nothing was lost irrecoverably, and that claim is checkable in
+front of the user — which is the entire point.
+
+If the native engine is missing, say so plainly and state that selection has
+not been query-conditioned, rather than reporting a figure that looks earned.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_first_run_copy.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Run the full affected suite**
+
+Run: `pytest tests/test_plugin_marketplace_manifest.py tests/test_plugin_launcher.py tests/test_marketplace_presence.py tests/test_first_run_copy.py tests/test_version_surfaces_are_complete.py -v --timeout=300`
+Expected: all pass. `--timeout=300` is required — `tests/test_docs_code_sync.py` and its neighbours allow a 300s subprocess, and a shorter pytest timeout kills them with a misleading error.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude-plugin/commands/entroly-first-run.md tests/test_first_run_copy.py
+git commit -m "feat(plugin): prove recovery on first run, without a percentage
+
+The savings figure is decided by the token budget before selection runs, so
+a first-run screen quoting it would distribute a number that flatters
+Entroly for a reason unrelated to Entroly. Shows named omissions and a live
+recovery instead, which is the property competitors do not have. A test
+fails if a percentage is reintroduced.
+
+Co-Authored-By: juyterman1000 <208309368+juyterman1000@users.noreply.github.com>"
+```
+
+---
+
+## Manual step, outside the plan
+
+Submit Entroly to Smithery once, by hand, at https://smithery.ai. `smithery.yaml` has been correct and unsubmitted for months. After submission, the advisory probe from Task 4 reports on it daily and it cannot silently die again.
+
+## Self-review
+
+**Spec coverage:** Part 1 → Tasks 1 and 2. Part 2 → Task 6. Part 3 → Tasks 3, 4 and 5. Failure mode 1 → Task 2. Failure mode 2 → Task 3 (`UNKNOWN` states). Failure mode 3 → Task 4 (`BLOCKING` set). Failure mode 4 → Task 3 (version comparison against the released version). Test matrix rows: unit → Tasks 3 and 4; regression → Task 3 Steps 1 and 5; schema → Task 1; contract → Task 5. Rollout step 3 → the manual step above. No spec requirement is unimplemented.
+
+**Placeholders:** none. Every code step carries the code.
+
+**Type consistency:** `Presence`, `Probe`, and `Fetch` are defined in Task 3 and used unchanged in Tasks 4 and 5. `probe_mcp_registry`, `probe_claude_marketplace`, and `probe_smithery` share one signature. The MCP command contract asserted in Task 1 Step 1 matches the file Task 2 creates and the `plugin.json` value in Task 1 Step 4.

--- a/docs/superpowers/specs/2026-09-06-marketplace-wedge-design.md
+++ b/docs/superpowers/specs/2026-09-06-marketplace-wedge-design.md
@@ -1,0 +1,173 @@
+# Marketplace Wedge: Presence as a Release Surface
+
+Date: 2026-09-06
+Status: design, approved for planning
+
+## Problem
+
+Entroly has capability parity with its competitors and loses on adoption. The
+gap is not depth. Between 2026-08-17 and 2026-09-06 the project took **364
+commits on `main`** and moved from **437 to 443 GitHub stars** — six stars in
+twenty days, against a target of 120 per week. Exactly **one** of those commits
+touched `marketing/`.
+
+Building a further capability is the intervention that has already been tried
+hardest and returned least. This design instead targets the channels where a
+developer discovers a tool from inside the editor they already have open.
+
+## Evidence
+
+The distribution surface was audited on 2026-09-06. Every row below was verified
+against the live service, not against the repository's intent.
+
+| Channel | Present in repo | Live |
+|---|---|---|
+| Official MCP registry | `server.json`, `.github/workflows/publish-mcp-registry.yml` | **Yes** — 20 versions, all `active`; publish workflow succeeded 2026-09-06 |
+| Smithery (one-click for Cursor, Claude Desktop, Windsurf) | `smithery.yaml` | **No** — server page does not exist |
+| Claude Code plugin | `.claude-plugin/manifest.json`, `.claude-plugin/plugin.json` | **No** — no `marketplace.json`, so there is no install path |
+
+One channel is alive. It is also the only channel with a workflow that publishes
+it without a human deciding to. The two dead channels each require someone to
+remember, and neither has been remembered. The same pattern governs
+`marketing/launch/` — three drafts, all still marked *"Status: prepared, not
+submitted."*
+
+The conclusion this design is built on: **a distribution channel that depends on
+human memory decays to zero, and nothing reports that it has.** Smithery's
+configuration is correct and has been for months. Nothing anywhere failed.
+
+## Goals
+
+1. Make Entroly installable from the Claude Code plugin marketplace, which today
+   is impossible rather than merely unadvertised.
+2. Make the first run inside the host tool demonstrate the one thing parity does
+   not cover.
+3. Make channel presence a release surface that fails loudly when it regresses,
+   so no channel can be silently dead again.
+
+## Non-goals
+
+- Positioning, README headline, and the three unsent launch drafts. These were
+  assessed as the larger constraint and deliberately deferred; they are not in
+  this spec.
+- Any new engine, selection, or receipt capability. This design ships what
+  exists through channels that do not currently carry it.
+- Marketplaces beyond the three named above.
+
+## Design
+
+### Part 1 — Make it installable
+
+`.claude-plugin/manifest.json` is a hand-rolled descriptor. Its `install.command`
+field (`pip install entroly`) is not read by anything; Claude Code discovers
+plugins through a marketplace manifest, which this repository does not have.
+
+- Add `.claude-plugin/marketplace.json`, the file `/plugin marketplace add
+  juyterman1000/entroly` reads.
+- Rewrite `.claude-plugin/plugin.json` to the Claude Code plugin schema.
+- The plugin carries an `.mcp.json` and the existing
+  `skills/entroly-evidence-operations/SKILL.md`. No new engine work.
+
+The MCP server command is `entroly-plugin-launch`, a shim that tries `uvx`, then
+`npx`, then an `entroly` already on `PATH`, and on total failure prints one
+actionable line. It ships as a script inside the plugin directory rather than as
+a new `[project.scripts]` console entry: a console entry would not exist until
+the package is installed, which is the exact condition the shim has to survive.
+This is deliberate: MCP configuration has no fallback chain, so
+naming `uvx` directly means that a user without `uv` installed sees a plugin that
+is silently inert. A dead plugin that reports nothing is the worst outcome
+available to this design, and it is worth twenty lines to avoid.
+
+### Part 2 — Make the first run prove something
+
+A plugin that installs and shows nothing gets uninstalled. First activation runs
+a bounded selection over the user's own repository and shows the omitted
+evidence *together with the handles that recover it* — the property competitors
+do not have. It reuses `simulate` and `verify-claims` as they exist.
+
+**The savings percentage must not appear on that screen.** `saved = max(0,
+baseline - selected_tokens)` with `baseline = min(total_tokens, 32_000)` in
+`entroly/cli.py` pins the figure at or above 75% for a budget of 8,000 before
+selection has run. It is budget arithmetic wearing the costume of a measurement.
+Shipping it into a first-run screen would distribute a number that flatters
+Entroly for a reason unrelated to Entroly, and it would be found.
+
+### Part 3 — Make presence self-enforcing
+
+`publish-mcp-registry.yml` already contains the mechanism this design needs. Its
+"Verify exact registry ownership and listing" step polls the registry up to 60
+times and asserts the server name, the released version, the canonical
+repository URL, and the exact package set. It is careful and it works — it is
+also hard-coded to one channel and duplicated as inline heredocs across two
+steps.
+
+The work is extraction, not invention.
+
+- `scripts/marketplace_presence.py` — given a channel and an expected version,
+  answers whether it is listed. It does not publish and has no side effects.
+- **Channel adapters**, one per channel, each returning three states:
+  `Present`, `Absent`, `Unknown`. Three rather than two is load-bearing;
+  see failure mode 2.
+- `publish-marketplaces.yml` — orchestration only, modeled on the workflow that
+  already works.
+- `publish-mcp-registry.yml`'s inline Python is replaced by a call into the
+  shared script, deleting the duplicated heredoc.
+
+Version synchronisation hooks into `scripts/bump_version.py` `TARGETS`, which
+already carries `.claude-plugin/manifest.json` and `.claude-plugin/plugin.json`
+at lines 88 and 91, with its repository-wide sweep as the backstop that names
+anything missed. It does **not** hook into a list in a document: the 1.0.82 bump
+left seven manifests behind precisely because a document list cannot know what
+was added after it was written.
+
+## Failure modes
+
+1. **`uvx` absent on the user's machine.** The plugin never starts and reports
+   nothing. Mitigated by the `entroly-plugin-launch` shim in Part 1.
+2. **Registry API drift.** `publish-mcp-registry.yml` queries `/v0.1/servers`;
+   the audit probe used `/v0/servers`. Both answered on 2026-09-06, so two paths
+   are live and the schema is moving. A gate that hard-fails on a shape change
+   turns a green release red for a reason that has nothing to do with Entroly.
+   `Unknown` therefore warns and is recorded; it never silently passes and never
+   blocks.
+3. **The gate blocks releases indefinitely.** Smithery has no publish API — it
+   indexes from GitHub on its own schedule, so `Absent` there can be nobody's
+   fault. Each channel carries a policy: `blocking` for channels Entroly pushes
+   to, `advisory` for channels that pull.
+4. **Version skew.** The registry currently lists 1.0.81 while the repository is
+   at 1.0.83. Probes compare against the released version, never `HEAD`.
+
+## Test matrix
+
+| Layer | Coverage | Network |
+|---|---|---|
+| Unit | Each adapter against recorded fixtures: present, absent, malformed, timeout | No |
+| Regression | The MCP adapter reproduces the current workflow's assertions exactly — name, version, repository URL, package set — proving the extraction is behavior-preserving | No |
+| Schema | `marketplace.json` and `plugin.json` validated in CI so a malformed manifest cannot ship | No |
+| Contract | One live probe per channel, in the release workflow only | Yes |
+
+## Rollout
+
+1. Land Parts 1 and 2 behind the schema test.
+2. Extract the presence gate; confirm the MCP regression test reproduces current
+   behavior before switching the workflow over to it.
+3. Submit to Smithery by hand once. From then on the advisory probe reports it.
+4. Add the marketplace probes to the release workflow as `blocking` only after
+   one full release cycle has run them green in advisory mode.
+
+Release remains tag-driven: merge to `main`, then tag the post-merge commit on
+`main`. Tagging a branch commit that is later squash-merged orphans the tag and
+every publish then fails.
+
+## Expected result, stated honestly
+
+The MCP registry is live at 20 published versions and did not move the star
+line. Registry presence is table stakes rather than a growth engine. The Claude
+Code marketplace is a better channel because it has a browse surface and an
+audience already inside the tool, but this work is a slower burn than the
+positioning and launch work deferred under Non-goals. It is recorded here so
+that the outcome is measured against the claim rather than against hope.
+
+What this design does guarantee is narrower and worth having on its own: after
+it lands, a channel cannot be dead for months without the release telling
+someone.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -89,6 +89,12 @@ TARGETS = [
     # `plugin.json` sits beside `manifest.json` and was never listed, so it
     # lagged a release behind every bump that touched its neighbour.
     (".claude-plugin/plugin.json", r'"version"\s*:\s*"[^"]+"', '"version": "{v}"'),
+    # The marketplace entry declares the plugin version to Claude Code's
+    # install UI. It is a third `.claude-plugin` surface; the sweep below
+    # would catch it, but catching it here means the bump never emits a
+    # warning in the first place.
+    (".claude-plugin/marketplace.json",
+        r'"version"\s*:\s*"[^"]+"', '"version": "{v}"'),
     (".mcpb-build/manifest.json", r'"version"\s*:\s*"[^"]+"', '"version": "{v}"'),
     # Agent bundles and per-host extension manifests. Each declares the product
     # version to its host, and none of them was in this list -- a bump left

--- a/scripts/entroly-plugin-launch.mjs
+++ b/scripts/entroly-plugin-launch.mjs
@@ -33,26 +33,36 @@ function resolve(command) {
   return null;
 }
 
+// Windows cannot exec a .cmd/.bat directly: spawnSync without a shell throws
+// EINVAL. Route those through cmd.exe with every part quoted, so `npx` -- which
+// ships as npx.cmd on Windows -- stays a real link in the chain instead of
+// being skipped. `/d` skips AutoRun, `/s` makes cmd strip exactly the outer
+// quote pair and take the rest verbatim.
+function runCandidate(executable, args) {
+  const options = {
+    stdio: "inherit",
+    env: { ...process.env, ENTROLY_NO_DOCKER: "1" },
+  };
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(executable)) {
+    const line = [executable, ...args].map((part) => `"${part}"`).join(" ");
+    return spawnSync(
+      process.env.COMSPEC || "cmd.exe",
+      ["/d", "/s", "/c", `"${line}"`],
+      { ...options, windowsVerbatimArguments: true },
+    );
+  }
+  return spawnSync(executable, args, options);
+}
+
 for (const candidate of CANDIDATES) {
   const executable = resolve(candidate.command);
   if (executable === null) continue;
 
-  // Skip .cmd and .bat files on Windows without shell support, since
-  // spawnSync cannot execute them without shell: true. They will not be
-  // invoked, which is correct behavior: uvx and entroly are real binaries,
-  // not batch files, and npx.cmd on Windows should not be used directly.
-  // Instead, look for npx without an extension, which exists on some systems.
-  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(executable)) {
-    continue;
-  }
-
-  const result = spawnSync(executable, candidate.args, {
-    stdio: "inherit",
-    env: { ...process.env, ENTROLY_NO_DOCKER: "1" },
-  });
-  if (result.status !== null) {
-    process.exit(result.status);
-  }
+  const result = runCandidate(executable, candidate.args);
+  // A null status means the process never launched. The next candidate may
+  // still work, so fall through instead of exiting -- this is exactly the
+  // "installed but broken" case the shell-free design exists to detect.
+  if (result.status !== null) process.exit(result.status);
 }
 
 process.stderr.write(

--- a/scripts/entroly-plugin-launch.mjs
+++ b/scripts/entroly-plugin-launch.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Entroly plugin launcher.
+//
+// The plugin's MCP config cannot express a fallback chain: it names one
+// command, and if that command is missing the server never starts and the
+// user sees a plugin that is silently inert. So the config names this file,
+// and the fallback lives here.
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
+
+const CANDIDATES = [
+  { command: "uvx", args: ["--from", "entroly", "entroly"] },
+  { command: "npx", args: ["-y", "entroly@latest"] },
+  { command: "entroly", args: [] },
+];
+
+// Resolve against PATH ourselves rather than passing `shell: true`. With a
+// shell, a missing command exits 1 like any other failure, and the chain
+// cannot tell "not installed" from "installed and broken".
+function resolve(command) {
+  const extensions =
+    process.platform === "win32"
+      ? (process.env.PATHEXT || ".EXE;.CMD;.BAT").split(";")
+      : [""];
+  for (const dir of (process.env.PATH || "").split(delimiter)) {
+    if (!dir) continue;
+    for (const extension of extensions) {
+      const candidate = join(dir, command + extension);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+for (const candidate of CANDIDATES) {
+  const executable = resolve(candidate.command);
+  if (executable === null) continue;
+
+  // Skip .cmd and .bat files on Windows without shell support, since
+  // spawnSync cannot execute them without shell: true. They will not be
+  // invoked, which is correct behavior: uvx and entroly are real binaries,
+  // not batch files, and npx.cmd on Windows should not be used directly.
+  // Instead, look for npx without an extension, which exists on some systems.
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(executable)) {
+    continue;
+  }
+
+  const result = spawnSync(executable, candidate.args, {
+    stdio: "inherit",
+    env: { ...process.env, ENTROLY_NO_DOCKER: "1" },
+  });
+  if (result.status !== null) {
+    process.exit(result.status);
+  }
+}
+
+process.stderr.write(
+  "Entroly plugin: no runner found. Install uv (https://docs.astral.sh/uv/) " +
+    "or Node, or run `pip install -U entroly`, then restart Claude Code.\n",
+);
+process.exit(1);

--- a/scripts/marketplace_presence.py
+++ b/scripts/marketplace_presence.py
@@ -1,0 +1,133 @@
+"""Is Entroly actually listed on the channels it claims to ship through?
+
+Smithery held a correct `smithery.yaml` for months while its server page did
+not exist, and nothing reported it. The one channel that stayed live is the
+one a workflow verified. This module is that verification, generalised.
+
+Three result states, not two. `/v0/servers` and `/v0.1/servers` both answered
+on 2026-09-06, so the registry schema is moving; a checker that treats an
+unrecognised payload as failure turns a green release red for a reason that
+has nothing to do with Entroly. UNKNOWN is recorded and warned about. It
+never silently passes and it never blocks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+CANONICAL_NAME = "io.github.juyterman1000/entroly"
+CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
+EXPECTED_PACKAGES = {("pypi", "entroly"), ("npm", "entroly-mcp")}
+USER_AGENT = "entroly-canonical-mcp-publisher"
+
+Fetch = Callable[[str], dict]
+
+
+class Presence(str, Enum):
+    PRESENT = "present"
+    ABSENT = "absent"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Probe:
+    channel: str
+    presence: Presence
+    detail: str
+
+
+def _fetch_json(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def probe_mcp_registry(version: str, *, fetch: Fetch = _fetch_json) -> Probe:
+    channel = "mcp-registry"
+    url = (
+        "https://registry.modelcontextprotocol.io/v0.1/servers?search="
+        + urllib.parse.quote(CANONICAL_NAME, safe="")
+    )
+
+    try:
+        payload = fetch(url)
+    except Exception as error:  # noqa: BLE001 - any failure to reach is UNKNOWN
+        return Probe(channel, Presence.UNKNOWN, f"could not reach registry: {error}")
+
+    servers = payload.get("servers")
+    if not isinstance(servers, list):
+        return Probe(channel, Presence.UNKNOWN, "unrecognised payload: no server list")
+
+    for item in servers:
+        server = item.get("server", item)
+        if server.get("name") != CANONICAL_NAME:
+            continue
+        if server.get("version") != version:
+            continue
+
+        repository = (server.get("repository") or {}).get("url")
+        if repository != CANONICAL_REPOSITORY:
+            return Probe(
+                channel,
+                Presence.ABSENT,
+                f"listing claims a non-canonical repository: {repository!r}",
+            )
+
+        packages = {
+            (package.get("registryType"), package.get("identifier"))
+            for package in server.get("packages", [])
+        }
+        if packages != EXPECTED_PACKAGES:
+            return Probe(
+                channel,
+                Presence.ABSENT,
+                f"unexpected package set: {sorted(packages)!r}",
+            )
+
+        return Probe(channel, Presence.PRESENT, f"listed at {version}")
+
+    return Probe(channel, Presence.ABSENT, f"not listed at {version}")
+
+
+PROBES: dict[str, Callable[..., Probe]] = {
+    "mcp-registry": probe_mcp_registry,
+}
+
+# Channels Entroly publishes to block a release when absent. Channels that
+# index on their own schedule cannot: Smithery pulls from GitHub whenever it
+# chooses, so ABSENT there can be nobody's fault.
+BLOCKING = {"mcp-registry"}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--channel", default="all", choices=["all", *PROBES])
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    names = list(PROBES) if args.channel == "all" else [args.channel]
+    probes = [PROBES[name](args.version) for name in names]
+
+    if args.json:
+        print(json.dumps([probe.__dict__ for probe in probes], indent=2, default=str))
+    else:
+        for probe in probes:
+            policy = "blocking" if probe.channel in BLOCKING else "advisory"
+            print(f"{probe.channel} [{policy}]: {probe.presence.value} - {probe.detail}")
+
+    failed = [
+        probe
+        for probe in probes
+        if probe.presence is Presence.ABSENT and probe.channel in BLOCKING
+    ]
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/marketplace_presence.py
+++ b/scripts/marketplace_presence.py
@@ -94,14 +94,72 @@ def probe_mcp_registry(version: str, *, fetch: Fetch = _fetch_json) -> Probe:
     return Probe(channel, Presence.ABSENT, f"not listed at {version}")
 
 
+RAW_MARKETPLACE_URL = (
+    "https://raw.githubusercontent.com/juyterman1000/entroly/main/"
+    ".claude-plugin/marketplace.json"
+)
+SMITHERY_URL = "https://smithery.ai/server/@juyterman1000/entroly"
+
+
+def probe_claude_marketplace(version: str, *, fetch: Fetch = _fetch_json) -> Probe:
+    channel = "claude-marketplace"
+
+    try:
+        payload = fetch(RAW_MARKETPLACE_URL)
+    except Exception as error:  # noqa: BLE001
+        return Probe(channel, Presence.UNKNOWN, f"could not read manifest: {error}")
+
+    plugins = payload.get("plugins")
+    if not isinstance(plugins, list):
+        return Probe(channel, Presence.UNKNOWN, "unrecognised manifest: no plugin list")
+
+    for plugin in plugins:
+        if plugin.get("name") != "entroly":
+            continue
+        if plugin.get("version") == version:
+            return Probe(channel, Presence.PRESENT, f"listed at {version}")
+        return Probe(
+            channel,
+            Presence.ABSENT,
+            f"manifest on main declares {plugin.get('version')!r}, not {version!r}",
+        )
+
+    return Probe(channel, Presence.ABSENT, "manifest does not list the entroly plugin")
+
+
+def _fetch_text(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return {"status": response.status}
+
+
+def probe_smithery(version: str, *, fetch: Fetch = _fetch_text) -> Probe:
+    channel = "smithery"
+
+    try:
+        payload = fetch(SMITHERY_URL)
+    except Exception as error:  # noqa: BLE001
+        # A 404 here is a real answer: the server page does not exist. That
+        # was the audited state while smithery.yaml sat correct in the repo.
+        if "404" in str(error):
+            return Probe(channel, Presence.ABSENT, "server page does not exist")
+        return Probe(channel, Presence.UNKNOWN, f"could not reach smithery: {error}")
+
+    if payload.get("status") == 200:
+        return Probe(channel, Presence.PRESENT, "server page exists")
+    return Probe(channel, Presence.UNKNOWN, f"unexpected status: {payload.get('status')}")
+
+
 PROBES: dict[str, Callable[..., Probe]] = {
     "mcp-registry": probe_mcp_registry,
+    "claude-marketplace": probe_claude_marketplace,
+    "smithery": probe_smithery,
 }
 
 # Channels Entroly publishes to block a release when absent. Channels that
 # index on their own schedule cannot: Smithery pulls from GitHub whenever it
 # chooses, so ABSENT there can be nobody's fault.
-BLOCKING = {"mcp-registry"}
+BLOCKING = {"mcp-registry", "claude-marketplace"}
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/marketplace_presence.py
+++ b/scripts/marketplace_presence.py
@@ -98,7 +98,11 @@ RAW_MARKETPLACE_URL = (
     "https://raw.githubusercontent.com/juyterman1000/entroly/main/"
     ".claude-plugin/marketplace.json"
 )
-SMITHERY_URL = "https://smithery.ai/server/@juyterman1000/entroly"
+# The registry API, not the human-facing page. `smithery.ai/server/...` answers
+# 308 to a redirect urllib will not follow, so probing it returns UNKNOWN
+# forever -- and UNKNOWN raises no warning, which would leave this channel
+# exactly as silently dead as it was before this checker existed.
+SMITHERY_URL = "https://registry.smithery.ai/servers/@juyterman1000/entroly"
 
 
 def probe_claude_marketplace(version: str, *, fetch: Fetch = _fetch_json) -> Probe:

--- a/tests/test_first_run_copy.py
+++ b/tests/test_first_run_copy.py
@@ -1,0 +1,36 @@
+"""The first-run screen may not carry a savings percentage.
+
+`saved = max(0, baseline - selected_tokens)` with
+`baseline = min(total_tokens, 32_000)` in entroly/cli.py pins the figure at
+or above 75% for a budget of 8,000 before selection has run. It is budget
+arithmetic wearing the costume of a measurement, and a first-run screen is
+the widest possible distribution for it.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMAND = ROOT / ".claude-plugin" / "commands" / "entroly-first-run.md"
+
+PERCENTAGE = re.compile(r"\d{1,3}\s?%")
+
+
+def test_first_run_command_exists() -> None:
+    assert COMMAND.is_file()
+
+
+def test_first_run_copy_states_no_savings_percentage() -> None:
+    matches = PERCENTAGE.findall(COMMAND.read_text(encoding="utf-8"))
+
+    assert matches == [], f"first-run copy must not quote a percentage: {matches}"
+
+
+def test_first_run_copy_shows_recovery_handles() -> None:
+    text = COMMAND.read_text(encoding="utf-8").lower()
+
+    # The differentiator is not that context got smaller. It is that what
+    # was left out is named and recoverable.
+    assert "recover" in text
+    assert "omitted" in text

--- a/tests/test_marketplace_presence.py
+++ b/tests/test_marketplace_presence.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from marketplace_presence import (  # noqa: E402
+    Presence,
+    probe_mcp_registry,
+)
+
+CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
+
+
+def _server(version: str, *, repository: str = CANONICAL_REPOSITORY, packages=None):
+    return {
+        "servers": [
+            {
+                "server": {
+                    "name": "io.github.juyterman1000/entroly",
+                    "version": version,
+                    "repository": {"url": repository, "source": "github"},
+                    "packages": packages
+                    if packages is not None
+                    else [
+                        {"registryType": "pypi", "identifier": "entroly"},
+                        {"registryType": "npm", "identifier": "entroly-mcp"},
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def test_present_when_the_released_version_is_listed() -> None:
+    probe = probe_mcp_registry("1.0.84", fetch=lambda url: _server("1.0.84"))
+
+    assert probe.presence is Presence.PRESENT
+    assert probe.channel == "mcp-registry"
+
+
+def test_absent_when_only_an_older_version_is_listed() -> None:
+    # The real skew this guards: the registry sat at 1.0.81 while the
+    # repository was at 1.0.83.
+    probe = probe_mcp_registry("1.0.84", fetch=lambda url: _server("1.0.81"))
+
+    assert probe.presence is Presence.ABSENT
+
+
+def test_absent_when_the_registry_returns_nothing() -> None:
+    probe = probe_mcp_registry("1.0.84", fetch=lambda url: {"servers": []})
+
+    assert probe.presence is Presence.ABSENT
+
+
+def test_unknown_when_the_payload_shape_is_unrecognised() -> None:
+    # Two API paths answered on 2026-09-06 (/v0 and /v0.1), so the schema is
+    # moving. A shape change must not redden a healthy release.
+    probe = probe_mcp_registry("1.0.84", fetch=lambda url: {"unexpected": True})
+
+    assert probe.presence is Presence.UNKNOWN
+
+
+def test_unknown_when_the_network_fails() -> None:
+    def explode(url: str) -> dict:
+        raise OSError("connection reset")
+
+    probe = probe_mcp_registry("1.0.84", fetch=explode)
+
+    assert probe.presence is Presence.UNKNOWN
+    assert "connection reset" in probe.detail
+
+
+def test_absent_when_the_listing_points_at_a_non_canonical_repository() -> None:
+    # Reproduces the workflow's ownership assertion: a listing under our name
+    # pointing somewhere else is a hijack, not a success.
+    probe = probe_mcp_registry(
+        "1.0.84",
+        fetch=lambda url: _server("1.0.84", repository="https://github.com/someone/else"),
+    )
+
+    assert probe.presence is Presence.ABSENT
+    assert "repository" in probe.detail
+
+
+def test_absent_when_the_package_set_is_unexpected() -> None:
+    # Reproduces the workflow's package-set assertion.
+    probe = probe_mcp_registry(
+        "1.0.84",
+        fetch=lambda url: _server(
+            "1.0.84",
+            packages=[{"registryType": "pypi", "identifier": "entroly"}],
+        ),
+    )
+
+    assert probe.presence is Presence.ABSENT
+    assert "package" in probe.detail

--- a/tests/test_marketplace_presence.py
+++ b/tests/test_marketplace_presence.py
@@ -97,3 +97,57 @@ def test_absent_when_the_package_set_is_unexpected() -> None:
 
     assert probe.presence is Presence.ABSENT
     assert "package" in probe.detail
+
+
+from marketplace_presence import (  # noqa: E402
+    BLOCKING,
+    probe_claude_marketplace,
+    probe_smithery,
+)
+
+
+def _marketplace(version: str) -> dict:
+    return {
+        "name": "entroly",
+        "owner": {"name": "juyterman1000"},
+        "plugins": [{"name": "entroly", "source": "./", "version": version}],
+    }
+
+
+def test_claude_marketplace_present_when_raw_manifest_lists_the_version() -> None:
+    probe = probe_claude_marketplace("1.0.84", fetch=lambda url: _marketplace("1.0.84"))
+
+    assert probe.presence is Presence.PRESENT
+    assert probe.channel == "claude-marketplace"
+
+
+def test_claude_marketplace_absent_when_the_manifest_lags() -> None:
+    probe = probe_claude_marketplace("1.0.84", fetch=lambda url: _marketplace("1.0.83"))
+
+    assert probe.presence is Presence.ABSENT
+
+
+def test_claude_marketplace_unknown_when_the_manifest_is_unreachable() -> None:
+    def explode(url: str) -> dict:
+        raise OSError("404 not found")
+
+    probe = probe_claude_marketplace("1.0.84", fetch=explode)
+
+    assert probe.presence is Presence.UNKNOWN
+
+
+def test_smithery_absent_when_the_server_page_is_missing() -> None:
+    # The audited state on 2026-09-06: correct smithery.yaml, no server page.
+    def missing(url: str) -> dict:
+        raise OSError("HTTP Error 404: Not Found")
+
+    probe = probe_smithery("1.0.84", fetch=missing)
+
+    assert probe.presence is Presence.ABSENT
+
+
+def test_smithery_is_advisory_so_it_cannot_block_a_release() -> None:
+    # Smithery indexes from GitHub on its own schedule, so ABSENT there can
+    # be nobody's fault and must never stop a release.
+    assert "smithery" not in BLOCKING
+    assert "claude-marketplace" in BLOCKING

--- a/tests/test_plugin_launcher.py
+++ b/tests/test_plugin_launcher.py
@@ -31,8 +31,15 @@ def _run(env_path: str, extra_env: dict | None = None) -> subprocess.CompletedPr
 
 
 def test_reports_one_actionable_line_when_no_runner_exists(tmp_path: Path) -> None:
-    node_dir = str(Path(shutil.which("node")).parent)
-    result = _run(node_dir)
+    # Create a PATH with only node, excluding npm/npx which may ship with node.
+    # This ensures we actually test the "no runner found" path.
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    node_exe = shutil.which("node")
+    node_copy = fake_bin / Path(node_exe).name
+    shutil.copy2(node_exe, node_copy)
+
+    result = _run(str(fake_bin))
 
     assert result.returncode == 1
     # The failure mode this guards is a plugin that starts nothing and says
@@ -83,3 +90,22 @@ def test_falls_through_to_npx_when_uvx_is_absent(tmp_path: Path) -> None:
 
     assert result.returncode == 0
     assert marker.read_text(encoding="utf-8") == "npx -y entroly@latest"
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="exercises the Windows .cmd invocation path",
+)
+def test_invokes_a_cmd_shim_on_windows(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "invoked.txt"
+    (fake_bin / "uvx.cmd").write_text(
+        f'@echo off\r\n> "{marker}" echo %*\r\n', encoding="utf-8"
+    )
+
+    node_dir = str(Path(shutil.which("node")).parent)
+    result = _run(f"{fake_bin}{os.pathsep}{node_dir}")
+
+    assert result.returncode == 0
+    assert "entroly" in marker.read_text(encoding="utf-8")

--- a/tests/test_plugin_launcher.py
+++ b/tests/test_plugin_launcher.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = ROOT / "scripts" / "entroly-plugin-launch.mjs"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="the launcher is a Node script; node is absent in this environment",
+)
+
+
+def _run(env_path: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PATH"] = env_path
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["node", str(LAUNCHER)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+
+def test_reports_one_actionable_line_when_no_runner_exists(tmp_path: Path) -> None:
+    node_dir = str(Path(shutil.which("node")).parent)
+    result = _run(node_dir)
+
+    assert result.returncode == 1
+    # The failure mode this guards is a plugin that starts nothing and says
+    # nothing, which is indistinguishable from a broken install.
+    assert "entroly" in result.stderr.lower()
+    assert "uv" in result.stderr.lower()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fake PATH executables need .cmd shims on Windows",
+)
+def test_prefers_uvx_and_passes_the_expected_arguments(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "invoked.txt"
+    uvx = fake_bin / "uvx"
+    uvx.write_text(
+        '#!/bin/sh\nprintf "%s" "$*" > "{marker}"\nexit 0\n'.format(marker=marker),
+        encoding="utf-8",
+    )
+    uvx.chmod(0o755)
+
+    node_dir = str(Path(shutil.which("node")).parent)
+    result = _run(f"{fake_bin}{os.pathsep}{node_dir}")
+
+    assert result.returncode == 0
+    assert marker.read_text(encoding="utf-8") == "--from entroly entroly"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fake PATH executables need .cmd shims on Windows",
+)
+def test_falls_through_to_npx_when_uvx_is_absent(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "invoked.txt"
+    npx = fake_bin / "npx"
+    npx.write_text(
+        '#!/bin/sh\nprintf "npx %s" "$*" > "{marker}"\nexit 0\n'.format(marker=marker),
+        encoding="utf-8",
+    )
+    npx.chmod(0o755)
+
+    node_dir = str(Path(shutil.which("node")).parent)
+    result = _run(f"{fake_bin}{os.pathsep}{node_dir}")
+
+    assert result.returncode == 0
+    assert marker.read_text(encoding="utf-8") == "npx -y entroly@latest"

--- a/tests/test_plugin_marketplace_manifest.py
+++ b/tests/test_plugin_marketplace_manifest.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CANONICAL_REPOSITORY = "https://github.com/juyterman1000/entroly"
+
+
+def _json(path: str) -> dict:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def _master_version() -> str:
+    text = (ROOT / "entroly" / "__init__.py").read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+    assert match is not None, "no __version__ in entroly/__init__.py"
+    return match.group(1)
+
+
+def test_marketplace_manifest_has_required_fields() -> None:
+    manifest = _json(".claude-plugin/marketplace.json")
+
+    assert manifest["name"] == "entroly"
+    assert manifest["owner"]["name"] == "juyterman1000"
+    assert isinstance(manifest["plugins"], list) and manifest["plugins"]
+
+
+def test_marketplace_lists_the_plugin_at_the_master_version() -> None:
+    manifest = _json(".claude-plugin/marketplace.json")
+    entry = next(p for p in manifest["plugins"] if p["name"] == "entroly")
+
+    assert entry["source"] == "./"
+    assert entry["version"] == _master_version()
+
+
+def test_plugin_declares_the_launcher_shim_not_a_bare_runner() -> None:
+    plugin = _json(".claude-plugin/plugin.json")
+    server = plugin["mcpServers"]["entroly"]
+
+    # A bare `uvx` here is the silent-dead-plugin failure mode: MCP config has
+    # no fallback chain, so a machine without uv gets a plugin that starts
+    # nothing and reports nothing.
+    assert server["command"] == "node"
+    assert server["args"] == [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/entroly-plugin-launch.mjs"
+    ]
+    assert server["env"]["ENTROLY_NO_DOCKER"] == "1"
+
+
+def test_plugin_identity_matches_the_canonical_repository() -> None:
+    plugin = _json(".claude-plugin/plugin.json")
+
+    assert plugin["name"] == "entroly"
+    assert plugin["repository"] == CANONICAL_REPOSITORY
+    assert plugin["version"] == _master_version()


### PR DESCRIPTION
## Why

An audit of the distribution surface on 2026-09-06 checked every channel against the **live service** rather than against the repository's intent:

| Channel | In repo | Live |
|---|---|---|
| Official MCP registry | `server.json` + `publish-mcp-registry.yml` | **Yes** — 20 versions, all `active` |
| Smithery | `smithery.yaml` | **No** — not listed |
| Claude Code plugin | `.claude-plugin/plugin.json` | **No** — no `marketplace.json`, so no install path exists |

One channel is alive, and it is the only one a workflow publishes without asking a human to remember. Both dead channels require someone to remember, and neither has been — the same way `marketing/launch/` has held three drafts at "prepared, not submitted."

So the fix is not "add more channels." It is that a channel added by hand silently rots, and nothing reports it.

## What this does

**Makes the plugin installable.** Adds `.claude-plugin/marketplace.json` — the file `/plugin marketplace add` reads, without which `plugin.json` is undiscoverable. MCP servers are declared inline in `plugin.json` rather than in a root `.mcp.json`, because `source: "./"` makes the plugin root the repo root and a root `.mcp.json` would load for anyone who merely opens this repository.

```
/plugin marketplace add juyterman1000/entroly
/plugin install entroly@entroly
```

**Survives a machine without `uv`.** MCP config cannot express a fallback chain, so naming `uvx` directly means a user without `uv` gets a plugin that starts nothing and reports nothing. `scripts/entroly-plugin-launch.mjs` resolves `uvx` → `npx` → `entroly` and prints one actionable line if all three fail. It resolves PATH itself rather than using a shell, because a shell collapses "not installed" and "installed but broken" into the same exit code — and it routes `.cmd`/`.bat` through `cmd.exe`, since `npx` ships as `npx.cmd` on Windows and `spawnSync` throws `EINVAL` on it.

**Makes presence self-enforcing.** `publish-mcp-registry.yml` already contained the mechanism: a step asserting server name, released version, canonical repository URL, and exact package set — careful, working, hard-coded to one channel, duplicated across two inline heredocs. `scripts/marketplace_presence.py` extracts it and gives it three result states.

`UNKNOWN` is load-bearing. Two registry API paths (`/v0` and `/v0.1`) both answered during the audit, so the schema is moving; a gate that hard-fails on a shape change reddens a healthy release, and a gate that reddens healthy releases gets disabled. `UNKNOWN` warns and is recorded — it never silently passes and never blocks. Channels this repo publishes to are blocking; channels that index on their own schedule are advisory.

A new daily workflow probes every channel, because Smithery died *between* releases and a release-time-only check would not have caught it. It ships advisory until one full cycle runs green.

**Proves something on first run.** `/entroly-first-run` shows named omissions together with the handles that recover them. It carries no savings percentage, and a test fails if one is reintroduced: `saved = max(0, baseline - selected_tokens)` with `baseline = min(total_tokens, 32_000)` pins the figure at ≥75% for a budget of 8,000 *before selection runs*. It measures the budget, not the selection.

## Two bugs the live probes caught

Both surfaced by running against real services rather than trusting unit tests:

- The post-publish verification step read an unreachable registry as a **successful publish**, because the checker exits `0` on `UNKNOWN` by design. The heredoc it replaced had no such hole — an unreachable registry raised out of `urlopen`. Now it matches `present` explicitly.
- The Smithery probe pointed at the human-facing page, which answers `308` to a redirect `urllib` will not follow, so it returned `UNKNOWN` forever — and `UNKNOWN` raises no warning, leaving the channel as silently dead as before the checker existed. Repointed at the registry API, which answers a clean `404`. It now reports `absent`, which is the audited truth.

## Testing

27 passed, 2 skipped (Unix-only, on Windows). `claude plugin validate .` passes from tracked files alone.

Live probe on this branch:

```
mcp-registry       [blocking]: absent  - not listed at 1.0.83
claude-marketplace [blocking]: unknown - could not read manifest: HTTP Error 404
smithery           [advisory]: absent  - server page does not exist
```

`claude-marketplace` reads `refs/heads/main` deliberately, so it stays `unknown` until this merges. That is the honest answer, not a bug.

## Follow-ups

- Submit to Smithery once, by hand. After that the daily probe watches it.
- Promote the daily workflow from advisory to blocking after one clean release cycle — the promotion condition is recorded in the workflow itself.
- Deferred minor: `item.get("server", item)` and `plugin.get("name")` assume list elements are dict-shaped; a malformed non-dict entry raises `AttributeError` instead of yielding `UNKNOWN`. Inherited from the original workflow step.

Spec: `docs/superpowers/specs/2026-09-06-marketplace-wedge-design.md`
Plan: `docs/superpowers/plans/2026-09-06-marketplace-wedge.md`
