### PR TITLE
ci(security): semantic analysis, Rust advisory audit, and enforced gates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+name: CodeQL
+
+# Semantic static analysis, which the repository had none of. `bandit` is a
+# pattern matcher over single lines; CodeQL follows data flow across functions
+# and files, so it reaches the class of bug -- tainted input arriving at a sink
+# several calls away -- that a line-level scan structurally cannot see.
+#
+# `actions` is scanned as well as `python`. Twenty-five workflows run with
+# repository credentials, and a script-injection through an untrusted
+# `github.event` field is a supply-chain compromise of every artifact this
+# project publishes.
+#
+# Rust is analysed by `cargo clippy -D warnings` and `cargo audit` in
+# deep-dogfood.yml rather than here.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - main
+      - "integration/**"
+  schedule:
+    # Advisories land after code does. A weekly run re-analyses an unchanged
+    # tree against updated queries, which a push-triggered scan never does.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL / ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      security-events: write   # required to upload results to code scanning
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          language: ${{ matrix.language }}
+          # security-extended adds lower-severity and higher-precision-cost
+          # queries. The default suite alone would leave this repository with
+          # roughly the coverage bandit already provides.
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,12 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          language: ${{ matrix.language }}
+          # `languages`, plural. The singular form is not an input: the action
+          # only warns about it, then falls back to auto-detecting languages,
+          # which picked Java in this repository and died finalizing a database
+          # for a language it does not contain. An ignored input failed as a
+          # build error several minutes later, nowhere near its cause.
+          languages: ${{ matrix.language }}
           # security-extended adds lower-severity and higher-precision-cost
           # queries. The default suite alone would leave this repository with
           # roughly the coverage bandit already provides.

--- a/.github/workflows/deep-dogfood.yml
+++ b/.github/workflows/deep-dogfood.yml
@@ -340,6 +340,21 @@ jobs:
           python -m compileall -q entroly tests scripts
           ruff check entroly tests/test_*dogfood.py tests/test_mcp_protocol.py tests/test_memory_launcher.py scripts/public_artifact_dogfood.py
 
+      # Python dependencies were audited by pip-audit below; Rust ones were
+      # audited by nothing. `cargo clippy` is a lint, not an advisory check, so
+      # a RUSTSEC advisory against a crate in entroly-core reached a release
+      # with no signal anywhere in CI.
+      - name: Install Rust advisory scanner
+        run: cargo install cargo-audit --locked --version ^0.21
+
+      - name: Rust dependency advisory audit
+        run: |
+          set +e
+          cargo audit --file entroly-core/Cargo.lock --deny warnings \
+            2>&1 | tee "$RUNNER_TEMP/cargo-audit.log"
+          echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/cargo-audit.status"
+          exit 0
+
       - name: High-severity static security scan
         run: |
           set +e
@@ -383,9 +398,28 @@ jobs:
             ${{ runner.temp }}/pip-audit-requirements.txt
             ${{ runner.temp }}/pip-audit.log
             ${{ runner.temp }}/pip-audit.status
+            ${{ runner.temp }}/cargo-audit.log
+            ${{ runner.temp }}/cargo-audit.status
           if-no-files-found: error
 
       - name: Enforce security gates
         run: |
-          test "$(cat "$RUNNER_TEMP/bandit.status")" -eq 0
-          test "$(cat "$RUNNER_TEMP/pip-audit.status")" -eq 0
+          # Each scan runs under `set +e` so its log is uploaded as evidence
+          # even when it fails; this step is what turns those logs into a
+          # verdict. A scan added above without a line here runs and reports
+          # nothing, which is indistinguishable from not running it.
+          failed=0
+          for gate in bandit pip-audit cargo-audit; do
+            status_file="$RUNNER_TEMP/$gate.status"
+            if [ ! -f "$status_file" ]; then
+              echo "::error::$gate produced no status file; the scan did not run"
+              failed=1
+              continue
+            fi
+            status="$(cat "$status_file")"
+            if [ "$status" -ne 0 ]; then
+              echo "::error::$gate failed with exit status $status"
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/.github/workflows/deep-dogfood.yml
+++ b/.github/workflows/deep-dogfood.yml
@@ -344,15 +344,37 @@ jobs:
       # audited by nothing. `cargo clippy` is a lint, not an advisory check, so
       # a RUSTSEC advisory against a crate in entroly-core reached a release
       # with no signal anywhere in CI.
