### PR TITLE
fix(ci): support non-fast-forward identity checks

### DIFF
--- a/.github/workflows/commit-identity-guard.yml
+++ b/.github/workflows/commit-identity-guard.yml
@@ -57,10 +57,35 @@ jobs:
 
           if event_name == "pull_request":
               rev = f'{event["pull_request"]["base"]["sha"]}..{event["pull_request"]["head"]["sha"]}'
+              revisions = [rev]
           else:
               before = event.get("before", "")
               after = event["after"]
-              rev = after if not before or set(before) == {"0"} else f"{before}..{after}"
+              if not before or set(before) == {"0"}:
+                  rev = after
+                  revisions = [after]
+              else:
+                  rev = f"{after} --not {before}"
+                  before_exists = subprocess.run(
+                      ["git", "cat-file", "-e", f"{before}^{{commit}}"],
+                      check=False,
+                      stdout=subprocess.DEVNULL,
+                      stderr=subprocess.DEVNULL,
+                  ).returncode == 0
+                  if before_exists:
+                      # Select commits introduced by the new tip without
+                      # assuming the push was fast-forward. This also handles
+                      # a pure rewind: there are no newly introduced commits.
+                      revisions = [after, "--not", before]
+                  else:
+                      # A force-pushed-away `before` object is not guaranteed
+                      # to remain fetchable. Validate the complete new
+                      # first-parent history instead of skipping the guard.
+                      print(
+                          f"Before commit {before} is unavailable; "
+                          "validating the complete new first-parent history"
+                      )
+                      revisions = [after]
 
           rows = subprocess.check_output(
               [
@@ -68,7 +93,7 @@ jobs:
                   "log",
                   "--first-parent",
                   "--format=%H%x1f%an%x1f%ae%x1f%cn%x1f%ce%x1e",
-                  rev,
+                  *revisions,
               ],
               text=True,
           )

--- a/tests/test_commit_identity_guard.py
+++ b/tests/test_commit_identity_guard.py
@@ -308,3 +308,76 @@ def test_dependabot_commit_cannot_carry_hand_written_source(tmp_path: Path) -> N
 
     assert result.returncode == 1
     assert "author is dependabot[bot]" in result.stdout
+
+
+def test_rewind_push_does_not_treat_before_after_as_a_revision_range(
+    tmp_path: Path,
+) -> None:
+    """A force-push to an existing ancestor introduces no new commits.
+
+    Git rejects ``child..parent`` when the child is not an ancestor of the
+    parent. The push payload still contains exactly that ordering for a rewind,
+    so the guard must use a revision set that is valid for either direction.
+    """
+
+    repo, parent = _init_repo(tmp_path)
+    (repo / "README.md").write_text("newer tip\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    owner = _identity_env(
+        author_name="juyterman1000",
+        author_email=OWNER_EMAIL,
+        committer_name="juyterman1000",
+        committer_email=OWNER_EMAIL,
+    )
+    _git(repo, "commit", "-m", "Temporary newer tip", env=owner)
+    child = _git(repo, "rev-parse", "HEAD")
+
+    result = _run_guard(
+        repo,
+        tmp_path,
+        event_name="push",
+        event=_push_event(child, parent),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Commit identity OK" in result.stdout
+
+
+def test_divergent_force_push_still_rejects_new_untrusted_commit(
+    tmp_path: Path,
+) -> None:
+    """Handling a rewrite must not turn the identity guard into a bypass."""
+
+    repo, base = _init_repo(tmp_path)
+    (repo / "old.txt").write_text("old tip\n", encoding="utf-8")
+    _git(repo, "add", "old.txt")
+    owner = _identity_env(
+        author_name="juyterman1000",
+        author_email=OWNER_EMAIL,
+        committer_name="juyterman1000",
+        committer_email=OWNER_EMAIL,
+    )
+    _git(repo, "commit", "-m", "Old trusted tip", env=owner)
+    before = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "checkout", "--detach", base)
+    (repo / "replacement.txt").write_text("replacement tip\n", encoding="utf-8")
+    _git(repo, "add", "replacement.txt")
+    untrusted = _identity_env(
+        author_name="Untrusted Contributor",
+        author_email="untrusted@example.com",
+        committer_name="Untrusted Contributor",
+        committer_email="untrusted@example.com",
+    )
+    _git(repo, "commit", "-m", "Replace main history", env=untrusted)
+    after = _git(repo, "rev-parse", "HEAD")
+
+    result = _run_guard(
+        repo,
+        tmp_path,
+        event_name="push",
+        event=_push_event(before, after),
+    )
+
+    assert result.returncode == 1
+    assert "author is Untrusted Contributor" in result.stdout


### PR DESCRIPTION
The Commit Identity Guard crashes on a non-fast-forward `main` update because it passes `before..after` to `git log`, which assumes `before` is an ancestor of `after`. The latest failure was a rewind from `5ab5793` to its parent `d6b000f`, so Git rejected the revision range before any identity checks ran.

This change selects commits reachable from the new tip and not the old tip using `after --not before`, which works for fast-forwards, divergent rewrites, and pure rewinds. If the old object is unavailable after a force-push, the guard checks the complete new first-parent history. Regression coverage proves a rewind succeeds without weakening the guard against an untrusted divergent commit.

Validation:

- `python -m pytest tests/test_commit_identity_guard.py -q` (`10 passed`)
- `python -m pytest tests/test_release_surface.py -q` (`24 passed`)
- `python -m ruff check tests/test_commit_identity_guard.py`
- pre-push Ruff, Clippy, and Rust library tests (`114 passed`, `5 ignored`)