+      # 0.22 or newer is required, not preferred. 0.21.2 cannot parse the
+      # current RustSec database at all -- it aborts with "unsupported CVSS
+      # version: 4.0" on an advisory that uses CVSS 4.0 scoring. That exits
+      # non-zero with no vulnerability involved, so the gate below would have
+      # blocked every pull request with a failure that reads exactly like a
+      # security finding.
       - name: Install Rust advisory scanner
-        run: cargo install cargo-audit --locked --version ^0.21
+        run: cargo install cargo-audit --locked --version ^0.22
 
       - name: Rust dependency advisory audit
         run: |
           set +e
-          cargo audit --file entroly-core/Cargo.lock --deny warnings \
-            2>&1 | tee "$RUNNER_TEMP/cargo-audit.log"
-          echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/cargo-audit.status"
+          # Both lock files, because entroly-engine has its own dependency
+          # closure and holds the SAST and selection code.
+          #
+          # RUSTSEC-2026-0176 and -0177 are open against pyo3 0.25.1 and are
+          # fixed only in 0.29.0, which is a breaking API migration across the
+          # PyO3 bindings. They are deferred here deliberately and visibly
+          # rather than left to fail the gate for everyone: an always-red gate
+          # gets bypassed, and then a genuinely new advisory arrives unnoticed.
+          # Remove these two flags with the PyO3 upgrade.
+          for lock in entroly-core/Cargo.lock entroly-engine/Cargo.lock; do
+            echo "== $lock =="
+            cargo audit --file "$lock" --deny warnings \
+              --ignore RUSTSEC-2026-0176 \
+              --ignore RUSTSEC-2026-0177
+            echo "$? $lock" >> "$RUNNER_TEMP/cargo-audit.exits"
+          done 2>&1 | tee "$RUNNER_TEMP/cargo-audit.log"
+          # Worst exit across both locks, so a finding in either one counts.
+          awk '{ if ($1 > worst) worst = $1 } END { print worst + 0 }' \
+            "$RUNNER_TEMP/cargo-audit.exits" > "$RUNNER_TEMP/cargo-audit.status"
           exit 0
 
       - name: High-severity static security scan

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,11 @@ benchmarks/simulated/
 tmp/
 /package.json
 /package-lock.json
+
+# Coverage artifacts. `pytest --cov` writes these into the working tree, and a
+# 3.4 MB coverage.json was one `git add -A` away from being committed.
+.coverage
+.coverage.*
+coverage.json
+coverage.xml
+htmlcov/

--- a/entroly-core/Cargo.lock
+++ b/entroly-core/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ascii"
@@ -89,9 +89,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/entroly-engine/Cargo.lock
+++ b/entroly-engine/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/scripts/self_sast_scan.py
+++ b/scripts/self_sast_scan.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Run Entroly's own static security engine over Entroly's own source.
+
+The Rust core ships a SAST engine and CI never pointed it at this repository.
+A scanner its author does not run is a scanner nobody has evidence works: the
+rules could be silently broken, or the source could contain exactly what they
+are written to find, and neither would surface.
+
+This is a gate, not a report. It fails on findings at or above
+``--fail-on`` severity so a regression blocks the pull request, and prints the
+whole finding set as evidence either way.
+
+The engine redacts secret-bearing lines itself (``line_content`` comes back as
+a placeholder for secret rules), so the output is safe to attach to a public
+build log.
+
+Exit codes: 0 clean, 1 findings at or above the threshold, 2 the engine is
+unavailable -- which is a failure, not a pass, because "no findings" and "no
+scanner" are indistinguishable in a green check.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Ordered, so a threshold means "this and anything worse".
+SEVERITY_ORDER = ["Info", "Low", "Medium", "High", "Critical"]
+
+# Scanning our own test corpus would report the vulnerable snippets the SAST
+# tests deliberately contain, so the gate would fail on its own fixtures.
+DEFAULT_EXCLUDES = (
+    "tests/",
+    "benchmarks/",
+    "docs/",
+    "scripts/self_sast_scan.py",  # the examples in this file's own docstring
+    ".git/",
+    "node_modules/",
+    "target/",
+    "build/",
+    "dist/",
+    # Vendored and installed third-party code. Omitting these made the first
+    # run scan `tmp/clean-venv-1.0.70/Lib/site-packages/` -- pip, setuptools,
+    # cryptography, pywin32 -- and report their findings as Entroly's. A
+    # scanner that blames its dependencies for its own hygiene is worse than
+    # no scanner, because the number looks like a measurement.
+    ".venv/",
+    "venv/",
+    "tmp/",
+    "site-packages/",
+    ".tox/",
+    "vendor/",
+)
+
+
+def _rank(severity: str) -> int:
+    try:
+        return SEVERITY_ORDER.index(severity)
+    except ValueError:
+        return 0
+
+
+def _iter_sources(root: Path, excludes: tuple[str, ...]) -> list[Path]:
+    files = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(root).as_posix()
+        if any(rel.startswith(prefix) or f"/{prefix}" in f"/{rel}" for prefix in excludes):
+            continue
+        files.append(path)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fail-on", default="High", choices=SEVERITY_ORDER)
+    parser.add_argument("--json-out", type=Path, default=None)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    args = parser.parse_args()
+
+    try:
+        import entroly_core
+    except Exception as exc:
+        print(f"FAIL: Entroly's security engine is unavailable: {exc}", file=sys.stderr)
+        print(
+            "A missing scanner must not read as a clean scan; build the native "
+            "engine with `cd entroly-core && maturin develop --release`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not hasattr(entroly_core, "py_scan_content"):
+        print(
+            "FAIL: the native engine exposes no py_scan_content; the SAST "
+            "binding was removed or renamed.",
+            file=sys.stderr,
+        )
+        return 2
+
+    threshold = _rank(args.fail_on)
+    sources = _iter_sources(args.root, DEFAULT_EXCLUDES)
+    findings: list[dict] = []
+    unreadable: list[str] = []
+
+    for path in sources:
+        rel = path.relative_to(args.root).as_posix()
+        try:
+            content = path.read_text(encoding="utf-8")
+        except Exception as exc:
+            unreadable.append(f"{rel}: {exc}")
+            continue
+        try:
+            report = json.loads(entroly_core.py_scan_content(content, rel))
+        except Exception as exc:
+            unreadable.append(f"{rel}: scan failed: {exc}")
+            continue
+        for finding in report.get("findings", []):
+            finding["file"] = rel
+            findings.append(finding)
+
+    blocking = [f for f in findings if _rank(f.get("severity", "Info")) >= threshold]
+
+    summary = {
+        "files_scanned": len(sources),
+        "findings_total": len(findings),
+        "findings_blocking": len(blocking),
+        "fail_on": args.fail_on,
+        "unreadable": unreadable,
+        "by_severity": {
+            level: sum(1 for f in findings if f.get("severity") == level)
+            for level in SEVERITY_ORDER
+        },
+        "findings": findings,
+    }
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+
+    print(f"Entroly self-SAST: {len(sources)} files scanned, {len(findings)} findings")
+    for level in reversed(SEVERITY_ORDER):
+        count = summary["by_severity"][level]
+        if count:
+            print(f"  {level:<8} {count}")
+
+    for finding in sorted(
+        blocking, key=lambda f: (-_rank(f.get("severity", "Info")), f.get("file", ""))
+    ):
+        print(
+            f"  {finding.get('severity')}: {finding.get('file')}:"
+            f"{finding.get('line_number')} [{finding.get('rule_id')}] "
+            f"CWE-{finding.get('cwe')} {finding.get('description', '')[:110]}"
+        )
+
+    if unreadable:
+        # Not fatal on its own, but never silent: a file that could not be read
+        # was not scanned, and an unscanned file is not a clean file.
+        print(f"  {len(unreadable)} file(s) could not be scanned:")
+        for item in unreadable[:10]:
+            print(f"    {item}")
+
+    if blocking:
+        print(
+            f"FAIL: {len(blocking)} finding(s) at or above {args.fail_on}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"PASS: no findings at or above {args.fail_on}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -115,3 +115,39 @@ def test_binary_upload_does_not_publish_the_draft() -> None:
     assert re.search(r"(?m)^\s+draft:\s*true\s*$", match.group("body")), (
         "the upload step must set draft: true so only finalize-release publishes"
     )
+
+
+def test_every_security_scan_is_enforced() -> None:
+    """A scan that writes a status file nobody reads is decorative.
+
+    The security job deliberately runs each scanner under `set +e` with a
+    trailing `exit 0`, so its log uploads as evidence even on failure. That
+    makes the enforcement step the only thing standing between a finding and a
+    green check -- and adding a scanner without adding it there produces a job
+    that runs, reports, and passes regardless.
+
+    Asserting the property rather than a fixed list, so a fourth scanner fails
+    here instead of silently not counting.
+    """
+    workflow = (ROOT / ".github/workflows/deep-dogfood.yml").read_text(encoding="utf-8")
+    job = re.search(
+        r"(?ms)^  security-static:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)", workflow
+    )
+    assert job is not None, "security-static job is missing"
+    body = job.group("body")
+
+    # Every scanner that records a verdict, taken from the writes themselves.
+    produced = set(re.findall(r'\$RUNNER_TEMP/([\w.-]+)\.status"', body))
+    assert produced, "no scanner writes a status file; the evidence pattern is gone"
+
+    enforce = re.search(
+        r"(?ms)^      - name: Enforce security gates\n(?P<body>.*?)(?=^      - |\Z)", body
+    )
+    assert enforce is not None, "the security gates are no longer enforced at all"
+    enforced_block = enforce.group("body")
+
+    unenforced = sorted(name for name in produced if name not in enforced_block)
+    assert not unenforced, (
+        f"these scanners run but no gate reads their result: {unenforced}. "
+        "They would report findings and still pass the job."
+    )

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -151,3 +151,34 @@ def test_every_security_scan_is_enforced() -> None:
         f"these scanners run but no gate reads their result: {unenforced}. "
         "They would report findings and still pass the job."
     )
+
+
+def test_codeql_declares_languages_not_language() -> None:
+    """`language:` is silently ignored by github/codeql-action/init.
+
+    The action warns about the unknown input and carries on with language
+    auto-detection, which in this repository selected Java and then failed
+    finalizing a database for a language it does not contain. The failure
+    surfaced minutes later as a build error with exit code 32, nowhere near
+    the typo that caused it.
+
+    Pinned because the two spellings differ by one character and the wrong one
+    fails in a way that does not name itself.
+    """
+    workflow = (ROOT / ".github/workflows/codeql.yml").read_text(encoding="utf-8")
+    init = re.search(
+        r"(?ms)^      - name: Initialize CodeQL\n(?P<body>.*?)(?=^      - |\Z)", workflow
+    )
+    assert init is not None, "the CodeQL init step is missing"
+    body = init.group("body")
+
+    assert re.search(r"(?m)^\s+languages:\s*\$\{\{\s*matrix\.language\s*\}\}", body), (
+        "the CodeQL init step must pass `languages:` (plural)"
+    )
+    # Scoped to the step body on purpose: `language:` is also the legitimate
+    # name of the matrix key, so searching the whole file would fail on a
+    # correct configuration.
+    assert not re.search(r"(?m)^\s+language:\s", body), (
+        "`language:` is not an input to codeql-action/init; it is ignored and "
+        "the action falls back to auto-detection"
+    )


### PR DESCRIPTION
Follows #428. These two commits were pushed after that PR merged, so they never landed.

The repository already had 25 workflows, 4,837 tests, ruff, clippy, bandit and pip-audit. The gap was **enforcement**, and three real holes underneath it.

## Rust dependencies had no advisory scanning at all

`cargo clippy` is a lint, not an advisory check, and `pip-audit` covers only Python. Enabling Dependabot alerts and running `cargo audit` for the first time found five findings. Three are fixed here by a semver-compatible lock update in both crates, with `cargo check --release` passing:

```
RUSTSEC-2026-0204  crossbeam-epoch  invalid pointer dereference  0.9.18 -> 0.9.21
RUSTSEC-2026-0190  anyhow           unsound Error::downcast_mut  1.0.102 -> 1.0.104
(yanked)           chacha20                                      0.10.1 -> 0.10.2
```

The remaining two — **RUSTSEC-2026-0176** (High, out-of-bounds read in `PyList`/`PyTuple` iterators) and **RUSTSEC-2026-0177** (missing `Sync` bound) — are open against `pyo3 0.25.1` and fixed only in `0.29.0`. That is a breaking migration across ~6,500 lines of bindings, so they are ignored **by ID, with the reason recorded at the call site**, and tracked separately. A permanently-red gate gets bypassed, and then a genuinely new advisory arrives unnoticed.

## The version pin was not a preference

`cargo-audit 0.21.2` **cannot parse the current RustSec database**. It aborts with `unsupported CVSS version: 4.0` on an advisory using CVSS 4.0 scoring — exit 1, with no vulnerability involved.

Since `Static security and dependency audit` is now a required check and admin bypass is disabled, that would have blocked **every merge** behind a failure indistinguishable from a real finding. Reproduced locally against this tree before it could reach CI; the pin is `^0.22`.

## No semantic static analysis

`bandit` matches patterns on single lines, so tainted input reaching a sink a few calls away was structurally invisible. CodeQL now runs on PRs and weekly — weekly matters because advisories land after code does, and a push-triggered scan never re-analyses an unchanged tree against updated queries.

It analyses `actions` as well as `python`: 25 workflows run with repository credentials, and a script injection through an untrusted `github.event` field would compromise every artifact this project publishes.

## The enforcement step listed its scanners by hand

Each scan deliberately runs under `set +e` so its log uploads as evidence even on failure — which makes the enforcement step the only thing between a finding and a green check. A scanner added without a line there runs, reports, and passes.

It now iterates over the scanners and **also fails when a status file is missing**, because a scan that did not run must not read as a scan that found nothing. `test_every_security_scan_is_enforced` asserts the property by reading which scanners write a status file, so a fourth one fails the test instead of quietly not counting. Mutation-checked by dropping `cargo-audit` from the loop.

## Entroly's own SAST is included but deliberately NOT gating

`scripts/self_sast_scan.py` points the engine at this repository. Against 412 first-party files it reports 98 findings, and **every one inspected is a false positive**:

- the secret rules match `_SECRET_PATTERNS` — the regexes that *detect* secrets — and the engine's own rule table
- `SQL-006` matches `def execute(query: ...)` inside code-generation f-strings, with no SQL present
- `CRYPTO-001` flags `hashlib.md5(..., usedforsecurity=False)` despite the explicit non-security declaration that bandit honours
- `CRYPTO-002` fires on the string literal `"sha1"` in `if value in {"sha1", "sha256"}`

All at **confidence 1.0**, with `suppressed_by` null on every finding — the documented false-positive suppression never fires. Gating on that would fail every PR on noise. The script is committed so the engine can be fixed against a reproducible baseline; this is also what a customer pointing it at their own code would see.

Its first version scanned `tmp/clean-venv-1.0.70/Lib/site-packages` and reported pip, setuptools and cryptography findings as Entroly's — which is why the exclusion list now names vendored trees explicitly.

## Also

Coverage artifacts are gitignored: `pytest --cov` writes a 3.4 MB `coverage.json` into the working tree, one `git add -A` from being committed.

No coverage threshold is set. The measurement run timed out — instrumentation pushes `test_config_propagates` past the 120s per-test limit — so there is no honest number to gate on yet.

## Verification

34 workflow-reading tests pass (`test_workflow_guards`, `test_release_surface`, `test_distribution_ci_coverage`), both workflows parse, and the exact CI audit command exits 0 across both lock files. `ruff` clean.
